### PR TITLE
Stop patching write_pkg_info

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -123,15 +123,6 @@ def write_pkg_file(self, file):
             file.write('Provides-Extra: %s\n' % extra)
 
 
-# from Python 3.4
-def write_pkg_info(self, base_dir):
-    """Write the PKG-INFO file into the release tree.
-    """
-    with open(os.path.join(base_dir, 'PKG-INFO'), 'w',
-              encoding='UTF-8') as pkg_info:
-        self.write_pkg_file(pkg_info)
-
-
 sequence = tuple, list
 
 

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -87,7 +87,6 @@ def patch_all():
         distutils.config.PyPIRCCommand.DEFAULT_REPOSITORY = warehouse
 
     _patch_distribution_metadata_write_pkg_file()
-    _patch_distribution_metadata_write_pkg_info()
 
     # Install Distribution throughout the distutils
     for module in distutils.dist, distutils.core, distutils.cmd:
@@ -108,21 +107,6 @@ def _patch_distribution_metadata_write_pkg_file():
     """Patch write_pkg_file to also write Requires-Python/Requires-External"""
     distutils.dist.DistributionMetadata.write_pkg_file = (
         setuptools.dist.write_pkg_file
-    )
-
-
-def _patch_distribution_metadata_write_pkg_info():
-    """
-    Workaround issue #197 - Python 3 prior to 3.2.2 uses an environment-local
-    encoding to save the pkg_info. Monkey-patch its write_pkg_info method to
-    correct this undesirable behavior.
-    """
-    environment_local = (3,) <= sys.version_info[:3] < (3, 2, 2)
-    if not environment_local:
-        return
-
-    distutils.dist.DistributionMetadata.write_pkg_info = (
-        setuptools.dist.write_pkg_info
     )
 
 


### PR DESCRIPTION
Fixes #1289. Since setuptools no longer supports Python 3.2, this patch is unnecessary.

I am aware that this may be an unnecessary risk considering this patch isn't actively hurting anything, but it's probably worth some cleanup.

I tried to dig around in the git history to figure out which, if any, tests test that this works correctly, but I couldn't find anything. @jaraco Do you know if there are any? If not, should I add them?