### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1808,7 +1808,7 @@ process to fail and PyPI uploads no longer accept files for 13.0.
 * Issue #313: Removed built-in support for subversion. Projects wishing to
   retain support for subversion will need to use a third party library. The
   extant implementation is being ported to `setuptools_svn
-  <https://pypi.python.org/pypi/setuptools_svn>`_.
+  <https://pypi.org/project/setuptools_svn/>`_.
 * Issue #315: Updated setuptools to hide its own loaded modules during
   installation of another package. This change will enable setuptools to
   upgrade (or downgrade) itself even when its own metadata and implementation
@@ -2313,7 +2313,7 @@ process to fail and PyPI uploads no longer accept files for 13.0.
 * Address security vulnerability in SSL match_hostname check as reported in
   Python #17997.
 * Prefer `backports.ssl_match_hostname
-  <https://pypi.python.org/pypi/backports.ssl_match_hostname>`_ for backport
+  <https://pypi.org/project/backports.ssl_match_hostname/>`_ for backport
   implementation if present.
 * Correct NameError in ``ssl_support`` module (``socket.error``).
 

--- a/docs/_templates/indexsidebar.html
+++ b/docs/_templates/indexsidebar.html
@@ -1,7 +1,7 @@
 <h3>Download</h3>
 
 <p>Current version: <b>{{ version }}</b></p>
-<p>Get Setuptools from the <a href="https://pypi.python.org/pypi/setuptools"> Python Package Index</a>
+<p>Get Setuptools from the <a href="https://pypi.org/project/setuptools/"> Python Package Index</a>
 
 <h3>Questions? Suggestions? Contributions?</h3>
 

--- a/docs/easy_install.txt
+++ b/docs/easy_install.txt
@@ -31,7 +31,7 @@ Using "Easy Install"
 Installing "Easy Install"
 -------------------------
 
-Please see the `setuptools PyPI page <https://pypi.python.org/pypi/setuptools>`_
+Please see the `setuptools PyPI page <https://pypi.org/project/setuptools/>`_
 for download links and basic installation instructions for each of the
 supported platforms.
 
@@ -831,7 +831,7 @@ Command-Line Options
 
 ``--index-url=URL, -i URL`` (New in 0.4a1; default changed in 0.6c7)
     Specifies the base URL of the Python Package Index.  The default is
-    https://pypi.python.org/simple if not specified.  When a package is requested
+    https://pypi.org/simple/ if not specified.  When a package is requested
     that is not locally available or linked from a ``--find-links`` download
     page, the package index will be searched for download pages for the needed
     package, and those download pages will be searched for links to download
@@ -1019,7 +1019,7 @@ that the User installation scheme alone does not provide, e.g. the ability to hi
 
 Please refer to the `virtualenv`_ documentation for more details.
 
-.. _virtualenv: https://pypi.python.org/pypi/virtualenv
+.. _virtualenv: https://pypi.org/project/virtualenv/
 
 
 
@@ -1620,4 +1620,3 @@ Future Plans
 * Signature checking?  SSL?  Ability to suppress PyPI search?
 * Display byte progress meter when downloading distributions and long pages?
 * Redirect stdout/stderr to log during run_setup?
-

--- a/docs/python3.txt
+++ b/docs/python3.txt
@@ -10,8 +10,8 @@ code.
 Setuptools provides a facility to invoke 2to3 on the code as a part of the
 build process, by setting the keyword parameter ``use_2to3`` to True, but
 the Setuptools strongly recommends instead developing a unified codebase
-using `six <https://pypi.python.org/pypi/six>`_,
-`future <https://pypi.python.org/pypi/future>`_, or another compatibility
+using `six <https://pypi.org/project/six/>`_,
+`future <https://pypi.org/project/future/>`_, or another compatibility
 library.
 
 

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2277,7 +2277,7 @@ The ``upload`` command is implemented and `documented
 in distutils.
 
 Setuptools augments the ``upload`` command with support
-for `keyring <https://pypi.python.org/pypi/keyring>`_,
+for `keyring <https://pypi.org/project/keyring/>`_,
 allowing the password to be stored in a secure
 location and not in plaintext in the .pypirc file. To use
 keyring, first install keyring and set the password for
@@ -2671,8 +2671,8 @@ Adding Support for Revision Control Systems
 If the files you want to include in the source distribution are tracked using
 Git, Mercurial or SVN, you can use the following packages to achieve that:
 
-- Git and Mercurial: `setuptools_scm <https://pypi.python.org/pypi/setuptools_scm>`_
-- SVN: `setuptools_svn <https://pypi.python.org/pypi/setuptools_svn>`_
+- Git and Mercurial: `setuptools_scm <https://pypi.org/project/setuptools_scm/>`_
+- SVN: `setuptools_svn <https://pypi.org/project/setuptools_svn/>`_
 
 If you would like to create a plugin for ``setuptools`` to find files tracked
 by another revision control system, you can do so by adding an entry point to

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -319,7 +319,7 @@ class easy_install(Command):
                     self.all_site_dirs.append(normalize_path(d))
         if not self.editable:
             self.check_site_dir()
-        self.index_url = self.index_url or "https://pypi.python.org/simple"
+        self.index_url = self.index_url or "https://pypi.org/simple/"
         self.shadow_path = self.all_site_dirs[:]
         for path_item in self.install_dir, normalize_path(self.script_dir):
             if path_item not in self.shadow_path:

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -297,7 +297,7 @@ class PackageIndex(Environment):
     """A distribution index that scans web pages for download URLs"""
 
     def __init__(
-            self, index_url="https://pypi.python.org/simple", hosts=('*',),
+            self, index_url="https://pypi.org/simple/", hosts=('*',),
             ca_bundle=None, verify_ssl=True, *args, **kw
     ):
         Environment.__init__(self, *args, **kw)

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -265,11 +265,11 @@ class TestPyPIConfig:
         with pypirc.open('w') as strm:
             strm.write(DALS("""
                 [pypi]
-                repository=https://pypi.python.org
+                repository=https://pypi.org
                 username=jaraco
                 password=pity%
             """))
         cfg = setuptools.package_index.PyPIConfig()
-        cred = cfg.creds_by_repository['https://pypi.python.org']
+        cred = cfg.creds_by_repository['https://pypi.org']
         assert cred.username == 'jaraco'
         assert cred.password == 'pity%'


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html