### PR TITLE
Add futures and backport to Python 2.7 test requirements

### DIFF
--- a/changelog.d/1572.misc.rst
+++ b/changelog.d/1572.misc.rst
@@ -1,0 +1,1 @@
+Added the ``concurrent.futures`` backport ``futures`` to the Python 2.7 test suite requirements.

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -11,8 +11,9 @@ from . import py2_only
 
 __metaclass__ = type
 
-futures = pytest.importorskip('concurrent.futures')
-importlib = pytest.importorskip('importlib')
+# Backports on Python 2.7
+import importlib
+from concurrent import futures
 
 
 class BuildBackendBase:

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,4 @@ wheel
 coverage>=4.5.1
 pytest-cov>=2.5.1
 paver; python_version>="3.6"
+futures; python_version=="2.7"


### PR DESCRIPTION
`setuptools.tests.test_build_meta` relies on the Python 3 feature `concurrent.futures` to run, and as a result has been silently skipped in Python 2.7. This adds the `futures` backport to the 2.7 test requirements and turns the `pytest.importorskip` invocations in test_build_meta into standard import statements.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
