### PR TITLE
remove private and redundant link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,10 +23,6 @@ See the `Installation Instructions
 User's Guide for instructions on installing, upgrading, and uninstalling
 Setuptools.
 
-The project is `maintained at GitHub <https://github.com/pypa/setuptools>`_
-by the `Setuptools Developers
-<https://github.com/orgs/pypa/teams/setuptools-developers>`_.
-
 Questions and comments should be directed to the `distutils-sig
 mailing list <http://mail.python.org/pipermail/distutils-sig/>`_.
 Bug reports and especially tested patches may be


### PR DESCRIPTION
## Summary of changes

The current link to [setuptools-developers](https://github.com/orgs/pypa/teams/setuptools-developers) is a private link (gives an HTTP 404 for not priviledged viewers). PyPI links to github as the homepage so both links (the whole line) can be removed.
