### PR TITLE
Drop python3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
 - &latest_py2 2.7
-- 3.3
 - 3.4
 - 3.5
 - &latest_py3 3.6

--- a/setup.py
+++ b/setup.py
@@ -161,7 +161,6 @@ setup_params = dict(
         Programming Language :: Python :: 2
         Programming Language :: Python :: 2.7
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.3
         Programming Language :: Python :: 3.4
         Programming Language :: Python :: 3.5
         Programming Language :: Python :: 3.6
@@ -170,7 +169,7 @@ setup_params = dict(
         Topic :: System :: Systems Administration
         Topic :: Utilities
         """).strip().splitlines(),
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     extras_require={
         "ssl:sys_platform=='win32'": "wincertstore==0.2",
         "certs": "certifi==2016.9.26",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 #
 # To run Tox against all supported Python interpreters, you can set:
 #
-# export TOXENV='py27,py3{3,4,5,6},pypy,pypy3'
+# export TOXENV='py27,py3{4,5,6},pypy,pypy3'
 
 [tox]
 envlist=python


### PR DESCRIPTION
As described in the changelog, the latest release of pytest-flake8 has a hard dependency on pytest>=3.5, which doesn't support python3.3

This is a two part proposal to remove it from travis ci as a minimal thing to get CI tests green, and then a follow-on to remove wider references to python3.3