### PR TITLE
Allow setting long_description_content_type externally

### DIFF
--- a/changelog.d/1343.misc.rst
+++ b/changelog.d/1343.misc.rst
@@ -1,0 +1,4 @@
+The ``setuptools`` specific ``long_description_content_type``,
+``project_urls`` and ``provides_extras`` fields are now set
+consistently after any ``distutils`` ``setup_keywords`` calls,
+allowing them to override values.


### PR DESCRIPTION
Some tools, such as PBR, might want to set `long_description_content_type` externally.  Modify the extant code to take the existing value from ``dist.metadata`` if it is already set.

I believe the path for this is that ```_Distribution.__init__()``` gets called, which calls the ``distutils`` initalizer, which calls into https://git.openstack.org/cgit/openstack-dev/pbr/tree/pbr/core.py.  This ``__init__`` call has setup ``dist.metadata`` within the object.

PBR then reads ``setup.cfg`` and populates a range of fields into the ``dist`` object, including some metadata.  However, it is not possible for it to set the ``long_description_content_type`` because setuptools only takes it from its own ``attr`` argument after the ``distutils`` initalizers have run.

By making setuptools check if there is already a value for it in metadata, we can modify PBR to write the value to ``dist.metadata`` and have it maintained.

This is a problem unique to this field, as it's not part of the base ``distutils`` metadata 