### PR TITLE
Fix: use os.chdir to change directory (fixes #688)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,6 @@ setup_params = dict(
 
 if __name__ == '__main__':
     # allow setup.py to run from another directory
-    here and os.path.chdir(here)
+    here and os.chdir(here)
     require_metadata()
     dist = setuptools.setup(**setup_params)


### PR DESCRIPTION
This fixes a bug introduced by commit https://github.com/pypa/setuptools/commit/5a63f386217cae916c60cc8a89ae1115df9ea7f4, that is using `os.path.chdir` instead of `os.chdir`.

Bumped into this issue after a build failing when trying to install setuptools, as reported in #688 .