### PR TITLE
numpy.distutils and distutils._msvccompiler compatibility

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@
 CHANGES
 =======
 
+v25.3.1
+-------
+
+* #739 Fix unquoted libpaths by fixing compatibility between `numpy.distutils` and `distutils._msvccompiler` for numpy < 1.11.2 (Fix issue #728, error also fixed in Numpy).
+
 v25.3.0
 -------
 
@@ -16,20 +21,21 @@ v25.2.0
 v25.1.6
 -------
 
-* #725
+* #725: revert `library_dir_option` patch (Error is related to `numpy.distutils` and make errors on non Numpy users).
 
 v25.1.5
 -------
 
 * #720
-* #723
+* #723: Improve patch for `library_dir_option`.
 
 v25.1.4
 -------
 
 * #717
 * #713
-* #707 via #715
+* #707: Fix Python 2 compatibility for MSVC by catching errors properly.
+* #715: Fix unquoted libpaths by patching `library_dir_option`.
 
 v25.1.3
 -------

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -6,6 +6,7 @@ import sys
 import platform
 import itertools
 import distutils.errors
+from distutils.version import StrictVersion
 
 from setuptools.extern.six.moves import filterfalse
 
@@ -228,9 +229,9 @@ def msvc14_gen_lib_options(*args, **kwargs):
     """
     if "numpy.distutils" in sys.modules:
         import numpy as np
-        return np.distutils.ccompiler.gen_lib_options(*args, **kwargs)
-    else:
-        return unpatched['msvc14_gen_lib_options'](*args, **kwargs)
+        if StrictVersion(np.__version__) < StrictVersion('1.11.2'):
+            return np.distutils.ccompiler.gen_lib_options(*args, **kwargs)
+    return unpatched['msvc14_gen_lib_options'](*args, **kwargs)
 
 
 def _augment_exception(exc, version, arch=''):

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -2,6 +2,7 @@
 This module adds improved support for Microsoft Visual C++ compilers.
 """
 import os
+import sys
 import platform
 import itertools
 import distutils.errors
@@ -225,7 +226,7 @@ def msvc14_gen_lib_options(*args, **kwargs):
     compatibility between "numpy.distutils" and "distutils._msvccompiler"
     (for Numpy < 1.11.2)
     """
-    if "numpy" in distutils.ccompiler.CCompiler.spawn.__module__:
+    if "numpy.distutils" in sys.modules:
         import numpy as np
         return np.distutils.ccompiler.gen_lib_options(*args, **kwargs)
     else:

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -75,14 +75,23 @@ def patch_for_specialized_compiler():
         msvc9compiler.find_vcvarsall = msvc9_find_vcvarsall
         unpatched['msvc9_query_vcvarsall'] = msvc9compiler.query_vcvarsall
         msvc9compiler.query_vcvarsall = msvc9_query_vcvarsall
-    except Exception:
+    except NameError:
         pass
 
     try:
         # Patch distutils._msvccompiler._get_vc_env
         unpatched['msvc14_get_vc_env'] = msvc14compiler._get_vc_env
         msvc14compiler._get_vc_env = msvc14_get_vc_env
-    except Exception:
+    except NameError:
+        pass
+
+    try:
+        # Apply "gen_lib_options" patch from Numpy to "distutils._msvccompiler"
+        # to fix compatibility between "numpy.distutils" and
+        # "distutils._msvccompiler" (for Numpy < 1.11.2)
+        import numpy.distutils as np_distutils
+        msvc14compiler.gen_lib_options = np_distutils.ccompiler.gen_lib_options
+    except (ImportError, NameError):
         pass
 
 
@@ -243,7 +252,8 @@ def _augment_exception(exc, version, arch=''):
         elif version >= 14.0:
             # For VC++ 14.0 Redirect user to Visual C++ Build Tools
             message += (' Get it with "Microsoft Visual C++ Build Tools": '
-                r'http://landinghub.visualstudio.com/visual-cpp-build-tools')
+                        r'http://landinghub.visualstudio.com/'
+                        'visual-cpp-build-tools')
 
     exc.args = (message, )
 

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -80,14 +80,14 @@ def patch_for_specialized_compiler():
         pass
 
     try:
-        # Patch distutils._msvccompiler._get_vc_env for numpy compatibility
+        # Patch distutils._msvccompiler._get_vc_env
         unpatched['msvc14_get_vc_env'] = msvc14compiler._get_vc_env
         msvc14compiler._get_vc_env = msvc14_get_vc_env
     except NameError:
         pass
 
     try:
-        # Patch distutils._msvccompiler.gen_lib_options
+        # Patch distutils._msvccompiler.gen_lib_options for Numpy
         unpatched['msvc14_gen_lib_options'] = msvc14compiler.gen_lib_options
         msvc14compiler.gen_lib_options = msvc14_gen_lib_options
     except NameError:


### PR DESCRIPTION
- Fix compatibility between `numpy.distutils` and `distutils._msvccompiler`. See #728 : Setuptools 24 `msvc.py` improvement import `distutils._msvccompiler` (New Python 3.5 C compiler for MSVC >= 14), but this one is not compatible with `numpy.distutils` (because not patched with `numpy.distutils.ccompiler.gen_lib_options`) and return unquoted libpaths when linking. The problem was patched in Numpy, but need to be patched also in Setuptools for compatibility between older versions of Numpy and `distutils._msvccompiler` (and indirectly Setuptools > 24).

Also some minor changes :
- Replace some residuals `except Exception`.
- PEP8.
- Better history of the problem in Change.rst.