### PR TITLE
Updates for Metadata 2.1 (PEP 566)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v38.5.3
+-------
+
+* Support Metadata 2.1 (`PEP 566 <https://www.python.org/dev/peps/pep-0566/>`_)
+
 v38.5.2
 -------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
-v38.5.3
+v38.6.0
 -------
 
-* Support Metadata 2.1 (`PEP 566 <https://www.python.org/dev/peps/pep-0566/>`_)
+* #1286: Add support for Metadata 2.1 (PEP 566).
 
 v38.5.2
 -------

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -546,6 +546,7 @@ class TestOptions:
                 'pdf': ['ReportLab>=1.2', 'RXP'],
                 'rest': ['docutils>=0.3', 'pack==1.1,==1.3']
             }
+            assert dist.metadata.provides_extras == set(['pdf', 'rest'])
 
     def test_entry_points(self, tmpdir):
         _, config = fake_env(

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -420,6 +420,24 @@ class TestEggInfo(object):
             self._run_install_command(tmpdir_cwd, env)
         assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
+    def test_provides_extra(self, tmpdir_cwd, env):
+        self._setup_script_with_requires(
+            'extras_require={"foobar": ["barbazquux"]},')
+        environ = os.environ.copy().update(
+            HOME=env.paths['home'],
+        )
+        code, data = environment.run_setup_py(
+            cmd=['egg_info'],
+            pypath=os.pathsep.join([env.paths['lib'], str(tmpdir_cwd)]),
+            data_stream=1,
+            env=environ,
+        )
+        egg_info_dir = os.path.join('.', 'foo.egg-info')
+        with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
+            pkg_info_lines = pkginfo_file.read().split('\n')
+        assert 'Provides-Extra: foobar' in pkg_info_lines
+        assert 'Metadata-Version: 2.1' in pkg_info_lines
+
     def test_long_description_content_type(self, tmpdir_cwd, env):
         # Test that specifying a `long_description_content_type` keyword arg to
         # the `setup` function results in writing a `Description-Content-Type`
@@ -444,6 +462,7 @@ class TestEggInfo(object):
             pkg_info_lines = pkginfo_file.read().split('\n')
         expected_line = 'Description-Content-Type: text/markdown'
         assert expected_line in pkg_info_lines
+        assert 'Metadata-Version: 2.1' in pkg_info_lines
 
     def test_project_urls(self, tmpdir_cwd, env):
         # Test that specifying a `project_urls` dict to the `setup`


### PR DESCRIPTION
This PR makes the necessary updates for Metadata 2.1 ([PEP 566](https://www.python.org/dev/peps/pep-0566/)):

* Handles the new `Description-Content-Type` and `Provides-Extra` fields
  * The former was already added in #1075, I made a slight tweak from #1207 to only set this field if it is present
* Correctly sets the `Version` field to `2.1` if either of the new fields are present