### PR TITLE
pytest: ignore all .* directories

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts=--doctest-modules --ignore release.py --ignore setuptools/lib2to3_ex.py --ignore tests/manual_test.py --ignore tests/shlib_test --doctest-glob=pkg_resources/api_tests.txt --ignore scripts/upload-old-releases-as-zip.py --ignore pavement.py
-norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern .tox
+norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern .*
 flake8-ignore =
     setuptools/site-patch.py F821
     setuptools/py*compat.py F811


### PR DESCRIPTION
In Cloud9 a .c9 directory is created. Other IDEs like to add .directories as well.

This PR has pytest ignoring all `.*` instead of just `.tox`