### PR TITLE
when trying to create a folder gracefully fall back when it already exists

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -12,7 +12,7 @@ import subprocess
 import io
 
 
-minimal_egg_info = textwrap.dedent("""
+minimal_egg_info = textwrap.dedent(u"""
     [distutils.commands]
     egg_info = setuptools.command.egg_info:egg_info
 

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -17,6 +17,7 @@ method.
 
 from __future__ import absolute_import
 
+import errno
 import sys
 import os
 import io
@@ -2958,8 +2959,11 @@ def _find_adapter(registry, ob):
 def ensure_directory(path):
     """Ensure that the parent directory of `path` exists"""
     dirname = os.path.dirname(path)
-    if not os.path.isdir(dirname):
+    try:
         os.makedirs(dirname)
+    except OSError as e:
+        if e.errno != errno.EEXIST:
+            raise
 
 
 def _bypass_ensure_directory(path):


### PR DESCRIPTION
When installing multiple packages into the same location in parallel each packages installation step tries to create the same directories (e.g. the `bin` folder). Currently the `isdir` and `makedirs` call are performed sequentially which makes this logic vulnerable to a race condition. The `isdir` call will return `False` but the following `makedirs` call will fail since the directory has been created in the meantime by another package being installed in parallel.

This patch changes the logic to use the Pythonic approach to try to create the directory and in case it already exists ignore the exception.