### PR TITLE
Switch over to using six.PY{2,3} when possible

### DIFF
--- a/changelog.d/1416.change.rst
+++ b/changelog.d/1416.change.rst
@@ -1,0 +1,1 @@
+Moved several Python version checks over to using ``six.PY2`` and ``six.PY3``.

--- a/pkg_resources/py31compat.py
+++ b/pkg_resources/py31compat.py
@@ -2,6 +2,8 @@ import os
 import errno
 import sys
 
+from .extern import six
+
 
 def _makedirs_31(path, exist_ok=False):
     try:
@@ -15,7 +17,7 @@ def _makedirs_31(path, exist_ok=False):
 #  and exists_ok considerations are disentangled.
 # See https://github.com/pypa/setuptools/pull/1083#issuecomment-315168663
 needs_makedirs = (
-    sys.version_info.major == 2 or
+    six.PY2 or
     (3, 4) <= sys.version_info < (3, 4, 1)
 )
 makedirs = _makedirs_31 if needs_makedirs else os.makedirs

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -411,7 +411,7 @@ def scan_module(egg_dir, base, name, stubs):
         return True  # Extension module
     pkg = base[len(egg_dir) + 1:].replace(os.sep, '.')
     module = pkg + (pkg and '.' or '') + os.path.splitext(name)[0]
-    if sys.version_info.major == 2:
+    if six.PY2:
         skip = 8  # skip magic & date
     elif sys.version_info < (3, 7):
         skip = 12  # skip magic & date & file size

--- a/setuptools/extern/__init__.py
+++ b/setuptools/extern/__init__.py
@@ -48,7 +48,7 @@ class VendorImporter:
                 # on later Python versions to cause relative imports
                 # in the vendor package to resolve the same modules
                 # as those going through this importer.
-                if sys.version_info.major >= 3:
+                if sys.version_info >= (3, ):
                     del sys.modules[extant]
                 return mod
             except ImportError:

--- a/setuptools/pep425tags.py
+++ b/setuptools/pep425tags.py
@@ -12,6 +12,8 @@ import sysconfig
 import warnings
 from collections import OrderedDict
 
+from .extern import six
+
 from . import glibc
 
 _osx_arch_pat = re.compile(r'(.+)_(\d+)_(\d+)_(.+)')
@@ -97,8 +99,8 @@ def get_abi_tag():
                     lambda: sys.maxunicode == 0x10ffff,
                     expected=4,
                     warn=(impl == 'cp' and
-                          sys.version_info.major == 2)) \
-                and sys.version_info.major == 2:
+                          six.PY2)) \
+                and six.PY2:
             u = 'u'
         abi = '%s%s%s%s%s' % (impl, get_impl_ver(), d, m, u)
     elif soabi and soabi.startswith('cpython-'):


### PR DESCRIPTION
## Summary of changes
Per the reasoning in #1415, I think that we should use `six.PY{2,3}` whenever possible and outsource how to determine the major version to them.

The one concession I made to #1413 is that I changed one `sys.version_info.major` to `sys.version_info[0]` in the version logic *itself*, because that is more consistent with how `six` does it. I'm not saying that we guaranteed that we'll never use `sys.version_info.major` in the future, just that this is another equally good way to check the value that doesn't trigger the Jython bug.

Closes #1415

### Pull Request Checklist
- Changes have tests **N/A**
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
