### PR TITLE
Bundle the license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ recursive-include pkg_resources *.py *.txt
 include *.py
 include *.rst
 include MANIFEST.in
+include LICENSE
 include launcher.c
 include msvc-build-launcher.cmd
 include pytest.ini


### PR DESCRIPTION
Adds the license file to `MANIFEST.in` to ensure it will be packaged in `sdist`s and similar packagings of `setuptools`.