### PR TITLE
Fix tox invocation in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,36 @@
 language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - pypy
-  - pypy3
-env:
- - ""
- - LC_ALL=C LC_CTYPE=C
+
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.6
+      env: TOXENV=py26 LC_ALL=C LC_CTYPE=C
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 2.7
+      env: TOXENV=py27 LC_ALL=C LC_CTYPE=C
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.3
+      env: TOXENV=py33 LC_ALL=C LC_CTYPE=C
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.4
+      env: TOXENV=py34 LC_ALL=C LC_CTYPE=C
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.5
+      env: TOXENV=py35 LC_ALL=C LC_CTYPE=C
+    - python: pypy
+      env: TOXENV=pypy
+    - python: pypy
+      env: TOXENV=pypy LC_ALL=C LC_CTYPE=C
+    - python: pypy3
+      env: TOXENV=pypy3
+    - python: pypy3
+      env: TOXENV=pypy3 LC_ALL=C LC_CTYPE=C
+
 script:
  - pip install tox
 
@@ -19,7 +40,6 @@ script:
  # update egg_info based on setup.py in checkout
  - python bootstrap.py
 
- #- python -m tox
  - tox
 
 before_deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,9 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python35-x64"
+      TOXENV: "py27"
     - PYTHON: "C:\\Python27-x64"
+      TOXENV: "py35"
 
 install:
   # symlink python from a directory with a space
@@ -14,4 +16,5 @@ build: off
 
 test_script:
   - "python bootstrap.py"
-  - "python setup.py test --addopts='-rsx'"
+  - "pip install tox"
+  - "tox"

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ deps=
 	pytest-flake8
 	pytest>=3.0.2
 	setuptools[ssl]
-	backports.unittest_mock
+	py{26,27,33,py,py3}: mock
 
 passenv=APPDATA USERPROFILE HOMEDRIVE HOMEPATH windir
 commands=python -m pytest -rsx


### PR DESCRIPTION
To run tox from Travis, you have to specify the tox environment to run with `tox -e ENV`. You can construct the correct env from the TRAVIS_PYTHON_VERSION variable.

I also fixed the Appveyor config a little, but something odd is going on and it is still broken.