### PR TITLE
netlify: fix build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
 
 [build]
     publish = "docs/build/html"
-    command = "pip install tox && tox -e docs"
+    command = "pip install tox && tox -e docs --notest && ./.tox/docs/bin/pip install 'Sphinx==1.7.9' && tox -e docs"


### PR DESCRIPTION
Pin Sphinx to 1.7.9 until https://github.com/sphinx-doc/sphinx/issues/5417 is fixed.