### PR TITLE
Implement PEP 517 Build backend

### DIFF
--- a/setuptools/command/__init__.py
+++ b/setuptools/command/__init__.py
@@ -2,7 +2,7 @@ __all__ = [
     'alias', 'bdist_egg', 'bdist_rpm', 'build_ext', 'build_py', 'develop',
     'easy_install', 'egg_info', 'install', 'install_lib', 'rotate', 'saveopts',
     'sdist', 'setopt', 'test', 'install_egg_info', 'install_scripts',
-    'register', 'bdist_wininst', 'upload_docs', 'upload', 'build_clib',
+    'register', 'bdist_wininst', 'upload_docs', 'upload', 'build_clib', 'dist_info',
 ]
 
 from distutils.command.bdist import bdist

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -1,0 +1,37 @@
+"""
+Create a dist_info directory
+As defined in the wheel specification
+"""
+
+import os
+import shutil
+
+from distutils.core import Command
+
+
+class dist_info(Command):
+
+    description = 'create a .dist-info directory'
+
+    user_options = [
+        ('egg-base=', 'e', "directory containing .egg-info directories"
+                           " (default: top of the source tree)"),
+    ]
+
+    def initialize_options(self):
+        self.egg_base = None
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        egg_info = self.get_finalized_command('egg_info')
+        egg_info.run()
+        dist_info_dir = egg_info.egg_info[:-len('.egg-info')] + '.dist-info'
+
+        bdist_wheel = self.get_finalized_command('bdist_wheel')
+        bdist_wheel.egg2dist(egg_info.egg_info, dist_info_dir)
+
+        if self.egg_base:
+            shutil.move(dist_info_dir, os.path.join(
+                self.egg_base, dist_info_dir))

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -30,6 +30,14 @@ __import__('pkg_resources.extern.packaging.specifiers')
 __import__('pkg_resources.extern.packaging.version')
 
 
+skip_install_eggs = False
+
+
+class SetupRequirementsError(BaseException):
+    def __init__(self, specifiers):
+        self.specifiers = specifiers
+
+
 def _get_unpatched(cls):
     warnings.warn("Do not call this function", DeprecationWarning)
     return get_unpatched(cls)
@@ -332,7 +340,10 @@ class Distribution(Distribution_parse_config_files, _Distribution):
             self.dependency_links = attrs.pop('dependency_links', [])
             assert_string_list(self, 'dependency_links', self.dependency_links)
         if attrs and 'setup_requires' in attrs:
-            self.fetch_build_eggs(attrs['setup_requires'])
+            if skip_install_eggs:
+                raise SetupRequirementsError(attrs['setup_requires'])
+            else:
+                self.fetch_build_eggs(attrs['setup_requires'])
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
             vars(self).setdefault(ep.name, None)
         _Distribution.__init__(self, attrs)

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -30,7 +30,7 @@ __import__('pkg_resources.extern.packaging.specifiers')
 __import__('pkg_resources.extern.packaging.version')
 
 
-skip_install_eggs = False
+_skip_install_eggs = False
 
 
 class SetupRequirementsError(BaseException):
@@ -340,10 +340,9 @@ class Distribution(Distribution_parse_config_files, _Distribution):
             self.dependency_links = attrs.pop('dependency_links', [])
             assert_string_list(self, 'dependency_links', self.dependency_links)
         if attrs and 'setup_requires' in attrs:
-            if skip_install_eggs:
+            if _skip_install_eggs:
                 raise SetupRequirementsError(attrs['setup_requires'])
-            else:
-                self.fetch_build_eggs(attrs['setup_requires'])
+            self.fetch_build_eggs(attrs['setup_requires'])
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
             vars(self).setdefault(ep.name, None)
         _Distribution.__init__(self, attrs)

--- a/setuptools/pep517.py
+++ b/setuptools/pep517.py
@@ -29,7 +29,7 @@ def fix_config(config_settings):
 def get_build_requires(config_settings):
     config_settings = fix_config(config_settings)
     requirements = ['setuptools', 'wheel']
-    dist.skip_install_eggs = True
+    dist._skip_install_eggs = True
 
     sys.argv = sys.argv[:1] + ['egg_info'] + \
         config_settings["--global-option"]
@@ -38,7 +38,7 @@ def get_build_requires(config_settings):
     except SetupRequirementsError as e:
         requirements += e.specifiers
 
-    dist.skip_install_eggs = False
+    dist._skip_install_eggs = False
 
     return requirements
 

