### PR TITLE
[WIP] setuptools: add support for reproducible source distributions

### DIFF
--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -4,15 +4,35 @@ import zipfile
 import tarfile
 import os
 import shutil
+import struct
+import time
 import posixpath
 import contextlib
 from distutils.errors import DistutilsError
+from distutils.dir_util import mkpath
+from distutils import log
+
+try:
+    from pwd import getpwnam
+except ImportError:
+    getpwnam = None
+
+try:
+    from grp import getgrnam
+except ImportError:
+    getgrnam = None
+
+try:
+    import lzma
+except:
+    lzma = None
 
 from pkg_resources import ensure_directory
 
 __all__ = [
     "unpack_archive", "unpack_zipfile", "unpack_tarfile", "default_filter",
     "UnrecognizedFormat", "extraction_drivers", "unpack_directory",
+    "make_archive",
 ]
 
 
@@ -171,3 +191,225 @@ def unpack_tarfile(filename, extract_dir, progress_filter=default_filter):
 
 
 extraction_drivers = unpack_directory, unpack_zipfile, unpack_tarfile
+
+
+def _get_gid(name):
+    """Returns a gid, given a group name."""
+    if getgrnam is None or name is None:
+        return None
+    try:
+        result = getgrnam(name)
+    except KeyError:
+        result = None
+    if result is not None:
+        return result[2]
+    return None
+
+def _get_uid(name):
+    """Returns an uid, given a user name."""
+    if getpwnam is None or name is None:
+        return None
+    try:
+        result = getpwnam(name)
+    except KeyError:
+        result = None
+    if result is not None:
+        return result[2]
+    return None
+
+def _find_sorted(base_dir):
+    yield base_dir
+    for path in sorted(
+        os.path.join(root, name)
+        for root, dirs, files in os.walk(base_dir)
+        for name in dirs + files
+    ):
+        yield path
+
+
+def make_tarball(base_name, base_dir, compress="gzip", verbose=0, dry_run=0,
+                 owner=None, group=None, timestamp=None):
+    """Create a (possibly compressed) tar file from all the files under
+    'base_dir'.
+
+    'compress' must be "gzip" (the default), "bzip2", "xz", "compress", or
+    None.  ("compress" will be deprecated in Python 3.2)
+
+    'owner' and 'group' can be used to define an owner and a group for the
+    archive that is being built. If not provided, the current owner and group
+    will be used.
+
+    'compress' is used to set the header timestamp when using "gzip".
+
+    The output tar file will be named 'base_dir' +  ".tar", possibly plus
+    the appropriate compression extension (".gz", ".bz2", ".xz" or ".Z").
+
+    Returns the output filename.
+    """
+    tar_compression = {'gzip': 'gz', 'bzip2': 'bz2', 'xz': 'xz', None: ''}
+    compress_ext = {'gzip': '.gz', 'bzip2': '.bz2', 'xz': '.xz'}
+
+    # flags for compression program, each element of list will be an argument
+    if compress is not None and compress not in compress_ext.keys():
+        raise ValueError(
+              "bad value for 'compress': must be None, 'gzip', 'bzip2', "
+              "'xz' or 'compress'")
+
+    archive_name = base_name + '.tar'
+    archive_name += compress_ext.get(compress, '')
+
+    mkpath(os.path.dirname(archive_name), dry_run=dry_run)
+
+    log.info('Creating tar archive')
+
+    if dry_run:
+        return archive_name
+
+    uid = _get_uid(owner)
+    gid = _get_gid(group)
+
+    def _set_uid_gid(tarinfo):
+        if gid is not None:
+            tarinfo.gid = gid
+            tarinfo.gname = group
+        if uid is not None:
+            tarinfo.uid = uid
+            tarinfo.uname = owner
+        if timestamp is not None:
+            tarinfo.mtime = timestamp
+        return tarinfo
+
+    tar = tarfile.open(archive_name, 'w|%s' % tar_compression[compress])
+    try:
+        for path in _find_sorted(base_dir):
+            tar.add(path, recursive=False, filter=_set_uid_gid)
+    finally:
+        tar.close()
+
+    # Patch gzip header to use the timestamp
+    # provided instead of the current time.
+    if compress == 'gzip' and timestamp is not None:
+        with open(archive_name, 'r+b') as fp:
+            fp.seek(4)
+            fp.write(struct.pack('<L', timestamp))
+
+    return archive_name
+
+def make_zipfile(base_name, base_dir, verbose=0, dry_run=0, timestamp=None):
+    """Create a zip file from all the files under 'base_dir'.
+
+    The output zip file will be named 'base_name' + ".zip".
+    Returns the name of the output zip file.
+    """
+    zip_filename = base_name + ".zip"
+    mkpath(os.path.dirname(zip_filename), dry_run=dry_run)
+
+    log.info("creating '%s' and adding '%s' to it",
+             zip_filename, base_dir)
+
+    if dry_run:
+        return zip_filename
+
+    compression = zipfile.ZIP_DEFLATED
+    try:
+        zip = zipfile.ZipFile(zip_filename, "w",
+                              compression=compression)
+    except RuntimeError:
+        compression = zipfile.ZIP_STORED
+        zip = zipfile.ZipFile(zip_filename, "w",
+                              compression=compression)
+    try:
+        for path in filter(os.path.isfile, _find_sorted(base_dir)):
+            st = os.stat(path)
+            date_time = time.localtime(
+                st.st_mtime if timestamp is None else timestamp
+            )[0:6]
+            info = zipfile.ZipInfo(path, date_time)
+            info.compress_type = compression
+            info.external_attr = st.st_mode << 16
+            with open(path, 'rb') as fp:
+                zip.writestr(info, fp.read())
+            log.info("adding '%s'", path)
+    finally:
+        zip.close()
+
+    return zip_filename
+
+ARCHIVE_FORMATS = {
+    'gztar': (make_tarball, [('compress', 'gzip')], "gzip'ed tar-file"),
+    'bztar': (make_tarball, [('compress', 'bzip2')], "bzip2'ed tar-file"),
+    'tar':   (make_tarball, [('compress', None)], "uncompressed tar file"),
+    'zip':   (make_zipfile, [],"ZIP file")
+    }
+if lzma is not None:
+    ARCHIVE_FORMATS.update({
+        'xztar': (make_tarball, [('compress', 'xz')], "xz'ed tar-file"),
+    })
+
+def check_archive_formats(formats):
+    """Returns the first format from the 'format' list that is unknown.
+
+    If all formats are known, returns None
+    """
+    for format in formats:
+        if format not in ARCHIVE_FORMATS:
+            return format
+    return None
+
+def make_archive(base_name, format, root_dir=None, base_dir=None, verbose=0,
+                 dry_run=0, owner=None, group=None, timestamp=None):
+    """Create an archive file (eg. zip or tar).
+
+    'base_name' is the name of the file to create, minus any format-specific
+    extension; 'format' is the archive format: one of "zip", "tar", "gztar",
+    "bztar", "xztar", or "ztar".
+
+    'root_dir' is a directory that will be the root directory of the
+    archive; ie. we typically chdir into 'root_dir' before creating the
+    archive.  'base_dir' is the directory where we start archiving from;
+    ie. 'base_dir' will be the common prefix of all files and
+    directories in the archive.  'root_dir' and 'base_dir' both default
+    to the current directory.  Returns the name of the archive file.
+
+    'owner' and 'group' are used when creating a tar archive. By default,
+    uses the current owner and group.
+
+    'timestamp' is used when creating a gzip'ed tar-file, to set the
+    gzip header timestamp.
+    """
+    save_cwd = os.getcwd()
+    if root_dir is not None:
+        log.debug("changing into '%s'", root_dir)
+        base_name = os.path.abspath(base_name)
+        if not dry_run:
+            os.chdir(root_dir)
+
+    if base_dir is None:
+        base_dir = os.curdir
+
+    kwargs = {'dry_run': dry_run}
+
+    try:
+        format_info = ARCHIVE_FORMATS[format]
+    except KeyError:
+        raise ValueError("unknown archive format '%s'" % format)
+
+    func = format_info[0]
+    for arg, val in format_info[1]:
+        kwargs[arg] = val
+
+    if format != 'zip':
+        kwargs['owner'] = owner
+        kwargs['group'] = group
+
+    if timestamp is not None:
+        kwargs['timestamp'] = timestamp
+
+    try:
+        filename = func(base_name, base_dir, **kwargs)
+    finally:
+        if root_dir is not None:
+            log.debug("changing back to '%s'", save_cwd)
+            os.chdir(save_cwd)
+
+    return filename

