### PR TITLE
fix Python 3.7 support

### DIFF
--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -409,8 +409,10 @@ def scan_module(egg_dir, base, name, stubs):
     module = pkg + (pkg and '.' or '') + os.path.splitext(name)[0]
     if sys.version_info < (3, 3):
         skip = 8  # skip magic & date
-    else:
+    elif sys.version_info < (3, 7):
         skip = 12  # skip magic & date & file size
+    else:
+        skip = 16 # skip magic & reserved? & date & file size
     f = open(filename, 'rb')
     f.read(skip)
     code = marshal.load(f)

--- a/setuptools/tests/test_sandbox.py
+++ b/setuptools/tests/test_sandbox.py
@@ -75,6 +75,8 @@ class TestExceptionSaver:
     def test_unpickleable_exception(self):
         class CantPickleThis(Exception):
             "This Exception is unpickleable because it's not in globals"
+            def __repr__(self):
+                return 'CantPickleThis%r' % (self.args,)
 
         with setuptools.sandbox.ExceptionSaver() as saved_exc:
             raise CantPickleThis('detail')


### PR DESCRIPTION
- update scanning code to handle pyc header change
- handle change to `Exception.__repr__` output