### PR TITLE
WIP: Add new long_description_content_type kwarg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup_params = dict(
     author="Python Packaging Authority",
     author_email="distutils-sig@python.org",
     long_description=long_description,
+    long_description_content_type='text/x-rst; charset=UTF-8',
     keywords="CPAN PyPI distutils eggs package management",
     url="https://github.com/pypa/setuptools",
     src_root=None,

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -397,6 +397,10 @@ def write_pkg_info(cmd, basename, filename):
         metadata = cmd.distribution.metadata
         metadata.version, oldver = cmd.egg_version, metadata.version
         metadata.name, oldname = cmd.egg_name, metadata.name
+        metadata.long_description_content_type = getattr(
+            cmd.distribution,
+            'long_description_content_type'
+        )
         try:
             # write unescaped data to PKG-INFO, so older pkg_resources
             # can still parse it

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -67,6 +67,13 @@ def _patch_distribution_metadata_write_pkg_file():
         if self.download_url:
             file.write('Download-URL: %s\n' % self.download_url)
 
+        long_desc_content_type = getattr(
+            self,
+            'long_description_content_type',
+            None
+        ) or 'UNKNOWN'
+        file.write('Description-Content-Type: %s\n' % long_desc_content_type)
+
         long_desc = rfc822_escape(self.get_long_description())
         file.write('Description: %s\n' % long_desc)
 
@@ -340,6 +347,9 @@ class Distribution(_Distribution):
         self.dist_files = []
         self.src_root = attrs and attrs.pop("src_root", None)
         self.patch_missing_pkg_info(attrs)
+        self.long_description_content_type = _attrs_dict.get(
+            'long_description_content_type'
+        )
         # Make sure we have any eggs needed to interpret 'attrs'
         if attrs is not None:
             self.dependency_links = attrs.pop('dependency_links', [])

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -210,6 +210,31 @@ class TestEggInfo(object):
         self._run_install_command(tmpdir_cwd, env)
         assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
+    def test_long_description_content_type(self, tmpdir_cwd, env):
+        # Test that specifying a `long_description_content_type` keyword arg to
+        # the `setup` function results in writing a `Description-Content-Type`
+        # line to the `PKG-INFO` file in the `<distribution>.egg-info`
+        # directory.
+        # `Description-Content-Type` is described at
+        # https://github.com/pypa/python-packaging-user-guide/pull/258
+
+        self._setup_script_with_requires(
+            "long_description_content_type='text/markdown',")
+        environ = os.environ.copy().update(
+            HOME=env.paths['home'],
+        )
+        code, data = environment.run_setup_py(
+            cmd=['egg_info'],
+            pypath=os.pathsep.join([env.paths['lib'], str(tmpdir_cwd)]),
+            data_stream=1,
+            env=environ,
+        )
+        egg_info_dir = os.path.join('.', 'foo.egg-info')
+        with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
+            pkg_info_lines = pkginfo_file.read().split('\n')
+        expected_line = 'Description-Content-Type: text/markdown'
+        assert expected_line in pkg_info_lines
+
     def test_python_requires_egg_info(self, tmpdir_cwd, env):
         self._setup_script_with_requires(
             """python_requires='>=2.7.12',""")


### PR DESCRIPTION
**Work in progress**

This is used to populate the newly proposed `Description-Content-Type` distribution metadata field, that is proposed in https://github.com/pypa/python-packaging-user-guide/pull/258.

**We can discuss and evolve the implementation, but I don't think this should be merged until https://github.com/pypa/python-packaging-user-guide/pull/258 is accepted.**
### Related:
- https://github.com/pypa/python-packaging-user-guide/pull/258 (Add `Description-Content-Type` field)
- https://github.com/pypa/readme_renderer/pull/3 (Add Markdown support)
- https://mail.python.org/pipermail/distutils-sig/2016-May/028689.html
### Branch

https://github.com/msabramo/setuptools/tree/long_description_content_type

Cc: @jaraco, @dstufft, @ncoghlan, @pfmoore, @nicktimko