--- a/setuptools/pep517.py
+++ b/setuptools/pep517.py
@@ -1,0 +1,70 @@
+import os
+import sys
+import subprocess
+import tokenize
+import shutil
+import tempfile
+
+from setuptools import dist
+from setuptools.dist import SetupRequirementsError
+
+
+SETUPTOOLS_IMPLEMENTATION_REVISION = 0.1
+
+def _run_setup(setup_script='setup.py'): #
+    # Note that we can reuse our build directory between calls
+    # Correctness comes first, then optimization later    
+    __file__=setup_script
+    f=getattr(tokenize, 'open', open)(__file__)
+    code=f.read().replace('\\r\\n', '\\n')
+    f.close()
+    exec(compile(code, __file__, 'exec'))
+
+
+def get_build_requires(config_settings):
+    requirements = ['setuptools', 'wheel']
+    dist.skip_install_eggs = True
+
+    sys.argv = sys.argv[:1] + ['egg_info'] + \
+        config_settings["--global-option"]
+    try:
+        _run_setup()
+    except SetupRequirementsError as e:
+        requirements += e.specifiers
+
+    dist.skip_install_eggs = False
+
+    return requirements
+
+
+def get_requires_for_build_wheel(config_settings=None):
+    return get_build_requires(config_settings)
+
+
+def get_requires_for_build_sdist(config_settings=None):
+    return get_build_requires(config_settings)
+
+
+def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
+    sys.argv = sys.argv[:1] + ['dist_info', '--egg-base', metadata_directory]
+    _run_setup()
+
+def build_wheel(wheel_directory, config_settings=None,
+                metadata_directory=None):
+    wheel_directory = os.path.abspath(wheel_directory)
+    sys.argv = sys.argv[:1] + ['bdist_wheel'] + \
+        config_settings["--global-option"]
+    _run_setup()
+    if wheel_directory != 'dist':
+        shutil.rmtree(wheel_directory)
+        shutil.copytree('dist', wheel_directory)
+
+
+def build_sdist(sdist_directory, config_settings=None):
+    sdist_directory = os.path.abspath(sdist_directory)
+    sys.argv = sys.argv[:1] + ['sdist'] + \
+        config_settings["--global-option"]
+    _run_setup()
+    if sdist_directory != 'dist':
+        shutil.rmtree(sdist_directory)
+        shutil.copytree('dist', sdist_directory)

--- a/setuptools/pep517.py
+++ b/setuptools/pep517.py
@@ -68,6 +68,11 @@ def build_wheel(wheel_directory, config_settings=None,
         shutil.rmtree(wheel_directory)
         shutil.copytree('dist', wheel_directory)
 
+    wheels = [f for f in os.listdir(wheel_directory)
+                if f.endswith('.whl')]
+
+    assert len(wheels) == 1
+    return wheels[0]
 
 def build_sdist(sdist_directory, config_settings=None):
     config_settings = fix_config(config_settings)
@@ -78,3 +83,9 @@ def build_sdist(sdist_directory, config_settings=None):
     if sdist_directory != 'dist':
         shutil.rmtree(sdist_directory)
         shutil.copytree('dist', sdist_directory)
+
+    sdists = [f for f in os.listdir(sdist_directory)
+                if f.endswith('.tar.gz')]
+
+    assert len(sdists) == 1
+    return sdists[0]

--- a/setuptools/pep517.py
+++ b/setuptools/pep517.py
@@ -26,6 +26,7 @@ def fix_config(config_settings):
     config_settings.setdefault('--global-option', [])
     return config_settings
 
+
 def get_build_requires(config_settings):
     config_settings = fix_config(config_settings)
     requirements = ['setuptools', 'wheel']
@@ -57,6 +58,13 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
     sys.argv = sys.argv[:1] + ['dist_info', '--egg-base', metadata_directory]
     _run_setup()
 
+    dist_infos = [f for f in os.listdir(metadata_directory)
+                  if f.endswith('.dist-info')]
+
+    assert len(dist_infos) == 1
+    return dist_infos[0]
+
+
 def build_wheel(wheel_directory, config_settings=None,
                 metadata_directory=None):
     config_settings = fix_config(config_settings)
@@ -69,10 +77,11 @@ def build_wheel(wheel_directory, config_settings=None,
         shutil.copytree('dist', wheel_directory)
 
     wheels = [f for f in os.listdir(wheel_directory)
-                if f.endswith('.whl')]
+              if f.endswith('.whl')]
 
     assert len(wheels) == 1
     return wheels[0]
+
 
 def build_sdist(sdist_directory, config_settings=None):
     config_settings = fix_config(config_settings)
@@ -85,7 +94,7 @@ def build_sdist(sdist_directory, config_settings=None):
         shutil.copytree('dist', sdist_directory)
 
     sdists = [f for f in os.listdir(sdist_directory)
-                if f.endswith('.tar.gz')]
+              if f.endswith('.tar.gz')]
 
     assert len(sdists) == 1
     return sdists[0]

