### PR TITLE
Tox maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ setuptools.egg-info
 *~
 .hg*
 requirements.txt
+.cache

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+# Note: Before running Tox, you need to install rwt and run
+# "rwt -- bootstrap.py" (outside of Tox) to generate the necessary files.
+
 [testenv]
 deps=
     -rtests/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,15 @@
 # Note: Before running Tox, you need to install rwt and run
 # "rwt -- bootstrap.py" (outside of Tox) to generate the necessary files.
 
+[tox]
+envlist =
+    py2{6,7}
+    py3{3,4,5,6}
+    pypy
+# Most people probably don't have all the above installed,
+# so skip unavailable ones without failing, by default.
+skip_missing_interpreters = True
+
 [testenv]
 deps=
     -rtests/requirements.txt


### PR DESCRIPTION
This adds instructions for running `rwt -- bootstrap.py` to `tox.ini`, to help new contributors get started, and extends the default Tox `envlist` to follow the Python versions being tested on Travis.