### PR TITLE
Fix trailing slash handling in pkg_resources.ZipProvider

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v38.2.5
+-------
+
+* #1232: Fix trailing slash handling in ``pkg_resources.ZipProvider``.
+
 v38.2.4
 -------
 

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1693,6 +1693,10 @@ class ZipProvider(EggProvider):
     def _zipinfo_name(self, fspath):
         # Convert a virtual filename (full path to file) into a zipfile subpath
         # usable with the zipimport directory cache for our target archive
+        while fspath.endswith(os.sep):
+            fspath = fspath[:-1]
+        if fspath == self.loader.archive:
+            return ''
         if fspath.startswith(self.zip_pre):
             return fspath[len(self.zip_pre):]
         raise AssertionError(

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1693,8 +1693,7 @@ class ZipProvider(EggProvider):
     def _zipinfo_name(self, fspath):
         # Convert a virtual filename (full path to file) into a zipfile subpath
         # usable with the zipimport directory cache for our target archive
-        while fspath.endswith(os.sep):
-            fspath = fspath[:-1]
+        fspath = fspath.rstrip(os.sep)
         if fspath == self.loader.archive:
             return ''
         if fspath.startswith(self.zip_pre):

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -62,16 +62,51 @@ class TestZipProvider(object):
         zip_info.filename = 'data.dat'
         zip_info.date_time = cls.ref_time.timetuple()
         zip_egg.writestr(zip_info, 'hello, world!')
+        zip_info = zipfile.ZipInfo()
+        zip_info.filename = 'subdir/mod2.py'
+        zip_info.date_time = cls.ref_time.timetuple()
+        zip_egg.writestr(zip_info, 'x = 6\n')
+        zip_info = zipfile.ZipInfo()
+        zip_info.filename = 'subdir/data2.dat'
+        zip_info.date_time = cls.ref_time.timetuple()
+        zip_egg.writestr(zip_info, 'goodbye, world!')
         zip_egg.close()
         egg.close()
 
         sys.path.append(egg.name)
+        subdir = os.path.join(egg.name, 'subdir')
+        sys.path.append(subdir)
+        cls.finalizers.append(EggRemover(subdir))
         cls.finalizers.append(EggRemover(egg.name))
 
     @classmethod
     def teardown_class(cls):
         for finalizer in cls.finalizers:
             finalizer()
+
+    def test_resource_listdir(self):
+        import mod
+        zp = pkg_resources.ZipProvider(mod)
+
+        expected_root = ['data.dat', 'mod.py', 'subdir']
+        assert sorted(zp.resource_listdir('')) == expected_root
+        assert sorted(zp.resource_listdir('/')) == expected_root
+
+        expected_subdir = ['data2.dat', 'mod2.py']
+        assert sorted(zp.resource_listdir('subdir')) == expected_subdir
+        assert sorted(zp.resource_listdir('subdir/')) == expected_subdir
+
+        assert zp.resource_listdir('nonexistent') == []
+        assert zp.resource_listdir('nonexistent/') == []
+
+        import mod2
+        zp2 = pkg_resources.ZipProvider(mod2)
+
+        assert sorted(zp2.resource_listdir('')) == expected_subdir
+        assert sorted(zp2.resource_listdir('/')) == expected_subdir
+
+        assert zp2.resource_listdir('subdir') == []
+        assert zp2.resource_listdir('subdir/') == []
 
     def test_resource_filename_rewrites_on_change(self):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 38.2.4
+current_version = 38.2.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def pypi_link(pkg_filename):
 
 setup_params = dict(
     name="setuptools",
-    version="38.2.4",
+    version="38.2.5",
     description="Easily download, build, install, upgrade, and uninstall "
         "Python packages",
     author="Python Packaging Authority",


### PR DESCRIPTION
Given a ZipProvider, if the underlying ZipImporter prefix is empty,
then resource_listdir('') and resource_listdir('subdir/') fail, while
resource_listdir('/') and resource_listdir('subdir') succeed.

On the other hand, if the underlying ZipImport prefix is not empty,
then resource_listdir('/') fails but resource_listdir('') succeeds.

With this change, the cases listed succeed with or without trailing
slashes.

Fixes #1188 

