### PR TITLE
Much faster implementation of FileList, for big egg_info speedups

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -2,7 +2,7 @@
 
 Create a distribution's .egg-info directory and contents"""
 
-from distutils.filelist import FileList as _FileList
+from distutils.filelist import FileList as _FileList, translate_pattern
 from distutils.util import convert_path
 from distutils import log
 import distutils.errors
@@ -235,6 +235,24 @@ class egg_info(Command):
 class FileList(_FileList):
     """File list that accepts only existing, platform-independent paths"""
 
+    def __init__(self):
+        _FileList.__init__(self)  # old-style class, can't use super
+
+        # Our version fixes the performance problems which stem from
+        # scanning filesystema and creating 'allfiles'.
+        #
+        # To ensure we didn't break anything, we want to fail loudly if any
+        # code is depending on the inherited behaviour of FileList in which it
+        # generates an 'allfiles' attribute as a side effect. So we remove the
+        # attribute so calling code will get AttributeError.
+        try:
+            del self.allfiles
+        except AttributeError:
+            pass
+
+    def findall(self, dir=None):
+        pass  # Don't scan the filesystem or create 'allfiles' attribute
+
     def append(self, item):
         if item.endswith('\r'):  # Fix older sdists built on Windows
             item = item[:-1]
@@ -245,6 +263,56 @@ class FileList(_FileList):
 
     def extend(self, paths):
         self.files.extend(filter(self._safe_path, paths))
