### PR TITLE
Remove compatibility shim for bytes type

### DIFF
--- a/changelog.d/1479.misc.rst
+++ b/changelog.d/1479.misc.rst
@@ -1,0 +1,1 @@
+Remove internal use of six.binary_type

--- a/setuptools/glob.py
+++ b/setuptools/glob.py
@@ -3,14 +3,12 @@ Filename globbing utility. Mostly a copy of `glob` from Python 3.5.
 
 Changes include:
  * `yield from` and PEP3102 `*` removed.
- * `bytes` changed to `six.binary_type`.
  * Hidden files are not ignored.
 """
 
 import os
 import re
 import fnmatch
-from setuptools.extern.six import binary_type
 
 __all__ = ["glob", "iglob", "escape"]
 
@@ -92,7 +90,7 @@ def _iglob(pathname, recursive):
 
 def glob1(dirname, pattern):
     if not dirname:
-        if isinstance(pattern, binary_type):
+        if isinstance(pattern, bytes):
             dirname = os.curdir.encode('ASCII')
         else:
             dirname = os.curdir
@@ -129,8 +127,8 @@ def glob2(dirname, pattern):
 # Recursively yields relative pathnames inside a literal directory.
 def _rlistdir(dirname):
     if not dirname:
-        if isinstance(dirname, binary_type):
-            dirname = binary_type(os.curdir, 'ASCII')
+        if isinstance(dirname, bytes):
+            dirname = os.curdir.encode('ASCII')
         else:
             dirname = os.curdir
     try:
@@ -149,7 +147,7 @@ magic_check_bytes = re.compile(b'([*?[])')
 
 
 def has_magic(s):
-    if isinstance(s, binary_type):
+    if isinstance(s, bytes):
         match = magic_check_bytes.search(s)
     else:
         match = magic_check.search(s)
@@ -157,7 +155,7 @@ def has_magic(s):
 
 
 def _isrecursive(pattern):
-    if isinstance(pattern, binary_type):
+    if isinstance(pattern, bytes):
         return pattern == b'**'
     else:
         return pattern == '**'
@@ -169,7 +167,7 @@ def escape(pathname):
     # Escaping is done by wrapping any of "*?[" between square brackets.
     # Metacharacters do not work in the drive part and shouldn't be escaped.
     drive, pathname = os.path.splitdrive(pathname)
-    if isinstance(pathname, binary_type):
+    if isinstance(pathname, bytes):
         pathname = magic_check_bytes.sub(br'[\1]', pathname)
     else:
         pathname = magic_check.sub(r'[\1]', pathname)

--- a/setuptools/tests/files.py
+++ b/setuptools/tests/files.py
@@ -1,7 +1,6 @@
 import os
 
 
-from setuptools.extern.six import binary_type
 import pkg_resources.py31compat
 
 
@@ -31,7 +30,7 @@ def build_files(file_defs, prefix=""):
             pkg_resources.py31compat.makedirs(full_name, exist_ok=True)
             build_files(contents, prefix=full_name)
         else:
-            if isinstance(contents, binary_type):
+            if isinstance(contents, bytes):
                 with open(full_name, 'wb') as f:
                     f.write(contents)
             else:

--- a/setuptools/tests/test_glob.py
+++ b/setuptools/tests/test_glob.py
@@ -1,0 +1,35 @@
+import pytest
+
+from setuptools.glob import glob
+
+from .files import build_files
+
+
+@pytest.mark.parametrize('tree, pattern, matches', (
+    ('', b'', []),
+    ('', '', []),
+    ('''
+     appveyor.yml
+     CHANGES.rst
+     LICENSE
+     MANIFEST.in
+     pyproject.toml
+     README.rst
+     setup.cfg
+     setup.py
+     ''', '*.rst', ('CHANGES.rst', 'README.rst')),
+    ('''
+     appveyor.yml
+     CHANGES.rst
+     LICENSE
+     MANIFEST.in
+     pyproject.toml
+     README.rst
+     setup.cfg
+     setup.py
+     ''', b'*.rst', (b'CHANGES.rst', b'README.rst')),
+))
+def test_glob(monkeypatch, tmpdir, tree, pattern, matches):
+    monkeypatch.chdir(tmpdir)
+    build_files({name: '' for name in tree.split()})
+    assert list(sorted(glob(pattern))) == list(sorted(matches))


### PR DESCRIPTION
## Summary of changes

The type `bytes` is available on all supported Pythons. Makes the code more forward compatible with Python 3.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
