### PR TITLE
Remove a same-variable-name class hierarchy

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2943,10 +2943,10 @@ def _get_mro(cls):
     """Get an mro for a type or classic class"""
     if not isinstance(cls, type):
 
-        class cls(cls, object):
+        class new_cls(cls, object):
             pass
 
-        return cls.__mro__[1:]
+        return new_cls.__mro__[1:]
     return cls.__mro__
 
 


### PR DESCRIPTION
pypa/pip#4545 is an attempt to add mypy type-checking to pip. In that PR, the vendored version of `pkg_resources` is patched (with this same change) since it is needed for `mypy` to run on the codebase.

This patch is really a workaround for mypy's crashing behaviour; as can be seen in https://travis-ci.org/pypa/pip/jobs/243330633#L120.

It would be nice if pip's vendoring task wouldn't have to do such a thing, given the triviality of this change.

@jaraco Thoughts?