### PR TITLE
expose PKG-INFO metadata from Distribution objs

### DIFF
--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -959,6 +959,13 @@ version
     metadata file.  If ``PKG-INFO`` is unavailable or can't be parsed,
     ``ValueError`` is raised.
 
+pkg_info
+    A dict containing the mapped fields read from its ``PKG-INFO`` metadata
+    file, as defined by `PEP-0314`_.  If ``PKG-INFO`` is unavailable or can't be
+    parsed, ``ValueError`` is raised.
+
+.. _PEP-0314: https://www.python.org/dev/peps/pep-0314/
+
 parsed_version
     The ``parsed_version`` is an object representing a "parsed" form of the
     distribution's ``version``.  ``dist.parsed_version`` is a shortcut for

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2503,6 +2503,20 @@ class Distribution(object):
                 raise ValueError(tmpl % self.PKG_INFO, self)
             return version
 
+
+    @property
+    def pkg_info(self):
+        if not hasattr(self, '_pkg_info'):
+            self._pkg_info = {}
+            for line in yield_lines(self._get_metadata(self.PKG_INFO)):
+                key, value = [field.strip() for field in line.split(':', 1)]
+                self._pkg_info[key] = value
+            if self._pkg_info is None:
+                tmpl = "Missing or empty %s file"
+                raise ValueError(tmpl % self.PKG_INFO, self)
+        return self._pkg_info
+
+
     @property
     def _dep_map(self):
         try:

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2509,8 +2509,12 @@ class Distribution(object):
         if not hasattr(self, '_pkg_info'):
             self._pkg_info = {}
             for line in yield_lines(self._get_metadata(self.PKG_INFO)):
-                key, value = [field.strip() for field in line.split(':', 1)]
-                self._pkg_info[key] = value
+                try:
+                    key, value = [field.strip() for field in line.split(':', 1)]
+                    self._pkg_info[key] = value
+                except ValueError:
+                    tmpl = "Malformed %s file"
+                    raise ValueError(tmpl % self.PKG_INFO, self)
             if self._pkg_info is None:
                 tmpl = "Missing or empty %s file"
                 raise ValueError(tmpl % self.PKG_INFO, self)


### PR DESCRIPTION
I've taken an attempt to implement the feature request I proposed (https://github.com/pypa/setuptools/issues/831).

I chose the `Distribution` class to expose the metadata attribute as I believe it is the first in its hierarchy to mandate a `PKG-INFO` resource. The alternative `IMetadataProvider` interface supports arbitrary documents and formats.

I chose to expose the data as an attribute as opposed to method call as I believe it better complements the existing attribute interface (i.e. `.version`). If updated data was desired a method would be preferable but I do not see a use case for that at this time.
