### PR TITLE
use ssl.create_default_context and SNI if available

### DIFF
--- a/setuptools/ssl_support.py
+++ b/setuptools/ssl_support.py
@@ -186,9 +186,14 @@ class VerifyingHTTPSConn(HTTPSConnection):
         else:
             actual_host = self.host
 
-        self.sock = ssl.wrap_socket(
-            sock, cert_reqs=ssl.CERT_REQUIRED, ca_certs=self.ca_bundle
-        )
+        if hasattr(ssl, 'create_default_context'):
+            ctx = ssl.create_default_context(cafile=self.ca_bundle)
+            self.sock = ctx.wrap_socket(sock, server_hostname=actual_host)
+        else:
+            # This is for python < 2.7.9 and < 3.4?
+            self.sock = ssl.wrap_socket(
+                sock, cert_reqs=ssl.CERT_REQUIRED, ca_certs=self.ca_bundle
+            )
         try:
             match_hostname(self.sock.getpeercert(), actual_host)
         except CertificateError:


### PR DESCRIPTION
I ran into a ssl certificate verification problem using buildout and a private package index using SNI.

The usual workaround to make sure that the ssl cert of the private registry server defaults to the package index hostname was not possible this time, so I thought I'll fix it at the core and use SNI when connecting to a ssl server.

Happy to ammend this pull request in any way, but I do believe that something like this would be good to have as it also uses good practice ssl settings maintained in python core ssl.py module, and sticks to officially document methods in ssl module.