### PR TITLE
Make install directory if it doesn't exist yet

### DIFF
--- a/changelog.d/1431.change.rst
+++ b/changelog.d/1431.change.rst
@@ -1,0 +1,1 @@
+In ``easy_install.check_site_dir``, ensure the installation directory exists.

--- a/changelog.d/1431.chnage.rst
+++ b/changelog.d/1431.chnage.rst
@@ -1,0 +1,3 @@
+Make install directory if it doesn't exist yet to prevent Fedora's
+specific setup to blow up if ``/usr/local/lib/pythonX.Y/site-packages``
+doesn't exist yet.

--- a/changelog.d/1431.chnage.rst
+++ b/changelog.d/1431.chnage.rst
@@ -1,3 +1,0 @@
-Make install directory if it doesn't exist yet to prevent Fedora's
-specific setup to blow up if ``/usr/local/lib/pythonX.Y/site-packages``
-doesn't exist yet.

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -450,6 +450,12 @@ class easy_install(Command):
         instdir = normalize_path(self.install_dir)
         pth_file = os.path.join(instdir, 'easy-install.pth')
 
+        if not os.path.exists(instdir):
+            try:
+                os.makedirs(instdir)
+            except (OSError, IOError):
+                self.cant_write_to_target()
+
         # Is it a configured, PYTHONPATH, implicit, or explicit site dir?
         is_site_dir = instdir in self.all_site_dirs
 


### PR DESCRIPTION
Problem: In Fedora, `sudo python3 setup.py install` installs to /usr/local/lib/pythonX.Y/site-packages. However that directory is not always there as it is not installed together with the python3 package (Fedora packages should not install stuff to /usr/local).

When the directory does not exist an installation attempt fails with:

    [Errno 2] No such file or directory: '/usr/local/lib/python3.7/site-packages/test-easy-install-11875.write-test'

Solution: Make the directory if it doesn't exists yet. If user has no permissions, the above error is preserved, yet with root (sudo) it works now.

I realize that this is not usefull outside Fedora's specific setup, yet I don't like downstream only patches and this breaks nothing.

- [ ] Changes have tests - not sure how to do that, as this is fairly Fedora specific
- [x] News fragment added in changelog.d