### PR TITLE
Do not search excluded directories for packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 CHANGES
 =======
 
+In development
+--------------
+
+* #733: Do not search excluded directories for packages.
+
 v27.3.0
 -------
 


### PR DESCRIPTION
Previously, PackageFinder.find would search the whole directory tree looking for packages, then remove excluded packages from this list. This made building a package very slow under some circumstances where the file tree was large.

In my case, I have a Python project that includes JavaScript and CSS assets. These assets are compiled by a node.js build chain. Every time the Python package is built, `setuptools` searches the whole (rather large) `node_modules` tree for python packages, before rejecting the whole tree because `node_modules/__init__.py` does not exist. As the build process is happening in a Vagrant virtual machine, and VirtualBox shared directories are notoriously slow, this caused the build process for the Python package to take 30+ seconds just to find the packages!

This change stops PackageFinder.find from descending in to directories that will never be included. The public API should be 100% backwards compatible with previous versions. All the current tests pass without any modifications.

I am unsure if I should write new tests for this specific change, as it might require mocking `os.walk` to check that the excluded directories are not being searched.