### PR TITLE
Add setup.cfg support for long_description_content_type

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -598,7 +598,7 @@ def write_pkg_info(cmd, basename, filename):
         metadata.version, oldver = cmd.egg_version, metadata.version
         metadata.name, oldname = cmd.egg_name, metadata.name
         metadata.long_description_content_type = getattr(
-            cmd.distribution,
+            cmd.distribution.metadata,
             'long_description_content_type'
         )
         try:

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -597,10 +597,7 @@ def write_pkg_info(cmd, basename, filename):
         metadata = cmd.distribution.metadata
         metadata.version, oldver = cmd.egg_version, metadata.version
         metadata.name, oldname = cmd.egg_name, metadata.name
-        metadata.long_description_content_type = getattr(
-            cmd.distribution.metadata,
-            'long_description_content_type'
-        )
+
         try:
             # write unescaped data to PKG-INFO, so older pkg_resources
             # can still parse it

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -58,11 +58,8 @@ def write_pkg_file(self, file):
     if self.download_url:
         file.write('Download-URL: %s\n' % self.download_url)
 
-    long_desc_content_type = getattr(
-        self,
-        'long_description_content_type',
-        None
-    ) or 'UNKNOWN'
+    long_desc_content_type = \
+        self.long_description_content_type or 'UNKNOWN'
     file.write('Description-Content-Type: %s\n' % long_desc_content_type)
 
     long_desc = rfc822_escape(self.get_long_description())
@@ -324,20 +321,15 @@ class Distribution(Distribution_parse_config_files, _Distribution):
         self.dist_files = []
         self.src_root = attrs.pop("src_root", None)
         self.patch_missing_pkg_info(attrs)
-        self.long_description_content_type = attrs.get(
-            'long_description_content_type'
-        )
         self.dependency_links = attrs.pop('dependency_links', [])
         self.setup_requires = attrs.pop('setup_requires', [])
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
             vars(self).setdefault(ep.name, None)
         _Distribution.__init__(self, attrs)
 
-        try:
-            self.metadata.long_description_content_type
-        except AttributeError:
-            self.metadata.long_description_content_type = \
-                self.long_description_content_type
+        self.metadata.long_description_content_type = attrs.get(
+            'long_description_content_type'
+        )
 
         if isinstance(self.metadata.version, numbers.Number):
             # Some people apparently take "version number" too literally :)

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -332,6 +332,13 @@ class Distribution(Distribution_parse_config_files, _Distribution):
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
             vars(self).setdefault(ep.name, None)
         _Distribution.__init__(self, attrs)
+
+        try:
+            self.metadata.long_description_content_type
+        except AttributeError:
+            self.metadata.long_description_content_type = \
+                self.long_description_content_type
+
         if isinstance(self.metadata.version, numbers.Number):
             # Some people apparently take "version number" too literally :)
             self.metadata.version = str(self.metadata.version)

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -110,6 +110,7 @@ class TestMetadata:
             '[metadata]\n'
             'version = 10.1.1\n'
             'description = Some description\n'
+            'long_description_content_type = text/something\n'
             'long_description = file: README\n'
             'name = fake_name\n'
             'keywords = one, two\n'
@@ -131,6 +132,7 @@ class TestMetadata:
 
             assert metadata.version == '10.1.1'
             assert metadata.description == 'Some description'
+            assert metadata.long_description_content_type == 'text/something'
             assert metadata.long_description == 'readme contents\nline2'
             assert metadata.provides == ['package', 'package.sub']
             assert metadata.license == 'BSD 3-Clause License'


### PR DESCRIPTION
[This was already claimed in the docs.](https://github.com/pypa/setuptools/blob/d45be2cc4f7a1e4ddc70b363baaa613c6b068b98/docs/setuptools.txt#L2417) That this did not work before can be seen by cherry picking the changed test in this PR without the other changes: it will fail. Fixes issue #1206 