### PR TITLE
Upgrade vendored appdirs from 1.4.0 to 1.4.3

### DIFF
--- a/changelog.d/1451.change.rst
+++ b/changelog.d/1451.change.rst
@@ -1,0 +1,1 @@
+Upgrade vendored appdirs from 1.4.0 to 1.4.3.

--- a/pkg_resources/_vendor/vendored.txt
+++ b/pkg_resources/_vendor/vendored.txt
@@ -1,4 +1,4 @@
 packaging==16.8
-pyparsing==2.1.10
+pyparsing==2.2.0
 six==1.10.0
-appdirs==1.4.0
+appdirs==1.4.3

--- a/setuptools/_vendor/vendored.txt
+++ b/setuptools/_vendor/vendored.txt
@@ -1,3 +1,3 @@
 packaging==16.8
-pyparsing==2.1.10
+pyparsing==2.2.0
 six==1.10.0


### PR DESCRIPTION
## Summary of changes

Fixes the second part of #1095 and #1450 (see https://github.com/pypa/setuptools/pull/1450 for the first part).

Upgrade vendored appdirs from 1.4.0 to 1.4.3 to remove deprecation warnings:

#### master

```console
$ python3 --version
Python 3.7.0
$ find . -name \*.py | xargs python3 -Wall -m py_compile
./setuptools/_vendor/pyparsing.py:147: DeprecationWarning: invalid escape sequence \d
  xmlcharref = Regex('&#\d+;')
./setuptools/_vendor/pyparsing.py:832: DeprecationWarning: invalid escape sequence \d
  """
./setuptools/_vendor/pyparsing.py:2736: DeprecationWarning: invalid escape sequence \d
  """
./setuptools/_vendor/pyparsing.py:2914: DeprecationWarning: invalid escape sequence \g
  ret = re.sub(self.escCharReplacePattern,"\g<1>",ret)
./pkg_resources/_vendor/appdirs.py:130: DeprecationWarning: invalid escape sequence \D
  """
./pkg_resources/_vendor/appdirs.py:235: DeprecationWarning: invalid escape sequence \P
  """
./pkg_resources/_vendor/pyparsing.py:147: DeprecationWarning: invalid escape sequence \d
  xmlcharref = Regex('&#\d+;')
./pkg_resources/_vendor/pyparsing.py:832: DeprecationWarning: invalid escape sequence \d
  """
./pkg_resources/_vendor/pyparsing.py:2736: DeprecationWarning: invalid escape sequence \d
  """
./pkg_resources/_vendor/pyparsing.py:2914: DeprecationWarning: invalid escape sequence \g
  ret = re.sub(self.escCharReplacePattern,"\g<1>",ret)
```

#### This PR

```console
$ python3 --version
Python 3.7.0
$ find . -name \*.py | xargs python3 -Wall -m py_compile
./setuptools/_vendor/pyparsing.py:147: DeprecationWarning: invalid escape sequence \d
  xmlcharref = Regex('&#\d+;')
./setuptools/_vendor/pyparsing.py:832: DeprecationWarning: invalid escape sequence \d
  """
./setuptools/_vendor/pyparsing.py:2736: DeprecationWarning: invalid escape sequence \d
  """
./setuptools/_vendor/pyparsing.py:2914: DeprecationWarning: invalid escape sequence \g
  ret = re.sub(self.escCharReplacePattern,"\g<1>",ret)
./pkg_resources/_vendor/pyparsing.py:147: DeprecationWarning: invalid escape sequence \d
  xmlcharref = Regex('&#\d+;')
./pkg_resources/_vendor/pyparsing.py:832: DeprecationWarning: invalid escape sequence \d
  """
./pkg_resources/_vendor/pyparsing.py:2736: DeprecationWarning: invalid escape sequence \d
  """
./pkg_resources/_vendor/pyparsing.py:2914: DeprecationWarning: invalid escape sequence \g
```


### Pull Request Checklist
- [x] Changes have tests: existing tests still pass
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