--- a/setuptools/tests/test_archive_util.py
+++ b/setuptools/tests/test_archive_util.py
@@ -1,13 +1,50 @@
 # coding: utf-8
 
-import tarfile
+from __future__ import unicode_literals
+
+from contextlib import contextmanager
+from os.path import splitdrive
 import io
+import os
+import sys
+import tarfile
+
+from distutils.spawn import find_executable, spawn
 
 from setuptools.extern import six
 
 import pytest
 
 from setuptools import archive_util
+
+try:
+    import grp
+    import pwd
+    UID_GID_SUPPORT = True
+except ImportError:
+    UID_GID_SUPPORT = False
+
+try:
+    import zipfile
+    ZIP_SUPPORT = True
+except ImportError:
+    ZIP_SUPPORT = find_executable('zip')
+
+try:
+    import zlib
+    ZLIB_SUPPORT = True
+except ImportError:
+    ZLIB_SUPPORT = False
+
+try:
+    import bz2
+except ImportError:
+    bz2 = None
+
+try:
+    import lzma
+except ImportError:
+    lzma = None
 
 
 @pytest.fixture
@@ -40,3 +77,313 @@ def tarfile_with_unicode(tmpdir):
 def test_unicode_files(tarfile_with_unicode, tmpdir):
     target = tmpdir / 'out'
     archive_util.unpack_archive(tarfile_with_unicode, six.text_type(target))
