### PR TITLE
Add tests for PEP 425 support

### DIFF
--- a/changelog.d/1369.misc.rst
+++ b/changelog.d/1369.misc.rst
@@ -1,0 +1,1 @@
+Added unit tests for PEP 425 compatibility tags support.

--- a/setuptools/tests/test_glibc.py
+++ b/setuptools/tests/test_glibc.py
@@ -1,0 +1,37 @@
+import warnings
+
+from setuptools.glibc import check_glibc_version
+
+
+class TestGlibc(object):
+    def test_manylinux1_check_glibc_version(self):
+        """
+        Test that the check_glibc_version function is robust against weird
+        glibc version strings.
+        """
+        for two_twenty in ["2.20",
+                           # used by "linaro glibc", see gh-3588
+                           "2.20-2014.11",
+                           # weird possibilities that I just made up
+                           "2.20+dev",
+                           "2.20-custom",
+                           "2.20.1",
+                           ]:
+            assert check_glibc_version(two_twenty, 2, 15)
+            assert check_glibc_version(two_twenty, 2, 20)
+            assert not check_glibc_version(two_twenty, 2, 21)
+            assert not check_glibc_version(two_twenty, 3, 15)
+            assert not check_glibc_version(two_twenty, 1, 15)
+
+        # For strings that we just can't parse at all, we should warn and
+        # return false
+        for bad_string in ["asdf", "", "foo.bar"]:
+            with warnings.catch_warnings(record=True) as ws:
+                warnings.filterwarnings("always")
+                assert not check_glibc_version(bad_string, 2, 5)
+                for w in ws:
+                    if "Expected glibc version with" in str(w.message):
+                        break
+                else:
+                    # Didn't find the warning we were expecting
+                    assert False

