### PR TITLE
msvc fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,12 @@
 CHANGES
 =======
 
+v24.0.1
+-------
+
+* Fixes on ``setuptools.msvc`` mainly for Python 2
+  and Linux.
+
 v24.0.0
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,11 @@ v24.0.0
 -------
 
 * Pull Request #174: Add more aggressive support for
-  Windows SDK in msvc9compiler patch.
+  standalone Microsoft Visual C++ compilers in
+  msvc9compiler patch.
+  Particularly : Windows SDK 6.0 and 6.1
+  (MSVC++ 9.0), Windows SDK 7.0 (MSVC++ 10.0),
+  Visual C++ Build Tools 2015 (MSVC++14)
 * Renamed ``setuptools.msvc9_support`` to
   ``setuptools.msvc``.
 

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -4,7 +4,6 @@ This module adds improved support for Microsoft Visual C++ compilers.
 import os
 import platform
 import itertools
-import collections
 import distutils.errors
 from setuptools.extern.six.moves import filterfalse
 
@@ -21,7 +20,7 @@ else:
         HKEY_CURRENT_USER = None
         HKEY_LOCAL_MACHINE = None
         HKEY_CLASSES_ROOT = None
-    safe_env = collections.defaultdict(lambda: '')
+    safe_env = dict()
 
 try:
     # Distutil file for MSVC++ 9.0 and upper (Python 2.7 to 3.4)

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -237,6 +237,10 @@ def _augment_exception(exc, version, arch=''):
             # For VC++ 10.0 Redirect user to Windows SDK 7.1
             message += ' Get it with "Microsoft Windows SDK 7.1": '
             message += msdownload % 8279
+        elif version >= 14.0:
+            # For VC++ 14.0 Redirect user to Visual C++ Build Tools
+            message += ' Get it with "Visual C++ Build Tools": '
+            r'http://landinghub.visualstudio.com/visual-cpp-build-tools'
 
     exc.args = (message, )
 

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -4,6 +4,7 @@ This module adds improved support for Microsoft Visual C++ compilers.
 import os
 import platform
 import itertools
+import collections
 import distutils.errors
 from setuptools.extern.six.moves import filterfalse
 

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -203,7 +203,7 @@ def msvc14_get_vc_env(plat_spec):
 
     # If error, try to set environment directly
     try:
-        return EnvironmentInfo(plat_spec, vc_ver_min=14.0).return_env()
+        return EnvironmentInfo(plat_spec, vc_min_ver=14.0).return_env()
     except distutils.errors.DistutilsPlatformError as exc:
         _augment_exception(exc, 14.0)
         raise
@@ -442,11 +442,11 @@ class RegistryInfo:
         for hkey in self.HKEYS:
             try:
                 bkey = winreg.OpenKey(hkey, key, 0, winreg.KEY_READ)
-            except FileNotFoundError:
+            except IOError:
                 continue
             try:
                 return winreg.QueryValueEx(bkey, name)[0]
-            except FileNotFoundError:
+            except IOError:
                 pass
 
 
@@ -489,7 +489,7 @@ class SystemInfo:
             for key in vckeys:
                 try:
                     bkey = winreg.OpenKey(hkey, key, 0, winreg.KEY_READ)
-                except FileNotFoundError:
+                except IOError:
                     continue
                 subkeys, values, _ = winreg.QueryInfoKey(bkey)
                 for i in range(values):
@@ -1187,5 +1187,5 @@ class EnvironmentInfo:
             if name:
                 return '%s\\' % name[0]
             return ''
-        except FileNotFoundError:
+        except IOError:
             return ''

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -3,7 +3,6 @@ This module adds improved support for Microsoft Visual C++ compilers.
 """
 
 import os
-import collections
 import itertools
 import distutils.errors
 from setuptools.extern.six.moves import filterfalse
@@ -21,7 +20,7 @@ except ImportError:
         HKEY_CURRENT_USER = None
         HKEY_LOCAL_MACHINE = None
         HKEY_CLASSES_ROOT = None
-    safe_env = collections.defaultdict(lambda: '')
+    safe_env = dict()
 
 
 try:
@@ -36,7 +35,7 @@ try:
 except ImportError:
     pass
 
-
+	
 unpatched = dict()
 
 
@@ -237,10 +236,6 @@ def _augment_exception(exc, version, arch=''):
             # For VC++ 10.0 Redirect user to Windows SDK 7.1
             message += ' Get it with "Microsoft Windows SDK 7.1": '
             message += msdownload % 8279
-        elif version >= 14.0:
-            # For VC++ 14.0 Redirect user to Visual C++ Build Tools
-            message += ' Get it with "Visual C++ Build Tools": '
-            r'http://landinghub.visualstudio.com/visual-cpp-build-tools'
 
     exc.args = (message, )
 
@@ -254,7 +249,7 @@ class PlatformInfo:
     arch: str
         Target architecture.
     """
