### PR TITLE
Improved handling of  module __path__ attribute for namespace packages, fixes #1321

### DIFF
--- a/changelog.d/1402.change.rst
+++ b/changelog.d/1402.change.rst
@@ -1,0 +1,2 @@
+Fixed a bug with namespace packages under python-3.6 when one package in
+current directory hides another which is installed.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2135,12 +2135,13 @@ def _rebuild_mod_path(orig_path, package_name, module):
         parts = path_parts[:-module_parts]
         return safe_sys_path_index(_normalize_cached(os.sep.join(parts)))
 
-    if not isinstance(orig_path, list):
-        # Is this behavior useful when module.__path__ is not a list?
-        return
+    new_path = sorted(orig_path, key=position_in_sys_path)
+    new_path = [_normalize_cached(p) for p in new_path]
 
-    orig_path.sort(key=position_in_sys_path)
-    module.__path__[:] = [_normalize_cached(p) for p in orig_path]
+    if isinstance(module.__path__, list):
+        module.__path__[:] = new_path
+    else:
+        module.__path__ = new_path
 
 
 def declare_namespace(packageName):

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -59,10 +59,6 @@ class TestNamespaces:
         with test.test.paths_on_pythonpath(map(str, targets)):
             subprocess.check_call(try_import)
 
-    @pytest.mark.xfail(
-        os.environ.get("APPVEYOR"),
-        reason="https://github.com/pypa/setuptools/issues/851",
-    )
     def test_pkg_resources_import(self, tmpdir):
         """
         Ensure that a namespace package doesn't break on import
@@ -87,10 +83,6 @@ class TestNamespaces:
         with test.test.paths_on_pythonpath([str(target)]):
             subprocess.check_call(try_import)
 
-    @pytest.mark.xfail(
-        os.environ.get("APPVEYOR"),
-        reason="https://github.com/pypa/setuptools/issues/851",
-    )
     def test_namespace_package_installed_and_cwd(self, tmpdir):
         """
         Installing a namespace packages but also having it in the current
@@ -118,11 +110,7 @@ class TestNamespaces:
         with test.test.paths_on_pythonpath([str(target)]):
             subprocess.check_call(pkg_resources_imp, cwd=str(pkg_A))
 
-    @pytest.mark.xfail(
-        os.environ.get("APPVEYOR"),
-        reason="https://github.com/pypa/setuptools/issues/851",
-    )
-    def test_packages_in_the_sampe_namespace_installed_and_cwd(self, tmpdir):
+    def test_packages_in_the_same_namespace_installed_and_cwd(self, tmpdir):
         """
         Installing one namespace package and also have another in the same
         namespace in the current working directory, both of them must be

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -16,10 +16,6 @@ class TestNamespaces:
         sys.version_info < (3, 5),
         reason="Requires importlib.util.module_from_spec",
     )
-    @pytest.mark.xfail(
-        os.environ.get("APPVEYOR"),
-        reason="https://github.com/pypa/setuptools/issues/851",
-    )
     def test_mixed_site_and_non_site(self, tmpdir):
         """
         Installing two packages sharing the same namespace, one installed

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -14,8 +14,10 @@ class TestNamespaces:
 
     @pytest.mark.xfail(sys.version_info < (3, 5),
         reason="Requires importlib.util.module_from_spec")
-    @pytest.mark.skipif(bool(os.environ.get("APPVEYOR")),
-        reason="https://github.com/pypa/setuptools/issues/851")
+    @pytest.mark.xfail(
+        os.environ.get("APPVEYOR"),
+        reason="https://github.com/pypa/setuptools/issues/851",
+    )
     def test_mixed_site_and_non_site(self, tmpdir):
         """
         Installing two packages sharing the same namespace, one installed
@@ -55,8 +57,10 @@ class TestNamespaces:
         with test.test.paths_on_pythonpath(map(str, targets)):
             subprocess.check_call(try_import)
 
-    @pytest.mark.skipif(bool(os.environ.get("APPVEYOR")),
-        reason="https://github.com/pypa/setuptools/issues/851")
+    @pytest.mark.xfail(
+        os.environ.get("APPVEYOR"),
+        reason="https://github.com/pypa/setuptools/issues/851",
+    )
     def test_pkg_resources_import(self, tmpdir):
         """
         Ensure that a namespace package doesn't break on import
@@ -81,8 +85,10 @@ class TestNamespaces:
         with test.test.paths_on_pythonpath([str(target)]):
             subprocess.check_call(try_import)
 
-    @pytest.mark.skipif(bool(os.environ.get("APPVEYOR")),
-        reason="https://github.com/pypa/setuptools/issues/851")
+    @pytest.mark.xfail(
+        os.environ.get("APPVEYOR"),
+        reason="https://github.com/pypa/setuptools/issues/851",
+    )
     def test_namespace_package_installed_and_cwd(self, tmpdir):
         """
         Installing a namespace packages but also having it in the current
@@ -110,8 +116,10 @@ class TestNamespaces:
         with test.test.paths_on_pythonpath([str(target)]):
             subprocess.check_call(pkg_resources_imp, cwd=str(pkg_A))
 
-    @pytest.mark.skipif(bool(os.environ.get("APPVEYOR")),
-        reason="https://github.com/pypa/setuptools/issues/851")
+    @pytest.mark.xfail(
+        os.environ.get("APPVEYOR"),
+        reason="https://github.com/pypa/setuptools/issues/851",
+    )
     def test_packages_in_the_sampe_namespace_installed_and_cwd(self, tmpdir):
         """
         Installing one namespace package and also have another in the same

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -12,8 +12,10 @@ from setuptools.command import test
 
 class TestNamespaces:
 
-    @pytest.mark.xfail(sys.version_info < (3, 5),
-        reason="Requires importlib.util.module_from_spec")
+    @pytest.mark.xfail(
+        sys.version_info < (3, 5),
+        reason="Requires importlib.util.module_from_spec",
+    )
     @pytest.mark.xfail(
         os.environ.get("APPVEYOR"),
         reason="https://github.com/pypa/setuptools/issues/851",


### PR DESCRIPTION
## Summary of changes

Improved ``__path__`` attribute handling for namespace packages, fixes a bug revealed with python3.6 when there are 2 packages in the same namespace one installed and one in current working directory.

Closes #1321 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d.