### PR TITLE
Feature/bundle build deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@ setuptools.egg-info
 *.swp
 *~
 .hg*
-requirements.txt
+build-deps.zip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v34.3.0
+-------
+
+* #980: Re-enable building of setuptools from source by
+  bundling its build dependencies.
+
 v34.2.0
 -------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ include launcher.c
 include msvc-build-launcher.cmd
 include pytest.ini
 include tox.ini
+include build-deps.zip

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -89,16 +89,20 @@ def install_deps():
         shutil.rmtree(tmpdir)
 
 
-def main():
-    ensure_egg_info()
+def bundle_deps():
+    """
+    Generate 'build-deps.zip'
+    """
     gen_deps()
-    try:
-        # first assume dependencies are present
-        run_egg_info()
-    except Exception:
-        # but if that fails, try again with dependencies just in time
-        with install_deps():
-            run_egg_info()
+    with install_deps() as dir:
+        shutil.make_archive('build-deps', 'zip', dir)
+    os.remove('requirements.txt')
+
+
+def main():
+    bundle_deps()
+    ensure_egg_info()
+    run_egg_info()
 
 
 __name__ == '__main__' and main()

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -89,6 +89,21 @@ def install_deps():
         shutil.rmtree(tmpdir)
 
 
+def py26_make_archive(filename, type, source_root):
+    "quick and dirty backport of shutil.make_archive"
+    import zipfile
+    assert type == 'zip'
+    filename += '.' + type
+    zip_file = zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED)
+    for root, dirs, files in os.walk(source_root):
+        for file in files:
+            target = os.path.join(root, file)
+            rel_target = os.path.relpath(target, os.path.join(source_root))
+            zip_file.write(target, rel_target)
+
+vars(shutil).setdefault('make_archive', py26_make_archive)
+
+
 def bundle_deps():
     """
     Generate 'build-deps.zip'

--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,10 @@ import os
 import sys
 import textwrap
 
-import setuptools
-
 here = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(os.path.join(here, 'build-deps.zip')))
+
+import setuptools
 
 
 def require_metadata():

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [testenv]
 deps=
     -rtests/requirements.txt
-    -rrequirements.txt
 passenv=APPDATA USERPROFILE HOMEDRIVE HOMEPATH windir APPVEYOR
 commands=py.test {posargs:-rsx}
 usedevelop=True


### PR DESCRIPTION
In an attempt to relieve the pressure for setuptools to once again vendor its dependencies, I'm attempting another technique in which setuptools bundles its dependencies for the purposes of building, but continues to rely on its declared dependencies for installation.

As I noted in #980, this change won't affect the most common use-case, that of pip installing setuptools from source when dependencies aren't met. It fails because the setuptools shim is invoked before setuptools has a chance to inject its build dependencies.

I expect this change to be stabilizing, even though it adds a 200k zip file to the sdist. I don't expect it to alter the wheel-based install technique in any way.

I'm interested in feedback from @dstufft in particular.