### PR TITLE
setuptools: fix regression with `egg_info` command

### DIFF
--- a/changelog.d/1465.change.rst
+++ b/changelog.d/1465.change.rst
@@ -1,0 +1,1 @@
+Fix regression with `egg_info` command when tagging is used.

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -160,7 +160,9 @@ class egg_info(InfoCommon, Command):
 
     def initialize_options(self):
         self.egg_base = None
+        self.egg_name = None
         self.egg_info = None
+        self.egg_version = None
         self.broken_egg_info = False
 
     ####################################
@@ -188,15 +190,13 @@ class egg_info(InfoCommon, Command):
         egg_info['tag_date'] = 0
         edit_config(filename, dict(egg_info=egg_info))
 
-    @property
-    def egg_name(self):
-        return self.name
-
-    @property
-    def egg_version(self):
-        return self.tagged_version()
-
     def finalize_options(self):
+        # Note: we need to capture the current value returned
+        # by `self.tagged_version()`, so we can later update
+        # `self.distribution.metadata.version` without
+        # repercussions.
+        self.egg_name = self.name
+        self.egg_version = self.tagged_version()
         parsed_version = parse_version(self.egg_version)
 
         try:

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -570,3 +570,19 @@ class TestEggInfo:
             raise AssertionError(data)
         if output:
             assert output in data
+
+    def test_egg_info_tag_only_once(self, tmpdir_cwd, env):
+        self._create_project()
+        build_files({
+            'setup.cfg': DALS("""
+                              [egg_info]
+                              tag_build = dev
+                              tag_date = 0
+                              tag_svn_revision = 0
+                              """),
+        })
+        self._run_egg_info_command(tmpdir_cwd, env)
+        egg_info_dir = os.path.join('.', 'foo.egg-info')
+        with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
+            pkg_info_lines = pkginfo_file.read().split('\n')
+        assert 'Version: 0.0.0.dev0' in pkg_info_lines


### PR DESCRIPTION
Ensure version is tagged only once. Fix #1462.