### PR TITLE
Use unmangled `extra` in `DistInfoDistribution._compute_dependencies`

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2731,8 +2731,8 @@ class DistInfoDistribution(Distribution):
         dm[None].extend(common)
 
         for extra in self._parsed_pkg_info.get_all('Provides-Extra') or []:
-            extra = safe_extra(extra.strip())
-            dm[extra] = list(frozenset(reqs_for_extra(extra)) - common)
+            safe = safe_extra(extra.strip())
+            dm[safe] = list(frozenset(reqs_for_extra(extra)) - common)
 
         return dm
 


### PR DESCRIPTION
With an `extra` of "GFK" this would not be found as "gfk".

I came up with this when investigating an issue with pip-tools / pip (https://github.com/pypa/pip/issues/3661).