### PR TITLE
Use a different method to lookup base classes on Jython

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v35.0.2
+-------
+
+* #1024: Add workaround for Jython #2581 in monkey module.
+
 v35.0.1
 -------
 

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -21,17 +21,18 @@ if you think you need this functionality.
 """
 
 
-def get_mro(cls):
-    """Returns the bases classes for cls sorted by the MRO.
+def _get_mro(cls):
+    """
+    Returns the bases classes for cls sorted by the MRO.
 
     Works around an issue on Jython where inspect.getmro will not return all
     base classes if multiple classes share the same name. Instead, this
     function will return a tuple containing the class itself, and the contents
-    of cls.__bases__ .
+    of cls.__bases__. See https://github.com/pypa/setuptools/issues/1024.
     """
-    if platform.python_implementation() != "Jython":
-        return inspect.getmro(cls)
-    return (cls,) + cls.__bases__
+    if platform.python_implementation() == "Jython":
+        return (cls,) + cls.__bases__
+    return inspect.getmro(cls)
 
 
 def get_unpatched(item):
@@ -51,7 +52,7 @@ def get_unpatched_class(cls):
     """
     external_bases = (
         cls
-        for cls in get_mro(cls)
+        for cls in _get_mro(cls)
         if not cls.__module__.startswith('setuptools')
     )
     base = next(external_bases)

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -21,6 +21,19 @@ if you think you need this functionality.
 """
 
 
+def get_mro(cls):
+    """Returns the bases classes for cls sorted by the MRO.
+
+    Works around an issue on Jython where inspect.getmro will not return all
+    base classes if multiple classes share the same name. Instead, this
+    function will return a tuple containing the class itself, and the contents
+    of cls.__bases__ .
+    """
+    if platform.python_implementation() != "Jython":
+        return inspect.getmro(cls)
+    return (cls,) + cls.__bases__
+
+
 def get_unpatched(item):
     lookup = (
         get_unpatched_class if isinstance(item, six.class_types) else
@@ -38,7 +51,7 @@ def get_unpatched_class(cls):
     """
     external_bases = (
         cls
-        for cls in inspect.getmro(cls)
+        for cls in get_mro(cls)
         if not cls.__module__.startswith('setuptools')
     )
     base = next(external_bases)


### PR DESCRIPTION
Jython seems to implement inspect.getmro differently, which causes
any classes with the same name as a class lower in the MRO not to
be returned.

This patch offloads the MRO lookup to a separate function, which
implements different logic for Jython only.

Ref #1024