### PR TITLE
Fix extras require handling

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -369,11 +369,12 @@ class Distribution(Distribution_parse_config_files, _Distribution):
         Move requirements in `install_requires` that
         are using environment markers to `extras_require`.
         """
-        if not self.install_requires:
+        if not getattr(self, 'install_requires', None):
             return
+        extras_require = getattr(self, 'extras_require', None)
         extras_require = defaultdict(list, (
             (k, list(pkg_resources.parse_requirements(v)))
-            for k, v in (self.extras_require or {}).items()
+            for k, v in (extras_require or {}).items()
         ))
         install_requires = []
         for r in pkg_resources.parse_requirements(self.install_requires):

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -9,7 +9,6 @@ import distutils.core
 import distutils.cmd
 import distutils.dist
 import itertools
-import operator
 from collections import defaultdict
 from distutils.errors import (
     DistutilsOptionError, DistutilsPlatformError, DistutilsSetupError,
@@ -17,7 +16,7 @@ from distutils.errors import (
 from distutils.util import rfc822_escape
 
 from setuptools.extern import six
-from setuptools.extern.six.moves import map, filter
+from setuptools.extern.six.moves import map
 from pkg_resources.extern import packaging
 
 from setuptools.depends import Require
@@ -133,30 +132,18 @@ def check_nsp(dist, attr, value):
 def check_extras(dist, attr, value):
     """Verify that extras_require mapping is valid"""
     try:
-        list(itertools.starmap(_check_extra, value.items()))
+        for k, v in value.items():
+            if ':' in k:
+                k, m = k.split(':', 1)
+                if pkg_resources.invalid_marker(m):
+                    raise DistutilsSetupError("Invalid environment marker: " + m)
+            list(pkg_resources.parse_requirements(v))
     except (TypeError, ValueError, AttributeError):
         raise DistutilsSetupError(
             "'extras_require' must be a dictionary whose values are "
             "strings or lists of strings containing valid project/version "
             "requirement specifiers."
         )
-
-
-def _check_extra(extra, reqs):
-    name, sep, marker = extra.partition(':')
-    if marker and pkg_resources.invalid_marker(marker):
-        raise DistutilsSetupError("Invalid environment marker: " + marker)
-
-    # extras requirements cannot themselves have markers
-    parsed = pkg_resources.parse_requirements(reqs)
-    marked_reqs = filter(operator.attrgetter('marker'), parsed)
-    bad_req = next(marked_reqs, None)
-    if bad_req:
-        tmpl = (
-            "'extras_require' requirements cannot include "
-            "environment markers, in {name!r}: '{bad_req!s}'"
-        )
-        raise DistutilsSetupError(tmpl.format(**locals()))
 
 
 def assert_bool(dist, attr, value):
@@ -366,18 +353,29 @@ class Distribution(Distribution_parse_config_files, _Distribution):
 
     def _finalize_requires(self):
         """
