### PR TITLE
remove version from develop scripts

### DIFF
--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -173,6 +173,8 @@ class develop(namespaces.DevelopInstaller, easy_install):
             return easy_install.install_egg_scripts(self, dist)
 
         # create wrapper scripts in the script dir, pointing to dist.scripts
+        # without pinning to the current version
+        dist = VersionlessRequirement(dist)
 
         # new-style...
         self.install_wrapper_scripts(dist)
@@ -184,10 +186,6 @@ class develop(namespaces.DevelopInstaller, easy_install):
             with io.open(script_path) as strm:
                 script_text = strm.read()
             self.install_script(dist, script_name, script_text, script_path)
-
-    def install_wrapper_scripts(self, dist):
-        dist = VersionlessRequirement(dist)
-        return easy_install.install_wrapper_scripts(self, dist)
 
 
 class VersionlessRequirement(object):

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -108,6 +108,7 @@ class TestDevelop:
         Test that console scripts are installed and that they reference
         only the project by name and not the current version.
         """
+        dest = str(test_env)
         settings = dict(
             name='foo',
             packages=['foo'],
@@ -123,15 +124,15 @@ class TestDevelop:
         cmd = develop(dist)
         cmd.user = 1
         cmd.ensure_finalized()
-        cmd.install_dir = test_env
-        cmd.script_dir = test_env
+        cmd.install_dir = dest
+        cmd.script_dir = dest
         cmd.user = 1
         cmd.run()
 
-        content = os.listdir(test_env)
+        content = os.listdir(dest)
         content.sort()
         assert content == ['foo', 'foo.egg-info', 'foocmd', 'setup.py']
-        fn = os.path.join(test_env, 'foocmd')
+        fn = os.path.join(dest, 'foocmd')
         with io.open(fn) as foocmd_file:
             foocmd_text = foocmd_file.read().strip()
 
@@ -142,6 +143,7 @@ class TestDevelop:
         Test that old-style scripts are installed and that they reference
         only the project by name and not the current version.
         """
+        dest = str(test_env)
         settings = dict(
             name='foo',
             packages=['foo'],
@@ -153,15 +155,15 @@ class TestDevelop:
         cmd = develop(dist)
         cmd.user = 1
         cmd.ensure_finalized()
-        cmd.install_dir = test_env
-        cmd.script_dir = test_env
+        cmd.install_dir = dest
+        cmd.script_dir = dest
         cmd.user = 1
         cmd.run()
 
-        content = os.listdir(test_env)
+        content = os.listdir(dest)
         content.sort()
         assert content == ['foo', 'foo.egg-info', 'foocmd', 'setup.py']
-        fn = os.path.join(test_env, 'foocmd')
+        fn = os.path.join(dest, 'foocmd')
         with io.open(fn) as foocmd_file:
             foocmd_text = foocmd_file.read().strip()
 


### PR DESCRIPTION
This extends https://github.com/pypa/setuptools/issues/439 to remove the specific version for scripts generated by `python setup.py develop` from projects using `scripts` instead of `entrypoints.console_scripts`.