### PR TITLE
Preserve order of egg_info section in setup.cfg

### DIFF
--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -2,6 +2,7 @@ from distutils.util import convert_path
 from distutils import log
 from distutils.errors import DistutilsOptionError
 import distutils
+import operator
 import os
 
 from setuptools.extern.six.moves import configparser
@@ -42,7 +43,8 @@ def edit_config(filename, settings, dry_run=False):
     log.debug("Reading configuration from %s", filename)
     opts = configparser.RawConfigParser()
     opts.read([filename])
-    for section, options in settings.items():
+    for section, options in sorted(settings.items(),
+                                   key=operator.itemgetter(0)):
         if options is None:
             log.info("Deleting section [%s] from %s", section, filename)
             opts.remove_section(section)
@@ -50,7 +52,8 @@ def edit_config(filename, settings, dry_run=False):
             if not opts.has_section(section):
                 log.debug("Adding new section [%s] to %s", section, filename)
                 opts.add_section(section)
-            for option, value in options.items():
+            for option, value in sorted(options.items(),
+                                        key=operator.itemgetter(0)):
                 if value is None:
                     log.debug(
                         "Deleting %s.%s from %s",


### PR DESCRIPTION
egg_info is the dictionary with information that is injected
into setup.cfg. edit_config uses RawConfigParser which uses
collections.OrderedDict for all the data. Since we use a
simple dict(), when we loop through items in edit_config, we
see random behavior as a result the fields
tag_svn_revision/tag_date/tag_build are added to the setup.cfg
randomly. Let's add a OrderedDict to make it more predictable.