### PR TITLE
unpin flake8<3dev

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -180,9 +180,7 @@ setup_params = dict(
     scripts=[],
     tests_require=[
         'setuptools[ssl]',
-        'pytest-flake8',
-        # workaround for pytest-flake8 #7
-        'flake8<3dev',
+        'pytest-flake8>=0.6',
         'pytest>=2.8',
     ] + (['mock'] if sys.version_info[:2] < (3, 3) else []),
     setup_requires=[


### PR DESCRIPTION
pytest-flake8 0.6 has been released, fixing the bug that prompted the pin.

The pin currently makes setuptools master fail to install because pytest-flake8 requires flake8 >= 3, while setuptools requires flake8 < 3.