### PR TITLE
make `minimal_egg_info` string in `bootstrap.py` unicode

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -12,7 +12,7 @@ import subprocess
 import io
 
 
-minimal_egg_info = textwrap.dedent("""
+minimal_egg_info = textwrap.dedent(u"""
     [distutils.commands]
     egg_info = setuptools.command.egg_info:egg_info
 


### PR DESCRIPTION
I believe this is likely to be safe in general, but have only tested with 2.7 on OS X.

Without this change, I am seeing error:

```
$ git clone git@github.com:pypa/setuptools
Cloning into 'setuptools'...
remote: Counting objects: 24321, done.
remote: Compressing objects: 100% (23/23), done.
remote: Total 24321 (delta 11), reused 20 (delta 7), pack-reused 24291
Receiving objects: 100% (24321/24321), 28.77 MiB | 7.38 MiB/s, done.
Resolving deltas: 100% (8669/8669), done.
$ cd setuptools
$ git rev-parse HEAD
995d309317c6895a123c03df28bc8f51f6ead5f5
$ python bootstrap.py
adding minimal entry_points
Traceback (most recent call last):
  File "bootstrap.py", line 63, in <module>
    __name__ == '__main__' and main()
  File "bootstrap.py", line 59, in main
    ensure_egg_info()
  File "bootstrap.py", line 37, in ensure_egg_info
    build_egg_info()
  File "bootstrap.py", line 47, in build_egg_info
    ep.write(minimal_egg_info)
TypeError: must be unicode, not str
```