### PR TITLE
egg_info: allow specification of setup requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,6 +133,7 @@ setup_params = dict(
         "egg_info.writers": [
             "PKG-INFO = setuptools.command.egg_info:write_pkg_info",
             "requires.txt = setuptools.command.egg_info:write_requirements",
+            "setup_requires.txt = setuptools.command.egg_info:write_setup_requirements",
             "entry_points.txt = setuptools.command.egg_info:write_entries",
             "eager_resources.txt = setuptools.command.egg_info:overwrite_arg",
             "namespace_packages.txt = setuptools.command.egg_info:overwrite_arg",

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -125,6 +125,8 @@ class egg_info(Command):
         ('tag-date', 'd', "Add date stamp (e.g. 20050528) to version number"),
         ('tag-build=', 'b', "Specify explicit tag to add to version number"),
         ('no-date', 'D', "Don't include date stamp [default]"),
+        ('skip-fetch-build-eggs', 's',
+         "Skip installation of setup requirements"),
     ]
 
     boolean_options = ['tag-date']
@@ -141,6 +143,7 @@ class egg_info(Command):
         self.tag_date = 0
         self.broken_egg_info = False
         self.vtags = None
+        self.skip_fetch_build_eggs = False
 
     ####################################
     # allow the 'tag_svn_revision' to be detected and
@@ -638,7 +641,7 @@ def write_requirements(cmd, basename, filename):
 
 
 def write_setup_requirements(cmd, basename, filename):
-    data = StringIO()
+    data = six.StringIO()
     _write_requirements(data, cmd.distribution.setup_requires)
     cmd.write_or_delete_file("setup-requirements", filename, data.getvalue())
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -314,7 +314,13 @@ class Distribution(Distribution_parse_config_files, _Distribution):
         if attrs is not None:
             self.dependency_links = attrs.pop('dependency_links', [])
             assert_string_list(self, 'dependency_links', self.dependency_links)
-        if attrs and 'setup_requires' in attrs:
+        if attrs and 'script_args' in attrs:
+            script_args = attrs['script_args']
+        else:
+            script_args = []
+        if attrs and 'setup_requires' in attrs and script_args[:2] != [
+                'egg_info', '--skip-fetch-build-eggs'
+        ]:
             self.fetch_build_eggs(attrs['setup_requires'])
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
             vars(self).setdefault(ep.name, None)


### PR DESCRIPTION
So I though about the setuptools dependency on pip and really did not like that idea because is more closely couples the two. This is a simple change that will allow pip to ask for build dependencies from setuptools if possible. 

This doesn't work all of the time and doesn't cover every corner case, but it is an improvement from the current situation. 