### PR TITLE
Fix "no module named 'six'"

### DIFF
--- a/setuptools/py27compat.py
+++ b/setuptools/py27compat.py
@@ -4,7 +4,7 @@ Compatibility Support for Python 2.7 and earlier
 
 import platform
 
-import six
+from setuptools.extern import six
 
 
 def get_all_headers(message, key):


### PR DESCRIPTION
I at least think this fixes this. Submitted from my smartphone. So didn't test.

Fixes: #1042