### PR TITLE
Revert #853 implicit wildcards in MANIFEST.in

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+In development
+--------------
+
+* #890: Revert #849. ``global-exclude .foo`` will not match all
+  ``*.foo`` files any more. Package authors must add an explicit
+  wildcard, such as ``global-exclude *.foo``, to match all
+  ``.foo`` files. See #886, #849.
+
 v31.0.1
 -------
 
@@ -132,7 +140,11 @@ v28.5.0
 
 * #810: Tests are now invoked with tox and not setup.py test.
 * #249 and #450 via #764: Avoid scanning the whole tree
-  when building the manifest.
+  when building the manifest. Also fixes a long-standing bug
+  where patterns in ``MANIFEST.in`` had implicit wildcard
+  matching. This caused ``global-exclude .foo`` to exclude
+  all ``*.foo`` files, but also ``global-exclude bar.py`` to
+  exclude ``foo_bar.py``.
 
 v28.4.0
 -------

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -457,7 +457,7 @@ class FileList(_FileList):
         """
         if self.allfiles is None:
             self.findall()
-        match = translate_pattern(os.path.join('**', '*' + pattern))
+        match = translate_pattern(os.path.join('**', pattern))
         found = [f for f in self.allfiles if match.match(f)]
         self.extend(found)
         return bool(found)
@@ -466,7 +466,7 @@ class FileList(_FileList):
         """
         Exclude all files anywhere that match the pattern.
         """
-        match = translate_pattern(os.path.join('**', '*' + pattern))
+        match = translate_pattern(os.path.join('**', pattern))
         return self._remove_files(match.match)
 
     def append(self, item):

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -449,11 +449,6 @@ class TestFileListTest(TempDirTestCase):
         assert file_list.files == ['a.py', l('d/c.py')]
         self.assertWarnings()
 
-        file_list.process_template_line('global-include .txt')
-        file_list.sort()
-        assert file_list.files == ['a.py', 'b.txt', l('d/c.py')]
-        self.assertNoWarnings()
-
     def test_global_exclude(self):
         l = make_local_path
         # global-exclude
@@ -469,13 +464,6 @@ class TestFileListTest(TempDirTestCase):
         file_list.sort()
         assert file_list.files == ['b.txt']
         self.assertWarnings()
-
-        file_list = FileList()
-        file_list.files = ['a.py', 'b.txt', l('d/c.pyc'), 'e.pyo']
-        file_list.process_template_line('global-exclude .py[co]')
-        file_list.sort()
-        assert file_list.files == ['a.py', 'b.txt']
-        self.assertNoWarnings()
 
     def test_recursive_include(self):
         l = make_local_path


### PR DESCRIPTION
Reverts #853, which restored old behaviour of implicit wildcard matching in MANIFEST.in patterns. This PR will require package authors to include explicit wildcards in their MANIFEST.in patterns: `global-exclude .foo` will need to be changed to `global-exclude *.foo`, and `recursive-include docs .rst` will need to be changed to `recursive-include docs *.rst`.

See #853, #849, #764, #886.