### PR TITLE
Drop unused safe_repr function

### DIFF
--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -15,17 +15,6 @@ from pkg_resources import (parse_requirements, VersionConflict, parse_version,
     WorkingSet)
 
 
-def safe_repr(obj, short=False):
-    """ copied from Python2.7"""
-    try:
-        result = repr(obj)
-    except Exception:
-        result = object.__repr__(obj)
-    if not short or len(result) < pkg_resources._MAX_LENGTH:
-        return result
-    return result[:pkg_resources._MAX_LENGTH] + ' [truncated]...'
-
-
 class Metadata(pkg_resources.EmptyProvider):
     """Mock object to return metadata as if from an on-disk distribution"""
 


### PR DESCRIPTION
When _assertIn was removed from test_resources, the safe_repr
function was not dropped, leaving it with no callers, so drop it.