### PR TITLE
Meaningful message if corrupted setuptools.

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -40,6 +40,8 @@ DEFAULT_VERSION = LATEST
 DEFAULT_URL = "https://pypi.io/packages/source/s/setuptools/"
 DEFAULT_SAVE_DIR = os.curdir
 
+MEANINGFUL_INVALID_ZIP_ERR_MSG = 'Maybe {0} is corrupted, delete it and try again.'
+
 
 def _python_cmd(*args):
     """
@@ -104,8 +106,16 @@ def archive_context(filename):
     old_wd = os.getcwd()
     try:
         os.chdir(tmpdir)
-        with ContextualZipFile(filename) as archive:
-            archive.extractall()
+        try:
+            with ContextualZipFile(filename) as archive:
+                archive.extractall()
+        except zipfile.BadZipfile as err:
+            if not err.args:
+                err.args = ('', )
+            err.args = err.args + (
+                MEANINGFUL_INVALID_ZIP_ERR_MSG.format(filename),
+            )
+            raise
 
         # going in the directory
         subdir = os.path.join(tmpdir, os.listdir(tmpdir)[0])

--- a/test_ez_setup.py
+++ b/test_ez_setup.py
@@ -1,4 +1,8 @@
+from zipfile import BadZipfile
+
 import py.path
+
+import pytest
 
 import ez_setup
 
@@ -11,3 +15,15 @@ def test_download(tmpdir_cwd):
     assert res.basename.endswith('.zip')
     # file should be bigger than 64k
     assert res.size() > 2**16
+
+
+def test_message_corrupted_setuptools(tmpdir_cwd):
+    cwd = py.path.local()
+    ez_setup.download_setuptools()
+    res, = cwd.listdir()
+    res.write('CORRUPT ME')
+    with pytest.raises(BadZipfile) as excinfo:
+        with ez_setup.archive_context(res.strpath):
+            pass
+    msg = ez_setup.MEANINGFUL_INVALID_ZIP_ERR_MSG.format(res.strpath)
+    assert msg in str(excinfo.value)


### PR DESCRIPTION
Fixes https://github.com/pypa/setuptools/issues/563.

Is not clear in ez_setup.py that it always uses a setuptools archive if
already downloaded: although useful (and even used as a feature in
buildout-bootstrap.py), it's hard for beginners that may have a
corrupted ez_setup.py.

So we just improve the error message, even showing the full path of the
probably "corrupted" zip.