### PR TITLE
Avoid resource warning from dev scripts installed editable

### DIFF
--- a/setuptools/script (dev).tmpl
+++ b/setuptools/script (dev).tmpl
@@ -2,4 +2,5 @@
 __requires__ = %(spec)r
 __import__('pkg_resources').require(%(spec)r)
 __file__ = %(dev_path)r
-exec(compile(open(__file__).read(), __file__, 'exec'))
+with open(__file__) as f:
+    exec(compile(f.read(), __file__, 'exec'))


### PR DESCRIPTION
Avoid resource warnings on dev scripts installed editable.

    ResourceWarning: unclosed file <_io.TextIOWrapper name='whatever' mode='r' encoding='UTF-8'> 

The `with` statement is supported since Python 2.5, so I assume we are OK to use this. Can use try: finally: instead if proj maintainers prefer?