### PR TITLE
Fix copy of files from .data dir of wheels if the files already exist

### DIFF
--- a/changelog.d/1362.change.rst
+++ b/changelog.d/1362.change.rst
@@ -1,0 +1,1 @@
+Fix copy of files from .data dir of wheels if the files already exist

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -35,6 +35,8 @@ def unpack(src_dir, dst_dir):
         for f in filenames:
             src = os.path.join(dirpath, f)
             dst = os.path.join(dst_dir, subdir, f)
+            if os.path.exists(dst):
+                os.remove(dst)
             os.renames(src, dst)
         for n, d in reversed(list(enumerate(dirnames))):
             src = os.path.join(dirpath, d)


### PR DESCRIPTION
See issue #1362.
From "rename" docs:
```
On Unix, if dst exists and is a file, it will be replaced silently if the user has permission. [...] On Windows, if dst already exists, OSError will be raised even if it is a file
```
To make the behavior the same on both platforms, this PR manually removes existing files before rename.