### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,7 @@ formats = zip
 [bdist_wheel]
 universal = 1
 
-[bumpversion:file:setup.py]
+[metadata]
+license_file = LICENSE
 
+[bumpversion:file:setup.py]


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file