### PR TITLE
Install py.test>=2.8,<3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
  - LC_ALL=C LC_CTYPE=C
 script:
  # avoid VersionConflict when newer version is required
- - pip install -U pytest
+ - pip install -U 'pytest>=2.8,<3'
 
  # Output the env, because the travis docs just can't be trusted
  - env

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ setup_params = dict(
     tests_require=[
         'setuptools[ssl]',
         'pytest-flake8',
-        'pytest>=2.8,!=3.0.0',
+        'pytest>=2.8,<3',
     ] + (['mock'] if sys.version_info[:2] < (3, 3) else []),
     setup_requires=[
     ] + pytest_runner + wheel,

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,8 @@
 envlist = py26,py27,py33,py34,py35,pypy,pypy3
 
 [testenv]
+deps=
+	pytest-flake8
+	pytest>=2.8,<3
 passenv=APPDATA USERPROFILE HOMEDRIVE HOMEPATH windir
-commands=python setup.py test
+commands=python setup.py test --addopts='-rsx'


### PR DESCRIPTION
The 3.x series is currently broken. Until py.test works again, 3.x should not be used by anything.