### PR TITLE
In case of requirement parse errors, produce more helpful error messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ v21.0.0
   branch and should be generally be retrieved from
   its canonical location at
   https://bootstrap.pypa.io/ez_setup.py.
+* In case of requirement parse errors, produce more helpful error messages.
 
 v20.10.0
 --------

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2477,11 +2477,26 @@ class Distribution(object):
                             extra, marker = extra.split(':', 1)
                             if invalid_marker(marker):
                                 # XXX warn
-                                reqs=[]
+                                reqs = []
                             elif not evaluate_marker(marker):
-                                reqs=[]
+                                reqs = []
                         extra = safe_extra(extra) or None
-                    dm.setdefault(extra,[]).extend(parse_requirements(reqs))
+                    try:
+                        dm.setdefault(extra, []).extend(
+                            parse_requirements(reqs))
+                    except (
+                        packaging.requirements.InvalidRequirement,
+                        RequirementParseError
+                    ) as e:
+                        raise RequirementParseError(
+                            "Error on parsing a requirement for package {0} "
+                            "({1}). Message: {2}".format(
+                                str(self),
+                                self.location,
+                                str(e)
+                            )
+                        )
+
             return dm
 
     def requires(self, extras=()):

--- a/pkg_resources/_vendor/packaging/requirements.py
+++ b/pkg_resources/_vendor/packaging/requirements.py
@@ -90,8 +90,12 @@ class Requirement(object):
             req = REQUIREMENT.parseString(requirement_string)
         except ParseException as e:
             raise InvalidRequirement(
-                "Invalid requirement, parse error at \"{0!r}\"".format(
-                    requirement_string[e.loc:e.loc + 8]))
+                "Invalid requirement for \"{0}\", "
+                "parse error at \"{1!r}\"".format(
+                    requirement_string,
+                    requirement_string[e.loc:e.loc + 8]
+                )
+            )
 
         self.name = req.name
         if req.url:

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -723,6 +723,18 @@ class TestParsing:
             hash(parse_version("1.0"))
         )
 
+    def testInvalid(self):
+        from pkg_resources import RequirementParseError
+        import pdb
+        pdb.set_trace()
+        with pytest.raises(RequirementParseError):
+            Requirement.parse("foobar,")
+
+        try:
+            Requirement.parse("foobar,")
+        except RequirementParseError as e:
+            assert 'Invalid requirement for "foobar,"' in str(e)
+
 
 class TestNamespaces:
 

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -724,15 +724,12 @@ class TestParsing:
         )
 
     def testInvalid(self):
-        from pkg_resources import RequirementParseError
-        import pdb
-        pdb.set_trace()
-        with pytest.raises(RequirementParseError):
+        with pytest.raises(pkg_resources.RequirementParseError):
             Requirement.parse("foobar,")
 
         try:
             Requirement.parse("foobar,")
-        except RequirementParseError as e:
+        except pkg_resources.RequirementParseError as e:
             assert 'Invalid requirement for "foobar,"' in str(e)
 
 


### PR DESCRIPTION
It often happened to me that I got a error message like this:

```
While:
  Installing instance.
Traceback (most recent call last):
  File "/home/thet-data/data/dev/plone/bda.plone.shop/bda.plone.shop/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1992, in main
    getattr(buildout, command)(args)
  File "/home/thet-data/data/dev/plone/bda.plone.shop/bda.plone.shop/lib/python2.7/site-packages/zc/buildout/buildout.py", line 666, in install
    installed_files = self[part]._call(recipe.install)
  File "/home/thet-data/data/dev/plone/bda.plone.shop/bda.plone.shop/lib/python2.7/site-packages/zc/buildout/buildout.py", line 1407, in _call
    return f()
  File "/home/thet-data/dotfiles-thet/home/.buildout/eggs/plone.recipe.zope2instance-4.2.20-py2.7.egg/plone/recipe/zope2instance/__init__.py", line 113, in install
    installed.extend(self.install_scripts())
  File "/home/thet-data/dotfiles-thet/home/.buildout/eggs/plone.recipe.zope2instance-4.2.20-py2.7.egg/plone/recipe/zope2instance/__init__.py", line 617, in install_scripts
    requirements, ws = self.egg.working_set(['plone.recipe.zope2instance'])
  File "/home/thet-data/dotfiles-thet/home/.buildout/eggs/zc.recipe.egg-2.0.3-py2.7.egg/zc/recipe/egg/egg.py", line 84, in working_set
    allow_hosts=self.allow_hosts)
  File "/home/thet-data/data/dev/plone/bda.plone.shop/bda.plone.shop/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 883, in install
    return installer.install(specs, working_set)
  File "/home/thet-data/data/dev/plone/bda.plone.shop/bda.plone.shop/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 716, in install
    self._maybe_add_setuptools(ws, dist)
  File "/home/thet-data/data/dev/plone/bda.plone.shop/bda.plone.shop/lib/python2.7/site-packages/zc/buildout/easy_install.py", line 609, in _maybe_add_setuptools
    for r in dist.requires():
  File "/home/thet-data/dotfiles-thet/home/.buildout/eggs/setuptools-20.2.2-py2.7.egg/pkg_resources/__init__.py", line 2462, in requires
    dm = self._dep_map
  File "/home/thet-data/dotfiles-thet/home/.buildout/eggs/setuptools-20.2.2-py2.7.egg/pkg_resources/__init__.py", line 2457, in _dep_map
    dm.setdefault(extra,[]).extend(parse_requirements(reqs))
  File "/home/thet-data/dotfiles-thet/home/.buildout/eggs/setuptools-20.2.2-py2.7.egg/pkg_resources/__init__.py", line 2762, in parse_requirements
    req = packaging.requirements.Requirement(line)
  File "/home/thet-data/dotfiles-thet/home/.buildout/eggs/setuptools-20.2.2-py2.7.egg/pkg_resources/_vendor/packaging/requirements.py", line 94, in __init__
    requirement_string[e.loc:e.loc + 8]))
InvalidRequirement: Invalid requirement, parse error at "','"
```

Absolutely not helpful, if you have a project with > 200 dependencies, like Plone.

This PR fixes it.