### PR TITLE
Allow to use `file:` directive for requirements.

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2430,8 +2430,8 @@ Options
 Key                      Type
 =======================  =====
 zip_safe                 bool
-setup_requires           list-semi
-install_requires         list-semi
+setup_requires           file:, list-semi
+install_requires         file:, list-semi
 extras_require           section
 python_requires          str
 entry_points             file:, section
@@ -2442,7 +2442,7 @@ convert_2to3_doctests    list-comma
 scripts                  list-comma
 eager_resources          list-comma
 dependency_links         list-comma
-tests_require            list-semi
+tests_require            file:, list-semi
 include_package_data     bool
 packages                 find:, list-comma
 package_dir              dict

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -450,6 +450,9 @@ class ConfigOptionsHandler(ConfigHandler):
         parse_list_semicolon = partial(self._parse_list, separator=';')
         parse_bool = self._parse_bool
         parse_dict = self._parse_dict
+        parse_file = self._parse_file
+        parse_file_and_list_semicolon = self._get_parser_compound(
+            parse_file, parse_list_semicolon)
 
         return {
             'zip_safe': parse_bool,
@@ -463,9 +466,9 @@ class ConfigOptionsHandler(ConfigHandler):
             'eager_resources': parse_list,
             'dependency_links': parse_list,
             'namespace_packages': parse_list,
-            'install_requires': parse_list_semicolon,
-            'setup_requires': parse_list_semicolon,
-            'tests_require': parse_list_semicolon,
+            'install_requires': parse_file_and_list_semicolon,
+            'setup_requires': parse_file_and_list_semicolon,
+            'tests_require': parse_file_and_list_semicolon,
             'packages': self._parse_packages,
             'entry_points': self._parse_file,
             'py_modules': parse_list,

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -562,3 +562,52 @@ class TestOptions:
 
         with get_dist(tmpdir) as dist:
             assert dist.entry_points == expected
+
+    def test_requirements_from_file(self, tmpdir):
+        setup_expected = [
+            'foo>=3.1',
+            'bar'
+        ]
+        install_expected = [
+            'docutils>=0.3',
+            'pack==1.1,==1.3',
+            'hey'
+        ]
+        test_expected = [
+            'mytest==1.0',
+            'pack2'
+        ]
+
+        fake_env(
+            tmpdir,
+            '[options]\n'
+            'setup_requires = file: setup-requirements.txt\n'
+            'install_requires = file: requirements.txt\n'
+            'tests_require = file: test-requirements.txt\n'
+        )
+
+        tmpdir.join('setup-requirements.txt').write(
+            'foo>=3.1\n'
+            'bar\n')
+        tmpdir.join('requirements.txt').write(
+            'docutils>=0.3\n'
+            'pack ==1.1, ==1.3\n'
+            'hey\n')
+        tmpdir.join('test-requirements.txt').write(
+            'mytest==1.0\n'
+            'pack2\n')
+        with get_dist(tmpdir) as dist:
+            assert dist.setup_requires == setup_expected
+            assert dist.install_requires == install_expected
+            assert dist.tests_require == test_expected
+
+        tmpdir.join('setup-requirements.txt').write(
+            'foo>=3.1; bar')
+        tmpdir.join('requirements.txt').write(
+            'docutils>=0.3; pack ==1.1, ==1.3; hey')
+        tmpdir.join('test-requirements.txt').write(
+            'mytest==1.0; pack2')
+        with get_dist(tmpdir) as dist:
+            assert dist.setup_requires == setup_expected
+            assert dist.install_requires == install_expected
+            assert dist.tests_require == test_expected


### PR DESCRIPTION
Fix #1074.