### PR TITLE
Update packaging to 16.7

### DIFF
--- a/pkg_resources/_vendor/packaging/__about__.py
+++ b/pkg_resources/_vendor/packaging/__about__.py
@@ -12,7 +12,7 @@ __title__ = "packaging"
 __summary__ = "Core utilities for Python packages"
 __uri__ = "https://github.com/pypa/packaging"
 
-__version__ = "16.6"
+__version__ = "16.7"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"

--- a/pkg_resources/_vendor/packaging/markers.py
+++ b/pkg_resources/_vendor/packaging/markers.py
@@ -78,9 +78,18 @@ VARIABLE = (
     L("platform.version") |  # PEP-345
     L("platform.machine") |  # PEP-345
     L("platform.python_implementation") |  # PEP-345
+    L("python_implementation") |  # undocumented setuptools legacy
     L("extra")
 )
-VARIABLE.setParseAction(lambda s, l, t: Variable(t[0].replace('.', '_')))
+ALIASES = {
+    'os.name': 'os_name',
+    'sys.platform': 'sys_platform',
+    'platform.version': 'platform_version',
+    'platform.machine': 'platform_machine',
+    'platform.python_implementation': 'platform_python_implementation',
+    'python_implementation': 'platform_python_implementation'
+}
+VARIABLE.setParseAction(lambda s, l, t: Variable(ALIASES.get(t[0], t[0])))
 
 VERSION_CMP = (
     L("===") |

--- a/pkg_resources/_vendor/vendored.txt
+++ b/pkg_resources/_vendor/vendored.txt
@@ -1,3 +1,3 @@
-packaging==16.6
+packaging==16.7
 pyparsing==2.0.6
 six==1.10.0


### PR DESCRIPTION
This adds support for the deprecated python_implementation marker which was an undocumented setuptools marker prior to 20.2 in addition to the newer markers.