### PR TITLE
Make safe_name compliant to PEP 503 and behaviour of pip > 8.1.2

### DIFF
--- a/changelog.d/1324.change.rst
+++ b/changelog.d/1324.change.rst
@@ -1,0 +1,1 @@
+Make safe_name compliant with PEP 503.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1309,9 +1309,9 @@ def get_default_cache():
 def safe_name(name):
     """Convert an arbitrary string to a standard distribution name
 
-    Any runs of non-alphanumeric/. characters are replaced with a single '-'.
+    Any runs of non-alphanumeric characters are replaced with a single '-'.
     """
-    return re.sub('[^A-Za-z0-9.]+', '-', name)
+    return re.sub('[^A-Za-z0-9]+', '-', name)
 
 
 def safe_version(version):


### PR DESCRIPTION
According to PEP 503, a "normalized" project name has all runs of the
characters ., - and _ replaced with a single - character. [0]

Similarly, since version 8.1.2, that is the behaviour of pip as well. [1]

However, Setuptools still allows a . in the normalized name, which
is causing trouble down the line.

[0] https://www.python.org/dev/peps/pep-0503/#normalized-names
[1] https://github.com/pypa/pip/issues/3666