### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/changelog.d/1342.breaking.rst
+++ b/changelog.d/1342.breaking.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.3.

--- a/docs/easy_install.txt
+++ b/docs/easy_install.txt
@@ -35,7 +35,7 @@ Please see the `setuptools PyPI page <https://pypi.org/project/setuptools/>`_
 for download links and basic installation instructions for each of the
 supported platforms.
 
-You will need at least Python 3.3 or 2.7.  An ``easy_install`` script will be
+You will need at least Python 3.4 or 2.7.  An ``easy_install`` script will be
 installed in the normal location for Python scripts on your platform.
 
 Note that the instructions on the setuptools PyPI page assume that you are

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -78,8 +78,8 @@ __import__('pkg_resources.extern.packaging.requirements')
 __import__('pkg_resources.extern.packaging.markers')
 
 
-if (3, 0) < sys.version_info < (3, 3):
-    raise RuntimeError("Python 3.3 or later is required")
+if (3, 0) < sys.version_info < (3, 4):
+    raise RuntimeError("Python 3.4 or later is required")
 
 if six.PY2:
     # Those builtin exceptions are only defined in Python 3
@@ -959,7 +959,7 @@ class Environment(object):
         `platform` is an optional string specifying the name of the platform
         that platform-specific distributions must be compatible with.  If
         unspecified, it defaults to the current platform.  `python` is an
-        optional string naming the desired version of Python (e.g. ``'3.3'``);
+        optional string naming the desired version of Python (e.g. ``'3.6'``);
         it defaults to the current version.
 
         You may explicitly set `platform` (and/or `python`) to ``None`` if you

--- a/pkg_resources/extern/__init__.py
+++ b/pkg_resources/extern/__init__.py
@@ -48,7 +48,7 @@ class VendorImporter:
                 # on later Python versions to cause relative imports
                 # in the vendor package to resolve the same modules
                 # as those going through this importer.
-                if sys.version_info > (3, 3):
+                if sys.version_info.major >= 3:
                     del sys.modules[extant]
                 return mod
             except ImportError:

