### PR TITLE
Document that rpmbuild is required for bdist_rpm

### DIFF
--- a/changelog.d/1456.doc.rst
+++ b/changelog.d/1456.doc.rst
@@ -1,1 +1,1 @@
-Document that rpmbuild is required to build bdist_rpm.
+Documented that the ``rpmbuild`` packages is required for the ``bdist_rpm`` command.

--- a/changelog.d/1456.doc.rst
+++ b/changelog.d/1456.doc.rst
@@ -1,0 +1,1 @@
+Document that rpmbuild is required to build bdist_rpm.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -1340,7 +1340,7 @@ Creating System Packages
     this kind of patching to work with setuptools.
 
     Please note that building system packages may require you to install
-    some system software, e.g. ``bdist_rpm`` requires the ``rpmbuild``
+    some system software, for example ``bdist_rpm`` requires the ``rpmbuild``
     command installed.
 
     If you or your users have a problem building a usable system package for

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -1339,6 +1339,9 @@ Creating System Packages
     ``bdist_deb`` command is an example of a command that currently requires
     this kind of patching to work with setuptools.
 
+    Please note that building system packages may require you to install
+    some system software, e.g. ``bdist_rpm`` requires the ``rpmbuild``
+    command installed.
     If you or your users have a problem building a usable system package for
     your project, please report the problem via the mailing list so that
     either the "bdist" tool in question or setuptools can be modified to

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -1342,6 +1342,7 @@ Creating System Packages
     Please note that building system packages may require you to install
     some system software, e.g. ``bdist_rpm`` requires the ``rpmbuild``
     command installed.
+
     If you or your users have a problem building a usable system package for
     your project, please report the problem via the mailing list so that
     either the "bdist" tool in question or setuptools can be modified to


### PR DESCRIPTION
Refs #1456

## Summary of changes

Document that rpmbuild is required for bdist_rpm, if distutils does not find it it'll use rpm which does not have (anymore?) the -b switch used to build packages.

Closes #1456 at least for the setuptools side

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
