### PR TITLE
Fix issues with distribution location from eggs

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1972,6 +1972,7 @@ def find_on_path(importer, path_item, only=False):
 
             path_item_entries = os.listdir(path_item)
             # Reverse so we find the newest version of a distribution,
+            path_item_entries.sort()
             path_item_entries.reverse()
             for entry in path_item_entries:
                 lower = entry.lower()

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1975,6 +1975,9 @@ def find_on_path(importer, path_item, only=False):
                     fullpath = os.path.join(path_item, entry)
                     if os.path.isdir(fullpath):
                         # egg-info directory, allow getting metadata
+                        if len(os.listdir(fullpath)) == 0:
+                            # Empty egg directory, skip.
+                            continue
                         metadata = PathMetadata(path_item, fullpath)
                     else:
                         metadata = FileMetadata(fullpath)

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1969,7 +1969,11 @@ def find_on_path(importer, path_item, only=False):
             )
         else:
             # scan for .egg and .egg-info in directory
-            for entry in os.listdir(path_item):
+
+            path_item_entries = os.listdir(path_item)
+            # Reverse so we find the newest version of a distribution,
+            path_item_entries.reverse()
+            for entry in path_item_entries:
                 lower = entry.lower()
                 if lower.endswith('.egg-info') or lower.endswith('.dist-info'):
                     fullpath = os.path.join(path_item, entry)


### PR DESCRIPTION
Please consider the following pull request, which addresses real-world issues (and took a while to debug).

1. "Skip empty egg directories, which may be leftover from previous installation" [1b228fa](https://github.com/pypa/setuptools/commit/1b228fa0e3f07c73de0053985565293b795e6e96)

This patch will ignore empty egg directories, which I think is intended.
Some background: When using setup.py install \-\-record option, only the FILES are listed, not the directories. It is common practice, especially from third-party distributions of RPMS to use this "record" option to generate a file list. This creates the side-effect that when the package is upgraded, the old .egg-info directory is left around, and empty. 

Thus, when something like pkg_resources.get_distribution('packageName') is called, it returns a distribution based off the OLD empty egg info, which causes issues and/or complete failure.

I'm sure there are many other circumstances that could leave behind an empty egg directory.

This patch causes empty egg-info directories to be skipped.

---------------------------------------------------------------------------------

\2. "Scan for distributions in reverse order, so we find the newest version of a distrubtion (instead of the oldest)" -- [fb1867e](https://github.com/pypa/setuptools/commit/fb1867e305660161c2960dfcfc5a95d41310e19d)

Since os.listdir returns (at least on POSIX) directories in lexicographical order, old versions of eggs will be found and associated with a distribution, even when newer versions are present.

This patch searches the reverse of os.listdir, which will find and associate the NEWEST version of a package instead of the OLDEST (for calls like pkg_resources.get_distribution)

If you don't want to apply number 1 (because, I understand that while nothing in practice does generate empty egg directories, the name itself can identify version, etc), this patch in practice usually will result in the same goal, since during upgrades the newer package will be found and the empty ignored anyway. However, this patch alone does not cover downgrades, etc.

------------------------------------------------------------------------------------------

Please seriously consider these two patches. I know there are workarounds in the sense of deleting old empty egg directories, but in real-world one often has no control over third-party RPMs etc which by template use the "record" option of setup.py. Also, it could be the case that someone manually installs an old egg on one server, and then an rpm comes along later and installs a newer version, and you have an issue that 1/4 times the application fails because it identifies the wrong egg, etc. All very hard to debug, and in the case of using third-party distributions require things like pruning empty directories through cron, etc. These patches could alleviate these issues, and I think overall harden the setuptools codebase.

Thanks,
Tim