### PR TITLE
Prepare submodules for dependency links to Git repositories.

### DIFF
--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -898,9 +898,10 @@ class PackageIndex(Environment):
                 filename,
                 rev,
             ))
-            os.system("(cd %s && git submodule update --init --recursive)" % (
-                filename
-            ))
+
+        os.system("(cd %s && git submodule update --init --recursive)" % (
+            filename
+        ))
 
         return filename
 

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -898,6 +898,9 @@ class PackageIndex(Environment):
                 filename,
                 rev,
             ))
+            os.system("(cd %s && git submodule update --init --recursive)" % (
+                filename
+            ))
 
         return filename
 


### PR DESCRIPTION
## Problem

I need to manage dependency between several Python projects hosted in private Git repositories. The orthodox way to do this is writting `dependency_links` in `setup.py` (or something similar purposed in `pip 10.0.0`).

Here is an example, one of my project `rabbit` is dependent on another private project `carrots`.

```Python
from setuptools import setup


DEPENDENCIES = [
    'carrots',
]
DEPENDENCY_LINKS = [
    'git+ssh://git@github.com/Czxck001/carrots@v0.0.1#egg=carrots-0.0.1'
]

setup(
    name='rabbit',
    version='0.0.1',
	...
    install_requires=DEPENDENCIES,
    dependency_links=DEPENDENCY_LINKS,
)

```

However, some of these depended Git repositories (`carrots`) may have submodules. These submodules are necessary to in their build. The problem is, `setuptools` only clone the depended repositories and check it out to user-specified branch. `setuptools` won't prepare the submodules.

In such circumstances, the user of `rabbit` will have to manually install `carrots` (after using `git submodule` to get all submodules prepared). That is to say, `setup.py` in `rabbit` cannot independently install `rabbit`.

I believe this is not a so-personal user case. Using submodules to integrate code is common for Git, especially for the C language. If one want to have a Python wrapper for a C project, using git submodules would be a good choice.

## Solution

I browsed the source code of `setuptools`. I found the git-clone operation is hard-coded in `setuptools/package_index.py`. Here is the method for downloading git repository:

```Python
    def _download_git(self, url, filename):
        filename = filename.split('#', 1)[0]
        url, rev = self._vcs_split_rev_from_url(url, pop_prefix=True)

        self.info("Doing git clone from %s to %s", url, filename)
        os.system("git clone --quiet %s %s" % (url, filename))

        if rev is not None:
            self.info("Checking out %s", rev)
            os.system("(cd %s && git checkout --quiet %s)" % (
                filename,
                rev,
            ))

        return filename
```

To solve the problem, I appended the git command recursively clone submodules after checkout:

```Python
    def _download_git(self, url, filename):
        filename = filename.split('#', 1)[0]
        url, rev = self._vcs_split_rev_from_url(url, pop_prefix=True)

        self.info("Doing git clone from %s to %s", url, filename)
        os.system("git clone --quiet %s %s" % (url, filename))

        if rev is not None:
            self.info("Checking out %s", rev)
            os.system("(cd %s && git checkout --quiet %s)" % (
                filename,
                rev,
            ))

        os.system("(cd %s && git submodule update --init --recursive)" % (
            filename
        ))

        return filename
```

Then it works fine for me.

I tested the code in both MacOS and Linux. I believe it will works for Windows too. 

This fix will not influence the case when user did not have submodules in their Git repository.