### PR TITLE
Find nested packages with excluded parent

### DIFF
--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -75,13 +75,17 @@ class PackageFinder(object):
                 rel_path = os.path.relpath(full_path, where)
                 package = rel_path.replace(os.path.sep, '.')
 
-                # Check if the directory is a package and passes the filters
-                if ('.' not in dir
-                        and include(package)
-                        and not exclude(package)
-                        and cls._looks_like_package(full_path)):
+                # Skip directory trees that are not valid packages
+                if ('.' in dir or not cls._looks_like_package(full_path)):
+                    continue
+
+                # Should this package be included?
+                if include(package) and not exclude(package):
                     yield package
-                    dirs.append(dir)
+
+                # Keep searching subdirectories, as there may be more packages
+                # down there, even if the parent was excluded.
+                dirs.append(dir)
 
     @staticmethod
     def _looks_like_package(path):

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -100,12 +100,12 @@ class TestFindPackages:
 
     def test_exclude_recursive(self):
         """
-        Excluding a parent package should exclude all child packages as well.
+        Excluding a parent package should not exclude child packages as well.
         """
         self._touch('__init__.py', self.pkg_dir)
         self._touch('__init__.py', self.sub_pkg_dir)
         packages = find_packages(self.dist_dir, exclude=('pkg',))
-        assert packages == []
+        assert packages == ['pkg.subpkg']
 
     def test_include_excludes_other(self):
         """


### PR DESCRIPTION
`find_packages(exclude=['pkg'])` should still find and include the `pkg.subpkg` package.

Fixes #808