### PR TITLE
Don't duplicate error case in package_index

### DIFF
--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -49,8 +49,9 @@ from setuptools.sandbox import run_setup
 from setuptools.py31compat import get_path, get_config_vars
 from setuptools.command import setopt
 from setuptools.archive_util import unpack_archive
-from setuptools.package_index import PackageIndex
-from setuptools.package_index import URL_SCHEME
+from setuptools.package_index import (
+    PackageIndex, parse_requirement_arg, URL_SCHEME,
+)
 from setuptools.command import bdist_egg, egg_info
 from pkg_resources import (
     yield_lines, normalize_path, resource_string, ensure_directory,
@@ -1520,15 +1521,6 @@ def get_exe_prefixes(exe_filename):
     prefixes.sort()
     prefixes.reverse()
     return prefixes
-
-
-def parse_requirement_arg(spec):
-    try:
-        return Requirement.parse(spec)
-    except ValueError:
-        raise DistutilsError(
-            "Not a URL, existing file, or requirement spec: %r" % (spec,)
-        )
 
 
 class PthDistributions(Environment):

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -52,6 +52,15 @@ _tmpl = "setuptools/{setuptools.__version__} Python-urllib/{py_major}"
 user_agent = _tmpl.format(py_major=sys.version[:3], **globals())
 
 
+def parse_requirement_arg(spec):
+    try:
+        return Requirement.parse(spec)
+    except ValueError:
+        raise DistutilsError(
+            "Not a URL, existing file, or requirement spec: %r" % (spec,)
+        )
+
+
 def parse_bdist_wininst(name):
     """Return (base,pyversion) or (None,None) for possible .exe name"""
 
@@ -561,13 +570,7 @@ class PackageIndex(Environment):
                 # Existing file or directory, just return it
                 return spec
             else:
-                try:
-                    spec = Requirement.parse(spec)
-                except ValueError:
-                    raise DistutilsError(
-                        "Not a URL, existing file, or requirement spec: %r" %
-                        (spec,)
-                    )
+                spec = parse_requirement_arg(spec)
         return getattr(self.fetch_distribution(spec, tmpdir), 'location', None)
 
     def fetch_distribution(


### PR DESCRIPTION
easy_install has code to handle parsing a requirement, catching the
ValueError and then raising a DistUtilsError. This code was entirely
duplicated in package_index, so I've slightly refactored to remove
the duplication.