### PR TITLE
MAI: rephrase messages about MANIFEST rules

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -333,7 +333,7 @@ class FileList(_FileList):
             self.debug_print("exclude " + ' '.join(patterns))
             for pattern in patterns:
                 if not self.exclude(pattern):
-                    log.warn(("warning: no previously-included files "
+                    log.warn(("warning: no to-exclude files "
                               "found matching '%s'"), pattern)
 
         elif action == 'global-include':
@@ -347,7 +347,7 @@ class FileList(_FileList):
             self.debug_print("global-exclude " + ' '.join(patterns))
             for pattern in patterns:
                 if not self.global_exclude(pattern):
-                    log.warn(("warning: no previously-included files matching "
+                    log.warn(("warning: no to-exclude files matching "
                               "'%s' found anywhere in distribution"),
                              pattern)
 
@@ -365,7 +365,7 @@ class FileList(_FileList):
                              (dir, ' '.join(patterns)))
             for pattern in patterns:
                 if not self.recursive_exclude(dir, pattern):
-                    log.warn(("warning: no previously-included files matching "
+                    log.warn(("warning: no to-exclude files matching "
                               "'%s' found under directory '%s'"),
                              pattern, dir)
 
@@ -378,7 +378,7 @@ class FileList(_FileList):
         elif action == 'prune':
             self.debug_print("prune " + dir_pattern)
             if not self.prune(dir_pattern):
-                log.warn(("no previously-included directories found "
+                log.warn(("no to-prune directories found "
                           "matching '%s'"), dir_pattern)
 
         else:


### PR DESCRIPTION
I was initially perplexed by these messages, because of the word "included". The messages for `exclude`, `global-exclude`, `recursive-exclude`, and `prune` are of the form "previously-included" (bb45468d27615c2ce9f9c9757a367c44d6ee80d2), which is different from the messages about `include`, `global-include`, `global-exclude` (e.g., "no files found matching"). So there is a distinction, but when seeing "previously-included" one may think about `include` rules. Also, `exclude` does not imply that previously the excluded files were included.

Corresponds to #1313.