### PR TITLE
Fix unicode maintainer

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -36,6 +36,7 @@ def _get_unpatched(cls):
     warnings.warn("Do not call this function", DeprecationWarning)
     return get_unpatched(cls)
 
+
 def get_metadata_version(dist_md):
     if dist_md.long_description_content_type or dist_md.provides_extras:
         return StrictVersion('2.1')
@@ -76,7 +77,7 @@ def write_pkg_file(self, file):
         for field, attr in optional_fields:
             attr_val = getattr(self, attr)
             if six.PY2:
-               attr_val = self._encode_field(attr_val)
+                attr_val = self._encode_field(attr_val)
 
             if attr_val is not None:
                 file.write('%s: %s\n' % (field, attr_val))
@@ -562,7 +563,7 @@ class Distribution(Distribution_parse_config_files, _Distribution):
                 # don't use any other settings
                 'find_links', 'site_dirs', 'index_url',
                 'optimize', 'site_dirs', 'allow_hosts',
-        ))
+            ))
         if self.dependency_links:
             links = self.dependency_links[:]
             if 'find_links' in opts:

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -51,7 +51,7 @@ def get_metadata_version(dist_md):
 
 
 # Based on Python 3.5 version
-def write_pkg_file(self, file, is_test=False):
+def write_pkg_file(self, file):
     """Write the PKG-INFO format data to a file object.
     """
     version = get_metadata_version(self)

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -125,10 +125,10 @@ def test_maintainer_author(name, attrs, tmpdir):
     dist.metadata.write_pkg_info(fn_s)
 
     with io.open(str(fn.join('PKG-INFO')), 'r', encoding='utf-8') as f:
-        pkg_lines = f.readlines()
+        raw_pkg_lines = f.readlines()
 
     # Drop blank lines
-    pkg_lines = list(filter(None, pkg_lines))
+    pkg_lines = list(filter(None, raw_pkg_lines))
 
     pkg_lines_set = set(pkg_lines)
 

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -2,7 +2,6 @@
 from setuptools import Distribution
 from setuptools.extern.six.moves.urllib.request import pathname2url
 from setuptools.extern.six.moves.urllib_parse import urljoin
-from setuptools.extern.six import StringIO
 
 from .textwrap import DALS
 from .test_easy_install import make_nspkg_sdist
@@ -85,15 +84,15 @@ def __maintainer_test_cases():
             {'author_email': 'author@name.com',
              'maintainer_email': 'maintainer@name.com'})),
         ('Author unicode', merge_dicts(attrs,
-            {'author': '鉄沢寛'})),
+            {'author': u'鉄沢寛'})),
         ('Maintainer unicode', merge_dicts(attrs,
-            {'maintainer': 'Jan Łukasiewicz'})),
+            {'maintainer': u'Jan Łukasiewicz'})),
     ]
 
     return test_cases
 
 @pytest.mark.parametrize('name,attrs', __maintainer_test_cases())
-def test_maintainer_author(name, attrs):
+def test_maintainer_author(name, attrs, tmpdir):
     tested_keys = {
         'author': 'Author',
         'author_email': 'Author-email',
@@ -103,11 +102,14 @@ def test_maintainer_author(name, attrs):
 
     # Generate a PKG-INFO file
     dist = Distribution(attrs)
-    PKG_INFO = StringIO()
-    dist.metadata.write_pkg_file(PKG_INFO)
-    PKG_INFO.seek(0)
+    fn = tmpdir.mkdir('pkg_info')
+    fn_s = str(fn)
 
-    pkg_lines = PKG_INFO.readlines()
+    dist.metadata.write_pkg_info(fn_s)
+
+    with open(str(fn.join('PKG-INFO')), 'r') as f:
+        pkg_lines = f.readlines()
+
     pkg_lines = [_ for _ in pkg_lines if _]   # Drop blank lines
     pkg_lines_set = set(pkg_lines)
 

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import unicode_literals
+
 from setuptools import Distribution
 from setuptools.extern.six.moves.urllib.request import pathname2url
 from setuptools.extern.six.moves.urllib_parse import urljoin
@@ -84,9 +87,9 @@ def __maintainer_test_cases():
             {'author_email': 'author@name.com',
              'maintainer_email': 'maintainer@name.com'})),
         ('Author unicode', merge_dicts(attrs,
-            {'author': u'鉄沢寛'})),
+            {'author': '鉄沢寛'})),
         ('Maintainer unicode', merge_dicts(attrs,
-            {'maintainer': u'Jan Łukasiewicz'})),
+            {'maintainer': 'Jan Łukasiewicz'})),
     ]
 
     return test_cases

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -2,6 +2,8 @@
 
 from __future__ import unicode_literals
 