-        Move requirements in `install_requires` that
-        are using environment markers to `extras_require`.
+        Fix environment markers in `install_requires` and `extras_require`.
+
+        - move requirements in `install_requires` that are using environment
+          markers to `extras_require`.
+        - convert requirements in `extras_require` of the form
+          `"extra": ["barbazquux; {marker}"]` to
+          `"extra:{marker}": ["barbazquux"]`.
         """
-        if not getattr(self, 'install_requires', None):
-            return
-        extras_require = getattr(self, 'extras_require', None)
-        extras_require = defaultdict(list, (
-            (k, list(pkg_resources.parse_requirements(v)))
-            for k, v in (extras_require or {}).items()
-        ))
+        extras_require = defaultdict(list)
+        for k, v in (
+            getattr(self, 'extras_require', None) or {}
+        ).items():
+            for r in pkg_resources.parse_requirements(v):
+                marker = r.marker
+                if marker:
+                    r.marker = None
+                    extras_require[k + ':' + str(marker)].append(r)
+                else:
+                    extras_require[k].append(r)
         install_requires = []
-        for r in pkg_resources.parse_requirements(self.install_requires):
+        for r in pkg_resources.parse_requirements(
+            getattr(self, 'install_requires', None) or ()
+        ):
             marker = r.marker
             if not marker:
                 install_requires.append(r)

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -182,6 +182,11 @@ class TestEggInfo(object):
     mismatch_marker = "python_version<'{this_ver}'".format(
         this_ver=sys.version_info[0],
     )
+    # Alternate equivalent syntax.
+    mismatch_marker_alternate = 'python_version < "{this_ver}"'.format(
+        this_ver=sys.version_info[0],
+    )
+    invalid_marker = "<=>++"
 
     def test_install_requires_with_markers(self, tmpdir_cwd, env):
         tmpl = 'install_requires=["barbazquux;{marker}"],'
@@ -193,9 +198,9 @@ class TestEggInfo(object):
         with open(requires_txt) as fp:
             install_requires = fp.read()
         expected_requires = DALS('''
-             [:python_version < "{sys.version_info[0]}"]
+             [:{marker}]
              barbazquux
-             ''').format(sys=sys)
+             ''').format(marker=self.mismatch_marker_alternate)
         assert install_requires.lstrip() == expected_requires
         assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
@@ -214,19 +219,53 @@ class TestEggInfo(object):
             tmpdir_cwd, env, cmd=['test'], output="Ran 0 tests in")
         assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
-    def test_extras_require_with_markers(self, tmpdir_cwd, env):
+    def test_extras_require_with_marker(self, tmpdir_cwd, env):
         tmpl = 'extras_require={{":{marker}": ["barbazquux"]}},'
         req = tmpl.format(marker=self.mismatch_marker)
         self._setup_script_with_requires(req)
         self._run_install_command(tmpdir_cwd, env)
+        egg_info_dir = self._find_egg_info_files(env.paths['lib']).base
+        requires_txt = os.path.join(egg_info_dir, 'requires.txt')
+        with open(requires_txt) as fp:
+            install_requires = fp.read()
+        expected_requires = DALS('''
+             [:{marker}]
+             barbazquux
+             ''').format(marker=self.mismatch_marker)
+        assert install_requires.lstrip() == expected_requires
         assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
-    def test_extras_require_with_markers_in_req(self, tmpdir_cwd, env):
+    def test_extras_require_with_marker_in_req(self, tmpdir_cwd, env):
         tmpl = 'extras_require={{"extra": ["barbazquux; {marker}"]}},'
         req = tmpl.format(marker=self.mismatch_marker)
         self._setup_script_with_requires(req)
+        self._run_install_command(tmpdir_cwd, env)
+        egg_info_dir = self._find_egg_info_files(env.paths['lib']).base
+        requires_txt = os.path.join(egg_info_dir, 'requires.txt')
+        with open(requires_txt) as fp:
+            install_requires = fp.read()
+        expected_requires = DALS('''
+             [extra:{marker}]
+             barbazquux
+             ''').format(marker=self.mismatch_marker_alternate)
+        assert install_requires.lstrip() == expected_requires
+        assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
+
+    def test_extras_require_with_invalid_marker(self, tmpdir_cwd, env):
+        tmpl = 'extras_require={{":{marker}": ["barbazquux"]}},'
+        req = tmpl.format(marker=self.invalid_marker)
+        self._setup_script_with_requires(req)
         with pytest.raises(AssertionError):
             self._run_install_command(tmpdir_cwd, env)
+        assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
+
+    def test_extras_require_with_invalid_marker_in_req(self, tmpdir_cwd, env):
+        tmpl = 'extras_require={{"extra": ["barbazquux; {marker}"]}},'
+        req = tmpl.format(marker=self.invalid_marker)
+        self._setup_script_with_requires(req)
+        with pytest.raises(AssertionError):
+            self._run_install_command(tmpdir_cwd, env)
+        assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
     def test_python_requires_egg_info(self, tmpdir_cwd, env):
         self._setup_script_with_requires(


### PR DESCRIPTION
Rework handling to not error out but automatically convert internally:
```python
extras_require={ 
   'notebook': ["enum34==1.1.6; python_version < '3.4'"]
}
```
to the equivalent of
```python
extras_require={ 
   'notebook: python_version < "3.4"': ['enum34==1.1.6']
}
```
(a syntax I did not know was possible as it's not documented). Fix #1087.

Note:
* include the fix from #1085 
* tested with a patched tox env so the tests can run:
```diff
diff --git a/tests/requirements.txt b/tests/requirements.txt
index 6e2e78e2..2a8e6767 100644
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,3 +2,4 @@ pytest-flake8
 pytest>=3.0.2
 # pinned to 1.2 as temporary workaround for #1038
 backports.unittest_mock>=1.2,<1.3
+setuptools==35.0.0
```