### PR TITLE
Tests: Run `python -m pip` instead of plain `pip`

### DIFF
--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -169,7 +169,7 @@ class TestNamespaces:
         install_cmd = [
             sys.executable,
             '-m',
-            'pip',
+            'pip.__main__',
             'install',
             str(pkg_A),
             '-t', str(target),

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -167,6 +167,8 @@ class TestNamespaces:
         target = tmpdir / 'packages'
         # use pip to install to the target directory
         install_cmd = [
+            sys.executable,
+            '-m',
             'pip',
             'install',
             str(pkg_A),

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -30,6 +30,8 @@ class TestNamespaces:
         targets = site_packages, path_packages
         # use pip to install to the target directory
         install_cmd = [
+            sys.executable,
+            '-m',
             'pip',
             'install',
             str(pkg_A),
@@ -38,6 +40,8 @@ class TestNamespaces:
         subprocess.check_call(install_cmd)
         namespaces.make_site_dir(site_packages)
         install_cmd = [
+            sys.executable,
+            '-m',
             'pip',
             'install',
             str(pkg_B),
@@ -88,6 +92,8 @@ class TestNamespaces:
         target = tmpdir / 'packages'
         # use pip to install to the target directory
         install_cmd = [
+            sys.executable,
+            '-m',
             'pip',
             'install',
             str(pkg_A),

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -32,7 +32,7 @@ class TestNamespaces:
         install_cmd = [
             sys.executable,
             '-m',
-            'pip',
+            'pip.__main__',
             'install',
             str(pkg_A),
             '-t', str(site_packages),
@@ -42,7 +42,7 @@ class TestNamespaces:
         install_cmd = [
             sys.executable,
             '-m',
-            'pip',
+            'pip.__main__',
             'install',
             str(pkg_B),
             '-t', str(path_packages),
@@ -94,7 +94,7 @@ class TestNamespaces:
         install_cmd = [
             sys.executable,
             '-m',
-            'pip',
+            'pip.__main__',
             'install',
             str(pkg_A),
             '-t', str(target),


### PR DESCRIPTION
This allows to run the testsuite on systems where `/usr/bin/pip` is a specific Python version, but the tests are run on a different one.

For example in Fedora RPM, when the Python 3 tests are invoked, they should use Python 3 pip, not Python 2 `/usr/bin/pip`.

Unlike other approaches, like using `pip2`/`pip3` which is currently done in Fedora RPM (downstream patch), this way it Works Everywhere™ and the downstream patch can be dropped.

See https://src.fedoraproject.org/rpms/python-setuptools/blob/54eaa03a4dc97f93a5e4c92c55e580a4ab55a058/f/0001-Run-test-on-a-version-specific-pip.patch

cc @torsava (author of that Fedora downstream patch)