### PR TITLE
Tests releated fixes and tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ python:
 matrix:
   include:
   - python: 3.6
-    env: LC_ALL=C LC_CTYPE=C
+    env: LANG=C
   - python: 2.7
-    env: LC_ALL=C LC_CTYPE=C
+    env: LANG=C
 script:
  # need tox to get started
  - pip install tox

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts=--doctest-modules --ignore release.py --ignore setuptools/lib2to3_ex.py --ignore tests/manual_test.py --ignore tests/test_pypi.py --ignore tests/shlib_test --doctest-glob=pkg_resources/api_tests.txt --ignore scripts/upload-old-releases-as-zip.py --ignore pavement.py --ignore setuptools/tests/mod_with_constant.py
+addopts=--doctest-modules --ignore release.py --ignore setuptools/lib2to3_ex.py --ignore tests/manual_test.py --ignore tests/test_pypi.py --ignore tests/shlib_test --doctest-glob=pkg_resources/api_tests.txt --ignore scripts/upload-old-releases-as-zip.py --ignore pavement.py --ignore setuptools/tests/mod_with_constant.py -rsxX
 norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern .*
 flake8-ignore =
     setuptools/site-patch.py F821

--- a/setuptools/tests/__init__.py
+++ b/setuptools/tests/__init__.py
@@ -1,4 +1,5 @@
 """Tests for the 'setuptools' package"""
+import locale
 import sys
 import os
 import distutils.core
@@ -16,8 +17,7 @@ import setuptools.depends as dep
 from setuptools import Feature
 from setuptools.depends import Require
 
-c_type = os.environ.get("LC_CTYPE", os.environ.get("LC_ALL"))
-is_ascii = c_type in ("C", "POSIX")
+is_ascii = locale.getpreferredencoding() == 'ANSI_X3.4-1968'
 fail_on_ascii = pytest.mark.xfail(is_ascii, reason="Test fails in this locale")
 
 

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -30,6 +30,7 @@ from setuptools.dist import Distribution
 from pkg_resources import normalize_path, working_set
 from pkg_resources import Distribution as PRDistribution
 import setuptools.tests.server
+from setuptools.tests import fail_on_ascii
 import pkg_resources
 
 from .py26compat import tarfile_open
@@ -166,6 +167,7 @@ class TestEasyInstallTest:
         sdist_zip.close()
         return str(sdist)
 
+    @fail_on_ascii
     def test_unicode_filename_in_sdist(self, sdist_unicode, tmpdir, monkeypatch):
         """
         The install command should execute correctly even if

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@
 [testenv]
 deps=-rtests/requirements.txt
 passenv=APPDATA USERPROFILE HOMEDRIVE HOMEPATH windir APPVEYOR
-commands=py.test {posargs:-rsxX}
+commands=py.test {posargs}
 usedevelop=True

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@
 [testenv]
 deps=-rtests/requirements.txt
 passenv=APPDATA USERPROFILE HOMEDRIVE HOMEPATH windir APPVEYOR
-commands=py.test {posargs:-rsx}
+commands=py.test {posargs:-rsxX}
 usedevelop=True


### PR DESCRIPTION
* move pytest report arguments to `pytest.ini`, so running tox with arguments does not loose those
* add xpassed tests to the pytest report
* fix `fail_on_ascii` fixture: correct detection
* mark `test_unicode_filename_in_sdist` with `fail_on_ascii`
* fix Travis ASCII builds: as evidenced by the log, all tests marked with `fail_on_ascii` were not xfailed

~~Note: first commit is a fix for the same issue as #1063, so I'll rebase once this is merged.~~