### PR TITLE
Sort file lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v36.4.0
+-------
+
+* #1068: Sort files and directories when building eggs for
+  deterministic order.
+
 v36.2.7
 -------
 


### PR DESCRIPTION
to generate reproducible zip files
that do not differ depending on (random) filesystem order

See https://reproducible-builds.org/ for why this matters.