### PR TITLE
Fix a problem with Jython by using the version_info as a tuple.

### DIFF
--- a/pkg_resources/py31compat.py
+++ b/pkg_resources/py31compat.py
@@ -15,7 +15,7 @@ def _makedirs_31(path, exist_ok=False):
 #  and exists_ok considerations are disentangled.
 # See https://github.com/pypa/setuptools/pull/1083#issuecomment-315168663
 needs_makedirs = (
-    sys.version_info.major == 2 or
+    sys.version_info[0] == 2 or
     (3, 4) <= sys.version_info < (3, 4, 1)
 )
 makedirs = _makedirs_31 if needs_makedirs else os.makedirs


### PR DESCRIPTION
Jython 2.7 does not have a named tuple for version_info, so revert to older, gentler tuple syntax.

## Summary of changes

Fix an incompatibility with Jython by using tuple syntax instead of named tuple.
