### PR TITLE
Reinstate the or guard in WorkingSet._markers_pass

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -861,7 +861,7 @@ class WorkingSet(object):
 
         result = []
         if req in extra_req_mapping:
-            for extra in extra_req_mapping[req]:
+            for extra in extra_req_mapping[req] or ['']:
                 result.append(req.marker.evaluate({'extra': extra}))
         else:
             result.append(req.marker.evaluate())

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -186,6 +186,12 @@ class TestDistro:
         res = ws.resolve(parse_requirements("Foo;python_version>='2'"), ad)
         assert list(res) == [Foo]
 
+    def test_environment_marker_evaluation_called(self):
+        ws = WorkingSet([])
+        req, = parse_requirements("bar;python_version<'4'")
+        extra_req_mapping = {req: ()}
+        assert ws._markers_pass(req, extra_req_mapping) == True
+
     def test_marker_evaluation_with_extras(self):
         """Extras are also evaluated as markers at resolution time."""
         ad = pkg_resources.Environment([])


### PR DESCRIPTION
Thanks to @jaraco refactoring the marker evaluation in WorkingSet.resolve(), we can test it directly to show that the [''] guard is required.