### PR TITLE
Use LegacyVersion instead of LooseVersion

### DIFF
--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -6,7 +6,7 @@ import sys
 import platform
 import itertools
 import distutils.errors
-from distutils.version import LooseVersion
+from pkg_resources.extern.packaging.version import LegacyVersion
 
 from setuptools.extern.six.moves import filterfalse
 
@@ -229,7 +229,7 @@ def msvc14_gen_lib_options(*args, **kwargs):
     """
     if "numpy.distutils" in sys.modules:
         import numpy as np
-        if LooseVersion(np.__version__) < LooseVersion('1.11.2'):
+        if LegacyVersion(np.__version__) < LegacyVersion('1.11.2'):
             return np.distutils.ccompiler.gen_lib_options(*args, **kwargs)
     return unpatched['msvc14_gen_lib_options'](*args, **kwargs)
 


### PR DESCRIPTION
- Also apply the patch for numpy 1.11.2 pre release