### PR TITLE
fix possible error when finalizing `install_requires`

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -369,11 +369,12 @@ class Distribution(Distribution_parse_config_files, _Distribution):
         Move requirements in `install_requires` that
         are using environment markers to `extras_require`.
         """
-        if not self.install_requires:
+        if not getattr(self, 'install_requires', None):
             return
+        extras_require = getattr(self, 'extras_require', None)
         extras_require = defaultdict(list, (
             (k, list(pkg_resources.parse_requirements(v)))
-            for k, v in (self.extras_require or {}).items()
+            for k, v in (extras_require or {}).items()
         ))
         install_requires = []
         for r in pkg_resources.parse_requirements(self.install_requires):


### PR DESCRIPTION
I assumed `install_requires` would always be defined, I guess I was wrong... One of my AppVeyor builds [failed](https://ci.appveyor.com/project/benoit-pierre/setuptools/build/1.0.32/job/hpwal39jn8f5e23q#L65), and this PR builds will fail too, now that 36.2.0 has been released.