### PR TITLE
tox: fix configuration so newer tox versions are supported

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,12 @@ envlist=python
 
 [testenv]
 deps=-rtests/requirements.txt
+# Changed from default (`python -m pip ...`)
+# to prevent the current working directory
+# from being added to `sys.path`.
+install_command={envbindir}/pip install {opts} {packages}
+# Same as above.
+list_dependencies_command={envbindir}/pip freeze
 setenv=COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 # TODO: The passed environment variables came from copying other tox.ini files
 # These should probably be individually annotated to explain what needs them.


### PR DESCRIPTION
Starting with tox 3.2.0, the commands for installing/listing dependencies changed from `pip` to `python -m pip`, which is problematic as this will leave bits of the previous (from the virtualenv creation) older version of setuptools installed in the site-packages directory because from pip's point of view, the active setuptools version is the one in the current directory (which cannot be uninstalled).