### PR TITLE
Update tox.ini envlist to match supported Pythons

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py31,py32,py33,py34
+envlist = py26,py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
 commands=python setup.py test


### PR DESCRIPTION
Pythons 3.1, 3.2 are no longer supported, but Python 3.5, Pypy, and
Pypy3 are.