### PR TITLE
Fix for auto_chmod behavior

### DIFF
--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1675,7 +1675,7 @@ def _first_line_re():
 
 
 def auto_chmod(func, arg, exc):
-    if func is os.remove and os.name == 'nt':
+    if func in [os.unlink, os.remove] and os.name == 'nt':
         chmod(arg, stat.S_IWRITE)
         return func(arg)
     et, ev, _ = sys.exc_info()


### PR DESCRIPTION
Apparently, in (at least) python 3.5.2, the function that is called on Windows to remove files is os.unlink and not os.remove. This results in permission errors when trying to clean up after easy_install has been used to install a package from a Git repository.