### PR TITLE
Fixes #999: support python_requires and py_modules in configuration files

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+v34.4.0
+-------
+
+* #999 via #1007: Extend support for declarative package
+  config in a setup.cfg file to include the options
+  ``python_requires`` and ``py_modules``.
+
 v34.3.3
 -------
 

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2425,6 +2425,7 @@ zip_safe                 bool
 setup_requires           list-semi
 install_requires         list-semi
 extras_require           section
+python_requires          str
 entry_points             file:, section
 use_2to3                 bool
 use_2to3_fixers          list-comma
@@ -2440,6 +2441,7 @@ package_dir              dict
 package_data             section
 exclude_package_data     section
 namespace_packages       list-comma
+py_modules               list-comma
 =======================  =====
 
 .. note::

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -462,6 +462,7 @@ class ConfigOptionsHandler(ConfigHandler):
             'tests_require': parse_list_semicolon,
             'packages': self._parse_packages,
             'entry_points': self._parse_file,
+            'py_modules': parse_list,
         }
 
     def _parse_packages(self, value):

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -166,7 +166,7 @@ def check_specifier(dist, attr, value):
         packaging.specifiers.SpecifierSet(value)
     except packaging.specifiers.InvalidSpecifier as error:
         tmpl = (
-            "{attr!r} must be a string or list of strings "
+            "{attr!r} must be a string "
             "containing valid version specifiers; {error}"
         )
         raise DistutilsSetupError(tmpl.format(attr=attr, error=error))
@@ -353,6 +353,8 @@ class Distribution(Distribution_parse_config_files, _Distribution):
         _Distribution.parse_config_files(self, filenames=filenames)
 
         parse_configuration(self, self.command_options)
+        if getattr(self, 'python_requires', None):
+            self.metadata.python_requires = self.python_requires
 
     def parse_command_line(self):
         """Process features after parsing command line options"""

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -312,6 +312,8 @@ class TestOptions:
             'setup_requires = docutils>=0.3; spack ==1.1, ==1.3; there\n'
             'dependency_links = http://some.com/here/1, '
                 'http://some.com/there/2\n'
+            'python_requires = >=1.0, !=2.8\n'
+            'py_modules = module1, module2\n'
         )
         with get_dist(tmpdir) as dist:
             assert dist.zip_safe
@@ -340,6 +342,8 @@ class TestOptions:
                 'there'
             ])
             assert dist.tests_require == ['mock==0.7.2', 'pytest']
+            assert dist.python_requires == '>=1.0, !=2.8'
+            assert dist.py_modules == ['module1', 'module2']
 
     def test_multiline(self, tmpdir):
         fake_env(


### PR DESCRIPTION
Changes:
- copy `self.metadata.python_requires = self.python_requires` patch to `Distribution.parse_config_files`
- add `'py_modules': parse_list` to `ConfigOptionsHandler.parsers` 
- add changes to docs and tests
- fix error message in `dist.check_specifier`

Concerning the last point: `packaging.specifiers.SpecifierSet.__init__` expects a `str` and no `list`. The fixed error is actually not thrown if a `list` is provided, since it fails on trying to call `split(",")` and thus will not throw a `packaging.specifiers.InvalidSpecifier` exception. If this case should be handled properly, it could be done here or rather in `packaging`.