### PR TITLE
Update vendored packaging to 16.6

### DIFF
--- a/pkg_resources/_vendor/packaging/__about__.py
+++ b/pkg_resources/_vendor/packaging/__about__.py
@@ -12,7 +12,7 @@ __title__ = "packaging"
 __summary__ = "Core utilities for Python packages"
 __uri__ = "https://github.com/pypa/packaging"
 
-__version__ = "16.5"
+__version__ = "16.6"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"

--- a/pkg_resources/_vendor/packaging/markers.py
+++ b/pkg_resources/_vendor/packaging/markers.py
@@ -73,9 +73,14 @@ VARIABLE = (
     L("python_version") |
     L("sys_platform") |
     L("os_name") |
+    L("os.name") |  # PEP-345
+    L("sys.platform") |  # PEP-345
+    L("platform.version") |  # PEP-345
+    L("platform.machine") |  # PEP-345
+    L("platform.python_implementation") |  # PEP-345
     L("extra")
 )
-VARIABLE.setParseAction(lambda s, l, t: Variable(t[0]))
+VARIABLE.setParseAction(lambda s, l, t: Variable(t[0].replace('.', '_')))
 
 VERSION_CMP = (
     L("===") |

--- a/pkg_resources/_vendor/vendored.txt
+++ b/pkg_resources/_vendor/vendored.txt
@@ -1,3 +1,3 @@
-packaging==16.5
+packaging==16.6
 pyparsing==2.0.6
 six==1.10.0


### PR DESCRIPTION
Update the vendored packaging to 16.6 to add support for PEP 345 environment markers.

Closes #503