### PR TITLE
Allow ResourceManager functions to use module types

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -424,11 +424,14 @@ def get_provider(moduleOrReq):
     """Return an IResourceProvider for the named module or requirement"""
     if isinstance(moduleOrReq, Requirement):
         return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
-    try:
-        module = sys.modules[moduleOrReq]
-    except KeyError:
-        __import__(moduleOrReq)
-        module = sys.modules[moduleOrReq]
+    elif isinstance(moduleOrReq, types.ModuleType):
+        module = moduleOrReq
+    else:
+        try:
+            module = sys.modules[moduleOrReq]
+        except KeyError:
+            __import__(moduleOrReq)
+            module = sys.modules[moduleOrReq]
     loader = getattr(module, '__loader__', None)
     return _find_adapter(_provider_factories, loader)(module)
 


### PR DESCRIPTION
Currently in the `pkg_resources.ResourceManager` class, you must use a `str` type value in the `package_or_requirement` method argument. This change modifies the `get_provider` function to allow the use of `module` type objects. This means  the `ResourceManager` methods may be used by passing in imported modules.


**Before**:
```python
import pkg_resources
import my_package.my_module as my_mod

# Use the module path
pkg_resources.resource_string('my_package.my_module', 'filename.ext')
pkg_resources.resource_listdir('my_package.my_module', 'directory')
pkg_resources.resource_exists('my_package.my_module', 'filename.ext')

# Alternatively, use imported the module __name__
pkg_resources.resource_filename(my_mod.__name__, 'filename.ext')
pkg_resources.resource_isdir(my_mod.__name__, 'directory'))
```
 
**After**:
```python
import pkg_resources
import my_package.my_module as my_mod

pkg_resources.resource_string(my_mod, 'filename.ext')
pkg_resources.resource_listdir(my_mod, 'directory')
pkg_resources.resource_exists(my_mod, 'filename.ext')
pkg_resources.resource_filename(my_mod, 'filename.ext')
pkg_resources.resource_isdir(my_mod, 'directory'))
```