### PR TITLE
Fix doc build warnings

### DIFF
--- a/changelog.d/1357.doc.rst
+++ b/changelog.d/1357.doc.rst
@@ -1,0 +1,1 @@
+Fixed warnings in documentation builds and started enforcing that the docs build without warnings in tox.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ import os
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['jaraco.packaging.sphinx', 'rst.linker', 'sphinx.ext.autosectionlabel']
+extensions = ['jaraco.packaging.sphinx', 'rst.linker']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -44,6 +44,9 @@ source_suffix = '.txt'
 
 # The master toctree document.
 master_doc = 'index'
+
+# A list of glob-style patterns that should be excluded when looking for source files.
+exclude_patterns = ['requirements.txt']
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.

--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -1087,6 +1087,7 @@ so that supporting custom importers or new distribution formats can be done
 simply by creating an appropriate `IResourceProvider`_ implementation; see the
 section below on `Supporting Custom Importers`_ for more details.
 
+.. _ResourceManager API:
 
 ``ResourceManager`` API
 =======================

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -242,7 +242,6 @@ have setuptools automatically tag your in-development releases with various
 pre- or post-release tags.  See the following sections for more details:
 
 * `Tagging and "Daily Build" or "Snapshot" Releases`_
-* `Managing "Continuous Releases" Using Subversion`_
 * The `egg_info`_ command
 
 
@@ -1366,6 +1365,7 @@ then make an explicit declaration of ``True`` or ``False`` for the ``zip_safe``
 flag, so that it will not be necessary for ``bdist_egg`` or ``EasyInstall`` to
 try to guess whether your project can work as a zipfile.
 
+.. _Namespace Packages:
 
 Namespace Packages
 ------------------

--- a/tox.ini
+++ b/tox.ini
@@ -38,8 +38,8 @@ deps = -r{toxinidir}/docs/requirements.txt
 skip_install=True
 commands =
     python {toxinidir}/bootstrap.py
-    sphinx-build -b html -d {envtmpdir}/doctrees docs docs/build/html
-    sphinx-build -b man -d {envtmpdir}/doctrees docs docs/build/man
+    sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/build/html
+    sphinx-build -W -b man -d {envtmpdir}/doctrees docs docs/build/man
 
 [coverage:run]
 source=


### PR DESCRIPTION
Fixed all the current warnings from documentation builds, and configured tox to fail doc builds if any new warnings are introduced.  The `autosectionlabel` extension had to be disabled because it caused "duplicate label" warnings in `CHANGES.rst` where the same subsections are used in a few different releases.  Only 2-3 of the cross-references seem to have been depending on it anyway, fixed here by adding explicit section labels.

There was one link that no longer seems to correspond to any section in the docs; I just removed that one, let me know if there's something it should actually point to instead.