### PR TITLE
build_meta sdist directory delegate to --dist-dir

### DIFF
--- a/changelog.d/1481.change.rst
+++ b/changelog.d/1481.change.rst
@@ -1,0 +1,1 @@
+join the sdist ``--dist-dir`` and the ``build_meta`` sdist directory argument to point to the same (this means the build frontend no longer needs to clean manually the dist dir - to avoid multiple sdist presence, and we no longer need to handle conflicts between these two flags)

--- a/changelog.d/1481.change.rst
+++ b/changelog.d/1481.change.rst
@@ -1,1 +1,1 @@
-join the sdist ``--dist-dir`` and the ``build_meta`` sdist directory argument to point to the same (this means the build frontend no longer needs to clean manually the dist dir - to avoid multiple sdist presence, and we no longer need to handle conflicts between these two flags)
+Join the sdist ``--dist-dir`` and the ``build_meta`` sdist directory argument to point to the same target (meaning the build frontend no longer needs to clean manually the dist dir to avoid multiple sdist presence, and setuptools no longer needs to handle conflicts between the two).

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -171,11 +171,9 @@ def build_sdist(sdist_directory, config_settings=None):
     config_settings = _fix_config(config_settings)
     sdist_directory = os.path.abspath(sdist_directory)
     sys.argv = sys.argv[:1] + ['sdist'] + \
-        config_settings["--global-option"]
+        config_settings["--global-option"] + \
+        ["--dist-dir", sdist_directory]
     _run_setup()
-    if sdist_directory != 'dist':
-        shutil.rmtree(sdist_directory)
-        shutil.copytree('dist', sdist_directory)
 
     sdists = [f for f in os.listdir(sdist_directory)
               if f.endswith('.tar.gz')]


### PR DESCRIPTION
This avoids a lot of current bugs (e.g. sdists are always generated in ``dist``, and at end moved out; however ``dist`` folder remains around - so if e.g. the version changes you'll get two sdists now); no need to move around just build in the requested location. Discovered this while trying to use this backend with tox's PEP-517/8.