### PR TITLE
Use canonicalize_name to look for .dist-info in wheel files

### DIFF
--- a/changelog.d/1360.change.rst
+++ b/changelog.d/1360.change.rst
@@ -1,0 +1,1 @@
+Fixed issue with a mismatch between the name of the package and the name of the .dist-info file in wheel files


### PR DESCRIPTION
wheel files contain a directory that ends with ".dist-info", but its full name may not exactly match the name of the package as written in the wheel filename. e.g. on Windows, the wheel file name may use different letter cases. Using canonicalize_name on both the package name from the wheel filename and the directories in the zip to find a match fixes the problem.
See issue #1350

The general logic was taken from the pip code: https://github.com/pypa/pip/blob/0ae0109901f63b7f133229a9fee41332dd7366b4/src/pip/_internal/wheel.py#L270