### PR TITLE
fix PEP 518 configuration

### DIFF
--- a/changelog.d/1404.misc.rst
+++ b/changelog.d/1404.misc.rst
@@ -1,0 +1,1 @@
+Fix PEP 518 configuration: set build requirements in ``pyproject.toml`` to ``["wheel"]``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["wheel"]
+
 [tool.towncrier]
     package = "setuptools"
     package_dir = "setuptools"


### PR DESCRIPTION
## Summary of changes

Add `build-system.requires` key to `pyproject.toml`:
- this is necessary with pip 10.0.1, as otherwise the defaults will be to require both `setuptools` and `wheel` (and we only need the later)
- a `pyproject.toml` with no `build-system.requires` key will be invalid and rejected by a future version of pip (see https://github.com/pypa/pip/issues/5416#issuecomment-399638608)

### Pull Request Checklist

- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
