### PR TITLE
Add data_files support in setup.cfg

### DIFF
--- a/changelog.d/1520.change.rst
+++ b/changelog.d/1520.change.rst
@@ -1,0 +1,1 @@
+Added support for ``data_files`` in ``setup.cfg``.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2367,6 +2367,11 @@ boilerplate code in some cases.
         src.subpackage1
         src.subpackage2
 
+    [options.data_files]
+    /etc/my_package =
+        site.d/00_default.conf
+        host.d/00_default.conf
+    data = data/img/logo.png, data/svg/icon.svg
 
 Metadata and options are set in the config sections of the same name.
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -598,3 +598,11 @@ class ConfigOptionsHandler(ConfigHandler):
         parse_list = partial(self._parse_list, separator=';')
         self['extras_require'] = self._parse_section_to_dict(
             section_options, parse_list)
+
+    def parse_section_data_files(self, section_options):
+        """Parses `data_files` configuration file section.
+
+        :param dict section_options:
+        """
+        parsed = self._parse_section_to_dict(section_options, self._parse_list)
+        self['data_files'] = [(k, v) for k, v in parsed.items()]

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -703,6 +703,23 @@ class TestOptions:
         with get_dist(tmpdir) as dist:
             assert dist.entry_points == expected
 
+    def test_data_files(self, tmpdir):
+        fake_env(
+            tmpdir,
+            '[options.data_files]\n'
+            'cfg =\n'
+            '      a/b.conf\n'
+            '      c/d.conf\n'
+            'data = e/f.dat, g/h.dat\n'
+        )
+
+        with get_dist(tmpdir) as dist:
+            expected = [
+                ('cfg', ['a/b.conf', 'c/d.conf']),
+                ('data', ['e/f.dat', 'g/h.dat']),
+            ]
+            assert sorted(dist.data_files) == sorted(expected)
+
 saved_dist_init = _Distribution.__init__
 class TestExternalSetters:
     # During creation of the setuptools Distribution() object, we call


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

These commits add data_files support in setup.cfg, discussed in the issue #1189, such like the following.
```
[options.data_files]
data = data/48x48/logo.png, data/scale/logo.svg
conf =
    site.d/00_default.conf
    host.d/00_default.conf
```

I think it may close #1189.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details