### PR TITLE
Fix #849 global-exclude globbing

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -457,7 +457,7 @@ class FileList(_FileList):
         """
         if self.allfiles is None:
             self.findall()
-        match = translate_pattern(os.path.join('**', pattern))
+        match = translate_pattern(os.path.join('**', '*' + pattern))
         found = [f for f in self.allfiles if match.match(f)]
         self.extend(found)
         return bool(found)
@@ -466,7 +466,7 @@ class FileList(_FileList):
         """
         Exclude all files anywhere that match the pattern.
         """
-        match = translate_pattern(os.path.join('**', pattern))
+        match = translate_pattern(os.path.join('**', '*' + pattern))
         return self._remove_files(match.match)
 
     def append(self, item):

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -449,6 +449,11 @@ class TestFileListTest(TempDirTestCase):
         assert file_list.files == ['a.py', l('d/c.py')]
         self.assertWarnings()
 
+        file_list.process_template_line('global-include .txt')
+        file_list.sort()
+        assert file_list.files == ['a.py', 'b.txt', l('d/c.py')]
+        self.assertNoWarnings()
+
     def test_global_exclude(self):
         l = make_local_path
         # global-exclude
@@ -464,6 +469,13 @@ class TestFileListTest(TempDirTestCase):
         file_list.sort()
         assert file_list.files == ['b.txt']
         self.assertWarnings()
+
+        file_list = FileList()
+        file_list.files = ['a.py', 'b.txt', l('d/c.pyc'), 'e.pyo']
+        file_list.process_template_line('global-exclude .py[co]')
+        file_list.sort()
+        assert file_list.files == ['a.py', 'b.txt']
+        self.assertNoWarnings()
 
     def test_recursive_include(self):
         l = make_local_path


### PR DESCRIPTION
After #764, `global-exclude .pyc` no longer excluded `.pyc` files. This fixes that regression, and adds a test for this behaviour.

Fixes #849.