### PR TITLE
Also suppress warning for a single file missing

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -554,9 +554,16 @@ class manifest_maker(sdist):
         msg = "writing manifest file '%s'" % self.manifest
         self.execute(write_file, (self.manifest, files), msg)
 
-    def warn(self, msg):  # suppress missing-file warnings from sdist
-        if not msg.startswith("standard file not found:"):
+    def warn(self, msg):
+        if not self._should_suppress_warning(msg):
             sdist.warn(self, msg)
+
+    @staticmethod
+    def _should_suppress_warning(msg):
+        """
+        suppress missing-file warnings from sdist
+        """
+        return re.match(r"standard file .*not found", msg)
 
     def add_defaults(self):
         sdist.add_defaults(self)

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -4,7 +4,7 @@ import re
 import stat
 import sys
 
-from setuptools.command.egg_info import egg_info
+from setuptools.command.egg_info import egg_info, manifest_maker
 from setuptools.dist import Distribution
 from setuptools.extern.six.moves import map
 
@@ -236,6 +236,15 @@ class TestEggInfo(object):
         egg_info_dir = self._find_egg_info_files(env.paths['lib']).base
         pkginfo = os.path.join(egg_info_dir, 'PKG-INFO')
         assert 'Requires-Python: >=1.2.3' in open(pkginfo).read().split('\n')
+
+    def test_manifest_maker_warning_suppresion(self):
+        fixtures = [
+            "standard file not found: should have one of foo.py, bar.py",
+            "standard file 'setup.py' not found"
+        ]
+
+        for msg in fixtures:
+            assert manifest_maker._should_suppress_warning(msg)
 
     def _run_install_command(self, tmpdir_cwd, env, cmd=None, output=None):
         environ = os.environ.copy().update(


### PR DESCRIPTION
Replaces #826
Fixes #825

In order to make a test without adding mocks or other monkeys patches, I extracted the check for suppression in a static method.