### PR TITLE
pkg_resources: fix str(Requirement())

### DIFF
--- a/pkg_resources/_vendor/packaging/markers.py
+++ b/pkg_resources/_vendor/packaging/markers.py
@@ -54,11 +54,15 @@ class Node(object):
 
 
 class Variable(Node):
-    pass
+
+    def __str__(self):
+        return self.value
 
 
 class Value(Node):
-    pass
+
+    def __str__(self):
+        return repr(str(self.value))
 
 
 VARIABLE = (
@@ -149,7 +153,7 @@ def _format_marker(marker, first=True):
         else:
             return "(" + " ".join(inner) + ")"
     elif isinstance(marker, tuple):
-        return '{0} {1} "{2}"'.format(*marker)
+        return '{0} {1} {2}'.format(*marker)
     else:
         return marker
 

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -518,6 +518,28 @@ class TestRequirements:
         assert (
             Requirement.parse('setuptools >= 0.7').project_name == 'setuptools')
 
+    def testMarkersStr(self):
+        for req_str, req_cannonical_str in (
+            ('pywin32 (>1.0); sys.platform == "win32"',
+             "pywin32>1.0; sys_platform == 'win32'"),
+            ("pywin31; sys.platform == 'win32'",
+             "pywin31; sys_platform == 'win32'"),
+            ("foo != 1.3; platform.machine=='i386'",
+             "foo!=1.3; platform_machine == 'i386'"),
+            ("bar; python_version=='2.4'or python_version==\"2.5\"",
+             "bar; python_version == '2.4' or python_version == '2.5'"),
+            ("bar; ('3.2' <= python_version and python_version <= '3.5')",
+             "bar; '3.2' <= python_version and python_version <= '3.5'"),
+            ("libxslt; 'linux' in sys.platform",
+             "libxslt; 'linux' in sys_platform"),
+            ("foobar; '\"' in sys_platform",
+             "foobar; '\"' in sys_platform"),
+            ("foobar; \"'\" in sys_platform",
+             "foobar; \"'\" in sys_platform"),
+        ):
+            req = Requirement(req_str)
+            assert str(req) == req_cannonical_str
+
 
 class TestParsing:
 


### PR DESCRIPTION
Ensure the result of str(Requirement()) is itself a valid requirement line that can be parsed back. Otherwise:
```python
In [1]: import pkg_resources, setuptools

In [2]: setuptools.__version__
Out[2]: '27.2.0'

In [3]: str(pkg_resources.Requirement("python-xlib>=0.16; 'linux' in sys_platform"))
Out[3]: 'python-xlib>=0.16; linux in "sys_platform"'
```
This caused some [regressions in pip](https://github.com/pypa/pip/issues/3781) when environment marker parsing was made consistent by only using the code copied from `setuptools`.