+
+
+def can_fs_encode(filename):
+    """
+    Return True if the filename can be saved in the file system.
+    """
+    if os.path.supports_unicode_filenames:
+        return True
+    try:
+        filename.encode(sys.getfilesystemencoding())
+    except UnicodeEncodeError:
+        return False
+    return True
+
+
+class ArchiveUtilTestHelper:
+
+    _created_files = ('dist', 'dist/file1', 'dist/file2',
+                      'dist/sub', 'dist/sub/file3', 'dist/sub2')
+
+    def __init__(self, monkeypatch, tmpdir_factory):
+        self.monkeypatch = monkeypatch
+        self.tmpdir_factory = tmpdir_factory
+
+    def mkdtemp(self):
+        return str(self.tmpdir_factory.mktemp('tmp'))
+
+    @contextmanager
+    def chdir(self, directory):
+        with self.monkeypatch.context() as m:
+            m.chdir(directory)
+            yield
+
+    def _make_tarball(self, tmpdir, target_name, suffix, **kwargs):
+        tmpdir2 = self.mkdtemp()
+        pytest.mark.skipif(not splitdrive(tmpdir)[0] == splitdrive(tmpdir2)[0],
+                            "source and target should be on same drive")
+
+        base_name = os.path.join(tmpdir2, target_name)
+
+        # working with relative paths to avoid tar warnings
+        with self.chdir(tmpdir):
+            archive_util.make_tarball(splitdrive(base_name)[1], 'dist', **kwargs)
+
+        # check if the compressed tarball was created
+        tarball = base_name + suffix
+        assert os.path.exists(tarball)
+        assert self._tarinfo(tarball) == self._created_files
+
+    @staticmethod
+    def _tarinfo(path):
+        tar = tarfile.open(path)
+        try:
+            names = tar.getnames()
+            names.sort()
+            return tuple(names)
+        finally:
+            tar.close()
+
+    @staticmethod
+    def write_file(path_components, contents):
+        with open(os.path.join(*path_components), 'w') as fp:
+            fp.write(contents)
+
+    def _create_files(self):
+        # creating something to tar
+        tmpdir = self.mkdtemp()
+        dist = os.path.join(tmpdir, 'dist')
+        os.mkdir(dist)
+        self.write_file([dist, 'file1'], 'xxx')
+        self.write_file([dist, 'file2'], 'xxx')
+        os.mkdir(os.path.join(dist, 'sub'))
+        self.write_file([dist, 'sub', 'file3'], 'xxx')
+        os.mkdir(os.path.join(dist, 'sub2'))
+        return tmpdir
+
+@pytest.fixture
+def helper(monkeypatch, tmpdir_factory):
+    return ArchiveUtilTestHelper(monkeypatch, tmpdir_factory)
+
+@pytest.mark.skipif(not ZLIB_SUPPORT, reason='Need zlib support to run')
+def test_make_tarball(helper, name='archive'):
+    # creating something to tar
+    tmpdir = helper._create_files()
+    helper._make_tarball(tmpdir, name, '.tar.gz')
+    # trying an uncompressed one
+    helper._make_tarball(tmpdir, name, '.tar', compress=None)
+
+@pytest.mark.skipif(not ZLIB_SUPPORT, reason='Need zlib support to run')
+def test_make_tarball_gzip(helper):
+    tmpdir = helper._create_files()
+    helper._make_tarball(tmpdir, 'archive', '.tar.gz', compress='gzip')
+
+@pytest.mark.skipif(not bz2, reason='Need bz2 support to run')
+def test_make_tarball_bzip2(helper):
+    tmpdir = helper._create_files()
+    helper._make_tarball(tmpdir, 'archive', '.tar.bz2', compress='bzip2')
+
+@pytest.mark.skipif(not lzma, reason='Need lzma support to run')
+def test_make_tarball_xz(helper):
+    tmpdir = helper._create_files()
+    helper._make_tarball(tmpdir, 'archive', '.tar.xz', compress='xz')
+
+@pytest.mark.skipif(not can_fs_encode('årchiv'),
+    reason='File system cannot handle this filename')
+def test_make_tarball_latin1(helper):
+    """
+    Mirror test_make_tarball, except filename contains latin characters.
+    """
+    test_make_tarball(helper, 'årchiv') # note this isn't a real word
+
+@pytest.mark.skipif(not can_fs_encode('のアーカイブ'),
+                    reason='File system cannot handle this filename')
+def test_make_tarball_extended(helper):
+    """
+    Mirror test_make_tarball, except filename contains extended
+    characters outside the latin charset.
+    """
+    test_make_tarball(helper, 'のアーカイブ') # japanese for archive
+
+@pytest.mark.skipif(not (find_executable('tar') and
+                         find_executable('gzip') and
+                         ZLIB_SUPPORT),
+                    reason='Need the tar, gzip and zlib command to run')
+def test_tarfile_vs_tar(helper):
+    tmpdir =  helper._create_files()
+    tmpdir2 = helper.mkdtemp()
+    base_name = os.path.join(tmpdir2, 'archive')
+    with helper.chdir(tmpdir):
+        archive_util.make_tarball(base_name, 'dist')
+
+    # check if the compressed tarball was created
+    tarball = base_name + '.tar.gz'
+    assert os.path.exists(tarball)
+
+    # now create another tarball using `tar`
+    tarball2 = os.path.join(tmpdir, 'archive2.tar.gz')
+    tar_cmd = ['tar', '-cf', 'archive2.tar', 'dist']
+    gzip_cmd = ['gzip', '-f', '-9', 'archive2.tar']
+    with helper.chdir(tmpdir):
+        spawn(tar_cmd)
+        spawn(gzip_cmd)
+
+    assert os.path.exists(tarball2)
+    # let's compare both tarballs
+    assert helper._tarinfo(tarball) == helper._created_files
+    assert helper._tarinfo(tarball2) == helper._created_files
+
+    # trying an uncompressed one
+    base_name = os.path.join(tmpdir2, 'archive')
+    with helper.chdir(tmpdir):
+        archive_util.make_tarball(base_name, 'dist', compress=None)
+    tarball = base_name + '.tar'
+    assert os.path.exists(tarball)
+
+    # now for a dry_run
+    base_name = os.path.join(tmpdir2, 'archive')
+    with helper.chdir(tmpdir):
+        archive_util.make_tarball(base_name, 'dist', compress=None, dry_run=True)
+    tarball = base_name + '.tar'
+    assert os.path.exists(tarball)
+
+@pytest.mark.skipif(not ZIP_SUPPORT and ZLIB_SUPPORT,
+                    reason='Need zip and zlib support to run')
+def test_make_zipfile(helper):
+    # creating something to tar
+    tmpdir = helper._create_files()
+    base_name = os.path.join(helper.mkdtemp(), 'archive')
+    with helper.chdir(tmpdir):
+        archive_util.make_zipfile(base_name, 'dist')
+
+    # check if the compressed tarball was created
+    tarball = base_name + '.zip'
+    assert os.path.exists(tarball)
+    with zipfile.ZipFile(tarball) as zf:
+        assert sorted(zf.namelist()) == ['dist/file1', 'dist/file2',
+                                         'dist/sub/file3']
+
+@pytest.mark.skipif(not ZIP_SUPPORT, reason='Need zip support to run')
+def test_make_zipfile_no_zlib(helper):
+    helper.monkeypatch.setattr(archive_util.zipfile, 'zlib', None)  # force zlib ImportError
+
+    called = []
+    zipfile_class = zipfile.ZipFile
+    def fake_zipfile(*a, **kw):
+        if kw.get('compression', None) == zipfile.ZIP_STORED:
+            called.append((a, kw))
+        return zipfile_class(*a, **kw)
+
+    helper.monkeypatch.setattr(archive_util.zipfile, 'ZipFile', fake_zipfile)
+
+    # create something to tar and compress
+    tmpdir = helper._create_files()
+    base_name = os.path.join(tmpdir, 'archive')
+    with helper.chdir(tmpdir):
+        archive_util.make_zipfile(base_name, 'dist')
+
+    tarball = base_name + '.zip'
+    assert called == [((tarball, "w"), {'compression': zipfile.ZIP_STORED})]
+    assert os.path.exists(tarball)
+    with zipfile.ZipFile(tarball) as zf:
+        assert sorted(zf.namelist()) == ['dist/file1', 'dist/file2', 'dist/sub/file3']
+
+def test_check_archive_formats(helper):
+    assert archive_util.check_archive_formats(['gztar', 'xxx', 'zip']) == 'xxx'
+    formats = ['gztar', 'bztar', 'tar', 'zip']
+    if lzma is not None:
+        formats.append('xztar')
+    assert archive_util.check_archive_formats(formats) is None
+
+def test_make_archive(tmpdir):
+    base_name = os.path.join(str(tmpdir), 'archive')
+    with pytest.raises(ValueError):
+        archive_util.make_archive(base_name, 'xxx')
+
+def test_make_archive_cwd(tmpdir):
+    current_dir = os.getcwd()
+    def _breaks(*args, **kw):
+        raise RuntimeError()
+    archive_util.ARCHIVE_FORMATS['xxx'] = (_breaks, [], 'xxx file')
+    try:
+        try:
+            archive_util.make_archive('xxx', 'xxx', root_dir=tmpdir)
+        except:
+            pass
+        assert os.getcwd() == current_dir
+    finally:
+        del archive_util.ARCHIVE_FORMATS['xxx']
+
+def test_make_archive_tar(helper):
+    tmpdir = helper._create_files()
+    base_name = os.path.join(tmpdir , 'archive')
+    res = archive_util.make_archive(base_name, 'tar', tmpdir, 'dist')
+    assert os.path.exists(res)
+    assert os.path.basename(res) == 'archive.tar'
+    assert helper._tarinfo(res) == helper._created_files
+
+@pytest.mark.skipif(not ZLIB_SUPPORT, reason='Need zlib support to run')
+def test_make_archive_gztar(helper, tmpdir):
+    tmpdir = helper._create_files()
+    base_name = os.path.join(tmpdir, 'archive')
+    res = archive_util.make_archive(base_name, 'gztar', tmpdir, 'dist')
+    assert os.path.exists(res)
+    assert os.path.basename(res) == 'archive.tar.gz'
+    assert helper._tarinfo(res) == helper._created_files
+
+@pytest.mark.skipif(not bz2, reason='Need bz2 support to run')
+def test_make_archive_bztar(helper, tmpdir):
+    tmpdir = helper._create_files()
+    base_name = os.path.join(tmpdir , 'archive')
+    res = archive_util.make_archive(base_name, 'bztar', tmpdir, 'dist')
+    assert os.path.exists(res)
+    assert os.path.basename(res) == 'archive.tar.bz2'
+    assert helper._tarinfo(res) == helper._created_files
+
+@pytest.mark.skipif(not lzma, reason='Need xz support to run')
+def test_make_archive_xztar(helper):
+    base_dir =  helper._create_files()
+    base_name = os.path.join(helper.mkdtemp(), 'archive')
+    res = archive_util.make_archive(base_name, 'xztar', base_dir, 'dist')
+    assert os.path.exists(res)
+    assert os.path.basename(res) == 'archive.tar.xz'
+    assert helper._tarinfo(res) == helper._created_files
+
+def test_make_archive_owner_group(helper):
+    # testing make_archive with owner and group, with various combinations
+    # this works even if there's not gid/uid support
+    if UID_GID_SUPPORT:
+        group = grp.getgrgid(0)[0]
+        owner = pwd.getpwuid(0)[0]
+    else:
+        group = owner = 'root'
+
+    base_dir = helper._create_files()
+    root_dir = helper.mkdtemp()
+    base_name = os.path.join(helper.mkdtemp(), 'archive')
+    res = archive_util.make_archive(base_name, 'zip', root_dir, base_dir,
+                                    owner=owner, group=group)
+    assert os.path.exists(res)
+
+    res = archive_util.make_archive(base_name, 'zip', root_dir, base_dir)
+    assert os.path.exists(res)
+
+    res = archive_util.make_archive(base_name, 'tar', root_dir, base_dir,
+                                    owner=owner, group=group)
+    assert os.path.exists(res)
+
+    res = archive_util.make_archive(base_name, 'tar', root_dir, base_dir,
+                                    owner='kjhkjhkjg', group='oihohoh')
+    assert os.path.exists(res)
+
+@pytest.mark.skipif(not ZLIB_SUPPORT, reason="Requires zlib")
+@pytest.mark.skipif(not UID_GID_SUPPORT, reason="Requires grp and pwd support")
+def test_tarfile_root_owner(helper):
+    tmpdir =  helper._create_files()
+    base_name = os.path.join(helper.mkdtemp(), 'archive')
+    group = grp.getgrgid(0)[0]
+    owner = pwd.getpwuid(0)[0]
+    with helper.chdir(tmpdir):
+        archive_name = archive_util.make_tarball(base_name, 'dist', compress=None,
+                                                 owner=owner, group=group)
+
+    # check if the compressed tarball was created
+    assert os.path.exists(archive_name)
+
+    # now checks the rights
+    with tarfile.open(archive_name) as archive:
+        for member in archive.getmembers():
+            assert member.uid == 0
+            assert member.gid == 0


### PR DESCRIPTION
## Summary of changes

I decided to take a look at making it possible to have reproducible outputs when using `python setup.py sdist`. This involve 2 changes: always sorting each archive entries so the order is deterministic, and supporting the use of the environment variable `SOURCE_DATE_EPOCH` for setting the timestamp of all entries (the same variable is supported by `wheel` to support reproducible .whl files with `bdist_wheel`).

I merged in part of distutils `archive_util.py` code from the Python 3.7 version (as well as backporting the tests).

Note: When `SOURCE_DATE_EPOCH`, all timestamps will set to the current time (instead of using the files actual timestamps). I dropped support for the `compressed tar file` format.  The `xz'ed tar-file` format is now supported with Python 3.4.

TODO:
- [x] tests
- [ ] news fragment
- [ ] fix `--help-formats` output
