### PR TITLE
Fix Python 2.6 support

### DIFF
--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -38,7 +38,7 @@ class sdist(sdist_add_defaults, orig.sdist):
     negative_opt = {}
 
     README_EXTENSIONS = ['', '.rst', '.txt', '.md']
-    READMES = tuple('README{}'.format(ext) for ext in README_EXTENSIONS)
+    READMES = tuple('README{0}'.format(ext) for ext in README_EXTENSIONS)
 
     def run(self):
         self.run_command('egg_info')


### PR DESCRIPTION
Fix `python2.6 bootstrap.py` failing on Travis.