### PR TITLE
Ensure package name isn't unicode in Python2 distutils

### DIFF
--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -8,6 +8,7 @@ import io
 import distutils.errors
 import itertools
 
+from setuptools.extern import six
 from setuptools.extern.six.moves import map, filter, filterfalse
 
 try:
@@ -66,6 +67,9 @@ class build_py(orig.build_py, Mixin2to3):
         return orig.build_py.__getattr__(self, attr)
 
     def build_module(self, module, module_file, package):
+        if six.PY2 and isinstance(package, six.string_types):
+            # avoid errors on Python 2 when unicode is passed (#190)
+            package = package.split('.')
         outfile, copied = orig.build_py.build_module(self, module, module_file,
                                                      package)
         if copied:


### PR DESCRIPTION
Problem encountered on Ubuntu 14.04

Fixes #190

If people need to fix this without this patch, they have to wrap their package names in `str()` like so:

```python
#!/usr/bin/env python
# -*- coding: utf-8 -*-
from __future__ import absolute_import, print_function, unicode_literals

setup(
    # ....
    package_dir=[
        str('package_name'),
    ]
)
```