### PR TITLE
[distutils] fix test failures

### DIFF
--- a/distutils/__init__.py
+++ b/distutils/__init__.py
@@ -9,5 +9,13 @@ used from a setup script as
 """
 
 import sys
+import os
 
-__version__ = sys.version[:sys.version.index(' ')]
+from os.path import abspath, normcase, dirname, basename
+
+if sys.version_info < (3, 6):
+    __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+    __path__ = (p for p in __path__ if normcase(abspath(p)) != normcase(abspath(dirname(__file__))))
+    __path__ = [p for p in __path__ if basename(dirname(abspath(p))) != 'site-packages']
+else:
+    __version__ = sys.version[:sys.version.index(' ')]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts=--doctest-modules --ignore release.py --ignore setuptools/lib2to3_ex.py --ignore tests/manual_test.py --ignore tests/test_pypi.py --ignore tests/shlib_test --doctest-glob=pkg_resources/api_tests.txt --ignore scripts/upload-old-releases-as-zip.py --ignore pavement.py --ignore setuptools/tests/mod_with_constant.py -rsxX
-norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern .*
+norecursedirs=distutils dist build *.egg setuptools/extern pkg_resources/extern .*
 flake8-ignore =
     setuptools/site-patch.py F821
     setuptools/py*compat.py F811

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -1,7 +1,16 @@
 """Extensions to the 'distutils' for large or complex distributions"""
 
 import os
+import sys
 import functools
+
+from os.path import dirname
+
+# Patch the distutils search location
+sys.path.insert(0, dirname(dirname(__file__)))
+import distutils
+sys.path.pop(0)
+
 import distutils.core
 import distutils.filelist
 from distutils.util import convert_path


### PR DESCRIPTION
On Python 3.6 and above, setuptools replaces the builtin distutils with it's own version. Python 3.5 and below is unaffected. The idea is to start with Python 3.6 and then roll in future versions as they come, until setuptools always uses it's own copy of distutils. Eventually, python can remove distutils and add an ensuresetuptools module for building.

/cc @jaraco @zooba 