### PR TITLE
Add namespace_packages parameter to find_packages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ v33.0.0
   still desired, consider adding the functionality to
   setuptools_svn in setuptools_svn #2.
 
+* #97: ``find_packages`` now has a ``namespace_packages``
+  parameter for explicitly specifying implicit (PEP 420)
+  namespace packages. These will be considered packages
+  during the search, despite not having an ``__init__.py``.
+
 v32.3.1
 -------
 

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -428,8 +428,10 @@ such projects also need something like ``package_dir={'':'src'}`` in their
 
 Anyway, ``find_packages()`` walks the target directory, filtering by inclusion
 patterns, and finds Python packages (any directory). On Python 3.2 and
-earlier, packages are only recognized if they include an ``__init__.py`` file.
-Finally, exclusion patterns are applied to remove matching packages.
+earlier, packages are only recognized if they include an ``__init__.py`` file,
+or if they are explicitly declared to be PEP 420 implicit namespace packages
+through the ``namespace_packages`` parameter. Finally, exclusion patterns are
+applied to remove matching packages.
 
 Inclusion and exclusion patterns are package names, optionally including
 wildcards.  For

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -150,6 +150,18 @@ class TestFindPackages:
         packages = find_packages(self.dist_dir)
         assert 'lpkg' in packages
 
+    def test_implicit_ns_package(self):
+        packages = find_packages(self.dist_dir, namespace_packages=('pkg',))
+        self._assert_packages(packages, ['pkg', 'pkg.subpkg'])
+
+    def test_implicit_ns_package_below_regular_package(self):
+        self._touch('__init__.py', self.pkg_dir)
+        self._mkdir('subnspkg', self.sub_pkg_dir)
+        packages = find_packages(self.dist_dir,
+            namespace_packages=('pkg.subpkg.subnspkg',))
+        self._assert_packages(packages,
+            ['pkg', 'pkg.subpkg.subnspkg', 'pkg.subpkg'])
+
     def _assert_packages(self, actual, expected):
         assert set(actual) == set(expected)
 


### PR DESCRIPTION
The user must pass any implicit (PEP 420) namespace packages in this parameter. Packages in this list will be recognized as such, despite not having any `__init__.py`.

Closes #97