### PR TITLE
Adds call to os.path.abspath() in pkg_resources.normalize_path() on Cygwin

### DIFF
--- a/changelog.d/1335.change.rst
+++ b/changelog.d/1335.change.rst
@@ -1,0 +1,1 @@
+In ``pkg_resources.normalize_path``, fix issue on Cygwin when cwd contains symlinks.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2220,7 +2220,15 @@ register_namespace_handler(object, null_ns_handler)
 
 def normalize_path(filename):
     """Normalize a file/dir name for comparison purposes"""
-    return os.path.normcase(os.path.realpath(filename))
+    if sys.platform == 'cygwin':
+      # This results in a call to getcwd() if `filename` is relative. Contrary
+      # to POSIX 2008 on Cygwin getcwd (3) contains symlink components. Using
+      # os.path.abspath() works around this limitation. A fix in os.getcwd()
+      # would probably better, in Cygwin even more so except that this seems
+      # to be by design...
+      return os.path.normcase(os.path.realpath(os.path.abspath(filename)))
+    else:
+      return os.path.normcase(os.path.realpath(filename))
 
 
 def _normalize_cached(filename, _cache={}):

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2220,15 +2220,18 @@ register_namespace_handler(object, null_ns_handler)
 
 def normalize_path(filename):
     """Normalize a file/dir name for comparison purposes"""
-    if sys.platform == 'cygwin':
-      # This results in a call to getcwd() if `filename` is relative. Contrary
-      # to POSIX 2008 on Cygwin getcwd (3) contains symlink components. Using
-      # os.path.abspath() works around this limitation. A fix in os.getcwd()
-      # would probably better, in Cygwin even more so except that this seems
-      # to be by design...
-      return os.path.normcase(os.path.realpath(os.path.abspath(filename)))
-    else:
-      return os.path.normcase(os.path.realpath(filename))
+    return os.path.normcase(os.path.realpath(_cygwin_patch(filename)))
+
+
+def _cygwin_patch(filename):  # pragma: nocover
+    """
+    Contrary to POSIX 2008, on Cygwin, getcwd (3) contains
+    symlink components. Using
+    os.path.abspath() works around this limitation. A fix in os.getcwd()
+    would probably better, in Cygwin even more so, except
+    that this seems to be by design...
+    """
+    return os.path.abspath(filename) if sys.platform == 'cygwin' else filename
 
 
 def _normalize_cached(filename, _cache={}):


### PR DESCRIPTION
This works around problems that stem from getcwd(3) on Cygwin returning paths containing symlinks. I am not sure at all whether this is a good place to fix it, but that's where I got hit by the issue when doing a `python setup.py develop` (or `pip install -e .`).