### PR TITLE
Make minor fixes to release docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ v39.2.0
   a text file.
 * #1360: Fixed issue with a mismatch between the name of the package and the
   name of the .dist-info file in wheel files
+* #1364: Add `__dir__()` implementation to `pkg_resources.Distribution()` that
+  includes the attributes in the `_provider` instance variable.
 * #1365: Take the package_dir option into account when loading the version from
   a module attribute.
 * #1353: Added coverage badge to README.

--- a/changelog.d/1364.rst
+++ b/changelog.d/1364.rst
@@ -1,1 +1,0 @@
-Add `__dir__()` implementation to `pkg_resources.Distribution()` that includes the attributes in the `_provider` instance variable.

--- a/changelog.d/1379.doc.rst
+++ b/changelog.d/1379.doc.rst
@@ -1,0 +1,1 @@
+Minor doc fixes after actually using the new release process.

--- a/docs/releases.txt
+++ b/docs/releases.txt
@@ -19,9 +19,13 @@ To update the changelog:
    ``git add`` for any modified files.
 3. Run ``towncrier --version {new.version.number}`` to stage the changelog
    updates in git.
+4. Verify that there are no remaining ``changelog.d/*.rst`` files.  If a
+   file was named incorrectly, it may be ignored by towncrier.
+5. Review the updated ``CHANGES.rst`` file.  If any changes are needed,
+   make the edits and stage them via ``git add CHANGES.rst``.
 
 Once the changelog edits are staged and ready to commit, cut a release by
-installing and running ``bump2version {part}`` where ``part``
+installing and running ``bump2version --allow-dirty {part}`` where ``part``
 is major, minor, or patch based on the scope of the changes in the
 release. Then, push the commits to the master branch::
 


### PR DESCRIPTION
## Summary of changes

I made some tweaks to the release process documentation after using it to create version 39.2.0.  I also updated the 39.2.0 changelog to reflect one item which was omitted because the file was named incorrectly (which prompted one of the doc updates).

The towncrier output is slightly inconsistent in its usage of newlines between preview and release modes, and edits to the template don't seem to affect this.  I manually added one newline and removed another for the 39.2.0 release to keep the formatting consistent; the new output review step is partially to catch things like this until we find a way to get towncrier to automatically get the formatting correct.

The `--allow-dirty` option is needed for bump2version to go ahead even though the changelog updates haven't been committed yet.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
