### PR TITLE
Exit on test failure

### DIFF
--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -226,12 +226,14 @@ class test(Command):
                 list(map(sys.modules.__delitem__, del_modules))
 
         exit_kwarg = {} if sys.version_info < (2, 7) else {"exit": False}
-        unittest_main(
+        test = unittest_main(
             None, None, self._argv,
             testLoader=self._resolve_as_ep(self.test_loader),
             testRunner=self._resolve_as_ep(self.test_runner),
             **exit_kwarg
         )
+        if not test.result.wasSuccessful():
+            sys.exit(1)
 
     @property
     def _argv(self):

--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -3,7 +3,8 @@ import operator
 import sys
 import contextlib
 import itertools
-from distutils.errors import DistutilsOptionError
+from distutils.errors import DistutilsError, DistutilsOptionError
+from distutils import log
 from unittest import TestLoader
 
 from setuptools.extern import six
@@ -233,7 +234,9 @@ class test(Command):
             **exit_kwarg
         )
         if not test.result.wasSuccessful():
-            sys.exit(1)
+            msg = 'Test failed: %s' % test.result
+            self.announce(msg, log.ERROR)
+            raise DistutilsError(msg)
 
     @property
     def _argv(self):


### PR DESCRIPTION
When test fails, it should not continue to run other commands.
Fixes #891