### PR TITLE
Pin pytest-flake8 to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ jobs:
 cache: pip
 
 install:
+# ensure we have recent pip/setuptools
+- pip install --upgrade pip setuptools
 # need tox to get started
 - pip install tox 'tox-venv; python_version!="3.3"'
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,7 @@
 importlib; python_version<"2.7"
 mock
-pytest-flake8; python_version>="2.7"
+pytest-flake8<=1.0.0; python_version>="3.3" and python_version<"3.5"
+pytest-flake8; python_version>="2.7" and python_version!="3.3" and python_version!="3.4"
 virtualenv>=13.0.0
 pytest-virtualenv>=1.2.7
 pytest>=3.0.2


### PR DESCRIPTION
pytest-flake8 1.0.1 has a hard dependency on pytest>=3.5 [1], which
does not support python3.3 [2].  Pin it until python3.3 is removed
[3].

[1] https://github.com/tholo/pytest-flake8/commit/25bbd3b42d3aa0962fb736202115dae9e5d2cd7c
[2] https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-0-2017-11-23
[3] https://github.com/pypa/setuptools/pull/1342