### PR TITLE
Implement a better setup-requires

### DIFF
--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -178,3 +178,10 @@ def findall(dir=os.curdir):
 
 
 monkey.patch_all()
+
+try:
+    from __main__ import __setup_requires__
+except ImportError:
+    pass
+else:
+    Distribution().fetch_build_eggs(__setup_requires__)


### PR DESCRIPTION
Install setup requirements on import of setuptools rather than having to later specify them.

Closes gh-1218.