### PR TITLE
Mark Py 2/3-only tests as skip instead of xfail

### DIFF
--- a/changelog.d/1531.misc.rst
+++ b/changelog.d/1531.misc.rst
@@ -1,0 +1,1 @@
+Converted Python version-specific tests to use ``skipif`` instead of ``xfail``, and removed Python 2.6-specific code from the tests.

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -7,6 +7,7 @@ import pytest
 
 from .files import build_files
 from .textwrap import DALS
+from . import py2_only
 
 __metaclass__ = type
 
@@ -143,7 +144,7 @@ def test_prepare_metadata_for_build_wheel(build_backend):
     assert os.path.isfile(os.path.join(dist_dir, dist_info, 'METADATA'))
 
 
-@pytest.mark.skipif('sys.version_info > (3,)')
+@py2_only
 def test_prepare_metadata_for_build_wheel_with_str(build_backend):
     dist_dir = os.path.abspath(str('pip-dist-info'))
     os.makedirs(dist_dir)

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -15,12 +15,11 @@ from setuptools.command.egg_info import FileList, egg_info, translate_pattern
 from setuptools.dist import Distribution
 from setuptools.extern import six
 from setuptools.tests.textwrap import DALS
+from . import py3_only
 
 import pytest
 
 __metaclass__ = type
-
-py3_only = pytest.mark.xfail(six.PY2, reason="Test runs on Python 3 only")
 
 
 def make_local_path(s):

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -12,7 +12,7 @@ from setuptools.command import test
 
 class TestNamespaces:
 
-    @pytest.mark.xfail(
+    @pytest.mark.skipif(
         sys.version_info < (3, 5),
         reason="Requires importlib.util.module_from_spec",
     )

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -20,8 +20,8 @@ from setuptools.command.egg_info import manifest_maker
 from setuptools.dist import Distribution
 from setuptools.tests import fail_on_ascii
 from .text import Filenames
+from . import py3_only
 
-py3_only = pytest.mark.xfail(six.PY2, reason="Test runs on Python 3 only")
 
 SETUP_ATTRS = {
     'name': 'sdist_test',

--- a/setuptools/tests/test_test.py
+++ b/setuptools/tests/test_test.py
@@ -93,10 +93,6 @@ def test_test(capfd):
     assert out == 'Foo\n'
 
 
-@pytest.mark.skipif(
-    sys.version_info < (2, 7),
-    reason="No discover support for unittest on Python 2.6",
-)
 @pytest.mark.usefixtures('tmpdir_cwd', 'quiet_log')
 def test_tests_are_run_once(capfd):
     params = dict(

--- a/setuptools/tests/test_test.py
+++ b/setuptools/tests/test_test.py
@@ -93,7 +93,7 @@ def test_test(capfd):
     assert out == 'Foo\n'
 
 
-@pytest.mark.xfail(
+@pytest.mark.skipif(
     sys.version_info < (2, 7),
     reason="No discover support for unittest on Python 2.6",
 )

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -57,9 +57,6 @@ def test_pip_upgrade_from_source(virtualenv):
     Check pip can upgrade setuptools from source.
     """
     dist_dir = virtualenv.workspace
-    if sys.version_info < (2, 7):
-        # Python 2.6 support was dropped in wheel 0.30.0.
-        virtualenv.run('pip install -U "wheel<0.30.0"')
     # Generate source distribution / wheel.
     virtualenv.run(' && '.join((
         'cd {source}',


### PR DESCRIPTION
## Summary of changes

Mark Python 2/3-only tests as skip instead of xfailing them. Also use predefined `py2_only` and `py3_only` decorators where appropriate.

Closes #1529.

### Pull Request Checklist
- [x] Changes have tests -> only modified existing tests?
- [x] News fragment added in changelog.d.
