### PR TITLE
Force vtags, version to str to avoid concat error

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -261,7 +261,7 @@ class egg_info(Command):
         # in which case the version string already contains all tags.
         if self.vtags and version.endswith(self.vtags):
             return safe_version(version)
-        return safe_version(version + self.vtags)
+        return safe_version(str(version) + str(self.vtags))
 
     def run(self):
         self.mkpath(self.egg_info)


### PR DESCRIPTION
The following errors occurs when attempting to use `pip` for Python 3 to install `mercurial`.

```
~/Development/Expenses(master) » pip install mercurial                                                                                          sean@helium
Collecting mercurial
  Using cached mercurial-4.1.tar.gz
    Complete output from command python setup.py egg_info:
    running egg_info
    /usr/local/lib/python3.6/site-packages/setuptools/dist.py:341: UserWarning: The version specified (b'4.1') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
      "details." % self.metadata.version
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/cd/54v7z59x65g2_sltvqngmlbw0000gn/T/pip-build-tf87ry22/mercurial/setup.py", line 758, in <module>
        **extra)
      File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 955, in run_commands
        self.run_command(cmd)
      File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 973, in run_command
        cmd_obj.ensure_finalized()
      File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 107, in ensure_finalized
        self.finalize_options()
      File "/usr/local/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 174, in finalize_options
        self.egg_version = self.tagged_version()
      File "/usr/local/lib/python3.6/site-packages/setuptools/command/egg_info.py", line 264, in tagged_version
        return safe_version(version + self.vtags)
    TypeError: can't concat bytes to str

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/cd/54v7z59x65g2_sltvqngmlbw0000gn/T/pip-build-tf87ry22/mercurial/
```

Forcing vtags and version to str allows them to be concatenated without error. The attempted build of the `mercurial` wheel still fails, yet the module is importable and usable, so this change is beneficial.

```
~/Development/Expenses(master) » pip install mercurial                                                                                           sean@helium
Collecting mercurial
  Using cached mercurial-4.1.tar.gz
Building wheels for collected packages: mercurial
  Running setup.py bdist_wheel for mercurial ... error
  Complete output from command /usr/local/opt/python3/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/private/var/folders/cd/54v7z59x65g2_sltvqngmlbw0000gn/T/pip-build-09xrekoh/mercurial/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /var/folders/cd/54v7z59x65g2_sltvqngmlbw0000gn/T/tmp8qafdt_4pip-wheel- --python-tag cp36:
  /usr/local/lib/python3.6/site-packages/setuptools/dist.py:341: UserWarning: The version specified (b'4.1') is an invalid version, this may not work as expected with newer versions of setuptools, pip, and PyPI. Please see PEP 440 for more details.
    "details." % self.metadata.version
  running bdist_wheel
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/private/var/folders/cd/54v7z59x65g2_sltvqngmlbw0000gn/T/pip-build-09xrekoh/mercurial/setup.py", line 758, in <module>
      **extra)
    File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 955, in run_commands
      self.run_command(cmd)
    File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/dist.py", line 973, in run_command
      cmd_obj.ensure_finalized()
    File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/cmd.py", line 107, in ensure_finalized
      self.finalize_options()
    File "/usr/local/lib/python3.6/site-packages/wheel/bdist_wheel.py", line 108, in finalize_options
      self.data_dir = self.wheel_dist_name + '.data'
    File "/usr/local/lib/python3.6/site-packages/wheel/bdist_wheel.py", line 131, in wheel_dist_name
      safer_version(self.distribution.get_version())))
    File "/usr/local/lib/python3.6/site-packages/wheel/bdist_wheel.py", line 47, in safer_version
      return safe_version(version).replace('-', '_')
    File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1382, in safe_version
      return str(packaging.version.Version(version))
    File "/usr/local/lib/python3.6/site-packages/pkg_resources/_vendor/packaging/version.py", line 200, in __init__
      match = self._regex.search(version)
  TypeError: cannot use a string pattern on a bytes-like object

  ----------------------------------------
  Failed building wheel for mercurial
  Running setup.py clean for mercurial
Failed to build mercurial
Installing collected packages: mercurial
  Running setup.py install for mercurial ... done
Successfully installed mercurial-b-4.1-
```

Thank you!