### PR TITLE
Solve race during creation of egg cache (fixes #1256)

### DIFF
--- a/changelog.d/1412.change.rst
+++ b/changelog.d/1412.change.rst
@@ -1,0 +1,1 @@
+Solve race during creation of egg cache

--- a/changelog.d/1412.change.rst
+++ b/changelog.d/1412.change.rst
@@ -1,1 +1,1 @@
-Solve race during creation of egg cache
+Solve race during creation of egg cache by removing bypass_ensure_directory and switching to ensure_directory

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -3030,7 +3030,13 @@ def _bypass_ensure_directory(path):
     dirname, filename = split(path)
     if dirname and filename and not isdir(dirname):
         _bypass_ensure_directory(dirname)
-        mkdir(dirname, 0o755)
+        try:
+          mkdir(dirname, 0o755)
+        except os.error:
+          # Check for a possible race where the directory was already
+          # created.
+          if not isdir(dirname):
+            raise
 
 
 def split_sections(s):

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1198,7 +1198,7 @@ class ResourceManager:
         extract_path = self.extraction_path or get_default_cache()
         target_path = os.path.join(extract_path, archive_name + '-tmp', *names)
         try:
-            _bypass_ensure_directory(target_path)
+            ensure_directory(target_path)
         except Exception:
             self.extraction_error()
 
@@ -3021,22 +3021,6 @@ def ensure_directory(path):
     """Ensure that the parent directory of `path` exists"""
     dirname = os.path.dirname(path)
     py31compat.makedirs(dirname, exist_ok=True)
-
-
-def _bypass_ensure_directory(path):
-    """Sandbox-bypassing version of ensure_directory()"""
-    if not WRITE_SUPPORT:
-        raise IOError('"os.mkdir" not supported on this platform.')
-    dirname, filename = split(path)
-    if dirname and filename and not isdir(dirname):
-        _bypass_ensure_directory(dirname)
-        try:
-          mkdir(dirname, 0o755)
-        except os.error:
-          # Check for a possible race where the directory was already
-          # created.
-          if not isdir(dirname):
-            raise
 
 
 def split_sections(s):


### PR DESCRIPTION
## Summary of changes
This patch solves a race condition in get_cache_path in pkg_resource init.py, which generally shows its head: 
- In high volume CICD systems with many cores
- where the build job is configured to use all of said cores
- where there is a lot of concurrent python-y stuff happening around the same time

Closes #1256

## Details of change
Upstreaming a private fix that we have applied to python-setuptools 0.9.8 that solves a race during the creation of an egg cache. We use setuptools 0.9.8 with this fix internally on some of our projects. This fix has been in production for May 2017 and is working great.

The challenge we ran into is that setuptools, by itself, works great, both on development laptops/desktops, our fleet of development VMs, and so on. When put in a high volume CICD pipeline, even the latest version of python-setuptools falls on its face immediately (39.2.0, we haven't tried 40.x since it just came out a few hours ago). there was a recent-ish change (#1083) that (sounded) like it would address this, but did not

We suspect that given the build machines have 32 cores, and we're using make -j32, the concurrency is biting us here. We've added this small patch to work around it, and as mentioned, it has been great. 

For sanity, I did include the most recent failure logging from this morning from the 32 core build system here: https://github.com/pypa/setuptools/issues/1256#issuecomment-403547646

In an effort to get off that ancient version of setuptools, we're submitting this upstream, with the hopes that we can get this mainlined, and can then stay on vanilla "fresh off the branch" versions going forward.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. 