### PR TITLE
docs: fix developer guide

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ v39.2.0
   after any ``distutils`` ``setup_keywords`` calls, allowing them to override
   values.
 * #1352: Added ``tox`` environment for documentation builds.
-* #1354: Added ``towncrier`` for changelog managment.
+* #1354: Added ``towncrier`` for changelog management.
 * #1355: Add PR template.
 * #1368: Fixed tests which failed without network connectivity.
 * #1369: Added unit tests for PEP 425 compatibility tags support.

--- a/changelog.d/1403.doc.rst
+++ b/changelog.d/1403.doc.rst
@@ -1,0 +1,1 @@
+Fix developer's guide.

--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -89,31 +89,6 @@ code changes. See the following for an example news fragment:
     $ cat changelog.d/1288.change.rst
     Add support for maintainer in PKG-INFO
 
------------
-Source Code
------------
-
-Grab the code at Github::
-
-    $ git clone https://github.com/pypa/setuptools
-
-If you want to contribute changes, we recommend you fork the repository on
-Github, commit the changes to your repository, and then make a pull request
-on Github. If you make some changes, don't forget to:
-
-- add a note in CHANGES.rst
-
-Please commit all changes in the 'master' branch against the latest available
-commit or for bug-fixes, against an earlier commit or release in which the
-bug occurred.
-
-If you find yourself working on more than one issue at a time, Setuptools
-generally prefers Git-style branches, so use Mercurial bookmarks or Git
-branches or multiple forks to maintain separate efforts.
-
-The Continuous Integration tests that validate every release are run
-from this repository.
-
 -------
 Testing
 -------


### PR DESCRIPTION
## Summary of changes

Drop `Source Code` section, as it contains an outdated guideline with respect to documenting changes and its contents are already covered by other sections.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
