### PR TITLE
 Read wheel metadata from extracted content instead of from zip

### DIFF
--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -78,84 +78,84 @@ class Wheel(object):
 
     def install_as_egg(self, destination_eggdir):
         '''Install wheel as an egg directory.'''
+        dist_basename = '%s-%s' % (self.project_name, self.version)
+        dist_info = '%s.dist-info' % dist_basename
+        dist_data = '%s.data' % dist_basename
+        # Extract to target directory.
+        os.mkdir(destination_eggdir)
         with zipfile.ZipFile(self.filename) as zf:
-            dist_basename = '%s-%s' % (self.project_name, self.version)
-            dist_info = '%s.dist-info' % dist_basename
-            dist_data = '%s.data' % dist_basename
-            # Extract to target directory.
-            os.mkdir(destination_eggdir)
             zf.extractall(destination_eggdir)
-            # Convert metadata.
-            dist_info = os.path.join(destination_eggdir, dist_info)
-            def get_metadata(name):
-                with open(os.path.join(dist_info, name)) as fp:
-                    value = fp.read()
-                    return email.parser.Parser().parsestr(value)
-            wheel_metadata = get_metadata('WHEEL')
-            # Check wheel format version is supported.
-            wheel_version = parse_version(wheel_metadata.get('Wheel-Version'))
-            if not parse_version('1.0') <= wheel_version < parse_version('2.0dev0'):
-                raise ValueError('unsupported wheel format version: %s' % wheel_version)
-            dist = Distribution.from_location(
-                destination_eggdir, dist_info,
-                metadata=PathMetadata(destination_eggdir, dist_info)
-            )
-            # Note: we need to evaluate and strip markers now,
-            # as we can't easily convert back from the syntax:
-            # foobar; "linux" in sys_platform and extra == 'test'
-            def raw_req(req):
-                req.marker = None
-                return str(req)
-            install_requires = list(sorted(map(raw_req, dist.requires())))
-            extras_require = {
-                extra: list(sorted(
-                    req
-                    for req in map(raw_req, dist.requires((extra,)))
-                    if req not in install_requires
-                ))
-                for extra in dist.extras
-            }
-            egg_info = os.path.join(destination_eggdir, 'EGG-INFO')
-            os.rename(dist_info, egg_info)
-            os.rename(os.path.join(egg_info, 'METADATA'),
-                      os.path.join(egg_info, 'PKG-INFO'))
-            setup_dist = SetuptoolsDistribution(attrs=dict(
-                install_requires=install_requires,
-                extras_require=extras_require,
+        # Convert metadata.
+        dist_info = os.path.join(destination_eggdir, dist_info)
+        def get_metadata(name):
+            with open(os.path.join(dist_info, name)) as fp:
+                value = fp.read()
+                return email.parser.Parser().parsestr(value)
+        wheel_metadata = get_metadata('WHEEL')
+        # Check wheel format version is supported.
+        wheel_version = parse_version(wheel_metadata.get('Wheel-Version'))
+        if not parse_version('1.0') <= wheel_version < parse_version('2.0dev0'):
+            raise ValueError('unsupported wheel format version: %s' % wheel_version)
+        dist = Distribution.from_location(
+            destination_eggdir, dist_info,
+            metadata=PathMetadata(destination_eggdir, dist_info)
+        )
+        # Note: we need to evaluate and strip markers now,
+        # as we can't easily convert back from the syntax:
+        # foobar; "linux" in sys_platform and extra == 'test'
+        def raw_req(req):
+            req.marker = None
+            return str(req)
+        install_requires = list(sorted(map(raw_req, dist.requires())))
+        extras_require = {
+            extra: list(sorted(
+                req
+                for req in map(raw_req, dist.requires((extra,)))
+                if req not in install_requires
             ))
-            write_requirements(setup_dist.get_command_obj('egg_info'),
-                               None, os.path.join(egg_info, 'requires.txt'))
-            # Move data entries to their correct location.
-            dist_data = os.path.join(destination_eggdir, dist_data)
-            dist_data_scripts = os.path.join(dist_data, 'scripts')
-            if os.path.exists(dist_data_scripts):
-                egg_info_scripts = os.path.join(destination_eggdir,
-                                                'EGG-INFO', 'scripts')
-                os.mkdir(egg_info_scripts)
-                for entry in os.listdir(dist_data_scripts):
-                    # Remove bytecode, as it's not properly handled
-                    # during easy_install scripts install phase.
-                    if entry.endswith('.pyc'):
-                        os.unlink(os.path.join(dist_data_scripts, entry))
-                    else:
-                        os.rename(os.path.join(dist_data_scripts, entry),
-                                  os.path.join(egg_info_scripts, entry))
-                os.rmdir(dist_data_scripts)
-            for subdir in filter(os.path.exists, (
-                os.path.join(dist_data, d)
-                for d in ('data', 'headers', 'purelib', 'platlib')
-            )):
-                unpack(subdir, destination_eggdir)
-            if os.path.exists(dist_data):
-                os.rmdir(dist_data)
-            # Fix namespace packages.
-            namespace_packages = os.path.join(egg_info, 'namespace_packages.txt')
-            if os.path.exists(namespace_packages):
-                with open(namespace_packages) as fp:
-                    namespace_packages = fp.read().split()
-                for mod in namespace_packages:
-                    mod_dir = os.path.join(destination_eggdir, *mod.split('.'))
-                    mod_init = os.path.join(mod_dir, '__init__.py')
-                    if os.path.exists(mod_dir) and not os.path.exists(mod_init):
-                        with open(mod_init, 'w') as fp:
-                            fp.write(NAMESPACE_PACKAGE_INIT)
+            for extra in dist.extras
+        }
+        egg_info = os.path.join(destination_eggdir, 'EGG-INFO')
+        os.rename(dist_info, egg_info)
+        os.rename(os.path.join(egg_info, 'METADATA'),
+                  os.path.join(egg_info, 'PKG-INFO'))
+        setup_dist = SetuptoolsDistribution(attrs=dict(
+            install_requires=install_requires,
+            extras_require=extras_require,
+        ))
+        write_requirements(setup_dist.get_command_obj('egg_info'),
+                           None, os.path.join(egg_info, 'requires.txt'))
+        # Move data entries to their correct location.
+        dist_data = os.path.join(destination_eggdir, dist_data)
+        dist_data_scripts = os.path.join(dist_data, 'scripts')
+        if os.path.exists(dist_data_scripts):
+            egg_info_scripts = os.path.join(destination_eggdir,
+                                            'EGG-INFO', 'scripts')
+            os.mkdir(egg_info_scripts)
+            for entry in os.listdir(dist_data_scripts):
+                # Remove bytecode, as it's not properly handled
+                # during easy_install scripts install phase.
+                if entry.endswith('.pyc'):
+                    os.unlink(os.path.join(dist_data_scripts, entry))
+                else:
+                    os.rename(os.path.join(dist_data_scripts, entry),
+                              os.path.join(egg_info_scripts, entry))
+            os.rmdir(dist_data_scripts)
+        for subdir in filter(os.path.exists, (
+            os.path.join(dist_data, d)
+            for d in ('data', 'headers', 'purelib', 'platlib')
+        )):
+            unpack(subdir, destination_eggdir)
+        if os.path.exists(dist_data):
+            os.rmdir(dist_data)
+        # Fix namespace packages.
+        namespace_packages = os.path.join(egg_info, 'namespace_packages.txt')
+        if os.path.exists(namespace_packages):
+            with open(namespace_packages) as fp:
+                namespace_packages = fp.read().split()
+            for mod in namespace_packages:
+                mod_dir = os.path.join(destination_eggdir, *mod.split('.'))
+                mod_init = os.path.join(mod_dir, '__init__.py')
+                if os.path.exists(mod_dir) and not os.path.exists(mod_init):
+                    with open(mod_init, 'w') as fp:
+                        fp.write(NAMESPACE_PACKAGE_INIT)


### PR DESCRIPTION
See issue #1350.

package_name is read from the filename, which can be case-insensitive (on Windows). zipfile is case-sensitive, so trying to read the dist-info from it can fail if the filename case does not match the project name case. Extracting the files first allows us to read dist-info from the filesystem, which is also case insensitive on Windows.

When reviewing, please review the two commits separately (there is a lot of indentation change in the second commit).