### PR TITLE
Use LooseVersion instread of StrictVersion

### DIFF
--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -6,7 +6,7 @@ import sys
 import platform
 import itertools
 import distutils.errors
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 from setuptools.extern.six.moves import filterfalse
 
@@ -229,7 +229,7 @@ def msvc14_gen_lib_options(*args, **kwargs):
     """
     if "numpy.distutils" in sys.modules:
         import numpy as np
-        if StrictVersion(np.__version__) < StrictVersion('1.11.2'):
+        if LooseVersion(np.__version__) < LooseVersion('1.11.2'):
             return np.distutils.ccompiler.gen_lib_options(*args, **kwargs)
     return unpatched['msvc14_gen_lib_options'](*args, **kwargs)
 


### PR DESCRIPTION
Feeback by @rgommers (https://github.com/pypa/setuptools/pull/739/files/8d1eecaef52a1baf2b9fc6c772880d8c537b562f#r77445452), numpy version can look like "1.11.1rc1+fa248ad" in dev branches.

`StrictVersion` fail to parse this kind of string. One solution is to use `LooseVersion`.

```
In [6]: distutils.version.LooseVersion("1.11.1rc1+fa248ad") < distutils.version.LooseVersion('1.11.2')
Out[6]: True

In [7]: distutils.version.LooseVersion("1.11.3rc1+fa248ad") < distutils.version.LooseVersion('1.11.2')
Out[7]: False
```