### PR TITLE
Don't use deprecated 'U' flag to read manifest

### DIFF
--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -179,7 +179,7 @@ class sdist(orig.sdist):
         distribution.
         """
         log.info("reading manifest file '%s'", self.manifest)
-        manifest = open(self.manifest, 'rbU')
+        manifest = open(self.manifest, 'rb')
         for line in manifest:
             # The manifest must contain UTF-8. See #303.
             if six.PY3:


### PR DESCRIPTION
The universal newlines mode ('U' flag) is deprecated since Python
3.4. It only replaces "\r\n" with "\n", but it doesn't split lines at
"\r" (Mac newline). In practice, the flag was useless, the
sdist.read_manifest() method already uses line.strip() and so removes
newline characters.

Example of warning:

.../setuptools/command/sdist.py:182: DeprecationWarning: 'U' mode is deprecated
  manifest = open(self.manifest, 'rbU')
