### PR TITLE
pkg_resources: filter entries before parsing them

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2041,8 +2041,17 @@ def find_on_path(importer, path_item, only=False):
                or hasattr(e, "winerror") and e.winerror == 267):
                 return
             raise
+        # first filter entries that interest us before sorting
+        def of_interest(entry):
+            """Return whetever `entry` is interesting to parse as an egg"""
+            return (entry.lower().endswith('.egg-info')
+                    or entry.lower().endswith('.dist-info')
+                    or (not only and _is_egg_path(entry))
+                    or (not only and entry.lower().endswith('.egg-link')))
+
         # scan for .egg and .egg-info in directory
-        path_item_entries = _by_version_descending(entries)
+        path_item_entries = _by_version_descending(
+            filter(of_interest, entries))
         for entry in path_item_entries:
             lower = entry.lower()
             if lower.endswith('.egg-info') or lower.endswith('.dist-info'):


### PR DESCRIPTION
`_by_version_descending` is quite heavy as it tries to parse versioning and
sort ALL files listed. This is one of the heaviest method.

Actually, there might not be any need to parse those file names it there will
be ignored in the loop just after, so let filter them before sorting.

On my system, this brings down the loading of time of pkg_resources by 20%:

$ python -m timeit -n 5 -r 3 -c 'import pkg_resources; reload(pkg_resources)'
5 loops, best of 3: 1.11 sec per loop

$ python -m timeit -n 5 -r 3 -c 'import pkg_resources; reload(pkg_resources)'
5 loops, best of 3: 889 msec per loop