### PR TITLE
Fix exception on mingw built Python 2

### DIFF
--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -4,6 +4,7 @@ Monkey patching of distutils.
 
 import sys
 import distutils.filelist
+from distutils.util import get_platform
 import platform
 import types
 import functools
@@ -152,12 +153,12 @@ def patch_for_msvc_specialized_compiler():
     Patch functions in distutils to use standalone Microsoft Visual C++
     compilers.
     """
-    # import late to avoid circular imports on Python < 3.5
-    msvc = import_module('setuptools.msvc')
-
-    if platform.system() != 'Windows':
+    if not get_platform().startswith('win'):
         # Compilers only availables on Microsoft Windows
         return
+
+    # import late to avoid circular imports on Python < 3.5
+    msvc = import_module('setuptools.msvc')
 
     def patch_params(mod_name, func_name):
         """

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -4,7 +4,6 @@ Monkey patching of distutils.
 
 import sys
 import distutils.filelist
-from distutils.util import get_platform
 import platform
 import types
 import functools
@@ -153,12 +152,12 @@ def patch_for_msvc_specialized_compiler():
     Patch functions in distutils to use standalone Microsoft Visual C++
     compilers.
     """
-    if not get_platform().startswith('win'):
-        # Compilers only availables on Microsoft Windows
-        return
-
     # import late to avoid circular imports on Python < 3.5
     msvc = import_module('setuptools.msvc')
+
+    if platform.system() != 'Windows':
+        # Compilers only availables on Microsoft Windows
+        return
 
     def patch_params(mod_name, func_name):
         """

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -47,7 +47,7 @@ else:
 
 try:
     from distutils.msvc9compiler import Reg
-except ImportError:
+except (ImportError, distutils.errors.DistutilsPlatformError):
     pass
 
 

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -45,9 +45,18 @@ else:
 
     safe_env = dict()
 
+_msvc9_suppress_errors = (
+    # msvc9compiler isn't available on some platforms
+    ImportError,
+    
+    # msvc9compiler raises DistutilsPlatformError in some
+    # environments. See #1118.
+    distutils.errors.DistutilsPlatformError,
+)
+
 try:
     from distutils.msvc9compiler import Reg
-except (ImportError, distutils.errors.DistutilsPlatformError):
+except _msvc9_suppress_errors:
     pass
 
 


### PR DESCRIPTION
The exception is caused by the VCForPython27 monkey patch. It's not needed on mingw built Python. Disable it and avoid the import by using the same function that `distutils` uses to decide it's running on a mingw built Python.

Hopefully this doesn't break in some random old Python version. 😩

Fixes #1118