### PR TITLE
fix CI builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,5 +16,6 @@ build: off
 
 test_script:
   - "python bootstrap.py"
+  - "python -m pip install --upgrade virtualenv"
   - "python -m pip install tox"
   - "tox"

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@
 # export TOXENV='py2{6,7},py3{3,4,5,6},pypy'
 
 [testenv]
+setenv =
+	VIRTUALENV_DOWNLOAD=0
 deps=-rtests/requirements.txt
 passenv=APPDATA USERPROFILE HOMEDRIVE HOMEPATH windir APPVEYOR
 commands=py.test {posargs}


### PR DESCRIPTION
Patch tox environment to prevent virtualenv from updating pip/setuptools/wheel and instead use the versions available per default on AppVeyor/Travis.