### PR TITLE
A local version label starts with a '+' sign

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ v34.2.0
 * #966: Add support for reading dist-info metadata and
   thus locating Distributions from zip files.
 
+* #968: Allow '+' and '!' in egg fragments
+  so that it can take package names that contain
+  PEP 440 conforming version specifiers.
+
 v34.1.1
 -------
 

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -30,7 +30,7 @@ from fnmatch import translate
 from setuptools.py26compat import strip_fragment
 from setuptools.py27compat import get_all_headers
 
-EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.+]+)$')
+EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.+!]+)$')
 HREF = re.compile("""href\\s*=\\s*['"]?([^'"> ]+)""", re.I)
 # this is here to fix emacs' cruddy broken syntax highlighting
 PYPI_MD5 = re.compile(

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -30,7 +30,7 @@ from fnmatch import translate
 from setuptools.py26compat import strip_fragment
 from setuptools.py27compat import get_all_headers
 
-EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.]+)$')
+EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.+]+)$')
 HREF = re.compile("""href\\s*=\\s*['"]?([^'"> ]+)""", re.I)
 # this is here to fix emacs' cruddy broken syntax highlighting
 PYPI_MD5 = re.compile(

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -181,6 +181,48 @@ class TestPackageIndex:
         res = setuptools.package_index.local_open(url)
         assert 'content' in res.read()
 
+    def test_egg_fragment(self):
+        """
+        EGG fragments must comply to PEP 440
+        """
+        epoch = [
+            '',
+            '1!',
+        ]
+        releases = [
+            '0',
+            '0.0',
+            '0.0.0',
+        ]
+        pre = [
+            'a0',
+            'b0',
+            'rc0',
+        ]
+        post = [
+            '.post0'
+        ]
+        dev = [
+            '.dev0',
+        ]
+        local = [
+            ('', ''),
+            ('+ubuntu.0', '+ubuntu.0'),
+            ('+ubuntu-0', '+ubuntu.0'),
+            ('+ubuntu_0', '+ubuntu.0'),
+        ]
+        versions = [
+            [''.join([e, r, p, l]) for l in ll]
+            for e in epoch
+            for r in releases
+            for p in sum([pre, post, dev], [''])
+            for ll in local]
+        for v, vc in versions:
+            dists = list(setuptools.package_index.distros_for_url(
+                'http://example.com/example.zip#egg=example-' + v))
+            assert dists[0].version == ''
+            assert dists[1].version == vc
+
 
 class TestContentCheckers:
     def test_md5(self):


### PR DESCRIPTION
 As per https://www.python.org/dev/peps/pep-0440/#local-version-identifiers:

```
Local version identifiers MUST comply with the following scheme:

<public version identifier>[+<local version label>]
```

But EGG_FRAGMENT's character set does not contain the plus sign, which seems to be a defect.