+
+    # Because we don't have 'allfiles', we have to re-implement include_pattern
+    # completely.
+    def include_pattern(self, pattern, anchor=1, prefix=None, is_regex=0):
+        files_found = 0
+        pattern_re = translate_pattern(pattern, anchor=anchor, prefix=prefix,
+                                       is_regex=is_regex)
+
+        dir = os.curdir
+        for (dirpath, dirnames, filenames) in os.walk(dir, topdown=True):
+            if dirpath == ".":
+                start = "."
+            else:
+                start = "." + os.path.sep
+            if dirpath.startswith(start):
+                dirpath_rel = dirpath[len(start):]
+
+            for filename in filenames:
+                fullname = os.path.join(dirpath_rel, filename)
+                if pattern_re.match(fullname):
+                    self.files.append(fullname)
+                    files_found = 1
+
+            if not is_regex:
+                # If we have a regex, we can't easily reverse engineer it.
+
+                if anchor:
+                    # Not 'global-include', which we can't do anything
+                    # about.
+                    if prefix is None:
+                        # 'include' - can't match subdirs
+                        dirnames[:] = []
+                    else:
+                        # 'recursive-include'
+                        def should_recurse(d):
+                            # dirpath will have OS specific separators:
+                            parts = dirpath_rel.split(os.path.sep)
+                            if parts[0] == '':
+                                parts.pop(0)
+                            parts.append(d)
+
+                            # MANIFEST.in paths should have /
+                            prefix_parts = prefix.split('/')
+
+                            # TODO handle 'graft' which can have patterns in
+                            # prefix
+                            return parts[0:len(prefix_parts)] == prefix_parts
+
+                        dirnames[:] = filter(should_recurse, dirnames)
+        return files_found
 
     def _repair(self):
         """
@@ -335,32 +403,7 @@ class manifest_maker(sdist):
         elif os.path.exists(self.manifest):
             self.read_manifest()
         ei_cmd = self.get_finalized_command('egg_info')
-        self._add_egg_info(cmd=ei_cmd)
         self.filelist.include_pattern("*", prefix=ei_cmd.egg_info)
-
-    def _add_egg_info(self, cmd):
-        """
-        Add paths for egg-info files for an external egg-base.
-
-        The egg-info files are written to egg-base. If egg-base is
-        outside the current working directory, this method
-        searchs the egg-base directory for files to include
-        in the manifest. Uses distutils.filelist.findall (which is
-        really the version monkeypatched in by setuptools/__init__.py)
-        to perform the search.
-
-        Since findall records relative paths, prefix the returned
-        paths with cmd.egg_base, so add_default's include_pattern call
-        (which is looking for the absolute cmd.egg_info) will match
-        them.
-        """
-        if cmd.egg_base == os.curdir:
-            # egg-info files were already added by something else
-            return
-
-        discovered = distutils.filelist.findall(cmd.egg_base)
-        resolved = (os.path.join(cmd.egg_base, path) for path in discovered)
-        self.filelist.allfiles.extend(resolved)
 
     def prune_file_list(self):
         build = self.get_finalized_command('build')


### PR DESCRIPTION
Refs #249 and #450 

This is not a complete PR, but request for the approach to be confirmed before I do more work.

There are some notes:

# Code

The approach, as outlined before, is to reduce `findall` to a no-op, so the directory tree is not scanned, and have `include_pattern` (which handles all 'include' type directives) execute an `os.walk` directly, but trimming the search tree according to the different types of rules.

It currently doesn't handle all cases correctly (specific `graft` doesn't work correctly), but is a proof of concept. If the approach is accepted, I would add more tests (since we can no longer rely on distutils have tests since we are overriding the implementation) and fix this bug. All the tests in setuptools pass with the patch.

Some testing on Windows will be necessary, the directory path separator thing gets quite involved, I don't have a Windows box I could easily use.

Performance tests are hard - we really want to test that other parts of the filesystem are *not* being scanned, which is hard to do.

## Removal of `_add_egg_info` function, called from `add_defaults`

I believe this is correct. The behaviour of `add_defaults` seems to be tested by `test_egg_base_installed_egg_info` and `test_install_requires_with_markers` which both fail if you break it, along with a few other tests that fail.

AFAICS, the code is only working around the fact that `include_pattern` queries the `allfiles` attribute and not the filesystem, and is therefore out of date with respect to files that have been created by setuptools itself. Since we've changed the behaviour of include_pattern, I don't think this is necessary, and the tests seem to verify this.


# Metrics

Obviously this depends on how many files you've got in your working folder, and on whether the directory listings are in the OS cache.

I used this project as a not-too-extreme example, and because I actually work on this project:

https://github.com/django-money/django-money

It uses tox to test against about 80 environments, which are stored as virtualenvs in .tox

## Without patch

From a 'cold' state, but with virtualenvs created from previous usage, I ran the tests on a single environment:

    tox -e django18-py27

This took 647 seconds (10 minutes), of which just 2.8 seconds were the actual tests i.e. 645 seconds of overhead from setuptools and tox.

Doing it a second time, this reduced to 37 seconds of overhead, due to OS caching of filesystem.

## With this patch

With the patch, the setuptools + tox overhead of the same command reduced to just 2 seconds, whether from warm or cold i.e. a speed up of 18 times to 320 times (and more importantly, down to "a few seconds", an acceptable time to wait for your tests to start running). This would make a BIG difference to workflow on quite a few projects I use.

To reproduce this speedup, however, you will need to install the dev version of setuptools in both the outer project (in which tox is installed) and in the virtualenvs it created.

There are obviously cases and projects where this strategy will be less efficient than the previous one, because it requires multiple `os.walk` walks over the file system, instead of just one, but for normal projects, and for any that contain large numbers of non source files, it is likely to be a very big
win.

## Notes

There will be no speedups if MANIFEST.in contains a global-include directive, and in fact probably severe slow-downs if you have lots of files or lots of global-include directives. This is because you cannot trim the search tree at all for this directive - a global-include includes all subdirectories, including hidden ones such as ".tox", ".my_IDE_like_to_put_stuff_here" etc. This means that in general the global-include directive should be avoided, because most tools expect to be able to put all kinds of things in hidden folders and have them ignored. This warning should probably be submitted to distutils as a documentation patch.

