### PR TITLE
improve certificate handling in SUSE Linux

### DIFF
--- a/setuptools/ssl_support.py
+++ b/setuptools/ssl_support.py
@@ -243,6 +243,7 @@ def find_ca_bundle():
             if os.path.isfile(cert_path):
                 return cert_path
     try:
-        return pkg_resources.resource_filename('certifi', 'cacert.pem')
+        import certifi
+        return certifi.where()
     except (ImportError, ResolutionError, ExtractionError):
         return None

--- a/setuptools/ssl_support.py
+++ b/setuptools/ssl_support.py
@@ -26,6 +26,7 @@ cert_paths = """
 /etc/ssl/cert.pem
 /System/Library/OpenSSL/certs/cert.pem
 /usr/local/share/certs/ca-root-nss.crt
+/etc/ssl/ca-bundle.pem
 """.strip().split()
 
 


### PR DESCRIPTION
The PR adds SUSE-specific CA bundle location to the list of searched locations.

It also replaces the reliance on certifi's bundle filename with a call to `certifi.where()` (fixing #760)