### PR TITLE
Monkeypatch distutils.filelist.findall for Python 3.4.6

### DIFF
--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -53,7 +53,7 @@ def patch_all():
     distutils.core.Command = setuptools.Command
 
     has_issue_12885 = (
-        sys.version_info < (3, 4, 6)
+        sys.version_info < (3, 4, 7)
         or
         (3, 5) < sys.version_info <= (3, 5, 3)
         or


### PR DESCRIPTION
Since the latest version of python 3.4.x series is 3.4.6 and it
does not include an fixed version of "distutils.filelist.findall",
this commit makes sure the patch is also applied.

For sake of comparison, this link highlights the "still broken"
implementation associated with v3.4.6:

  https://github.com/python/cpython/blob/v3.4.6/Lib/distutils/filelist.py#L245-L273

And this link highlights the correct version found in Python 3.5.3:

  https://github.com/python/cpython/blob/v3.5.3/Lib/distutils/filelist.py#L245-L273

Finally, simply using ``sys.version_info <= (3, 4, 6)`` would not work because
``sys.version_info`` returns a tuple like ``(3, 4, 6, 'final', 0)`` which is in
fact greater than the other one:

```
>>> (3, 4, 6, 'final', 0) <= (3, 4, 6)
False

>>> (3, 4, 6, 'final', 0) <= (3, 4, 7)
True

>>> (3, 4, 6, 'final', 0) <= (3, 4, 6)
False

>>> (3, 4, 6) <= (3, 4, 6, 'final', 0)
True

>>> (3, 4, 6) < (3, 4, 6, 'final', 0)
True

```

It may be reasonable to revisit the monkey patch check to use
``sys.version_info[:3]`` instead.