### PR TITLE
Add support for overriding .pypirc location

### DIFF
--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1002,7 +1002,8 @@ class PyPIConfig(configparser.RawConfigParser):
         defaults = dict.fromkeys(['username', 'password', 'repository'], '')
         configparser.RawConfigParser.__init__(self, defaults)
 
-        rc = os.path.join(os.path.expanduser('~'), '.pypirc')
+        default_rc = os.path.join(os.path.expanduser('~'), '.pypirc')
+        rc = os.environ.get('PYPI_CONFIG_FILE', default_rc)
         if os.path.exists(rc):
             self.read(rc)
 

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -5,7 +5,7 @@ import os
 import distutils.errors
 
 import six
-from six.moves import urllib, http_client
+from six.moves import urllib, http_client, configparser
 
 import pkg_resources
 import setuptools.package_index
@@ -231,3 +231,52 @@ class TestPyPIConfig:
         cred = cfg.creds_by_repository['https://pypi.python.org']
         assert cred.username == 'jaraco'
         assert cred.password == 'pity%'
+
+    def test_default_config(self, tmpdir, monkeypatch):
+        monkeypatch.setitem(os.environ, 'HOME', str(tmpdir))
+        pypirc = tmpdir / '.pypirc'
+        with pypirc.open('w') as strm:
+            strm.write(DALS("""
+                [example]
+                name=johndoe
+                location=here
+            """))
+        cfg = setuptools.package_index.PyPIConfig()
+        assert cfg.get('example', 'name') == 'johndoe'
+        assert cfg.get('example' , 'location') == 'here'
+
+    def test_overriden_config(self, tmpdir, monkeypatch):
+        # Write the home config, as well as the override config
+        # Then check that home config is ignored and override is processed
+        monkeypatch.setitem(os.environ, 'HOME', str(tmpdir))
+        pypirc = tmpdir / '.pypirc'
+        with pypirc.open('w') as strm:
+            strm.write(DALS("""
+                [example]
+                name=johndoe
+                location=here
+                thing=ignored
+            """))
+
+        override_pypirc = tmpdir / '.override_pypirc'
+        with override_pypirc.open('w') as strm:
+            strm.write(DALS("""
+                [example]
+                name=janesmith
+                location=there
+                something=special
+            """))
+
+        monkeypatch.setitem(os.environ, 'PYPI_CONFIG_FILE', str(override_pypirc))
+        cfg = setuptools.package_index.PyPIConfig()
+        assert cfg.get('example', 'name') == 'janesmith'
+        assert cfg.get('example', 'location') == 'there'
+        assert cfg.get('example', 'something') == 'special'
+
+        # Make sure the default config was never read
+        try:
+            cfg.get('example', 'thing')
+        except configparser.NoOptionError:
+            pass
+        else:
+            assert False, 'Key \'thing\' unexpectedly found in overriden config'


### PR DESCRIPTION
Add support for overriding .pypirc location via an environment variable `PYPI_CONFIG_FILE`. I've added tests as well. Happy to address any review feedback. This fixes #954 