### PR TITLE
Get real `site-packages`

### DIFF
--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1347,6 +1347,11 @@ def get_site_dirs():
     if site.ENABLE_USER_SITE:
         sitedirs.append(site.USER_SITE)
 
+    try:
+        sitedirs.extend(site.getsitepackages())
+    except AttributeError:
+        pass
+
     sitedirs = list(map(normalize_path, sitedirs))
 
     return sitedirs

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -119,6 +119,10 @@ class TestEasyInstallTest:
         with pytest.raises(distutils.errors.DistutilsError):
             cmd.cant_write_to_target()
 
+    @mock.patch('site.getsitepackages', lambda: ['/setuptools/test/site-packages'])
+    def test_all_site_dirs(self):
+        assert '/setuptools/test/site-packages' in ei.get_site_dirs()
+
 
 class TestPTHFileWriter:
     def test_add_from_cwd_site_sets_dirty(self):


### PR DESCRIPTION
On debian-based systems and inside conda environments site package directories could be different from default one so we need to use information about site-packages directories from `site.py`.

This PR also fixes *VERY* annoying bug:
https://github.com/last-g/setuptools-shadowbug

Fixes: #539