### PR TITLE
Revert "Make safe_name compliant to PEP 503 and behaviour of pip > 8.1.2"

### DIFF
--- a/changelog.d/1324.change.rst
+++ b/changelog.d/1324.change.rst
@@ -1,1 +1,0 @@
-Make safe_name compliant with PEP 503.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1312,9 +1312,9 @@ def get_default_cache():
 def safe_name(name):
     """Convert an arbitrary string to a standard distribution name
 
-    Any runs of non-alphanumeric characters are replaced with a single '-'.
+    Any runs of non-alphanumeric/. characters are replaced with a single '-'.
     """
-    return re.sub('[^A-Za-z0-9]+', '-', name)
+    return re.sub('[^A-Za-z0-9.]+', '-', name)
 
 
 def safe_version(version):


### PR DESCRIPTION
Reverts pypa/setuptools#1324