-    current_cpu = safe_env['processor_architecture'].lower()
+    current_cpu = safe_env.get('processor_architecture', '').lower()
 
     def __init__(self, arch):
         self.arch = arch.lower().replace('x64', 'amd64')
@@ -467,9 +462,9 @@ class SystemInfo:
     """
     # Variables and properties in this class use originals CamelCase variables
     # names from Microsoft source files for more easy comparaison.
-    WinDir = safe_env['WinDir']
-    ProgramFiles = safe_env['ProgramFiles']
-    ProgramFilesx86 = os.environ.get('ProgramFiles(x86)', ProgramFiles)
+    WinDir = safe_env.get('WinDir', '')
+    ProgramFiles = safe_env.get('ProgramFiles', '')
+    ProgramFilesx86 = safe_env.get('ProgramFiles(x86)', ProgramFiles)
 
     def __init__(self, registry_info, vc_ver=None):
         self.ri = registry_info

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -1,27 +1,16 @@
 """
 This module adds improved support for Microsoft Visual C++ compilers.
 """
-
 import os
+import platform
 import itertools
 import distutils.errors
 from setuptools.extern.six.moves import filterfalse
 
 try:
     from setuptools.extern.six.moves import winreg
-    safe_env = os.environ
 except ImportError:
-    """
-    Mock winreg and environ so the module can be imported
-    on this platform.
-    """
-    class winreg:
-        HKEY_USERS = None
-        HKEY_CURRENT_USER = None
-        HKEY_LOCAL_MACHINE = None
-        HKEY_CLASSES_ROOT = None
-    safe_env = dict()
-
+    pass
 
 try:
     # Distutil file for MSVC++ 9.0 and upper (Python 2.7 to 3.4)
@@ -35,7 +24,7 @@ try:
 except ImportError:
     pass
 
-	
+
 unpatched = dict()
 
 
@@ -57,6 +46,10 @@ def patch_for_specialized_compiler():
     Microsoft Visual C++ 14.0:
         Microsoft Visual C++ Build Tools 2015 (x86, x64, arm)
     """
+    if platform.system() != Windows:
+        # Compilers only availables on Microsoft Windows
+        return
+
     if 'distutils' not in globals():
         # The module isn't available to be patched
         return
@@ -249,7 +242,7 @@ class PlatformInfo:
     arch: str
         Target architecture.
     """
-    current_cpu = safe_env.get('processor_architecture', '').lower()
+    current_cpu = os.environ.get('processor_architecture', '').lower()
 
     def __init__(self, arch):
         self.arch = arch.lower().replace('x64', 'amd64')
@@ -462,9 +455,9 @@ class SystemInfo:
     """
     # Variables and properties in this class use originals CamelCase variables
     # names from Microsoft source files for more easy comparaison.
-    WinDir = safe_env.get('WinDir', '')
-    ProgramFiles = safe_env.get('ProgramFiles', '')
-    ProgramFilesx86 = safe_env.get('ProgramFiles(x86)', ProgramFiles)
+    WinDir = os.environ.get('WinDir', '')
+    ProgramFiles = os.environ.get('ProgramFiles', '')
+    ProgramFilesx86 = os.environ.get('ProgramFiles(x86)', ProgramFiles)
 
     def __init__(self, registry_info, vc_ver=None):
         self.ri = registry_info

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -7,10 +7,10 @@ import itertools
 import distutils.errors
 from setuptools.extern.six.moves import filterfalse
 
-try:
+if platform.system() == Windows:
     from setuptools.extern.six.moves import winreg
     safe_env = os.environ
-except ImportError:
+else:
     """
     Mock winreg and environ so the module can be imported
     on this platform.

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -8,7 +8,7 @@ import collections
 import distutils.errors
 from setuptools.extern.six.moves import filterfalse
 
-if platform.system() == Windows:
+if platform.system() == 'Windows':
     from setuptools.extern.six.moves import winreg
     safe_env = os.environ
 else:
@@ -57,7 +57,7 @@ def patch_for_specialized_compiler():
     Microsoft Visual C++ 14.0:
         Microsoft Visual C++ Build Tools 2015 (x86, x64, arm)
     """
-    if platform.system() != Windows:
+    if platform.system() != 'Windows':
         # Compilers only availables on Microsoft Windows
         return
 


### PR DESCRIPTION
Fixes : 
- Bad argument name #625
- Better Python 2 compatibility (FileNotFoundError => IOError)
- Python 2 on Linux compatibility #626

Also add new link from Microsoft for Visual C++ 2015 standalone compiler.
Improve Change.rst.