### PR TITLE
Removed warning when PYTHONDONTWRITEBYTECODE is enabled

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v38.2.5
+-------
+
+* Removed warning when PYTHONDONTWRITEBYTECODE is enabled
+
 v38.2.4
 -------
 

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1248,7 +1248,6 @@ class easy_install(Command):
 
     def byte_compile(self, to_compile):
         if sys.dont_write_bytecode:
-            self.warn('byte-compiling is disabled, skipping.')
             return
 
         from distutils.util import byte_compile


### PR DESCRIPTION
This is an old warning (from 8 years ago) that isn't useful anymore.
If one disables generation of .pyc files, one constantly gets these warnings, polluting the output.