### PR TITLE
Update release process docs

### DIFF
--- a/changelog.d/1352.misc.rst
+++ b/changelog.d/1352.misc.rst
@@ -1,0 +1,1 @@
+Added ``tox`` environment for documentation builds.

--- a/changelog.d/1353.doc.rst
+++ b/changelog.d/1353.doc.rst
@@ -1,0 +1,1 @@
+Added coverage badge to README.

--- a/changelog.d/1356.doc.rst
+++ b/changelog.d/1356.doc.rst
@@ -1,0 +1,1 @@
+Made small fixes to the developer guide documentation.

--- a/changelog.d/1376.doc.rst
+++ b/changelog.d/1376.doc.rst
@@ -1,0 +1,1 @@
+Updated release process docs.

--- a/docs/releases.txt
+++ b/docs/releases.txt
@@ -7,20 +7,31 @@ mechanical technique for releases, enacted by Travis following a
 successful build of a tagged release per
 `PyPI deployment <https://docs.travis-ci.com/user/deployment/pypi>`_.
 
-Prior to cutting a release, please check that the CHANGES.rst reflects
-the summary of changes since the last release.
-Ideally, these changelog entries would have been added
-along with the changes, but it's always good to check.
-Think about it from the
-perspective of a user not involved with the development--what would
-that person want to know about what has changed--or from the
-perspective of your future self wanting to know when a particular
-change landed.
+Prior to cutting a release, please use `towncrier`_ to update
+``CHANGES.rst`` to summarize the changes since the last release.
+To update the changelog:
 
-To cut a release, install and run ``bump2version {part}`` where ``part``
+1. Install towncrier via ``pip install towncrier`` if not already installed.
+2. Preview the new ``CHANGES.rst`` entry by running
+   ``towncrier --draft --version {new.version.number}`` (enter the desired
+   version number for the next release).  If any changes are needed, make
+   them and generate a new preview until the output is acceptable.  Run
+   ``git add`` for any modified files.
+3. Run ``towncrier --version {new.version.number}`` to stage the changelog
+   updates in git.
+
+Once the changelog edits are staged and ready to commit, cut a release by
+installing and running ``bump2version {part}`` where ``part``
 is major, minor, or patch based on the scope of the changes in the
-release. Then, push the commits to the master branch. If tests pass,
-the release will be uploaded to PyPI (from the Python 3.6 tests).
+release. Then, push the commits to the master branch::
+
+    $ git push origin master
+    $ git push --tags
+
+If tests pass, the release will be uploaded to PyPI (from the Python 3.6
+tests).
+
+.. _towncrier: https://pypi.org/project/towncrier/
 
 Release Frequency
 -----------------

--- a/towncrier_template.rst
+++ b/towncrier_template.rst
@@ -8,7 +8,6 @@
 {% for text, values in sections[section][category].items() %}
 * {{ values|join(', ') }}: {{ text }}
 {% endfor %}
-
 {% else %}
 *  {{ sections[section][category]['']|join(', ') }}
 


### PR DESCRIPTION
## Summary of changes

* Updated the release process docs to account for towncrier
* Removed blank lines between the non-labeled categories of changes in a release
* Added `changelog.d` entries for PRs going into the next release which preceded the addition of towncrier support

Currently the changelog entry for the next release comes out like this:

```
v39.2.0
-------

* #1359: Support using "file:" to load a PEP 440-compliant package version from
  a text file.
* #1360: Fixed issue with a mismatch between the name of the package and the
  name of the .dist-info file in wheel files
* #1365: Take the package_dir option into account when loading the version from
  a module attribute.
* #1353: Added coverage badge to README.
* #1356: Made small fixes to the developer guide documentation.
* #1357: Fixed warnings in documentation builds and started enforcing that the
  docs build without warnings in tox.
* #1376: Updated release process docs.
* #1352: Added ``tox`` environment for documentation builds.
* #1354: Added ``towncrier`` for changelog managment.
* #1355: Add PR template.
* #1368: Fixed tests which failed without network connectivity.
* #1369: Added unit tests for PEP 425 compatibility tags support.
* #1372: Stop testing Python 3.3 in Travis CI, now that the latest version of
  ``wheel`` no longer installs on it.
```

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
