### PR TITLE
Fix wheel build in Python 3.3 tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,13 @@ if include_windows_files:
     package_data.setdefault('setuptools.command', []).extend(['*.xml'])
 
 needs_wheel = set(['release', 'bdist_wheel']).intersection(sys.argv)
-wheel = ['wheel'] if needs_wheel else []
+wheel = []
+if needs_wheel:
+    if sys.version[0:2] == (3, 3):
+        # Pin wheel until 3.3 support is dropped
+        wheel = ['wheel==0.30.0']
+    else:
+        wheel = ['wheel']
 
 
 def pypi_link(pkg_filename):

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -11,6 +11,8 @@ import pytest_virtualenv
 from .textwrap import DALS
 from .test_easy_install import make_nspkg_sdist
 
+xfail_33 = pytest.mark.xfail(sys.version_info[0:2] == (3, 3),
+                             reason='pytest_virtualenv fails on Python 3.3')
 
 @pytest.fixture(autouse=True)
 def pytest_virtualenv_works(virtualenv):
@@ -42,6 +44,7 @@ def bare_virtualenv():
 SOURCE_DIR = os.path.join(os.path.dirname(__file__), '../..')
 
 
+@xfail_33
 def test_clean_env_install(bare_virtualenv):
     """
     Check setuptools can be installed in a clean environment.
@@ -52,6 +55,7 @@ def test_clean_env_install(bare_virtualenv):
     )).format(source=SOURCE_DIR))
 
 
+@xfail_33
 def test_pip_upgrade_from_source(virtualenv):
     """
     Check pip can upgrade setuptools from source.
@@ -60,6 +64,9 @@ def test_pip_upgrade_from_source(virtualenv):
     if sys.version_info < (2, 7):
         # Python 2.6 support was dropped in wheel 0.30.0.
         virtualenv.run('pip install -U "wheel<0.30.0"')
+    elif sys.version_info[0:2] == (3, 3):
+        virtualenv.run('pip install -U "wheel==0.30.0"')
+
     # Generate source distribution / wheel.
     virtualenv.run(' && '.join((
         'cd {source}',
@@ -74,6 +81,7 @@ def test_pip_upgrade_from_source(virtualenv):
     virtualenv.run('pip install --no-cache-dir --upgrade ' + sdist)
 
 
+@xfail_33
 def test_test_command_install_requirements(bare_virtualenv, tmpdir):
     """
     Check the test command will install all required dependencies.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -5,6 +5,7 @@ pytest-flake8; python_version>="2.7" and python_version!="3.3" and python_versio
 virtualenv>=13.0.0
 pytest-virtualenv>=1.2.7
 pytest>=3.0.2
-wheel
+wheel; python_version!="3.3"
+wheel==0.30.0; python_version=="3.3"
 coverage>=4.5.1
 pytest-cov>=2.5.1


### PR DESCRIPTION
Until we're ready to land #1342, this will allow the test suite to pass.

Changelog not necessary, this will be essentially removed when #1342 is merged.