### PR TITLE
ignore .tox in pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts=--doctest-modules --ignore release.py --ignore setuptools/lib2to3_ex.py --ignore tests/manual_test.py --ignore tests/shlib_test --doctest-glob=pkg_resources/api_tests.txt --ignore scripts/upload-old-releases-as-zip.py --ignore pavement.py
-norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern
+norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern .tox
 flake8-ignore =
     setuptools/site-patch.py F821
     setuptools/py*compat.py F811


### PR DESCRIPTION
avoids errors in setup.py test if tox has been run