### PR TITLE
Don't check if dist is an instance of distutils.dist.Distribution, its not

### DIFF
--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -133,8 +133,50 @@ class Command(_Command):
         """
         Construct the command for dist, updating
         vars(self) with any keyword parameters.
+        Backported from distutils
         """
-        _Command.__init__(self, dist)
+        # late import because of mutual dependence between these classes
+        from distutils.dist import Distribution
+
+        if not hasattr(dist, 'get_requires'):
+            raise TypeError, "dist must be a Distribution instance"
+        if self.__class__ is Command:
+            raise RuntimeError, "Command is an abstract class"
+
+        self.distribution = dist
+        self.initialize_options()
+
+        # Per-command versions of the global flags, so that the user can
+        # customize Distutils' behaviour command-by-command and let some
+        # commands fall back on the Distribution's behaviour.  None means
+        # "not defined, check self.distribution's copy", while 0 or 1 mean
+        # false and true (duh).  Note that this means figuring out the real
+        # value of each flag is a touch complicated -- hence "self._dry_run"
+        # will be handled by __getattr__, below.
+        # XXX This needs to be fixed.
+        self._dry_run = None
+
+        # verbose is largely ignored, but needs to be set for
+        # backwards compatibility (I think)?
+        self.verbose = dist.verbose
+
+        # Some commands define a 'self.force' option to ignore file
+        # timestamps, but methods defined *here* assume that
+        # 'self.force' exists for all commands.  So define it here
+        # just to be safe.
+        self.force = None
+
+        # The 'help' flag is just used for command-line parsing, so
+        # none of that complicated bureaucracy is needed.
+        self.help = 0
+
+        # 'finalized' records whether or not 'finalize_options()' has been
+        # called.  'finalize_options()' itself should not pay attention to
+        # this flag: it is the business of 'ensure_finalized()', which
+        # always calls 'finalize_options()', to respect/update it.
+        self.finalized = 0
+
+
         vars(self).update(kw)
 
     def reinitialize_command(self, command, reinit_subcommands=0, **kw):

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -139,9 +139,9 @@ class Command(_Command):
         from distutils.dist import Distribution
 
         if not hasattr(dist, 'get_requires'):
-            raise TypeError, "dist must be a Distribution instance"
-        if self.__class__ is Command:
-            raise RuntimeError, "Command is an abstract class"
+            raise TypeError("dist must be a Distribution instance")
+        if self.__class__ is _Command:
+            raise RuntimeError("Command is an abstract class")
 
         self.distribution = dist
         self.initialize_options()


### PR DESCRIPTION
based on this patch for Distutils (but we can't patch distutils in old python versions can we?)
http://bugs.python.org/issue23102

Whilst we wait for this to get merged into python, it could be fixed this way for setuptools?