### PR TITLE
Fix documentation inconsistency on version specifier

### DIFF
--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -638,7 +638,7 @@ Requirements Parsing
     sorted into ascending version order, and used to establish what ranges of
     versions are acceptable.  Adjacent redundant conditions are effectively
     consolidated (e.g. ``">1, >2"`` produces the same results as ``">2"``, and
-    ``"<2,<3"`` produces the same results as``"<2"``). ``"!="`` versions are
+    ``"<2,<3"`` produces the same results as ``"<2"``). ``"!="`` versions are
     excised from the ranges they fall within.  The version being tested for
     acceptability is then checked for membership in the resulting ranges.
 

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -571,7 +571,7 @@ project name or version identifier must be replaced with ``-``.
 Version specifiers for a given project are internally sorted into ascending
 version order, and used to establish what ranges of versions are acceptable.
 Adjacent redundant conditions are also consolidated (e.g. ``">1, >2"`` becomes
-``">1"``, and ``"<2,<3"`` becomes ``"<3"``). ``"!="`` versions are excised from
+``">2"``, and ``"<2,<3"`` becomes ``"<2"``). ``"!="`` versions are excised from
 the ranges they fall within.  A project's version is then checked for
 membership in the resulting ranges. (Note that providing conflicting conditions
 for the same version (e.g. "<2,>=2" or "==2,!=2") is meaningless and may


### PR DESCRIPTION
The `,` is the equivalent of an "and".
Also, the `pkg_resources` documents and behave like this too:
http://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirement-methods-and-attributes
> [...] Adjacent redundant conditions are effectively consolidated (e.g. ">1, >2" produces the same results as ">2", and "<2,<3" produces the same results as``”<2”).

```
>>> pkg_resources.Requirement('requests>1,>2').specifier.contains('1.2.3')
False
>>> pkg_resources.Requirement('requests>1,>2').specifier.contains('2.3.4')
True
```

Also fixed a small spacing error messing up with formatting in the mentioned `pkg_resources` section.