### PR TITLE
Also update the Metadata-Version when adding Requires-Python

### DIFF
--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -223,8 +223,10 @@ class TestEggInfo(object):
             env=environ,
         )
         egg_info_dir = os.path.join('.', 'foo.egg-info')
-        pkginfo = os.path.join(egg_info_dir, 'PKG-INFO')
-        assert 'Requires-Python: >=2.7.12' in open(pkginfo).read().split('\n')
+        with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
+            pkg_info_lines = pkginfo_file.read().split('\n')
+        assert 'Requires-Python: >=2.7.12' in pkg_info_lines
+        assert 'Metadata-Version: 1.2' in pkg_info_lines
 
     def test_python_requires_install(self, tmpdir_cwd, env):
         self._setup_script_with_requires(


### PR DESCRIPTION
Follow-up on #631 to also update the Metadata-Version to 1.2 (PEP 345).

This code seems cumbersome, I'm wondering if completely rewriting `write_pkg_file` would not be cleaner cc @jaraco @dstufft 