### PR TITLE
Set license to MIT in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ setup_params = dict(
         "Python packages",
     author="Python Packaging Authority",
     author_email="distutils-sig@python.org",
+    license="MIT",
     long_description=long_description,
     keywords="CPAN PyPI distutils eggs package management",
     url="https://github.com/pypa/setuptools",


### PR DESCRIPTION
Currently, `pip show setuptools` shows license field as "UNKNOWN", this PR fixes that.