### PR TITLE
Exclude .pyc in sdist output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,9 @@ jobs:
     install: skip
     script: skip
     after_success: true
-    before_deploy: python bootstrap.py
+    before_deploy:
+      - python bootstrap.py
+      - ! grep pyc setuptools.egg-info/SOURCES.txt
     deploy:
       provider: pypi
       on:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ recursive-include setuptools *.py *.exe *.xml
 recursive-include tests *.py
 recursive-include setuptools/tests *.html
 recursive-include docs *.py *.txt *.conf *.css *.css_t Makefile indexsidebar.html
-recursive-include setuptools/_vendor *
+recursive-include setuptools/_vendor *.py *.txt
 recursive-include pkg_resources *.py *.txt
 include *.py
 include *.rst

--- a/changelog.d/1533.misc.rst
+++ b/changelog.d/1533.misc.rst
@@ -1,0 +1,1 @@
+Restrict the `recursive-include setuptools/_vendor` to contain only .py and .txt files


### PR DESCRIPTION
## Summary of changes

This restricts the `recursive-include setuptools/_vendor` to contain only .py and .txt files.

Closes #1414

### Pull Request Checklist
- ~Changes have tests~
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
