### PR TITLE
Add missing word to sentence in docs

### DIFF
--- a/changelog.d/1552.doc.rst
+++ b/changelog.d/1552.doc.rst
@@ -1,1 +1,1 @@
- Add missing word to sentence in docs
+Fixed a minor typo in the python 2/3 compatibility documentation.

--- a/changelog.d/1552.doc.rst
+++ b/changelog.d/1552.doc.rst
@@ -1,0 +1,1 @@
+ Add missing word to sentence in docs

--- a/docs/python3.txt
+++ b/docs/python3.txt
@@ -9,7 +9,7 @@ code.
 
 Setuptools provides a facility to invoke 2to3 on the code as a part of the
 build process, by setting the keyword parameter ``use_2to3`` to True, but
-the Setuptools strongly recommends instead developing a unified codebase
+the Setuptools project strongly recommends instead developing a unified codebase
 using `six <https://pypi.org/project/six/>`_,
 `future <https://pypi.org/project/future/>`_, or another compatibility
 library.


### PR DESCRIPTION
"the Setuptools strongly recommends" -> "the Setuptools project strongly recommends"

- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
