### PR TITLE
Add tox environment for docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin
 build
 dist
+docs/build
 include
 lib
 distribute.egg-info

--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -106,10 +106,12 @@ Setuptools follows ``semver``.
 Building Documentation
 ----------------------
 
-Setuptools relies on the Sphinx system for building documentation.
-To accommodate RTD, docs must be built from the docs/ directory.
+Setuptools relies on the `Sphinx`_ system for building documentation.
+The `published documentation`_ is hosted on Read the Docs.
 
-To build them, you need to have installed the requirements specified
-in docs/requirements.txt. One way to do this is to use rwt:
+To build the docs locally, use tox::
 
-    setuptools/docs$ python -m rwt -r requirements.txt -- -m sphinx . html
+    $ tox -e docs
+
+.. _Sphinx: http://www.sphinx-doc.org/en/master/
+.. _published documentation: https://setuptools.readthedocs.io/en/latest/

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,14 @@ deps=codecov
 skip_install=True
 commands=codecov --file {toxworkdir}/coverage.xml
 
+[testenv:docs]
+deps = -r{toxinidir}/docs/requirements.txt
+skip_install=True
+commands =
+    python {toxinidir}/bootstrap.py
+    sphinx-build -b html -d {envtmpdir}/doctrees docs docs/build/html
+    sphinx-build -b man -d {envtmpdir}/doctrees docs docs/build/man
+
 [coverage:run]
 source=
 	pkg_resources


### PR DESCRIPTION
Support easy local builds of docs via `tox -e docs`, and update the developer documentation accordingly.