### PR TITLE
Handle not-zip-safe egg (folder) deletion in rotate command

### DIFF
--- a/setuptools/command/rotate.py
+++ b/setuptools/command/rotate.py
@@ -2,6 +2,7 @@ from distutils.util import convert_path
 from distutils import log
 from distutils.errors import DistutilsOptionError
 import os
+import shutil
 
 from setuptools.extern import six
 
@@ -59,4 +60,7 @@ class rotate(Command):
             for (t, f) in files:
                 log.info("Deleting %s", f)
                 if not self.dry_run:
-                    os.unlink(f)
+                    if os.path.isdir(f):
+                        shutil.rmtree(f)
+                    else:
+                        os.unlink(f)


### PR DESCRIPTION
Handle setuptools roate deletion when egg package is not in file format (zip-save)
but in folder format (not-zip-save).