### PR TITLE
Fixes #1208: Improved exception message of pkg_resources.ResolutionError

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1513,7 +1513,9 @@ class NullProvider:
     def run_script(self, script_name, namespace):
         script = 'scripts/' + script_name
         if not self.has_metadata(script):
-            raise ResolutionError("No script named %r" % script_name)
+            raise ResolutionError(
+                "No script named %r in 'scripts' directory of metadata "
+                "directory %r" % (script_name, self.egg_info))
         script_text = self.get_metadata(script).replace('\r\n', '\n')
         script_text = script_text.replace('\r', '\n')
         script_filename = self._fn(self.egg_info, script)


### PR DESCRIPTION
This PR improves the message of the one place in `pkg_resources` that raises `ResolutionError`.
For the motivation for this change, see issue #1208.