### PR TITLE
Call os.path.normpath to normalize paths for comp

### DIFF
--- a/changelog.d/1519.change.rst
+++ b/changelog.d/1519.change.rst
@@ -1,1 +1,1 @@
-Perform additional path normalization to ensure path values to a directory is always the same, preventing false positives when checking scripts have a consistent prefix to set up on Windows.
+In ``pkg_resources.normalize_path``, additional path normalization is now performed to ensure path values to a directory is always the same, preventing false positives when checking scripts have a consistent prefix to set up on Windows.

--- a/changelog.d/1519.change.rst
+++ b/changelog.d/1519.change.rst
@@ -1,0 +1,1 @@
+Perform additional path normalization to ensure path values to a directory is always the same, preventing false positives when checking scripts have a consistent prefix to set up on Windows.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2228,7 +2228,7 @@ register_namespace_handler(object, null_ns_handler)
 
 def normalize_path(filename):
     """Normalize a file/dir name for comparison purposes"""
-    return os.path.normcase(os.path.realpath(filename))
+    return os.path.normcase(os.path.normpath(os.path.realpath(filename)))
 
 
 def _normalize_cached(filename, _cache={}):

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -236,3 +236,8 @@ class TestDeepVersionLookupDistutils:
         req = pkg_resources.Requirement.parse('foo>=1.9')
         dist = pkg_resources.WorkingSet([env.paths['lib']]).find(req)
         assert dist.version == version
+
+    def test_normalize_path(self, tmpdir):
+        path = str(tmpdir)
+        expected = os.path.normcase(os.path.normpath(os.path.realpath(path)))
+        assert pkg_resources.normalize_path(path) == expected


### PR DESCRIPTION
Closes #1519.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details

I’m not sure how the test should be constructred. It seems silly to just test whether the function is identical to calling the three functions, but any fixed strings would be platform-dependant.