### PR TITLE
use abi3 extension if Extension().is_abi3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,14 @@ v25.1.3
 * #714 and #704: Revert fix as it breaks other components
   downstream that can't handle unicode. See #709, #710,
   and #712.
+* Add Extension(py_limited_api=True). When set to a truthy value,
+  that extension gets a filename apropriate for code using Py_LIMITED_API.
+  When used correctly this allows a single compiled extension to work on
+  all future versions of CPython 3.
+  The py_limited_api argument only controls the filename. To be
+  compatible with multiple versions of Python 3, the C extension
+  will also need to set -DPy_LIMITED_API=... and be modified to use
+  only the functions in the limited API.
 
 v25.1.2
 -------

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -104,7 +104,9 @@ class build_ext(_build_ext):
         filename = _build_ext.get_ext_filename(self, fullname)
         if fullname in self.ext_map:
             ext = self.ext_map[fullname]
-            if sys.version_info[0] != 2 and getattr(ext, 'is_abi3'):
+            if (sys.version_info[0] != 2 
+                and getattr(ext, 'py_limited_api')
+                and get_abi3_suffix()):
                 from distutils.sysconfig import get_config_var
                 so_ext = get_config_var('SO')
                 filename = filename[:-len(so_ext)]

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -59,6 +59,14 @@ elif os.name != 'nt':
 
 if_dl = lambda s: s if have_rtld else ''
 
+def get_abi3_suffix():
+    """Return the file extension for an abi3-compliant Extension()"""
+    import imp
+    for suffix, _, _ in (s for s in imp.get_suffixes() if s[2] == imp.C_EXTENSION):
+        if '.abi3' in suffix:   # Unix
+            return suffix
+        elif suffix == '.pyd':  # Windows
+            return suffix
 
 class build_ext(_build_ext):
 
@@ -96,6 +104,11 @@ class build_ext(_build_ext):
         filename = _build_ext.get_ext_filename(self, fullname)
         if fullname in self.ext_map:
             ext = self.ext_map[fullname]
+            if sys.version_info[0] != 2 and getattr(ext, 'is_abi3'):
+                from distutils.sysconfig import get_config_var
+                so_ext = get_config_var('SO')
+                filename = filename[:-len(so_ext)]
+                filename = filename + get_abi3_suffix()
             if isinstance(ext, Library):
                 fn, ext = os.path.splitext(filename)
                 return self.shlib_compiler.library_filename(fn, libtype)

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -36,6 +36,10 @@ have_pyrex = _have_cython
 class Extension(_Extension):
     """Extension that uses '.c' files in place of '.pyx' files"""
 
+    def __init__(self, name, sources, is_abi3=False, **kw):
+        self.is_abi3 = is_abi3
+        _Extension.__init__(self, name, sources, **kw)
+
     def _convert_pyx_sources_to_lang(self):
         """
         Replace sources with .pyx extensions to sources with the target

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -36,8 +36,8 @@ have_pyrex = _have_cython
 class Extension(_Extension):
     """Extension that uses '.c' files in place of '.pyx' files"""
 
-    def __init__(self, name, sources, is_abi3=False, **kw):
-        self.is_abi3 = is_abi3
+    def __init__(self, name, sources, py_limited_api=False, **kw):
+        self.py_limited_api = py_limited_api
         _Extension.__init__(self, name, sources, **kw)
 
     def _convert_pyx_sources_to_lang(self):

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -1,8 +1,10 @@
+import sys
 import distutils.command.build_ext as orig
 
+from distutils.sysconfig import get_config_var
 from setuptools.command.build_ext import build_ext
 from setuptools.dist import Distribution
-
+from setuptools.extension import Extension
 
 class TestBuildExt:
 
@@ -18,3 +20,19 @@ class TestBuildExt:
         res = cmd.get_ext_filename('foo')
         wanted = orig.build_ext.get_ext_filename(cmd, 'foo')
         assert res == wanted
+
+    def test_abi3_filename(self):
+        """
+        Filename needs to be loadable by several versions
+        of Python 3 if 'is_abi3' is truthy on Extension()
+        """
+        dist = Distribution(dict(ext_modules=[Extension('spam.eggs', [], is_abi3=True)]))
+        cmd = build_ext(dist)
+        res = cmd.get_ext_filename('spam.eggs')
+
+        if sys.version_info[0] == 2:
+            assert res.endswith(get_config_var('SO'))
+        elif sys.platform == 'win32':
+            assert res.endswith('eggs.pyd')
+        else:
+            assert 'abi3' in res

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -28,7 +28,7 @@ class TestBuildExt:
         """
         print(get_abi3_suffix())
         
-        extension = Extension('spam.eggs', ['eggs.c'], is_abi3=True)
+        extension = Extension('spam.eggs', ['eggs.c'], py_limited_api=True)
         dist = Distribution(dict(ext_modules=[extension]))
         cmd = build_ext(dist)
         cmd.finalize_options()

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -2,7 +2,7 @@ import sys
 import distutils.command.build_ext as orig
 
 from distutils.sysconfig import get_config_var
-from setuptools.command.build_ext import build_ext
+from setuptools.command.build_ext import build_ext, get_abi3_suffix
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
 
@@ -26,8 +26,13 @@ class TestBuildExt:
         Filename needs to be loadable by several versions
         of Python 3 if 'is_abi3' is truthy on Extension()
         """
-        dist = Distribution(dict(ext_modules=[Extension('spam.eggs', [], is_abi3=True)]))
+        print(get_abi3_suffix())
+        
+        extension = Extension('spam.eggs', ['eggs.c'], is_abi3=True)
+        dist = Distribution(dict(ext_modules=[extension]))
         cmd = build_ext(dist)
+        cmd.finalize_options()
+        assert 'spam.eggs' in cmd.ext_map
         res = cmd.get_ext_filename('spam.eggs')
 
         if sys.version_info[0] == 2:

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -35,7 +35,7 @@ class TestBuildExt:
         assert 'spam.eggs' in cmd.ext_map
         res = cmd.get_ext_filename('spam.eggs')
 
-        if sys.version_info[0] == 2:
+        if sys.version_info[0] == 2 or not get_abi3_suffix():
             assert res.endswith(get_config_var('SO'))
         elif sys.platform == 'win32':
             assert res.endswith('eggs.pyd')


### PR DESCRIPTION
Add an Extension(is_abi3=True) property that can be used to set its filename to something that will be loadable by more than one version of Python 3. An '.abi3.so' extension on Linux, just .pyd on Windows. Tested on Linux so far.

It will still be necessary to `-DPy_LIMITED_API=0x03030000` somewhere for the extension to truly be abi3.