### PR TITLE
Fixes "AttributeError: module 'packaging' has no attribute 'specifiers'"

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -15,6 +15,7 @@ from distutils.util import rfc822_escape
 import six
 from six.moves import map
 import packaging
+import packaging.specifiers
 
 from setuptools.depends import Require
 from setuptools import windows_support


### PR DESCRIPTION
Related pypa/setuptools#967

The issue is clearly reproducible on Debian stretch with latest setuptools & virtualenv on both Python 2.7.13 and 3.5.3.
__init__.py of packaging does not explicitly export specifiers sub-module.

I'm not sure how and why it worked before. Perhaps, specifiers got loaded some other way.
However, it is not reproducible on Ubuntu Xenial or Yakkety

P.S. it's really a blind fix reproducing change I made in local virtualenv.

UPD:
I believe it's related to this change:
bpo-27419: Standard __import__() no longer look up “__import__” in
globals or builtins for importing submodules or “from import”. Fixed
handling an error of non-string package name.
https://bugs.python.org/issue27419