--- a/setuptools/pep517.py
+++ b/setuptools/pep517.py
@@ -21,7 +21,13 @@ def _run_setup(setup_script='setup.py'): #
     exec(compile(code, __file__, 'exec'))
 
 
+def fix_config(config_settings):
+    config_settings = config_settings or {}
+    config_settings.setdefault('--global-option', [])
+    return config_settings
+
 def get_build_requires(config_settings):
+    config_settings = fix_config(config_settings)
     requirements = ['setuptools', 'wheel']
     dist.skip_install_eggs = True
 
@@ -38,10 +44,12 @@ def get_build_requires(config_settings):
 
 
 def get_requires_for_build_wheel(config_settings=None):
+    config_settings = fix_config(config_settings)
     return get_build_requires(config_settings)
 
 
 def get_requires_for_build_sdist(config_settings=None):
+    config_settings = fix_config(config_settings)
     return get_build_requires(config_settings)
 
 
@@ -51,6 +59,7 @@ def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
 
 def build_wheel(wheel_directory, config_settings=None,
                 metadata_directory=None):
+    config_settings = fix_config(config_settings)
     wheel_directory = os.path.abspath(wheel_directory)
     sys.argv = sys.argv[:1] + ['bdist_wheel'] + \
         config_settings["--global-option"]
@@ -61,6 +70,7 @@ def build_wheel(wheel_directory, config_settings=None,
 
 
 def build_sdist(sdist_directory, config_settings=None):
+    config_settings = fix_config(config_settings)
     sdist_directory = os.path.abspath(sdist_directory)
     sys.argv = sys.argv[:1] + ['sdist'] + \
         config_settings["--global-option"]

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -110,6 +110,7 @@ def test_prepare_metadata_for_build_wheel(build_backend):
         dist_dir = os.path.abspath('pip-dist-info')
         os.makedirs(dist_dir)
 
-        b.prepare_metadata_for_build_wheel()
+        dist_info = b.prepare_metadata_for_build_wheel(dist_dir)
 
-        assert os.path.isfile(os.path.join(dist_dir, 'METADATA'))
+        assert os.path.isfile(os.path.join(dist_dir, dist_info,
+                              'METADATA'))

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -49,18 +49,16 @@ class BuildBackendCaller(BuildBackendBase):
 
 @contextmanager
 def enter_directory(dir, val=None):
-    while True:
-        original_dir = os.getcwd()
-        os.chdir(dir)
-        yield val
-        os.chdir(original_dir)
+    original_dir = os.getcwd()
+    os.chdir(dir)
+    yield val
+    os.chdir(original_dir)
 
 
 @pytest.fixture
 def build_backend():
     tmpdir = mkdtemp()
-    ctx = enter_directory(tmpdir, BuildBackend(cwd='.'))
-    with ctx:
+    with enter_directory(tmpdir):
         setup_script = DALS("""
         from setuptools import setup
 
@@ -81,7 +79,7 @@ def build_backend():
                 """)
         })
 
-    return ctx
+    return enter_directory(tmpdir, BuildBackend(cwd='.'))
 
 
 def test_get_requires_for_build_wheel(build_backend):

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -34,17 +34,16 @@ class BuildBackend(BuildBackendBase):
             return self.pool.submit(
                 BuildBackendCaller(os.path.abspath(self.cwd), self.env,
                                    self.backend_name),
-                (name, args, kw)).result()
+                name, *args, **kw).result()
 
         return method
 
 
 class BuildBackendCaller(BuildBackendBase):
-    def __call__(self, info):
+    def __call__(self, name, *args, **kw):
         """Handles aribrary function invokations on the build backend."""
         os.chdir(self.cwd)
         os.environ.update(self.env)
-        name, args, kw = info
         return getattr(import_module(self.backend_name), name)(*args, **kw)
 
 

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -49,10 +49,11 @@ class BuildBackendCaller(BuildBackendBase):
 
 @contextmanager
 def enter_directory(dir, val=None):
-    original_dir = os.getcwd()
-    os.chdir(dir)
-    yield val
-    os.chdir(original_dir)
+    while True:
+        original_dir = os.getcwd()
+        os.chdir(dir)
+        yield val
+        os.chdir(original_dir)
 
 
 @pytest.fixture

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -22,7 +22,7 @@ class BuildBackendBase(object):
         self.backend_name = backend_name
 
 
-class BuildBackend(object):
+class BuildBackend(BuildBackendBase):
     """PEP 517 Build Backend"""
     def __init__(self, *args, **kwargs):
         super(BuildBackend, self).__init__(*args, **kwargs)

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -15,17 +15,21 @@ from .textwrap import DALS
 from . import contexts
 
 
