### PR TITLE
tests: disable pytest-flake8 on Python 2.6

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 importlib; python_version<"2.7"
 mock
-pytest-flake8
+pytest-flake8; python_version>="2.7"
 pytest-virtualenv>=1.2.7
 pytest>=3.0.2


### PR DESCRIPTION
Python 2.6 support has been official dropped from flake8 for some time, and broken since 3.4.0.