### PR TITLE
Support PEP 345 Project-URL metadata list

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2406,6 +2406,7 @@ name                                               str
 version                                            attr:, str
 url                             home-page          str
 download_url                    download-url       str
+project_url                     project-url        dict
 author                                             str
 author_email                    author-email       str
 maintainer                                         str

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,11 @@ setup_params = dict(
     long_description_content_type='text/x-rst; charset=UTF-8',
     keywords="CPAN PyPI distutils eggs package management",
     url="https://github.com/pypa/setuptools",
+    project_url={
+        "Bug Tracker": "https://github.com/pypa/setuptools/issues",
+        "Documentation": "http://setuptools.readthedocs.io/",
+        "Source Code": "https://github.com/pypa/setuptools",
+    },
     src_root=None,
     packages=setuptools.find_packages(exclude=['*.tests']),
     package_data=package_data,

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -601,6 +601,10 @@ def write_pkg_info(cmd, basename, filename):
             cmd.distribution,
             'long_description_content_type'
         )
+        metadata.project_url = getattr(
+            cmd.distribution,
+            'project_url'
+        )
         try:
             # write unescaped data to PKG-INFO, so older pkg_resources
             # can still parse it

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -44,7 +44,7 @@ def write_pkg_file(self, file):
             self.classifiers or self.download_url):
         version = '1.1'
     # Setuptools specific for PEP 345
-    if hasattr(self, 'python_requires'):
+    if hasattr(self, 'python_requires') or getattr(self, 'project_url', None):
         version = '1.2'
 
     file.write('Metadata-Version: %s\n' % version)
@@ -57,6 +57,9 @@ def write_pkg_file(self, file):
     file.write('License: %s\n' % self.get_license())
     if self.download_url:
         file.write('Download-URL: %s\n' % self.download_url)
+    if getattr(self, 'project_url', None):
+        file.write('Project-URL:%s\n' % ''.join(
+            ['\n    '+', '.join(x) for x in self.project_url.items()]))
 
     long_desc_content_type = getattr(
         self,
@@ -327,6 +330,7 @@ class Distribution(Distribution_parse_config_files, _Distribution):
         self.long_description_content_type = attrs.get(
             'long_description_content_type'
         )
+        self.project_url = attrs.get('project_url', {})
         self.dependency_links = attrs.pop('dependency_links', [])
         self.setup_requires = attrs.pop('setup_requires', [])
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):


### PR DESCRIPTION
A Project-URL list is supported in v1.2 PKG-INFO metadata with
pkginfo 0.6 or later, and is used primarily by PyPI to display
helpful hyperlinks in a generic manner. Add support here to be able
to pass it through setup.py. See the corresponding section of the
Core Metadata Specifications from the Python Packaging User Guide
for details:

https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use