### PR TITLE
on Windows when setuptools is imported, appdirs is imported and in turn will lock pywin32's dlls

### DIFF
--- a/changelog.d/1443.change.rst
+++ b/changelog.d/1443.change.rst
@@ -1,0 +1,1 @@
+Avoid loading pywin32's dlls so that pywin32 can be updated via setuptools/pip.

--- a/pkg_resources/_vendor/appdirs.py
+++ b/pkg_resources/_vendor/appdirs.py
@@ -507,18 +507,14 @@ def _get_win_folder_with_jna(csidl_name):
 
 if system == "win32":
     try:
-        import win32com.shell
-        _get_win_folder = _get_win_folder_with_pywin32
+        from ctypes import windll
+        _get_win_folder = _get_win_folder_with_ctypes
     except ImportError:
         try:
-            from ctypes import windll
-            _get_win_folder = _get_win_folder_with_ctypes
+            import com.sun.jna
+            _get_win_folder = _get_win_folder_with_jna
         except ImportError:
-            try:
-                import com.sun.jna
-                _get_win_folder = _get_win_folder_with_jna
-            except ImportError:
-                _get_win_folder = _get_win_folder_from_registry
+            _get_win_folder = _get_win_folder_from_registry
 
 
 #---- self test code


### PR DESCRIPTION
## Summary of changes

on Windows when `setuptools` is imported, `appdirs` is imported and in turn it will import `pywin32` if available, which will lock `pywin32`'s dlls and because of that `pywin32` cannot be updated anymore (your pip install command will fail too)

fix is to apply the same patch as the `pip` project did in     https://github.com/pypa/pip/pull/4992

Sample error output:
```
Consider using the `--user` option or check the permissions.
Traceback (most recent call last):
  File "D:\temp\test_venv\v27\lib\site-packages\pip\_internal\commands\install.py", line 347, in run
    use_user_site=options.use_user_site,
  File "D:\temp\test_venv\v27\lib\site-packages\pip\_internal\req\__init__.py", line 49, in install_given_reqs
    **kwargs
  File "D:\temp\test_venv\v27\lib\site-packages\pip\_internal\req\req_install.py", line 941, in install
    use_user_site=use_user_site, pycompile=pycompile,
  File "D:\temp\test_venv\v27\lib\site-packages\pip\_internal\req\req_install.py", line 526, in move_wheel_files
    warn_script_location=warn_script_location,
  File "D:\temp\test_venv\v27\lib\site-packages\pip\_internal\wheel.py", line 324, in move_wheel_files
    clobber(source, lib_dir, True)
  File "D:\temp\test_venv\v27\lib\site-packages\pip\_internal\wheel.py", line 295, in clobber
    os.unlink(destfile)
WindowsError: [Error 5] Access is denied: 'D:\\temp\\test_venv\\v27\\Lib\\site-packages\\win32\\win32api.pyd'
```

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
