### PR TITLE
Stop testing Python 3.3 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
 - &latest_py2 2.7
-- 3.3
 - 3.4
 - 3.5
 - &latest_py3 3.6
@@ -43,7 +42,7 @@ install:
 # ensure we have recent pip/setuptools
 - pip install --upgrade pip setuptools
 # need tox to get started
-- pip install tox 'tox-venv; python_version!="3.3"'
+- pip install tox tox-venv
 
 # Output the env, to verify behavior
 - env

--- a/changelog.d/1372.misc.rst
+++ b/changelog.d/1372.misc.rst
@@ -1,0 +1,2 @@
+Stop testing Python 3.3 in Travis CI, now that the latest version of
+``wheel`` no longer installs on it.


### PR DESCRIPTION
## Summary of changes

The Python 3.3 job in Travis failed in the last build on master because the new `wheel` release won't install on it.  We planned on dropping 3.3 support soon anyway, so just stop testing it on Travis to avoid further job failures.  We'll release one more version that officially supports Python 3.3 while incorporating all the latest fixes from master, and then the next one will fully remove support for it.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
