### PR TITLE
only insert eggs ahead of parent if not already on path

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2620,7 +2620,11 @@ class Distribution(object):
 
         for p, item in enumerate(npath):
             if item == nloc:
-                break
+                if replace:
+                    break
+                else:
+                    # don't modify path (even removing duplicates) if found and not replace
+                    return
             elif item == bdir and self.precedence == EGG_DIST:
                 # if it's an .egg, give it precedence over its directory
                 # UNLESS it's already been added to sys.path and replace=False


### PR DESCRIPTION
in `insert_on(replace=False)`

and set `replace=False` by default in `activate()`

Fixes pkg_resources modifying sys.path for all eggs with SETUPTOOLS_SYS_PATH_TECHINQUE=raw

There's one failing test where setup_requires should be loading a package at higher priority, but the `activate(replace=False)` change means it is showing up at lower priority, rather than higher.

The setup_requires code triggered in this test does indeed have several explicit `replace=True`, `remove_conflicting` flags, but the only one that seems to matter with respect to sys.path is the *implicit* one passed to `.activate()`, which is registered as a zero-argument callback in `self.callbacks`. I'll see if I can figure out a way to pass the same `replace` argument in `.add` to `.activate`.

closes #686