### PR TITLE
Clean up resource warnings during tests

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2124,7 +2124,11 @@ def non_empty_lines(path):
     """
     Yield non-empty lines from file at path
     """
-    return (line.rstrip() for line in open(path) if line.strip())
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield line
 
 
 def resolve_egg_link(path):

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -92,8 +92,8 @@ class TestZipProvider(object):
         ts = timestamp(self.ref_time)
         os.utime(filename, (ts, ts))
         filename = zp.get_resource_filename(manager, 'data.dat')
-        f = open(filename)
-        assert f.read() == 'hello, world!'
+        with open(filename) as f:
+            assert f.read() == 'hello, world!'
         manager.cleanup_resources()
 
 

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -164,7 +164,8 @@ class TestEggInfo(object):
         self._run_install_command(tmpdir_cwd, env)
         egg_info_dir = self._find_egg_info_files(env.paths['lib']).base
         sources_txt = os.path.join(egg_info_dir, 'SOURCES.txt')
-        assert 'docs/usage.rst' in open(sources_txt).read().split('\n')
+        with open(sources_txt) as f:
+            assert 'docs/usage.rst' in f.read().split('\n')
 
     def _setup_script_with_requires(self, requires, use_setup_cfg=False):
         setup_script = DALS(
@@ -447,7 +448,8 @@ class TestEggInfo(object):
         self._run_install_command(tmpdir_cwd, env)
         egg_info_dir = self._find_egg_info_files(env.paths['lib']).base
         pkginfo = os.path.join(egg_info_dir, 'PKG-INFO')
-        assert 'Requires-Python: >=1.2.3' in open(pkginfo).read().split('\n')
+        with open(pkginfo) as f:
+            assert 'Requires-Python: >=1.2.3' in f.read().split('\n')
 
     def test_manifest_maker_warning_suppression(self):
         fixtures = [


### PR DESCRIPTION
When tests are invoked with the Python flag -Wall, warnings appear in the form of:

```
  ResourceWarning: unclosed file ...
```

Close all files and resources deterministically to avoid such warnings. Most often, easiest to do using a context manager.