### PR TITLE
Support the empty-string extra

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2628,6 +2628,12 @@ class Distribution:
                 raise UnknownExtra(
                     "%s has no such extra feature %r" % (self, ext)
                 )
+        # If no extras have been requested, add dependencies from the "empty
+        # string extra". Usually this will not exist, but if it does, it will
+        # allow users to specify requirements that should only be installed
+        # when no extras have been requested.
+        if not extras:
+            deps.extend(dm.get('', ()))
         return deps
 
     def _get_metadata(self, name):

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -349,6 +349,21 @@ class TestDistro:
         with pytest.raises(pkg_resources.UnknownExtra):
             d.requires(["foo"])
 
+    def testEmptyStringExtras(self):
+        d = self.distRequires("""
+            foobar
+            [aiohttp]
+            aiohttp
+            [tornado]
+            tornado
+            []
+            requests""")
+        self.checkRequires(d, "foobar requests".split())
+        self.checkRequires(d, "foobar requests".split(), [""])
+        self.checkRequires(d, "foobar requests".split(), [])
+        self.checkRequires(d, "foobar aiohttp".split(), ["aiohttp"])
+        self.checkRequires(d, "foobar tornado".split(), ["tornado"])
+
 
 class TestWorkingSet:
     def test_find_conflicting(self):


### PR DESCRIPTION
## Summary of changes
Allows users to specify an "empty string extra", whose dependencies which will be included in a package's dependencies only if no extras have been requested (i.e., by default).

Closes #1139.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
