### PR TITLE
Rename [wheel] section to [bdist_wheel] as the former is legacy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,7 @@ repository = https://upload.pypi.org/legacy/
 [sdist]
 formats = zip
 
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [bumpversion:file:setup.py]
-


### PR DESCRIPTION
See:

https://bitbucket.org/pypa/wheel/src/54ddbcc9cec25e1f4d111a142b8bfaa163130a61/wheel/bdist_wheel.py?fileviewer=file-view-default#bdist_wheel.py-119:125

http://pythonwheels.com/