### PR TITLE
Fix hard link to URLs that should have been internal (method 1: via manual reference labels)

### DIFF
--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -1090,6 +1090,8 @@ simply by creating an appropriate `IResourceProvider`_ implementation; see the
 section below on `Supporting Custom Importers`_ for more details.
 
 
+.. _pkg-resources-resource-manager-api:
+
 ``ResourceManager`` API
 =======================
 

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -940,16 +940,14 @@ Typically, existing programs manipulate a package's ``__file__`` attribute in
 order to find the location of data files.  However, this manipulation isn't
 compatible with PEP 302-based import hooks, including importing from zip files
 and Python Eggs.  It is strongly recommended that, if you are using data files,
-you should use the `Resource Management API`_ of ``pkg_resources`` to access
-them.  The ``pkg_resources`` module is distributed as part of setuptools, so if
-you're using setuptools to distribute your package, there is no reason not to
-use its resource management API.  See also `Accessing Package Resources`_ for
-a quick example of converting code that uses ``__file__`` to use
-``pkg_resources`` instead.
+you should use the :ref:`pkg-resources-resource-manager-api` of
+``pkg_resources`` to access them.  The ``pkg_resources`` module is distributed
+as part of setuptools, so if you're using setuptools to distribute your
+package, there is no reason not to use its resource management API.  See also
+`Accessing Package Resources`_ for a quick example of converting code that uses
+``__file__`` to use ``pkg_resources`` instead.
 
-.. _Resource Management API: http://peak.telecommunity.com/DevCenter/PkgResources#resourcemanager-api
 .. _Accessing Package Resources: http://peak.telecommunity.com/DevCenter/PythonEggs#accessing-package-resources
-
 
 Non-Package Data Files
 ----------------------
@@ -959,8 +957,9 @@ location (e.g. ``/usr/share``).  This feature intended to be used for things
 like documentation, example configuration files, and the like.  ``setuptools``
 does not install these data files in a separate location, however.  They are
 bundled inside the egg file or directory, alongside the Python modules and
-packages.  The data files can also be accessed using the `Resource Management
-API`_, by specifying a ``Requirement`` instead of a package name::
+packages.  The data files can also be accessed using the
+:ref:`pkg-resources-resource-manager-api`, by specifying a ``Requirement``
+instead of a package name::
 
     from pkg_resources import Requirement, resource_filename
     filename = resource_filename(Requirement.parse("MyProject"),"sample.conf")


### PR DESCRIPTION
There is another suggestion for how to solve this at #957.

In this case, I'm doing what [the Sphinx documentation](http://www.sphinx-doc.org/en/stable/markup/inline.html#cross-referencing-arbitrary-locations) suggests by manually adding a reference label to the linked section.

There are some more "outdated hard links" like this, but I'm waiting for you guys' input on what the preferred way of fixing this is before changing them all.