### PR TITLE
quote library_dir_option after calling unpatched version

### DIFF
--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -233,10 +233,11 @@ def msvc14_library_dir_option(self, dir):
     ------
     "\LIBPATH" argument: str
     """
-    if ' ' in dir and '"' not in dir:
+    opt = unpatched['msvc14_library_dir_option'](self, dir)
+    if ' ' in opt and '"' not in opt:
         # Quote if space and not already quoted
-        dir = '"%s"' % dir
-    return unpatched['msvc14_library_dir_option'](self, dir)
+        opt = '"%s"' % opt
+    return opt
 
 
 def _augment_exception(exc, version, arch=''):


### PR DESCRIPTION
rather than before (#715), which should avoid double-quotes if the unpatched function does its own quoting.

I *believe* this closes #722