### PR TITLE
addresses #436: Updating MANIFEST.in does not correctly update the package sdist creates

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -564,8 +564,6 @@ class manifest_maker(sdist):
         rcfiles = list(walk_revctrl())
         if rcfiles:
             self.filelist.extend(rcfiles)
-        elif os.path.exists(self.manifest):
-            self.read_manifest()
         ei_cmd = self.get_finalized_command('egg_info')
         self.filelist.graft(ei_cmd.egg_info)
 


### PR DESCRIPTION
The `egg_info` command reads an existing `.egg-info/SOURCES.txt` before writing the new one. Therefore state is preserved, and files once added to `SOURCES.txt` (e.g. by an include line in `MANIFEST.in`) will remain forever in `SOURCES.txt` even if there is no more reason for inclusion.

The problem described in #436  is due to the fact that `.egg-info/SOURCES.txt` is used for building the list of files in a source distribution (`sdist` command).

This PR is surgical, in the sense that solves the issue by removing 2 lines of code. However after this modification the `setuptools.command.sdist.sdist.read_manifest` method is not called anymore within `setuptools` and its removal could be considered, along with the relevant unit tests.