### PR TITLE
 Fix hard link to URLs that should have been internal (method 2: via autosectionlabel Sphinx extension)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ import setup as setup_script
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['rst.linker']
+extensions = ['rst.linker', 'sphinx.ext.autosectionlabel']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -143,10 +143,10 @@ namespace package for Zope Corporation packages, and the ``peak`` namespace
 package for the Python Enterprise Application Kit.
 
 To create a namespace package, you list it in the ``namespace_packages``
-argument to ``setup()``, in your project's ``setup.py``.  (See the `setuptools
-documentation on namespace packages`_ for more information on this.)  Also,
-you must add a ``declare_namespace()`` call in the package's ``__init__.py``
-file(s):
+argument to ``setup()``, in your project's ``setup.py``.  (See the
+:ref:`setuptools documentation on namespace packages <Namespace Packages>` for
+more information on this.)  Also, you must add a ``declare_namespace()`` call
+in the package's ``__init__.py`` file(s):
 
 ``declare_namespace(name)``
     Declare that the dotted package name `name` is a "namespace package" whose
@@ -174,8 +174,6 @@ Although by default ``pkg_resources`` only supports namespace packages for
 filesystem and zip importers, you can extend its support to other "importers"
 compatible with PEP 302 using the ``register_namespace_handler()`` function.
 See the section below on `Supporting Custom Importers`_ for details.
-
-.. _setuptools documentation on namespace packages: http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
 
 
 ``WorkingSet`` Objects

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -940,14 +940,13 @@ Typically, existing programs manipulate a package's ``__file__`` attribute in
 order to find the location of data files.  However, this manipulation isn't
 compatible with PEP 302-based import hooks, including importing from zip files
 and Python Eggs.  It is strongly recommended that, if you are using data files,
-you should use the `Resource Management API`_ of ``pkg_resources`` to access
+you should use the :ref:`ResourceManager API` of ``pkg_resources`` to access
 them.  The ``pkg_resources`` module is distributed as part of setuptools, so if
 you're using setuptools to distribute your package, there is no reason not to
 use its resource management API.  See also `Accessing Package Resources`_ for
 a quick example of converting code that uses ``__file__`` to use
 ``pkg_resources`` instead.
 
-.. _Resource Management API: http://peak.telecommunity.com/DevCenter/PkgResources#resourcemanager-api
 .. _Accessing Package Resources: http://peak.telecommunity.com/DevCenter/PythonEggs#accessing-package-resources
 
 
@@ -959,8 +958,8 @@ location (e.g. ``/usr/share``).  This feature intended to be used for things
 like documentation, example configuration files, and the like.  ``setuptools``
 does not install these data files in a separate location, however.  They are
 bundled inside the egg file or directory, alongside the Python modules and
-packages.  The data files can also be accessed using the `Resource Management
-API`_, by specifying a ``Requirement`` instead of a package name::
+packages.  The data files can also be accessed using the :ref:`ResourceManager
+API`, by specifying a ``Requirement`` instead of a package name::
 
     from pkg_resources import Requirement, resource_filename
     filename = resource_filename(Requirement.parse("MyProject"),"sample.conf")


### PR DESCRIPTION
There is another suggestion for how to solve this at #956.

Here I'm using the [Sphinx autosectionlabel extension](http://www.sphinx-doc.org/en/stable/ext/autosectionlabel.html) as suggested in [this answer on Stack Overflow](http://stackoverflow.com/a/40225340/2748899).
I like this approach better than the one in #956, but it does lead to some warnings during doc build about duplicate headings, because every section heading has to be unique if you want to link to it. What would be best is if there was a version of ``sphinx.ext.autosectionlabel`` that concatenates the document and section heading to form a unique heading, but that doesn't seem to exist... Any other ideas?