### PR TITLE
Fix for Unicode handling in PEP 518 backend

### DIFF
--- a/changelog.d/1466.change.rst
+++ b/changelog.d/1466.change.rst
@@ -1,0 +1,1 @@
+Fix handling of Unicode arguments in PEP 517 backend

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -61,6 +61,19 @@ class Distribution(setuptools.dist.Distribution):
             distutils.core.Distribution = orig
 
 
+def _to_str(s):
+    """
+    Convert a filename to a string (on Python 2, explicitly
+    a byte string, not Unicode) as distutils checks for the
+    exact type str.
+    """
+    if sys.version_info[0] == 2 and not isinstance(s, str):
+        # Assume it's Unicode, as that's what the PEP says
+        # should be provided.
+        return s.encode(sys.getfilesystemencoding())
+    return s
+
+
 def _run_setup(setup_script='setup.py'):
     # Note that we can reuse our build directory between calls
     # Correctness comes first, then optimization later
@@ -109,7 +122,7 @@ def get_requires_for_build_sdist(config_settings=None):
 
 
 def prepare_metadata_for_build_wheel(metadata_directory, config_settings=None):
-    sys.argv = sys.argv[:1] + ['dist_info', '--egg-base', metadata_directory]
+    sys.argv = sys.argv[:1] + ['dist_info', '--egg-base', _to_str(metadata_directory)]
     _run_setup()
     
     dist_info_directory = metadata_directory

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -126,3 +126,12 @@ def test_prepare_metadata_for_build_wheel(build_backend):
     dist_info = build_backend.prepare_metadata_for_build_wheel(dist_dir)
 
     assert os.path.isfile(os.path.join(dist_dir, dist_info, 'METADATA'))
+
+
+def test_prepare_metadata_for_build_wheel_with_unicode(build_backend):
+    dist_dir = os.path.abspath(u'pip-dist-info')
+    os.makedirs(dist_dir)
+
+    dist_info = build_backend.prepare_metadata_for_build_wheel(dist_dir)
+
+    assert os.path.isfile(os.path.join(dist_dir, dist_info, 'METADATA'))


### PR DESCRIPTION
## Summary of changes

Modifies the PEP 517 backend to handle a Unicode value for the `metadata_directory` in `prepare_metadata_for_build_wheel`. Distutils has an explicit check for a `str` value for `egg-base`, which fails on Python 2 when passed Unicode (even if the value is convertible to str), so we convert the parameter to a string using the filesystem encoding in that case.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
