### PR TITLE
Deprecate requires

### DIFF
--- a/changelog.d/1541.deprecation.rst
+++ b/changelog.d/1541.deprecation.rst
@@ -1,0 +1,1 @@
+Officially deprecated the ``requires`` parameter in ``setup()``.

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -391,6 +391,23 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert set(dist.metadata.classifiers) == expected
 
+    def test_deprecated_config_handlers(self, tmpdir):
+        fake_env(
+            tmpdir,
+            '[metadata]\n'
+            'version = 10.1.1\n'
+            'description = Some description\n'
+            'requires = some, requirement\n'
+        )
+
+        with pytest.deprecated_call():
+            with get_dist(tmpdir) as dist:
+                metadata = dist.metadata
+
+                assert metadata.version == '10.1.1'
+                assert metadata.description == 'Some description'
+                assert metadata.requires == ['some', 'requirement']
+
 
 class TestOptions:
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Will throw a `DeprecatedWarning` whenever `requires` parameter is used. 
<!-- Summary goes here -->

Closes #1374 <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
