### PR TITLE
package_index: fix bug not catching some network timeouts

### DIFF
--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -768,7 +768,7 @@ class PackageIndex(Environment):
                     'down, %s' %
                     (url, v.line)
                 )
-        except http_client.HTTPException as v:
+        except (http_client.HTTPException, socket.error) as v:
             if warning:
                 self.warn(warning, v)
             else:


### PR DESCRIPTION
There are already so many exceptions catched, like socket errors (e.g. failure in name resolution) or HTTP errors. Depending on when a timeout occurs, it is either catched (URLError during the SSL handshake) or not (socket.error while getting a HTTP response).

When used by buildout, this fixes random failures when running in newest mode (which is the default case), or when the requested version is available in the download-cache.