### PR TITLE
Improve README file list handling and add Markdown to the current list

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v36.3.1
+
+* Improved handling of README files extensions and added 
+  Markdown to the list of searched READMES. 
+
 v36.3.0
 -------
 

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -37,7 +37,8 @@ class sdist(sdist_add_defaults, orig.sdist):
 
     negative_opt = {}
 
-    READMES = 'README', 'README.rst', 'README.txt'
+    README_EXTENSIONS = ['', '.rst', '.txt', '.md']
+    READMES = tuple('README{}'.format(ext) for ext in README_EXTENSIONS)
 
     def run(self):
         self.run_command('egg_info')


### PR DESCRIPTION
Markdown is a widely used format to write README files and documentation. 

This patch aims to simplify adding new formats and at the same time adds that one to the list.