### PR TITLE
Revert "Ensure that tmpdir is unicode. Fixes #704."

### DIFF
--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -627,7 +627,7 @@ class easy_install(Command):
             )
 
     def easy_install(self, spec, deps=False):
-        tmpdir = tempfile.mkdtemp(prefix=six.u("easy_install-"))
+        tmpdir = tempfile.mkdtemp(prefix="easy_install-")
         if not self.editable:
             self.install_site_py()
 


### PR DESCRIPTION
This reverts commit 857949575022946cc60c7cd1d0d088246d3f7540.

As we can see on https://github.com/pypa/setuptools/issues/709,
this breaks many things (easy_install C extensions, all py3.5 tests,
run with LANG=C).

So instead of fixing in a hurry all new bugs due to this, I propose to
revert this commit until all downsides of this change have been
investigated.

Related bug: https://github.com/pypa/setuptools/issues/709
Related bug: https://github.com/pypa/setuptools/issues/710
Related bug: https://github.com/pypa/setuptools/issues/712