### PR TITLE
Don't require network in tests

### DIFF
--- a/changelog.d/1368.misc.rst
+++ b/changelog.d/1368.misc.rst
@@ -1,0 +1,1 @@
+Fixed tests which failed without network connectivity.

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -233,27 +233,27 @@ class TestEggInfo(object):
         '''
         install_requires_deterministic
 
-        install_requires=["fake-factory==0.5.2", "pytz"]
+        install_requires=["wheel>=0.5", "pytest"]
 
         [options]
         install_requires =
-            fake-factory==0.5.2
-            pytz
+            wheel>=0.5
+            pytest
 
-        fake-factory==0.5.2
-        pytz
+        wheel>=0.5
+        pytest
         ''',
 
         '''
         install_requires_ordered
 
-        install_requires=["fake-factory>=1.12.3,!=2.0"]
+        install_requires=["pytest>=3.0.2,!=10.9999"]
 
         [options]
         install_requires =
-            fake-factory>=1.12.3,!=2.0
+            pytest>=3.0.2,!=10.9999
 
-        fake-factory!=2.0,>=1.12.3
+        pytest!=10.9999,>=3.0.2
         ''',
 
         '''

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -128,11 +128,11 @@ class TestEggInfo(object):
 
         self._validate_content_order(content, expected_order)
 
-    def test_egg_base_installed_egg_info(self, tmpdir_cwd, env):
+    def test_expected_files_produced(self, tmpdir_cwd, env):
         self._create_project()
 
-        self._run_install_command(tmpdir_cwd, env)
-        actual = self._find_egg_info_files(env.paths['lib'])
+        self._run_egg_info_command(tmpdir_cwd, env)
+        actual = os.listdir('foo.egg-info')
 
         expected = [
             'PKG-INFO',
@@ -154,8 +154,8 @@ class TestEggInfo(object):
                 'usage.rst': "Run 'hi'",
             }
         })
-        self._run_install_command(tmpdir_cwd, env)
-        egg_info_dir = self._find_egg_info_files(env.paths['lib']).base
+        self._run_egg_info_command(tmpdir_cwd, env)
+        egg_info_dir = os.path.join('.', 'foo.egg-info')
         sources_txt = os.path.join(egg_info_dir, 'SOURCES.txt')
         with open(sources_txt) as f:
             assert 'docs/usage.rst' in f.read().split('\n')
@@ -394,7 +394,7 @@ class TestEggInfo(object):
             self, tmpdir_cwd, env, requires, use_setup_cfg,
             expected_requires, install_cmd_kwargs):
         self._setup_script_with_requires(requires, use_setup_cfg)
-        self._run_install_command(tmpdir_cwd, env, **install_cmd_kwargs)
+        self._run_egg_info_command(tmpdir_cwd, env, **install_cmd_kwargs)
         egg_info_dir = os.path.join('.', 'foo.egg-info')
         requires_txt = os.path.join(egg_info_dir, 'requires.txt')
         if os.path.exists(requires_txt):
@@ -414,14 +414,14 @@ class TestEggInfo(object):
         req = 'install_requires={"fake-factory==0.5.2", "pytz"}'
         self._setup_script_with_requires(req)
         with pytest.raises(AssertionError):
-            self._run_install_command(tmpdir_cwd, env)
+            self._run_egg_info_command(tmpdir_cwd, env)
 
     def test_extras_require_with_invalid_marker(self, tmpdir_cwd, env):
         tmpl = 'extras_require={{":{marker}": ["barbazquux"]}},'
         req = tmpl.format(marker=self.invalid_marker)
         self._setup_script_with_requires(req)
         with pytest.raises(AssertionError):
-            self._run_install_command(tmpdir_cwd, env)
+            self._run_egg_info_command(tmpdir_cwd, env)
         assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
     def test_extras_require_with_invalid_marker_in_req(self, tmpdir_cwd, env):
@@ -429,7 +429,7 @@ class TestEggInfo(object):
         req = tmpl.format(marker=self.invalid_marker)
         self._setup_script_with_requires(req)
         with pytest.raises(AssertionError):
-            self._run_install_command(tmpdir_cwd, env)
+            self._run_egg_info_command(tmpdir_cwd, env)
         assert glob.glob(os.path.join(env.paths['lib'], 'barbazquux*')) == []
 
     def test_provides_extra(self, tmpdir_cwd, env):
@@ -541,15 +541,6 @@ class TestEggInfo(object):
         assert 'Requires-Python: >=2.7.12' in pkg_info_lines
         assert 'Metadata-Version: 1.2' in pkg_info_lines
 
-    def test_python_requires_install(self, tmpdir_cwd, env):
-        self._setup_script_with_requires(
-            """python_requires='>=1.2.3',""")
-        self._run_install_command(tmpdir_cwd, env)
-        egg_info_dir = self._find_egg_info_files(env.paths['lib']).base
-        pkginfo = os.path.join(egg_info_dir, 'PKG-INFO')
-        with open(pkginfo) as f:
-            assert 'Requires-Python: >=1.2.3' in f.read().split('\n')
-
     def test_manifest_maker_warning_suppression(self):
         fixtures = [
             "standard file not found: should have one of foo.py, bar.py",
@@ -559,17 +550,13 @@ class TestEggInfo(object):
         for msg in fixtures:
             assert manifest_maker._should_suppress_warning(msg)
 
-    def _run_install_command(self, tmpdir_cwd, env, cmd=None, output=None):
+    def _run_egg_info_command(self, tmpdir_cwd, env, cmd=None, output=None):
         environ = os.environ.copy().update(
             HOME=env.paths['home'],
         )
         if cmd is None:
             cmd = [
-                'install',
-                '--home', env.paths['home'],
-                '--install-lib', env.paths['lib'],
-                '--install-scripts', env.paths['scripts'],
-                '--install-data', env.paths['data'],
+                'egg_info',
             ]
         code, data = environment.run_setup_py(
             cmd=cmd,
@@ -581,18 +568,3 @@ class TestEggInfo(object):
             raise AssertionError(data)
         if output:
             assert output in data
-
-    def _find_egg_info_files(self, root):
-        class DirList(list):
-            def __init__(self, files, base):
-                super(DirList, self).__init__(files)
-                self.base = base
-
-        results = (
-            DirList(filenames, dirpath)
-            for dirpath, dirnames, filenames in os.walk(root)
-            if os.path.basename(dirpath) == 'EGG-INFO'
-        )
-        # expect exactly one result
-        result, = results
-        return result


### PR DESCRIPTION
## Summary of changes

This fixes the only test cases which would fail if the network is unavailable.  They were running a `setup.py` with packages listed in `install_requires` that usually aren't installed locally.  This was causing 4 parameterized variants of the test case to fail if the network was unavailable, and triggered some AppVeyor failures when network access was slow or intermittent:

* https://ci.appveyor.com/project/pypa/setuptools/build/5/job/5bpipnfs2x66j2th
* https://ci.appveyor.com/project/pypa/setuptools/build/6/job/d6v69rilgjwqjvc4
* https://ci.appveyor.com/project/pypa/setuptools/build/19/job/c1l1r8n9ntags30o

I resolved this by switching the packages listed in `install_requires` to ones which are dependencies of the test suite, and hence should always be installed by the time the test runs.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
