### PR TITLE
Update msvc9_support.py

### DIFF
--- a/setuptools/msvc9_support.py
+++ b/setuptools/msvc9_support.py
@@ -1,7 +1,10 @@
+import distutils.errors
+
 try:
     import distutils.msvc9compiler
-except ImportError:
-    pass
+    HAVE_MSVC9COMPILER = True
+except (ImportError, distutils.errors.DistutilsPlatformError):
+    HAVE_MSVC9COMPILER = False
 
 unpatched = dict()
 
@@ -11,7 +14,7 @@ def patch_for_specialized_compiler():
     build for Python (Windows only). Fall back to original behavior when the
     standalone compiler is not available.
     """
-    if 'distutils' not in globals():
+    if not HAVE_MSVC9COMPILER:
         # The module isn't available to be patched
         return
 


### PR DESCRIPTION
This module causes `import setuptools` to crash in mingw-w64's python, like so:

```
$ python -m setuptools
Traceback (most recent call last):
  File "C:/msys64/mingw64/lib/python2.7/runpy.py", line 151, in _run_module_as_main
    mod_name, loader, code, fname = _get_module_details(mod_name)
  File "C:/msys64/mingw64/lib/python2.7/runpy.py", line 109, in _get_module_details
    return _get_module_details(pkg_main_name)
  File "C:/msys64/mingw64/lib/python2.7/runpy.py", line 101, in _get_module_details
    loader = get_loader(mod_name)
  File "C:/msys64/mingw64/lib/python2.7/pkgutil.py", line 464, in get_loader
    return find_loader(fullname)
  File "C:/msys64/mingw64/lib/python2.7/pkgutil.py", line 474, in find_loader
    for importer in iter_importers(fullname):
  File "C:/msys64/mingw64/lib/python2.7/pkgutil.py", line 430, in iter_importers
    __import__(pkg)
  File "C:/msys64/mingw64/lib/python2.7/site-packages/setuptools/__init__.py", line 14, in <module>
    from setuptools.extension import Extension
  File "C:/msys64/mingw64/lib/python2.7/site-packages/setuptools/extension.py", line 11, in <module>
    from . import msvc9_support
  File "C:/msys64/mingw64/lib/python2.7/site-packages/setuptools/msvc9_support.py", line 2, in <module>
    import distutils.msvc9compiler
  File "C:/msys64/mingw64/lib/python2.7/distutils/msvc9compiler.py", line 306, in <module>
    raise DistutilsPlatformError("VC %0.1f is not supported by this module" % VERSION)
distutils.errors.DistutilsPlatformError: VC 6.0 is not supported by this module
```

This is because `distutils.msvccompiler` parses `sys.version` to get the MSVC version that compiled Python--in this case MSVC was not used to build Python and for some reason this causes it to default to `6` which makes `msvc9compiler` to crash at import-time.  Ouch!