### PR TITLE
unnecessary and error-causing import in sandbox.py

### DIFF
--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -12,7 +12,7 @@ import textwrap
 from setuptools.extern import six
 from setuptools.extern.six.moves import builtins, map
 
-import pkg_resources.py31compat
+import pkg_resources
 
 if sys.platform.startswith('java'):
     import org.python.modules.posix.PosixModule as _os


### PR DESCRIPTION
Regarding issue #1167, sandbox.py was importing pkg_resources.py31compat, which is an individual python file already imported by the pkg_resources submodule's init.py

See issue for errors caused / errors fixed.

This commit just has sandbox.py import pkg_resources and not pkg_resources.py31compat.