### PR TITLE
Reflect find_packages behavior in doc

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -437,9 +437,9 @@ such projects also need something like ``package_dir={'':'src'}`` in their
 ``setup()`` arguments, but that's just a normal distutils thing.)
 
 Anyway, ``find_packages()`` walks the target directory, filtering by inclusion
-patterns, and finds Python packages (any directory). On Python 3.2 and
-earlier, packages are only recognized if they include an ``__init__.py`` file.
-Finally, exclusion patterns are applied to remove matching packages.
+patterns, and finds Python packages (any directory). Packages are only
+recognized if they include an ``__init__.py`` file. Finally, exclusion 
+patterns are applied to remove matching packages.
 
 Inclusion and exclusion patterns are package names, optionally including
 wildcards.  For


### PR DESCRIPTION
find_packages doesnt find PEP420 packages but
the documentation suggests that it does.

see: pypa/setuptools#97