### PR TITLE
update Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ jobs:
   - python: &latest_py3 3.6
   - python: nightly
   - python: pypy
+  - python: pypy3
   - python: *latest_py3
     env: LANG=C
   - python: *latest_py2


### PR DESCRIPTION
Update to the [future defaults](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming):
* `dist: trusty`
* `sudo: required`

Note:
* include #1090 
* the version of PyPy now being tested is `pypy-5.4`: `PyPy 5.4.0 [Python 2.7.10]` (previously: `PyPy 2.5.0 [Python 2.7.8]`)
* `pypy3-5.4` is also available, should it be added to the matrix?