### PR TITLE
docs: reorder ToC; update stray Bitbucket links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -139,10 +139,10 @@ Package Index`_. Scroll to the very bottom of the page to find the links.
 .. _the project's home page in the Python Package Index: https://pypi.python.org/pypi/setuptools
 
 In addition to the PyPI downloads, the development version of ``setuptools``
-is available from the `Bitbucket repo`_, and in-development versions of the
+is available from the `GitHub repo`_, and in-development versions of the
 `0.6 branch`_ are available as well.
 
-.. _Bitbucket repo: https://bitbucket.org/pypa/setuptools/get/default.tar.gz#egg=setuptools-dev
+.. _GitHub repo: https://github.com/pypa/setuptools/archive/master.tar.gz#egg=setuptools-dev
 .. _0.6 branch: http://svn.python.org/projects/sandbox/branches/setuptools-0.6/#egg=setuptools-dev06
 
 Uninstalling

--- a/docs/_templates/indexsidebar.html
+++ b/docs/_templates/indexsidebar.html
@@ -5,4 +5,4 @@
 
 <h3>Questions? Suggestions? Contributions?</h3>
 
-<p>Visit the <a href="https://bitbucket.org/pypa/setuptools">Setuptools project page</a> </p>
+<p>Visit the <a href="https://github.com/pypa/setuptools">Setuptools project page</a> </p>

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -16,10 +16,10 @@ Documentation content:
 .. toctree::
    :maxdepth: 2
 
-   history
-   roadmap
-   python3
    setuptools
    easy_install
    pkg_resources
+   python3
    development
+   roadmap
+   history


### PR DESCRIPTION
Visitors to https://setuptools.readthedocs.io/en/latest/ are currently confronted by a ten-page list of old version numbers before they reach the ToC entry they are probably most interested in:“Building and Distributing Packages with Setuptools”.

When attempting to write this PR, I noticed that the sidebar directs contributors to Bitbucket.