### PR TITLE
Add .pytest_cache/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ setuptools.egg-info
 *~
 .hg*
 .cache
+.pytest_cache/


### PR DESCRIPTION
As of version 3.4.0, `pytest` renamed their cache from `.cache` to `.pytest_cache`.