### PR TITLE
Fix _have_cython

### DIFF
--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -19,7 +19,7 @@ def _have_cython():
     """
     Return True if Cython can be imported.
     """
-    cython_impl = 'Cython.Distutils.build_ext',
+    cython_impl = 'Cython.Distutils.build_ext'
     try:
         # from (cython_impl) import build_ext
         __import__(cython_impl, fromlist=['build_ext']).build_ext


### PR DESCRIPTION
In 3c047624, we remove the loop, but we miss to convert the tuple
to a string. Because the exception is just ignored, we don't see
that __import__ won't works