### PR TITLE
remove _markerlib from manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,6 @@ recursive-include setuptools *.py *.exe *.xml
 recursive-include tests *.py
 recursive-include setuptools/tests *.html
 recursive-include docs *.py *.txt *.conf *.css *.css_t Makefile indexsidebar.html
-recursive-include _markerlib *.py
 recursive-include setuptools/_vendor *
 recursive-include pkg_resources *.py *.txt
 include *.py


### PR DESCRIPTION
leftovers