### PR TITLE
Prepare 40.1.0rc1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,18 @@
+v40.1.0
+-------
+
+* #1410: Deprecated ``upload`` and ``register`` commands.
+* #1312: Introduced find_namespace_packages() to find PEP 420 namespace packages.
+* #1420: Added find_namespace: directive to config parser.
+* #1418: Solved race in when creating egg cache directories.
+* #1450: Upgraded vendored PyParsing from 2.1.10 to 2.2.0.
+* #1451: Upgraded vendored appdirs from 1.4.0 to 1.4.3.
+* #1388: Fixed "Microsoft Visual C++ Build Tools" link in exception when Visual C++ not found.
+* #1389: Added support for scripts which have unicode content.
+* #1416: Moved several Python version checks over to using ``six.PY2`` and ``six.PY3``.
+* #1441: Removed spurious executable permissions from files that don't need them.
+
+
 v40.0.0
 -------
 

--- a/changelog.d/1312.change.rst
+++ b/changelog.d/1312.change.rst
@@ -1,1 +1,0 @@
-Introduce find_namespace_packages() to find PEP 420 namespace packages.

--- a/changelog.d/1388.change.rst
+++ b/changelog.d/1388.change.rst
@@ -1,1 +1,0 @@
-Fixed "Microsoft Visual C++ Build Tools" link in exception when Visual C++ not found.

--- a/changelog.d/1389.change.rst
+++ b/changelog.d/1389.change.rst
@@ -1,1 +1,0 @@
-Scripts which have unicode content are now supported

--- a/changelog.d/1410.change.rst
+++ b/changelog.d/1410.change.rst
@@ -1,1 +1,0 @@
-Deprecate ``upload`` and ``register`` commands.

--- a/changelog.d/1416.change.rst
+++ b/changelog.d/1416.change.rst
@@ -1,1 +1,0 @@
-Moved several Python version checks over to using ``six.PY2`` and ``six.PY3``.

--- a/changelog.d/1418.change.rst
+++ b/changelog.d/1418.change.rst
@@ -1,1 +1,0 @@
-Solved race in when creating egg cache directories.

--- a/changelog.d/1420.change.rst
+++ b/changelog.d/1420.change.rst
@@ -1,1 +1,0 @@
-Add find_namespace: directive to config parser

--- a/changelog.d/1441.misc.rst
+++ b/changelog.d/1441.misc.rst
@@ -1,1 +1,0 @@
-Remove spurious executable permissions from files that don't need them.

--- a/changelog.d/1450.change.rst
+++ b/changelog.d/1450.change.rst
@@ -1,1 +1,0 @@
-Upgrade vendored PyParsing from 2.1.10 to 2.2.0.

--- a/changelog.d/1451.change.rst
+++ b/changelog.d/1451.change.rst
@@ -1,1 +1,0 @@
-Upgrade vendored appdirs from 1.4.0 to 1.4.3.


### PR DESCRIPTION
I think we're ready to cut a new release. I don't see any breaking changes, so I'm calling this the 40.1.0 release.

I think it might be a good idea to release an 40.1.0rc1 for a few days and then cut the final 40.1.0 release.

Thoughts @benoit-pierre @jaraco @jmbowman?

Anyone have any blockers that they wanted to make sure as in the next release?