### PR TITLE
#707 MSVC patch and Python 2

### DIFF
--- a/setuptools/tests/test_msvc.py
+++ b/setuptools/tests/test_msvc.py
@@ -73,8 +73,6 @@ class TestModulePatch:
         mod_name = distutils.msvc9compiler.find_vcvarsall.__module__
         assert mod_name == "setuptools.msvc", "find_vcvarsall unpatched"
 
-    @pytest.mark.xfail(six.PY2,
-        reason="https://github.com/pypa/setuptools/issues/707")
     def test_no_registry_entries_means_nothing_found(self):
         """
         No registry entries or environment variable should lead to an error


### PR DESCRIPTION
#707
Fix Python 2 compatibility, and improve registry lookup (Key may not always be in 64bit registry node).