### PR TITLE
Fix attr: with package_dirs

### DIFF
--- a/changelog.d/1365.change.rst
+++ b/changelog.d/1365.change.rst
@@ -1,0 +1,2 @@
+Take the package_dir option into account when loading the version from a
+module attribute.


### PR DESCRIPTION
## Summary of changes

Takes the `package_dir` option into account when loading `version` from a module attribute.  This should handle cases where all modules are located under a common parent and where that particular module is in a subdirectory and/or has a different name.  It doesn't attempt to handle cases where `package_dir` contains keys like "foo.bar", but I'm not sure such entries are even valid.

This required adding a dependency on the `options` section parsing in the `metadata` section parsing, in order to get the value of `package_dir`.  This seems pretty harmless since they happen right after each other, but let me know if it poses any problems.

Closes #1333 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
