### PR TITLE
password prompt on upload command

### DIFF
--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -3,13 +3,18 @@ from distutils.command import upload as orig
 
 class upload(orig.upload):
     """
-    Override default upload behavior to look up password
-    in the keyring if available.
+    Override default upload behavior to obtain password
+    in a variety of different ways.
     """
 
     def finalize_options(self):
         orig.upload.finalize_options(self)
-        self.password or self._load_password_from_keyring()
+        # Attempt to obtain password. Short circuit evaluation at the first
+        # sign of success.
+        self.password = (
+            self.password or self._load_password_from_keyring() or
+            self._prompt_for_password()
+        )
 
     def _load_password_from_keyring(self):
         """
@@ -17,7 +22,22 @@ class upload(orig.upload):
         """
         try:
             keyring = __import__('keyring')
-            self.password = keyring.get_password(self.repository,
-                self.username)
+            password = keyring.get_password(self.repository, self.username)
         except Exception:
-            pass
+            password = None
+        finally:
+            return password
+
+    def _prompt_for_password(self):
+        """
+        Prompt for a password on the tty. Suppress Exceptions.
+        """
+        password = None
+        try:
+            import getpass
+            while not password:
+                password = getpass.getpass()
+        except (Exception, KeyboardInterrupt):
+            password = None
+        finally:
+            return password


### PR DESCRIPTION
Resolves #554 

If there is no password in `~/.pypirc`, running the upload command
```
python setup.py sdist upload
```
Will now prompt for the user password in the same manner that
```
python setup.py sdist register
```
does.

---

Let me know if I've missed anything or if there is anything that I could change!

I couldn't find any place to document this functionality (ie, in a readme or anything).