-class BuildBackend(object):
-    """PEP 517 Build Backend"""
+class BuildBackendBase(object):
     def __init__(self, cwd=None, env={}, backend_name='setuptools.pep517'):
         self.cwd = cwd
         self.env = env
         self.backend_name = backend_name
+
+
+class BuildBackend(object):
+    """PEP 517 Build Backend"""
+    def __init__(self, *args, **kwargs):
+        super(BuildBackend, self).__init__(*args, **kwargs)
         self.pool = ProcessPoolExecutor()
 
     def __getattr__(self, name):
-        """Handles aribrary function invokations on the build backend."""
-
+        """Handles aribrary function invocations on the build backend."""
         def method(*args, **kw):
             return self.pool.submit(
                 BuildBackendCaller(os.path.abspath(self.cwd), self.env,
@@ -35,12 +39,7 @@ class BuildBackend(object):
         return method
 
 
-class BuildBackendCaller(object):
-    def __init__(self, cwd, env, backend_name):
-        self.cwd = cwd
-        self.env = env
-        self.backend_name = backend_name
-
+class BuildBackendCaller(BuildBackendBase):
     def __call__(self, info):
         """Handles aribrary function invokations on the build backend."""
         os.chdir(self.cwd)

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -104,3 +104,12 @@ def test_build_sdist(build_backend):
         sdist_name = b.build_sdist(dist_dir)
 
         assert os.path.isfile(os.path.join(dist_dir, sdist_name))
+
+def test_prepare_metadata_for_build_wheel(build_backend):
+    with build_backend as b:
+        dist_dir = os.path.abspath('pip-dist-info')
+        os.makedirs(dist_dir)
+
+        b.prepare_metadata_for_build_wheel()
+
+        assert os.path.isfile(os.path.join(dist_dir, 'METADATA'))

--- a/setuptools/tests/test_pep517.py
+++ b/setuptools/tests/test_pep517.py
@@ -41,7 +41,7 @@ class BuildBackend(BuildBackendBase):
 
 class BuildBackendCaller(BuildBackendBase):
     def __call__(self, name, *args, **kw):
-        """Handles aribrary function invokations on the build backend."""
+        """Handles aribrary function invocations on the build backend."""
         os.chdir(self.cwd)
         os.environ.update(self.env)
         return getattr(import_module(self.backend_name), name)(*args, **kw)
@@ -58,7 +58,8 @@ def enter_directory(dir, val=None):
 @pytest.fixture
 def build_backend():
     tmpdir = mkdtemp()
-    with enter_directory(tmpdir):
+    ctx = enter_directory(tmpdir, BuildBackend(cwd='.'))
+    with ctx:
         setup_script = DALS("""
         from setuptools import setup
 
@@ -79,7 +80,7 @@ def build_backend():
                 """)
         })
 
-    return enter_directory(tmpdir, BuildBackend(cwd='.'))
+    return ctx
 
 
 def test_get_requires_for_build_wheel(build_backend):

--- a/setuptools/tests/test_pep_517.py
+++ b/setuptools/tests/test_pep_517.py
@@ -1,0 +1,41 @@
+import pytest
+import os
+
+# Only test the backend on Python 3
+# because we don't want to require
+# a concurrent.futures backport for testing
+pytest.importorskip('concurrent.futures')
+
+from importlib import import_module
+from concurrent.futures import ProcessPoolExecutor
+
+class BuildBackend(object):
+    """PEP 517 Build Backend"""
+    def __init__(self, cwd=None, env={}, backend_name='setuptools.pep517'):
+        self.cwd = cwd
+        self.env = env
+        self.backend_name = backend_name
+        self.pool = ProcessPoolExecutor()
+
+    def __getattr__(self, name):
+        """Handles aribrary function invokations on the build backend."""
+
+        def method(**kw):
+            return self.pool.submit(
+                BuildBackendCaller(self.cwd, self.env, self.backend_name),
+                (name, kw)).result()
+
+        return method
+
+
+class BuildBackendCaller(object):
+    def __init__(self, cwd, env, backend_name):
+        self.cwd = cwd
+        self.env = env
+        self.backend_name = backend_name
+
+    def __getattr__(self, name):
+        """Handles aribrary function invokations on the build backend."""
+        os.chdir(self.cwd)
+        os.environ.update(self.env)
+        return getattr(import_module(self.backend_name), name)


### PR DESCRIPTION
This PR combines the dist_info PR and the [original PR](/pypa/setuptools/pull/1039).

Summary:
- the `setuptools.pep517` module is added, which allows querying for `setup_requires`, among other things (see the PEP for full details)
- the functions in the added module are the ONLY public API added here. The `SetupRequirementsError` is not intended to be used except within setuptools.