--- a/setuptools/tests/test_pep425tags.py
+++ b/setuptools/tests/test_pep425tags.py
@@ -1,0 +1,164 @@
+import sys
+
+from mock import patch
+
+from setuptools import pep425tags
+
+
+class TestPEP425Tags(object):
+
+    def mock_get_config_var(self, **kwd):
+        """
+        Patch sysconfig.get_config_var for arbitrary keys.
+        """
+        get_config_var = pep425tags.sysconfig.get_config_var
+
+        def _mock_get_config_var(var):
+            if var in kwd:
+                return kwd[var]
+            return get_config_var(var)
+        return _mock_get_config_var
+
+    def abi_tag_unicode(self, flags, config_vars):
+        """
+        Used to test ABI tags, verify correct use of the `u` flag
+        """
+        config_vars.update({'SOABI': None})
+        base = pep425tags.get_abbr_impl() + pep425tags.get_impl_ver()
+
+        if sys.version_info < (3, 3):
+            config_vars.update({'Py_UNICODE_SIZE': 2})
+            mock_gcf = self.mock_get_config_var(**config_vars)
+            with patch('setuptools.pep425tags.sysconfig.get_config_var', mock_gcf):
+                abi_tag = pep425tags.get_abi_tag()
+                assert abi_tag == base + flags
+
+            config_vars.update({'Py_UNICODE_SIZE': 4})
+            mock_gcf = self.mock_get_config_var(**config_vars)
+            with patch('setuptools.pep425tags.sysconfig.get_config_var',
+                       mock_gcf):
+                abi_tag = pep425tags.get_abi_tag()
+                assert abi_tag == base + flags + 'u'
+
+        else:
+            # On Python >= 3.3, UCS-4 is essentially permanently enabled, and
+            # Py_UNICODE_SIZE is None. SOABI on these builds does not include
+            # the 'u' so manual SOABI detection should not do so either.
+            config_vars.update({'Py_UNICODE_SIZE': None})
+            mock_gcf = self.mock_get_config_var(**config_vars)
+            with patch('setuptools.pep425tags.sysconfig.get_config_var',
+                       mock_gcf):
+                abi_tag = pep425tags.get_abi_tag()
+                assert abi_tag == base + flags
+
+    def test_broken_sysconfig(self):
+        """
+        Test that pep425tags still works when sysconfig is broken.
+        Can be a problem on Python 2.7
+        Issue #1074.
+        """
+        def raises_ioerror(var):
+            raise IOError("I have the wrong path!")
+
+        with patch('setuptools.pep425tags.sysconfig.get_config_var',
+                   raises_ioerror):
+            assert len(pep425tags.get_supported())
+
+    def test_no_hyphen_tag(self):
+        """
+        Test that no tag contains a hyphen.
+        """
+        mock_gcf = self.mock_get_config_var(SOABI='cpython-35m-darwin')
+
+        with patch('setuptools.pep425tags.sysconfig.get_config_var',
+                   mock_gcf):
+            supported = pep425tags.get_supported()
+
+        for (py, abi, plat) in supported:
+            assert '-' not in py
+            assert '-' not in abi
+            assert '-' not in plat
+
+    def test_manual_abi_noflags(self):
+        """
+        Test that no flags are set on a non-PyDebug, non-Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('', {'Py_DEBUG': False, 'WITH_PYMALLOC': False})
+
+    def test_manual_abi_d_flag(self):
+        """
+        Test that the `d` flag is set on a PyDebug, non-Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('d', {'Py_DEBUG': True, 'WITH_PYMALLOC': False})
+
+    def test_manual_abi_m_flag(self):
+        """
+        Test that the `m` flag is set on a non-PyDebug, Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('m', {'Py_DEBUG': False, 'WITH_PYMALLOC': True})
+
+    def test_manual_abi_dm_flags(self):
+        """
+        Test that the `dm` flags are set on a PyDebug, Pymalloc ABI tag.
+        """
+        self.abi_tag_unicode('dm', {'Py_DEBUG': True, 'WITH_PYMALLOC': True})
+
+
+class TestManylinux1Tags(object):
+
+    @patch('setuptools.pep425tags.get_platform', lambda: 'linux_x86_64')
+    @patch('setuptools.glibc.have_compatible_glibc',
+           lambda major, minor: True)
+    def test_manylinux1_compatible_on_linux_x86_64(self):
+        """
+        Test that manylinux1 is enabled on linux_x86_64
+        """
+        assert pep425tags.is_manylinux1_compatible()
+
+    @patch('setuptools.pep425tags.get_platform', lambda: 'linux_i686')
+    @patch('setuptools.glibc.have_compatible_glibc',
+           lambda major, minor: True)
+    def test_manylinux1_compatible_on_linux_i686(self):
+        """
+        Test that manylinux1 is enabled on linux_i686
+        """
+        assert pep425tags.is_manylinux1_compatible()
+
+    @patch('setuptools.pep425tags.get_platform', lambda: 'linux_x86_64')
+    @patch('setuptools.glibc.have_compatible_glibc',
+           lambda major, minor: False)
+    def test_manylinux1_2(self):
+        """
+        Test that manylinux1 is disabled with incompatible glibc
+        """
+        assert not pep425tags.is_manylinux1_compatible()
+
+    @patch('setuptools.pep425tags.get_platform', lambda: 'arm6vl')
+    @patch('setuptools.glibc.have_compatible_glibc',
+           lambda major, minor: True)
+    def test_manylinux1_3(self):
+        """
+        Test that manylinux1 is disabled on arm6vl
+        """
+        assert not pep425tags.is_manylinux1_compatible()
+
+    @patch('setuptools.pep425tags.get_platform', lambda: 'linux_x86_64')
+    @patch('setuptools.glibc.have_compatible_glibc',
+           lambda major, minor: True)
+    @patch('sys.platform', 'linux2')
+    def test_manylinux1_tag_is_first(self):
+        """
+        Test that the more specific tag manylinux1 comes first.
+        """
+        groups = {}
+        for pyimpl, abi, arch in pep425tags.get_supported():
+            groups.setdefault((pyimpl, abi), []).append(arch)
+
+        for arches in groups.values():
+            if arches == ['any']:
+                continue
+            # Expect the most specific arch first:
+            if len(arches) == 3:
+                assert arches == ['manylinux1_x86_64', 'linux_x86_64', 'any']
+            else:
+                assert arches == ['manylinux1_x86_64', 'linux_x86_64']


### PR DESCRIPTION
## Summary of changes

When code for supporting PEP 425 compatibility tags was copied from `pip` in https://github.com/pypa/setuptools/pull/1200, the unit tests weren't copied with it.  I'm adding those to make sure we don't inadvertently break that functionality.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
