### PR TITLE
Support Python 3.3.0 for extension suffix

### DIFF
--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -109,7 +109,7 @@ class build_ext(_build_ext):
                 and get_abi3_suffix()
             )
             if use_abi3:
-                so_ext = get_config_var("EXT_SUFFIX") or get_config_var("SO")
+                so_ext = get_config_var('EXT_SUFFIX') or get_config_var('SO')
                 filename = filename[:-len(so_ext)]
                 filename = filename + get_abi3_suffix()
             if isinstance(ext, Library):

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -109,7 +109,7 @@ class build_ext(_build_ext):
                 and get_abi3_suffix()
             )
             if use_abi3:
-                so_ext = get_config_var('EXT_SUFFIX')
+                so_ext = get_config_var("EXT_SUFFIX") or get_config_var("SO")
                 filename = filename[:-len(so_ext)]
                 filename = filename + get_abi3_suffix()
             if isinstance(ext, Library):


### PR DESCRIPTION
In setuptools 27.0+ extension building fails on Python 3.3.0 because the extension suffix is obtained using `SO` and not `EXT_SUFFIX` (which is used in 3.3.1 and above). See: https://hg.python.org/cpython/file/v3.3.0/Lib/distutils/command/build_ext.py#l673

This patch tries `EXT_SUFFIX` and falls back to `SO` if `EXT_SUFFIX` is falsey.