### PR TITLE
Change find_module to find_spec for py37 compat

### DIFF
--- a/changelog.d/1563.change.rst
+++ b/changelog.d/1563.change.rst
@@ -1,0 +1,1 @@
+If find_module fails or does not exist, attempt to use find_spec(...).loader

--- a/changelog.d/1563.change.rst
+++ b/changelog.d/1563.change.rst
@@ -1,1 +1,1 @@
-If find_module fails or does not exist, attempt to use find_spec(...).loader
+In ``pkg_resources`` prefer ``find_spec`` (PEP 451) to ``find_module``.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2098,10 +2098,11 @@ def _handle_ns(packageName, path_item):
     # capture warnings due to #1111
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        loader = importer.find_module(packageName)
-
-    if loader is None:
-        return None
+        spec = importer.find_spec(packageName)
+        if spec is not None:
+            loader = spec.loader
+        else:
+            return None
     module = sys.modules.get(packageName)
     if module is None:
         module = sys.modules[packageName] = types.ModuleType(packageName)

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2098,11 +2098,15 @@ def _handle_ns(packageName, path_item):
     # capture warnings due to #1111
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        spec = importer.find_spec(packageName)
-        if spec is not None:
-            loader = spec.loader
-        else:
-            return None
+        try:
+            loader = importer.find_module(packageName)
+        except AttributeError:
+            try:
+                loader = importer.find_spec(packageName).loader
+            except:
+                loader = None
+    if loader is None:
+        return None
     module = sys.modules.get(packageName)
     if module is None:
         module = sys.modules[packageName] = types.ModuleType(packageName)

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2098,16 +2098,19 @@ def _handle_ns(packageName, path_item):
     if importer is None:
         return None
 
-    # capture warnings due to #1111
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
+    # use find_spec (PEP 451) and fall-back to find_module (PEP 302)
+    try:
+        loader = importer.find_spec(packageName).loader
+    except AttributeError:
         try:
-            loader = importer.find_module(packageName)
+            # capture warnings due to #1111
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                loader = importer.find_module(packageName)
         except AttributeError:
-            try:
-                loader = importer.find_spec(packageName).loader
-            except:
-                loader = None
+            # not a system module
+            loader = None
+
     if loader is None:
         return None
     module = sys.modules.get(packageName)

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2102,14 +2102,10 @@ def _handle_ns(packageName, path_item):
     try:
         loader = importer.find_spec(packageName).loader
     except AttributeError:
-        try:
-            # capture warnings due to #1111
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                loader = importer.find_module(packageName)
-        except AttributeError:
-            # not a system module
-            loader = None
+        # capture warnings due to #1111
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            loader = importer.find_module(packageName)
 
     if loader is None:
         return None


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Change the call of `find_module` to `find_spec`.

Attempts to fix Ron89/thesaurus_query.vim#33 and analogous issue tbabej/taskwiki#183, probably others brought about by vim/vim@79a494d5.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
- [ ] Review - PR author is not sure what this will break or how to write a test for it!
