### PR TITLE
Small fixes to Docs:Developer Guide

### DIFF
--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -86,8 +86,12 @@ from this repository.
 Testing
 -------
 
-The primary tests are run using tox. To run the tests, first make
-sure you have tox installed, then invoke it::
+The primary tests are run using tox. To run the tests, first create the metadata
+needed to run the tests::
+
+    $ python bootstrap.py
+
+Then make sure you have tox installed, and invoke it::
 
     $ tox
 

--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -63,7 +63,7 @@ Source Code
 
 Grab the code at Github::
 
-    $ git checkout https://github.com/pypa/setuptools
+    $ git clone https://github.com/pypa/setuptools
 
 If you want to contribute changes, we recommend you fork the repository on
 Github, commit the changes to your repository, and then make a pull request


### PR DESCRIPTION
As discussed at the PycCn sprints 2018, day 1. These are small changes to the developer guide section of the docs to make the directions easier to follow for new developers.

Two changes: 
* changed `git checkout` to `git clone` in instructions for initially getting the codebase 
* Added instruction to run `python bootstrap.py` before invoking `tox` for the first time.

I did not update the CHANGES.txt as I was unsure on the protocol there and these are essentially typo fixes. Please let me know if I need to change that. 



