### PR TITLE
Drop use of six.u

### DIFF
--- a/changelog.d/1517.change.rst
+++ b/changelog.d/1517.change.rst
@@ -1,0 +1,1 @@
+Dropped use of six.u in favor of `u""` literals.

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -632,7 +632,7 @@ class easy_install(Command):
 
     @contextlib.contextmanager
     def _tmpdir(self):
-        tmpdir = tempfile.mkdtemp(prefix=six.u("easy_install-"))
+        tmpdir = tempfile.mkdtemp(prefix=u"easy_install-")
         try:
             # cast to str as workaround for #709 and #710 and #712
             yield str(tmpdir)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Drop use of six.u in the code. Trivial changes, I thought you folks had more than one occurrence of six.u here.

Closes #1516 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