--- a/pkg_resources/py31compat.py
+++ b/pkg_resources/py31compat.py
@@ -15,8 +15,7 @@ def _makedirs_31(path, exist_ok=False):
 #  and exists_ok considerations are disentangled.
 # See https://github.com/pypa/setuptools/pull/1083#issuecomment-315168663
 needs_makedirs = (
-    sys.version_info < (3, 2, 5) or
-    (3, 3) <= sys.version_info < (3, 3, 6) or
+    sys.version_info.major == 2 or
     (3, 4) <= sys.version_info < (3, 4, 1)
 )
 makedirs = _makedirs_31 if needs_makedirs else os.makedirs

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -668,7 +668,7 @@ class TestParsing:
         assert (
             Requirement.parse("name==1.1;python_version=='2.7'")
             !=
-            Requirement.parse("name==1.1;python_version=='3.3'")
+            Requirement.parse("name==1.1;python_version=='3.6'")
         )
         assert (
             Requirement.parse("name==1.0;python_version=='2.7'")
@@ -676,9 +676,9 @@ class TestParsing:
             Requirement.parse("name==1.2;python_version=='2.7'")
         )
         assert (
-            Requirement.parse("name[foo]==1.0;python_version=='3.3'")
+            Requirement.parse("name[foo]==1.0;python_version=='3.6'")
             !=
-            Requirement.parse("name[foo,bar]==1.0;python_version=='3.3'")
+            Requirement.parse("name[foo,bar]==1.0;python_version=='3.6'")
         )
 
     def test_local_version(self):

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,6 @@ setup_params = dict(
         Programming Language :: Python :: 2
         Programming Language :: Python :: 2.7
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.3
         Programming Language :: Python :: 3.4
         Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
@@ -170,7 +169,7 @@ setup_params = dict(
         Topic :: System :: Systems Administration
         Topic :: Utilities
         """).strip().splitlines(),
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     extras_require={
         "ssl:sys_platform=='win32'": "wincertstore==0.2",
         "certs": "certifi==2016.9.26",

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -411,7 +411,7 @@ def scan_module(egg_dir, base, name, stubs):
         return True  # Extension module
     pkg = base[len(egg_dir) + 1:].replace(os.sep, '.')
     module = pkg + (pkg and '.' or '') + os.path.splitext(name)[0]
-    if sys.version_info < (3, 3):
+    if sys.version_info.major == 2:
         skip = 8  # skip magic & date
     elif sys.version_info < (3, 7):
         skip = 12  # skip magic & date & file size

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -112,7 +112,7 @@ class build_ext(_build_ext):
                 and get_abi3_suffix()
             )
             if use_abi3:
-                so_ext = _get_config_var_837('EXT_SUFFIX')
+                so_ext = get_config_var('EXT_SUFFIX')
                 filename = filename[:-len(so_ext)]
                 filename = filename + get_abi3_suffix()
             if isinstance(ext, Library):
@@ -319,13 +319,3 @@ else:
         self.create_static_lib(
             objects, basename, output_dir, debug, target_lang
         )
-
-
-def _get_config_var_837(name):
-    """
-    In https://github.com/pypa/setuptools/pull/837, we discovered
-    Python 3.3.0 exposes the extension suffix under the name 'SO'.
-    """
-    if sys.version_info < (3, 3, 1):
-        name = 'SO'
-    return get_config_var(name)

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -40,12 +40,13 @@ import subprocess
 import shlex
 import io
 
+from sysconfig import get_config_vars, get_path
+
 from setuptools.extern import six
 from setuptools.extern.six.moves import configparser, map
 
 from setuptools import Command
 from setuptools.sandbox import run_setup
-from setuptools.py31compat import get_path, get_config_vars
 from setuptools.py27compat import rmtree_safe
 from setuptools.command import setopt
 from setuptools.archive_util import unpack_archive

--- a/setuptools/extern/__init__.py
+++ b/setuptools/extern/__init__.py
@@ -48,7 +48,7 @@ class VendorImporter:
                 # on later Python versions to cause relative imports
                 # in the vendor package to resolve the same modules
                 # as those going through this importer.
-                if sys.version_info > (3, 3):
+                if sys.version_info.major >= 3:
                     del sys.modules[extant]
                 return mod
             except ImportError:

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -75,8 +75,6 @@ def patch_all():
     needs_warehouse = (
         sys.version_info < (2, 7, 13)
         or
-        (3, 0) < sys.version_info < (3, 3, 7)
-        or
         (3, 4) < sys.version_info < (3, 4, 6)
         or
         (3, 5) < sys.version_info <= (3, 5, 3)

--- a/setuptools/pep425tags.py
+++ b/setuptools/pep425tags.py
@@ -97,8 +97,8 @@ def get_abi_tag():
                     lambda: sys.maxunicode == 0x10ffff,
                     expected=4,
                     warn=(impl == 'cp' and
-                          sys.version_info < (3, 3))) \
-                and sys.version_info < (3, 3):
+                          sys.version_info.major == 2)) \
+                and sys.version_info.major == 2:
             u = 'u'
         abi = '%s%s%s%s%s' % (impl, get_impl_ver(), d, m, u)
     elif soabi and soabi.startswith('cpython-'):

--- a/setuptools/py31compat.py
+++ b/setuptools/py31compat.py
@@ -1,3 +1,5 @@
+__all__ = []
+
 try:
     # Python >=3.2
     from tempfile import TemporaryDirectory

--- a/setuptools/py31compat.py
+++ b/setuptools/py31compat.py
@@ -1,17 +1,3 @@
-__all__ = ['get_config_vars', 'get_path']
-
-try:
-    # Python 2.7 or >=3.2
-    from sysconfig import get_config_vars, get_path
-except ImportError:
-    from distutils.sysconfig import get_config_vars, get_python_lib
-
-    def get_path(name):
-        if name not in ('platlib', 'purelib'):
-            raise ValueError("Name must be purelib or platlib")
-        return get_python_lib(name == 'platlib')
-
-
 try:
     # Python >=3.2
     from tempfile import TemporaryDirectory

--- a/setuptools/site-patch.py
+++ b/setuptools/site-patch.py
@@ -23,7 +23,7 @@ def __boot():
                 break
         else:
             try:
-                import imp  # Avoid import loop in Python >= 3.3
+                import imp  # Avoid import loop in Python 3
                 stream, path, descr = imp.find_module('site', [item])
             except ImportError:
                 continue

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -688,7 +688,7 @@ def create_setup_requires_package(path, distname='foobar', version='0.1',
 )
 class TestScriptHeader:
     non_ascii_exe = '/Users/José/bin/python'
-    exe_with_spaces = r'C:\Program Files\Python33\python.exe'
+    exe_with_spaces = r'C:\Program Files\Python36\python.exe'
 
     def test_get_script_header(self):
         expected = '#!%s\n' % ei.nt_quote_arg(os.path.normpath(sys.executable))

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -452,7 +452,7 @@ class TestEggInfo(object):
 
     def test_doesnt_provides_extra(self, tmpdir_cwd, env):
         self._setup_script_with_requires(
-            '''install_requires=["spam ; python_version<'3.3'"]''')
+            '''install_requires=["spam ; python_version<'3.6'"]''')
         environ = os.environ.copy().update(
             HOME=env.paths['home'],
         )

--- a/setuptools/tests/test_install_scripts.py
+++ b/setuptools/tests/test_install_scripts.py
@@ -19,7 +19,7 @@ class TestInstallScripts:
     )
     unix_exe = '/usr/dummy-test-path/local/bin/python'
     unix_spaces_exe = '/usr/bin/env dummy-test-python'
-    win32_exe = 'C:\\Dummy Test Path\\Program Files\\Python 3.3\\python.exe'
+    win32_exe = 'C:\\Dummy Test Path\\Program Files\\Python 3.6\\python.exe'
 
     def _run_install_scripts(self, install_dir, executable=None):
         dist = Distribution(self.settings)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 #
 # To run Tox against all supported Python interpreters, you can set:
 #
-# export TOXENV='py27,py3{3,4,5,6},pypy,pypy3'
+# export TOXENV='py27,py3{4,5,6},pypy,pypy3'
 
 [tox]
 envlist=python


### PR DESCRIPTION
As suggested in https://github.com/pypa/setuptools/issues/1339, as it's EOL and Tox no longer supports it.

Also remove redundant code and update other code.