### PR TITLE
use --depth 1 for git clone + use separate git fetch to download rev

### DIFF
--- a/changelog.d/1446.change.rst
+++ b/changelog.d/1446.change.rst
@@ -1,0 +1,1 @@
+Using shallow ``clone`` and separate shallow ``fetch`` when downloading from git.

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -890,10 +890,15 @@ class PackageIndex(Environment):
         filename = filename.split('#', 1)[0]
         url, rev = self._vcs_split_rev_from_url(url, pop_prefix=True)
 
-        self.info("Doing git clone from %s to %s", url, filename)
-        os.system("git clone --quiet %s %s" % (url, filename))
+        self.info("Doing shallow git clone from %s to %s", url, filename)
+        os.system("git clone --quiet --depth 1 %s %s" % (url, filename))
 
         if rev is not None:
+            self.info("Fetching origin %s", rev)
+            os.system("(cd %s && git fetch --quiet --depth 1 origin %s)" % (
+                filename,
+                rev,
+            ))
             self.info("Checking out %s", rev)
             os.system("(cd %s && git checkout --quiet %s)" % (
                 filename,


### PR DESCRIPTION
## Summary of changes

- use `--depth 1` with `git clone` to get a shallow clone of a required repo
- use a separate `git fetch --depth 1` to fetch a specific revision from the shallow clone

Closes #1446

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details

### Manual Tests
I did not find any git-download tests to extend and currently only tested manually using:
- `python3.6 -m easy_install --user -v git+ssh://git@github.com/private/repo.git@master`
- `python3.6 -m easy_install --user -v git+ssh://git@github.com/private/repo.git`
