### PR TITLE
Document use of environment markers in extras_require

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -787,21 +787,21 @@ For example, here is a project that uses the ``enum`` module and ``pywin32``::
     setup(
         name="Project",
         ...
-        extras_require={
-            ':python_version < "3.4"': ["enum34"],
-            ':sys_platform == "win32"': ["pywin32 >= 1.0"]
-        }
+        install_requires=[
+            'enum34;python_version<"3.4"',
+            'pywin32 >= 1.0;platform_system=="Windows"'
+        ]
     )
 
-Since the ``enum`` module was added in python 3.4, it should only be installed
+Since the ``enum`` module was added in Python 3.4, it should only be installed
 if the python version is earlier.  Since ``pywin32`` will only be used on
 windows, it should only be installed when the operating system is Windows.
 Specifying version requirements for the dependencies is supported as normal.
 
 The environmental markers that may be used for testing platform types are
-detailed in `PEP 496`_.
+detailed in `PEP 508`_.
 
-.. _PEP 496: https://www.python.org/dev/peps/pep-0496/
+.. _PEP 508: https://www.python.org/dev/peps/pep-0508/
 
 Including Data Files
 ====================

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -799,7 +799,9 @@ windows, it should only be installed when the operating system is Windows.
 Specifying version requirements for the dependencies is supported as normal.
 
 The environmental markers that may be used for testing platform types are
-detailed in PEP 496.
+detailed in `PEP 496`_.
+
+.. _PEP 496: https://www.python.org/dev/peps/pep-0496/
 
 Including Data Files
 ====================

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -769,6 +769,38 @@ so that Package B doesn't have to remove the ``[PDF]`` from its requirement
 specifier.
 
 
+.. _Platform Specific Dependencies:
+
+
+Declaring platform specific dependencies
+----------------------------------------
+
+Sometimes a project might require a dependency to run on a specific platform.
+This could to a package that back ports a module so that it can be used in
+older python versions.  Or it could be a package that is required to run on a
+specific operating system.  This will allow a project to work on multiple
+different platforms without installing dependencies that are not required for
+a platform that is installing the project.
+
+For example, here is a project that uses the ``enum`` module and ``pywin32``::
+
+    setup(
+        name="Project",
+        ...
+        extras_require={
+            ':python_version < "3.4"': ["enum34"],
+            ':sys_platform == "win32"': ["pywin32 >= 1.0"]
+        }
+    )
+
+Since the ``enum`` module was added in python 3.4, it should only be installed
+if the python version is earlier.  Since ``pywin32`` will only be used on
+windows, it should only be installed when the operating system is Windows.
+Specifying version requirements for the dependencies is supported as normal.
+
+The environmental markers that may be used for testing platform types are
+detailed in PEP 496.
+
 Including Data Files
 ====================
 


### PR DESCRIPTION
This explains gives a basic explanation of how to use environment markers in extras_require (addressing #909).

The changelog for [20.5](https://setuptools.readthedocs.io/en/latest/history.html#id163) seems to indicate that environment markers should be supported in `install_requires`, but I was not able to get that to work. Specifically, the example from [PEP 496](https://www.python.org/dev/peps/pep-0496/#examples) causes an error.

> 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Invalid requirement, parse error at "': sys.pl'"

However, making that work properly would be out of scope for this ticket and require knowledge of the code base, so it is not mentioned in the documentation.