### PR TITLE
Feature/msvc discovery

### DIFF
--- a/setuptools/msvc9_support.py
+++ b/setuptools/msvc9_support.py
@@ -810,7 +810,7 @@ class EnvironmentInfo:
         """
         forcex86 = True if self.vcver <= 10.0 else False
         arch_subdir = self.pi.cross_dir(forcex86)
-        tools = [os.path.join(self.si.VCInstallDir, r'VCPackages'),
+        tools = [os.path.join(self.si.VCInstallDir, 'VCPackages'),
                  os.path.join(self.si.VCInstallDir, 'Bin%s' % arch_subdir)]
 
         if self.pi.cross_dir() and self.vcver >= 14.0:


### PR DESCRIPTION
**Tests advancement:**

I tested WinSDK 7.1, WinSDK 7.0, WinSDK 6.1, VC for Python 2.7 with current architecture as X86 and all possible target architectures. Environment generated from script is good in all cases (With some little fixes in this commit), some paths are added on some case, I will look if I need to remove them. I need also to check .Net Framework 64bits if x86 is current architecture (Files don't exists, but path are on vcvars batchs).

I need also to do test for sames compilers on X64 architecture, I will also test MSVC++ 2015 Build tools on X64.

I looked for create CI automated test on [AppVeyor ](http://www.appveyor.com) for this, but it is impossible to only have one of theses compilers only installed... So I did all tests manually.

I added a parameter on `return_env` method to return paths without checks if exists (Helpful for test and debugging).

I also added a security check on `arch` parameter to avoid possible accidental use of `x64` (in place of `amd64`)

For avoid errors on Travis CI, is it maybe possible to add a "Is Windows" condition somewhere on the script ?