### PR TITLE
MRG: add release candidate to release notes

### DIFF
--- a/docs/releases.txt
+++ b/docs/releases.txt
@@ -2,25 +2,71 @@
 Release Process
 ===============
 
-In order to allow for rapid, predictable releases, Setuptools uses a
-mechanical technique for releases, enacted by Travis following a
-successful build of a tagged release per
-`PyPI deployment <https://docs.travis-ci.com/user/deployment/pypi>`_.
+In order to allow for rapid, predictable release candidates and releases,
+Setuptools uses a mechanical technique for releases, enacted by Travis
+following a successful build of a tagged release per `PyPI deployment
+<https://docs.travis-ci.com/user/deployment/pypi>`_.
 
-Prior to cutting a release, please check that the CHANGES.rst reflects
-the summary of changes since the last release.
-Ideally, these changelog entries would have been added
-along with the changes, but it's always good to check.
-Think about it from the
-perspective of a user not involved with the development--what would
-that person want to know about what has changed--or from the
-perspective of your future self wanting to know when a particular
-change landed.
+Prior to cutting a release candidate, or release, please check that the
+CHANGES.rst reflects the summary of changes since the last release.
 
-To cut a release, install and run ``bump2version {part}`` where ``part``
-is major, minor, or patch based on the scope of the changes in the
-release. Then, push the commits to the master branch. If tests pass,
-the release will be uploaded to PyPI (from the Python 3.6 tests).
+Ideally, these changelog entries would have been added along with the changes,
+but it's always good to check.  Think about it from the perspective of a user
+not involved with the development--what would that person want to know about
+what has changed--or from the perspective of your future self wanting to know
+when a particular change landed.
+
+To do the release, first cut a release candidate, then cut the final release.
+
+For both release candidate and release, you will need `Bump2version
+<https://pypi.python.org/pypi/bump2version>`_ (``pip install bump2version``).
+
+Before making the release candidate, decide whether this is going to be a
+major, minor or patch release, based on the scope of the changes in the
+release.
+
+Release candidate
+-----------------
+
+Run ``bump2version {part}`` where ``part`` is "major", "minor", or "patch"
+from the release type you decided above::
+
+    bump2version patch
+
+Bump2version will:
+
+* update the package version in ``setup.cfg`` and in ``setup.py``, appending
+  ``rc1`` for the release candidate;
+* commit this version change to version control (Git in our case);
+* make a tag with the version number prepended by "v", e.g. ``v36.0.2rc1``.
+
+Then, push the commits and the tag to the master branch, e.g::
+
+    git push origin master
+    git push origin v36.0.2rc1
+
+If tests pass, the release candidate will be uploaded to PyPI (from the Python
+3.6 tests).
+
+Send an email to `distutils-sig <https://mail.python.org/mailman/listinfo/distutils-sig>`_ announcing the release candidate, with the changes relative to the last version, asking for testing via::
+
+    pip install --pre setuptools
+
+Release proper
+--------------
+
+If no issues arose from the release candidate above, release the code removing
+the "rc1" suffix with::
+
+    bump2version release
+
+This removes the ``rc1`` suffix from the version number, makes the commit, and
+makes the tag.
+
+Then, push the commits and the tag to the master branch, e.g::
+
+    git push origin master
+    git push origin v36.0.2
 
 Release Frequency
 -----------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,16 @@
 current_version = 36.0.1
 commit = True
 tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>rc1))?
+serialize = 
+	{major}.{minor}.{patch}{release}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:release]
+optional_value = placeholder
+values = 
+	rc1
+	placeholder
 
 [egg_info]
 tag_build = .post


### PR DESCRIPTION
Expand release instructions somewhat, and add release candidate step.

Adapt bump2version's own setup to go to release candidate first, before release.

See #1045 for discussion.