### PR TITLE
Allow combining several files in metadata.long_description

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 v36.3.0
 -------
 
-* #1131: Make possible using several ``file:`` directives
-  within metadata.long_description in ``setup.cfg``.
+* #1131: Make possible using several files within ``file:`` directive
+  in metadata.long_description in ``setup.cfg``.
 
 v36.2.7
 -------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+v36.3.0
+-------
+
+* #1131: Make possible using several ``file:`` directives
+  within metadata.long_description in ``setup.cfg``.
+
 v36.2.7
 -------
 

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2306,7 +2306,7 @@ boilerplate code in some cases.
     name = my_package
     version = attr: src.VERSION
     description = My package description
-    long_description = file: README.rst
+    long_description = file: README.rst, CHANGELOG.rst, LICENSE.rst
     keywords = one, two
     license = BSD 3-Clause License
     classifiers =
@@ -2379,7 +2379,7 @@ Type names used below:
 Special directives:
 
 * ``attr:`` - value could be read from module attribute
-* ``file:`` - value could be read from a file
+* ``file:`` - value could be read from a list of files and then concatenated
 
 
 .. note::

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -260,11 +260,8 @@ class ConfigHandler(object):
         if not value.startswith(include_directive):
             return value
 
-        filepaths = value[len(include_directive):]
-        filepaths = filepaths.split(',')
-        filepaths = map(str, filepaths)  # Needed for Python 2
-        filepaths = map(str.strip, filepaths)
-        filepaths = map(os.path.abspath, filepaths)
+        spec = value[len(include_directive):]
+        filepaths = (os.path.abspath(path.strip()) for path in spec.split(','))
 
         current_directory = os.getcwd()
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -262,6 +262,7 @@ class ConfigHandler(object):
 
         filepaths = value[len(include_directive):]
         filepaths = filepaths.split(',')
+        filepaths = map(str, filepaths)  # Needed for Python 2
         filepaths = map(str.strip, filepaths)
         filepaths = map(os.path.abspath, filepaths)
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -245,8 +245,8 @@ class ConfigHandler(object):
         directory with setup.py.
 
         Examples:
-            include: LICENSE
-            include: src/file.txt
+            file: LICENSE
+            file: src/file.txt
 
         :param str value:
         :rtype: str
@@ -408,7 +408,7 @@ class ConfigMetadataHandler(ConfigHandler):
             'classifiers': self._get_parser_compound(parse_file, parse_list),
             'license': parse_file,
             'description': parse_file,
-            'long_description': parse_file,
+            'long_description': self._get_parser_compound(parse_list, lambda l: '\n'.join(map(parse_file, l))),
             'version': self._parse_version,
         }
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -262,21 +262,20 @@ class ConfigHandler(object):
         spec = value[len(include_directive):]
         filepaths = (os.path.abspath(path.strip()) for path in spec.split(','))
         return '\n'.join(
-            cls._read_local_file(path)
+            cls._read_file(path)
             for path in filepaths
-            if os.path.isfile(path)
+            if (cls._assert_local(path) or True)
+            and os.path.isfile(path)
         )
 
     @staticmethod
-    def _read_local_file(filepath):
-        """
-        Read contents of filepath. Raise error if the file
-        isn't in the current directory.
-        """
+    def _assert_local(filepath):
         if not filepath.startswith(os.getcwd()):
             raise DistutilsOptionError(
                 '`file:` directive can not access %s' % filepath)
 
+    @staticmethod
+    def _read_file(filepath):
         with io.open(filepath, encoding='utf-8') as f:
             return f.read()
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -262,7 +262,7 @@ class ConfigHandler(object):
         spec = value[len(include_directive):]
         filepaths = (os.path.abspath(path.strip()) for path in spec.split(','))
         return '\n'.join(
-            self._read_local_file(path)
+            cls._read_local_file(path)
             for path in filepaths
             if os.path.isfile(path)
         )

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -263,7 +263,7 @@ class ConfigHandler(object):
         filepaths = (os.path.abspath(path.strip()) for path in spec.split(','))
         return '\n'.join(
             self._read_local_file(path)
-            for path in filepath
+            for path in filepaths
             if os.path.isfile(path)
         )
 

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -162,7 +162,7 @@ class TestMetadata:
         fake_env(
             tmpdir,
             '[metadata]\n'
-            'long_description = file: CHANGES.rst, ../../README\n'
+            'long_description = file: ../../README\n'
         )
 
         with get_dist(tmpdir, parse=False) as dist:

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -139,6 +139,30 @@ class TestMetadata:
             assert metadata.download_url == 'http://test.test.com/test/'
             assert metadata.maintainer_email == 'test@test.com'
 
+    def test_file_mixed(self, tmpdir):
+
+        fake_env(
+            tmpdir,
+            '[metadata]\n'
+            'long_description =\n'
+            '    Some normal line\n'
+            '    file: README.rst\n'
+            '    Another line\n'
+            '    file: CHANGES.rst\n'
+            '\n'
+        )
+
+        tmpdir.join('README.rst').write('readme contents\nline2')
+        tmpdir.join('CHANGES.rst').write('changelog contents\nand stuff')
+
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.long_description == (
+                'Some normal line\n'
+                'readme contents\nline2\n'
+                'Another line\n'
+                'changelog contents\nand stuff'
+            )
+
     def test_file_sandboxed(self, tmpdir):
 
         fake_env(

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -144,11 +144,7 @@ class TestMetadata:
         fake_env(
             tmpdir,
             '[metadata]\n'
-            'long_description =\n'
-            '    Some normal line\n'
-            '    file: README.rst\n'
-            '    Another line\n'
-            '    file: CHANGES.rst\n'
+            'long_description = file: README.rst, CHANGES.rst\n'
             '\n'
         )
 
@@ -157,9 +153,7 @@ class TestMetadata:
 
         with get_dist(tmpdir) as dist:
             assert dist.metadata.long_description == (
-                'Some normal line\n'
                 'readme contents\nline2\n'
-                'Another line\n'
                 'changelog contents\nand stuff'
             )
 
@@ -168,7 +162,7 @@ class TestMetadata:
         fake_env(
             tmpdir,
             '[metadata]\n'
-            'long_description = file: ../../README\n'
+            'long_description = file: CHANGES.rst, ../../README\n'
         )
 
         with get_dist(tmpdir, parse=False) as dist:


### PR DESCRIPTION
This basically allows one to include several files into `long_description` via `setup.cfg` in a declarative way.

#### Use case

Sometimes one wants to have their README and CHANGELOG stored as separate files, so that GitHub would only render README contents on a main repo page. But it is nice to [list changes](https://github.com/aio-libs/aiohttp/blob/v2.2.5/setup.py#L90) on PYPI as well.

For such cases I suggest parsing `long_description` config value as a list with possibility to inject static files contents via `file:` directive.

This would've been possible with [RST `.. include::`](https://github.com/aio-libs/aiohttp/blob/master/docs/changes.rst#L3-L5), but setuptools doesn't process RST internally. So it's not an option.

In general, suggested change doesn't break compatibility.

/cc: @jaraco it would be interesting to see your feedback :)