### PR TITLE
config: Allow `file:` directive with `version`

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2421,7 +2421,7 @@ Metadata
 Key                             Aliases            Type
 ==============================  =================  =====
 name                                               str
-version                                            attr:, str
+version                                            file:, attr:, str
 url                             home-page          str
 download_url                    download-url       str
 project_urls                                       dict

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -237,7 +237,7 @@ class ConfigHandler(object):
         return value in ('1', 'true', 'yes')
 
     @classmethod
-    def _parse_file(cls, value):
+    def _parse_file(cls, value, separator='\n'):
         """Represents value as a string, allowing including text
         from nearest files using `file:` directive.
 
@@ -249,6 +249,7 @@ class ConfigHandler(object):
             file: README.rst, CHANGELOG.md, src/file.txt
 
         :param str value:
+        :param str separator:
         :rtype: str
         """
         include_directive = 'file:'
@@ -261,7 +262,7 @@ class ConfigHandler(object):
 
         spec = value[len(include_directive):]
         filepaths = (os.path.abspath(path.strip()) for path in spec.split(','))
-        return '\n'.join(
+        return separator.join(
             cls._read_file(path)
             for path in filepaths
             if (cls._assert_local(path) or True)
@@ -429,7 +430,7 @@ class ConfigMetadataHandler(ConfigHandler):
         """
         include_directive = 'file:'
         if value.startswith(include_directive):
-            return self._parse_file(value)
+            return self._parse_file(value, separator='')
 
         version = self._parse_attr(value)
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -431,6 +431,8 @@ class ConfigMetadataHandler(ConfigHandler):
 
         if callable(version):
             version = version()
+        else:
+            version = self._parse_file(value)
 
         if not isinstance(version, string_types):
             if hasattr(version, '__iter__'):

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -237,7 +237,7 @@ class ConfigHandler(object):
         return value in ('1', 'true', 'yes')
 
     @classmethod
-    def _parse_file(cls, value, separator='\n'):
+    def _parse_file(cls, value):
         """Represents value as a string, allowing including text
         from nearest files using `file:` directive.
 
@@ -249,7 +249,6 @@ class ConfigHandler(object):
             file: README.rst, CHANGELOG.md, src/file.txt
 
         :param str value:
-        :param str separator:
         :rtype: str
         """
         include_directive = 'file:'
@@ -262,7 +261,7 @@ class ConfigHandler(object):
 
         spec = value[len(include_directive):]
         filepaths = (os.path.abspath(path.strip()) for path in spec.split(','))
-        return separator.join(
+        return '\n'.join(
             cls._read_file(path)
             for path in filepaths
             if (cls._assert_local(path) or True)
@@ -430,7 +429,7 @@ class ConfigMetadataHandler(ConfigHandler):
         """
         include_directive = 'file:'
         if value.startswith(include_directive):
-            version = self._parse_file(value, separator='')
+            version = self._parse_file(value)
             return ''.join(version.splitlines())
 
         version = self._parse_attr(value)

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -430,7 +430,8 @@ class ConfigMetadataHandler(ConfigHandler):
         """
         include_directive = 'file:'
         if value.startswith(include_directive):
-            return self._parse_file(value, separator='')
+            version = self._parse_file(value, separator='')
+            return ''.join(version.splitlines())
 
         version = self._parse_attr(value)
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -427,12 +427,14 @@ class ConfigMetadataHandler(ConfigHandler):
         :rtype: str
 
         """
+        include_directive = 'file:'
+        if value.startswith(include_directive):
+            return self._parse_file(value)
+
         version = self._parse_attr(value)
 
         if callable(version):
             version = version()
-        else:
-            version = self._parse_file(value)
 
         if not isinstance(version, string_types):
             if hasattr(version, '__iter__'):

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -257,9 +257,9 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1'
 
-        tmpdir.join('VERSION').write('1.2.3')
-        tmpdir.join('BUILD').write('+20180316')
-        package_dir.join('VERSION').write('3.4.5')
+        tmpdir.join('VERSION').write('1.2.3\n')
+        tmpdir.join('BUILD').write('+20180316\n')
+        package_dir.join('VERSION').write('3.4.5\r\n')
 
         config.write(
             '[metadata]\n'


### PR DESCRIPTION
Reading version number directly from a plaintext file, e.g. VERSION, is a language-independent alternative to importing a module attribute. For example, it is very easily readable in shell scripts, batch scripts, makefiles, powershell, nix packages, you name it.

This change allows the `version` option to use either the `attr:` directive or the `file:` directive. As far as I know this would make it the first option to accept multiple different directives, so I'm unsure if this implementation is the best option. The potential alternative I see is accepting nested directives... but that seems to me like it'd be overcomplicating things.