+import io
+
 from setuptools import Distribution
 from setuptools.extern.six.moves.urllib.request import pathname2url
 from setuptools.extern.six.moves.urllib_parse import urljoin
@@ -122,7 +124,7 @@ def test_maintainer_author(name, attrs, tmpdir):
 
     dist.metadata.write_pkg_info(fn_s)
 
-    with open(str(fn.join('PKG-INFO')), 'r') as f:
+    with io.open(str(fn.join('PKG-INFO')), 'r', encoding='utf-8') as f:
         pkg_lines = f.readlines()
 
     pkg_lines = [_ for _ in pkg_lines if _]   # Drop blank lines

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -11,12 +11,14 @@ from .test_easy_install import make_nspkg_sdist
 
 import pytest
 
+
 def test_dist_fetch_build_egg(tmpdir):
     """
     Check multiple calls to `Distribution.fetch_build_egg` work as expected.
     """
     index = tmpdir.mkdir('index')
     index_url = urljoin('file://', pathname2url(str(index)))
+
     def sdist_with_index(distname, version):
         dist_dir = index.mkdir(distname)
         dist_sdist = '%s-%s.tar.gz' % (distname, version)
@@ -65,34 +67,44 @@ def __maintainer_test_cases():
 
     test_cases = [
         ('No author, no maintainer', attrs.copy()),
-        ('Author (no e-mail), no maintainer', merge_dicts(attrs,
+        ('Author (no e-mail), no maintainer', merge_dicts(
+            attrs,
             {'author': 'Author Name'})),
-        ('Author (e-mail), no maintainer', merge_dicts(attrs,
+        ('Author (e-mail), no maintainer', merge_dicts(
+            attrs,
             {'author': 'Author Name',
              'author_email': 'author@name.com'})),
-        ('No author, maintainer (no e-mail)', merge_dicts(attrs,
+        ('No author, maintainer (no e-mail)', merge_dicts(
+            attrs,
             {'maintainer': 'Maintainer Name'})),
-        ('No author, maintainer (e-mail)', merge_dicts(attrs,
+        ('No author, maintainer (e-mail)', merge_dicts(
+            attrs,
             {'maintainer': 'Maintainer Name',
              'maintainer_email': 'maintainer@name.com'})),
-        ('Author (no e-mail), Maintainer (no-email)', merge_dicts(attrs,
+        ('Author (no e-mail), Maintainer (no-email)', merge_dicts(
+            attrs,
             {'author': 'Author Name',
              'maintainer': 'Maintainer Name'})),
-        ('Author (e-mail), Maintainer (e-mail)', merge_dicts(attrs,
+        ('Author (e-mail), Maintainer (e-mail)', merge_dicts(
+            attrs,
             {'author': 'Author Name',
              'author_email': 'author@name.com',
              'maintainer': 'Maintainer Name',
              'maintainer_email': 'maintainer@name.com'})),
-        ('No author (e-mail), no maintainer (e-mail)', merge_dicts(attrs,
+        ('No author (e-mail), no maintainer (e-mail)', merge_dicts(
+            attrs,
             {'author_email': 'author@name.com',
              'maintainer_email': 'maintainer@name.com'})),
-        ('Author unicode', merge_dicts(attrs,
+        ('Author unicode', merge_dicts(
+            attrs,
             {'author': '鉄沢寛'})),
-        ('Maintainer unicode', merge_dicts(attrs,
+        ('Maintainer unicode', merge_dicts(
+            attrs,
             {'maintainer': 'Jan Łukasiewicz'})),
     ]
 
     return test_cases
+
 
 @pytest.mark.parametrize('name,attrs', __maintainer_test_cases())
 def test_maintainer_author(name, attrs, tmpdir):
@@ -127,4 +139,3 @@ def test_maintainer_author(name, attrs, tmpdir):
         else:
             line = '%s: %s' % (fkey, val)
             assert line in pkg_lines_set
-

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -127,7 +127,9 @@ def test_maintainer_author(name, attrs, tmpdir):
     with io.open(str(fn.join('PKG-INFO')), 'r', encoding='utf-8') as f:
         pkg_lines = f.readlines()
 
-    pkg_lines = [_ for _ in pkg_lines if _]   # Drop blank lines
+    # Drop blank lines
+    pkg_lines = list(filter(None, pkg_lines))
+
     pkg_lines_set = set(pkg_lines)
 
     # Duplicate lines should not be generated


### PR DESCRIPTION
Fixes #1297.

I also don't think the version comparisons were working correctly in the original patch in certain situations, so that was updated.