### PR TITLE
Update CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,9 @@ jobs:
   - <<: *latest_py2
     env: LANG=C
   - python: pypy
+    env: DISABLE_COVERAGE=1  # Don't run coverage on pypy (too slow).
   - python: pypy3
+    env: DISABLE_COVERAGE=1
   - python: 3.4
   - python: 3.5
   - &default_py
@@ -21,6 +23,7 @@ jobs:
     env: LANG=C
   - python: 3.8-dev
     dist: xenial
+    env: DISABLE_COVERAGE=1  # Ignore invalid coverage data.
   - <<: *default_py
     stage: deploy (to PyPI for tagged commits)
     if: tag IS present
@@ -59,28 +62,20 @@ install:
 script:
   - |
     ( # Run testsuite.
-      set -ex
-      case $TRAVIS_PYTHON_VERSION in
-      pypy*)
-        # Don't run coverage on pypy (too slow).
-        tox
-        ;;
-      *)
+      if [ -z "$DISABLE_COVERAGE" ]
+      then
         tox -- --cov
-        ;;
-      esac
+      else
+        tox
+      fi
     )
 
 after_success:
   - |
     ( # Upload coverage data.
-      set -ex
-      case $TRAVIS_PYTHON_VERSION in
-      pypy*)
-        ;;
-        *)
+      if [ -z "$DISABLE_COVERAGE" ]
+      then
         export TRAVIS_JOB_NAME="${TRAVIS_PYTHON_VERSION} (LANG=$LANG)" CODECOV_ENV=TRAVIS_JOB_NAME
         tox -e coverage,codecov
-        ;;
-      esac
+      fi
     )

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,14 @@ jobs:
 cache: pip
 
 install:
-# ensure we have recent pip/setuptools
-- pip install --upgrade pip setuptools
+
+# ensure we have recent pip/setuptools/wheel
+- pip install --disable-pip-version-check --upgrade pip setuptools wheel
 # need tox to get started
-- pip install tox tox-venv
+- pip install --upgrade tox tox-venv
 
 # Output the env, to verify behavior
+- pip freeze --all
 - env
 
 # update egg_info based on setup.py in checkout

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: trusty
-sudo: false
 language: python
 python:
 - &latest_py2 2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,29 @@
 dist: trusty
 language: python
-python:
-- &latest_py2 2.7
-- 3.4
-- 3.5
-- &latest_py3 3.6
-- nightly
-- pypy
-- pypy3
 
 jobs:
   fast_finish: true
   include:
-  - python: *latest_py3
+  - &latest_py2
+    python: 2.7
+  - <<: *latest_py2
     env: LANG=C
-  - python: *latest_py2
+  - python: pypy
+  - python: pypy3
+  - python: 3.4
+  - python: 3.5
+  - &default_py
+    python: 3.6
+  - &latest_py3
+    python: 3.7
+    dist: xenial
+  - <<: *latest_py3
     env: LANG=C
-  - stage: deploy (to PyPI for tagged commits)
+  - python: 3.8-dev
+    dist: xenial
+  - <<: *default_py
+    stage: deploy (to PyPI for tagged commits)
     if: tag IS present
-    python: *latest_py3
     install: skip
     script: skip
     after_success: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,5 @@
+clone_depth: 50
+
 environment:
 
   APPVEYOR: True

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,12 @@ cache:
   - '%LOCALAPPDATA%\pip\Cache'
 
 test_script:
-  - "python bootstrap.py"
-  - "python -m pip install tox"
-  - "tox -- --cov"
+  - python --version
+  - python -m pip install --disable-pip-version-check --upgrade pip setuptools wheel
+  - pip install --upgrade tox tox-venv
+  - pip freeze --all
+  - python bootstrap.py
+  - tox -- --cov
 
 after_test:
     - tox -e coverage,codecov

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ commands=coverage erase
 description=[Only run on CI]: Upload coverage data to codecov
 deps=codecov
 skip_install=True
-commands=codecov --file {toxworkdir}/coverage.xml
+commands=codecov -X gcov --file {toxworkdir}/coverage.xml
 
 [testenv:docs]
 deps = -r{toxinidir}/docs/requirements.txt


### PR DESCRIPTION
Travis:
- preemptively switch to VM-based jobs (rational: https://blog.travis-ci.com/2018-10-04-combining-linux-infrastructures)
- fix support for Python 3.7 and add support for 3.8
- ensure test requirements are installed and up-to-date

AppVeyor:
- only clone the first 50 commits (same as Travis)
- ensure test requirements are installed and up-to-date

Additionally, disable codecov's gcov processing: we don't need it and it generates a couple of error messages on AppVeyor.
