### PR TITLE
Fix upload metadata

### DIFF
--- a/changelog.d/1576.change.rst
+++ b/changelog.d/1576.change.rst
@@ -1,0 +1,1 @@
+Started monkey-patching ``get_metadata_version`` and ``read_pkg_file`` onto ``distutils.DistributionMetadata`` to retain the correct version on the ``PKG-INFO`` file in the (deprecated) ``upload`` command.

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -172,9 +172,11 @@ class upload(orig.upload):
             self.announce('Server response (%s): %s' % (status, reason),
                           log.INFO)
             if self.show_response:
-                text = self._read_pypi_response(result)
-                msg = '\n'.join(('-' * 75, text, '-' * 75))
-                self.announce(msg, log.INFO)
+                text = getattr(self, '_read_pypi_response',
+                               lambda x: None)(result)
+                if text is not None:
+                    msg = '\n'.join(('-' * 75, text, '-' * 75))
+                    self.announce(msg, log.INFO)
         else:
             msg = 'Upload failed (%s): %s' % (status, reason)
             self.announce(msg, log.ERROR)

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -1,14 +1,24 @@
+import io
+import os
+import hashlib
 import getpass
+
+from base64 import standard_b64encode
+
 from distutils import log
 from distutils.command import upload as orig
 
+from distutils.errors import DistutilsError
+
+from six.moves.urllib.request import urlopen, Request
+from six.moves.urllib.error import HTTPError
+from six.moves.urllib.parse import urlparse
 
 class upload(orig.upload):
     """
     Override default upload behavior to obtain password
     in a variety of different ways.
     """
-
     def run(self):
         try:
             orig.upload.run(self)
@@ -32,6 +42,141 @@ class upload(orig.upload):
             self._load_password_from_keyring() or
             self._prompt_for_password()
         )
+
+    def upload_file(self, command, pyversion, filename):
+        # Makes sure the repository URL is compliant
+        schema, netloc, url, params, query, fragments = \
+            urlparse(self.repository)
+        if params or query or fragments:
+            raise AssertionError("Incompatible url %s" % self.repository)
+
+        if schema not in ('http', 'https'):
+            raise AssertionError("unsupported schema " + schema)
+
+        # Sign if requested
+        if self.sign:
+            gpg_args = ["gpg", "--detach-sign", "-a", filename]
+            if self.identity:
+                gpg_args[2:2] = ["--local-user", self.identity]
+            spawn(gpg_args,
+                  dry_run=self.dry_run)
+
+        # Fill in the data - send all the meta-data in case we need to
+        # register a new release
+        with open(filename, 'rb') as f:
+            content = f.read()
+
+        meta = self.distribution.metadata
+
+        data = {
+            # action
+            ':action': 'file_upload',
+            'protocol_version': '1',
+
+            # identify release
+            'name': meta.get_name(),
+            'version': meta.get_version(),
+
+            # file content
+            'content': (os.path.basename(filename),content),
+            'filetype': command,
+            'pyversion': pyversion,
+            'md5_digest': hashlib.md5(content).hexdigest(),
+
+            # additional meta-data
+            'metadata_version': '1.0',
+            'summary': meta.get_description(),
+            'home_page': meta.get_url(),
+            'author': meta.get_contact(),
+            'author_email': meta.get_contact_email(),
+            'license': meta.get_licence(),
+            'description': meta.get_long_description(),
+            'keywords': meta.get_keywords(),
+            'platform': meta.get_platforms(),
+            'classifiers': meta.get_classifiers(),
+            'download_url': meta.get_download_url(),
+            # PEP 314
+            'provides': meta.get_provides(),
+            'requires': meta.get_requires(),
+            'obsoletes': meta.get_obsoletes(),
+            }
+        comment = ''
+        if command == 'bdist_rpm':
+            dist, version, id = platform.dist()
+            if dist:
+                comment = 'built for %s %s' % (dist, version)
+        elif command == 'bdist_dumb':
+            comment = 'built for %s' % platform.platform(terse=1)
+        data['comment'] = comment
+
+        if self.sign:
+            data['gpg_signature'] = (os.path.basename(filename) + ".asc",
+                                     open(filename+".asc", "rb").read())
+
+        # set up the authentication
+        user_pass = (self.username + ":" + self.password).encode('ascii')
+        # The exact encoding of the authentication string is debated.
+        # Anyway PyPI only accepts ascii for both username or password.
+        auth = "Basic " + standard_b64encode(user_pass).decode('ascii')
+
+        # Build up the MIME payload for the POST data
+        boundary = '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254'
+        sep_boundary = b'\r\n--' + boundary.encode('ascii')
+        end_boundary = sep_boundary + b'--\r\n'
+        body = io.BytesIO()
+        for key, value in data.items():
+            title = '\r\nContent-Disposition: form-data; name="%s"' % key
+            # handle multiple entries for the same name
+            if not isinstance(value, list):
+                value = [value]
+            for value in value:
+                if type(value) is tuple:
+                    title += '; filename="%s"' % value[0]
+                    value = value[1]
+                else:
+                    value = str(value).encode('utf-8')
+                body.write(sep_boundary)
+                body.write(title.encode('utf-8'))
+                body.write(b"\r\n\r\n")
+                body.write(value)
+        body.write(end_boundary)
+        body = body.getvalue()
+
+        msg = "Submitting %s to %s" % (filename, self.repository)
+        self.announce(msg, log.INFO)
+
+        # build the Request
+        headers = {
+            'Content-type': 'multipart/form-data; boundary=%s' % boundary,
+            'Content-length': str(len(body)),
+            'Authorization': auth,
+        }
+
+        request = Request(self.repository, data=body,
+                          headers=headers)
+        # send the data
+        try:
+            result = urlopen(request)
+            status = result.getcode()
+            reason = result.msg
+        except HTTPError as e:
+            status = e.code
+            reason = e.msg
+        except OSError as e:
+            self.announce(str(e), log.ERROR)
+            raise
+
+        if status == 200:
+            self.announce('Server response (%s): %s' % (status, reason),
+                          log.INFO)
+            if self.show_response:
+                text = self._read_pypi_response(result)
+                msg = '\n'.join(('-' * 75, text, '-' * 75))
+                self.announce(msg, log.INFO)
+        else:
+            msg = 'Upload failed (%s): %s' % (status, reason)
+            self.announce(msg, log.ERROR)
+            raise DistutilsError(msg)
 
     def _load_password_from_keyring(self):
         """

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -84,7 +84,7 @@ class upload(orig.upload):
             'md5_digest': hashlib.md5(content).hexdigest(),
 
             # additional meta-data
-            'metadata_version': '1.0',
+            'metadata_version': str(meta.get_metadata_version()),
             'summary': meta.get_description(),
             'home_page': meta.get_url(),
             'author': meta.get_contact(),

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -102,14 +102,8 @@ class upload(orig.upload):
             'requires': meta.get_requires(),
             'obsoletes': meta.get_obsoletes(),
             }
-        comment = ''
-        if command == 'bdist_rpm':
-            dist, version, id = platform.dist()
-            if dist:
-                comment = 'built for %s %s' % (dist, version)
-        elif command == 'bdist_dumb':
-            comment = 'built for %s' % platform.platform(terse=1)
-        data['comment'] = comment
+
+        data['comment'] = ''
 
         if self.sign:
             data['gpg_signature'] = (os.path.basename(filename) + ".asc",

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -2,6 +2,7 @@ import io
 import os
 import hashlib
 import getpass
+import platform
 
 from base64 import standard_b64encode
 

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -7,6 +7,7 @@ from base64 import standard_b64encode
 
 from distutils import log
 from distutils.command import upload as orig
+from distutils.spawn import spawn
 
 from distutils.errors import DistutilsError
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -53,6 +53,59 @@ def get_metadata_version(dist_md):
     return StrictVersion('1.0')
 
 
+def read_pkg_file(self, file):
+    """Reads the metadata values from a file object."""
+    msg = message_from_file(file)
+
+    def _read_field(name):
+        value = msg[name]
+        if value == 'UNKNOWN':
+            return None
+        return value
+
+    def _read_list(name):
+        values = msg.get_all(name, None)
+        if values == []:
+            return None
+        return values
+
+    metadata_version = msg['metadata-version']
+    self.name = _read_field('name')
+    self.version = _read_field('version')
+    self.description = _read_field('summary')
+    # we are filling author only.
+    self.author = _read_field('author')
+    self.maintainer = None
+    self.author_email = _read_field('author-email')
+    self.maintainer_email = None
+    self.url = _read_field('home-page')
+    self.license = _read_field('license')
+
+    if 'download-url' in msg:
+        self.download_url = _read_field('download-url')
+    else:
+        self.download_url = None
+
+    self.long_description = _read_field('description')
+    self.description = _read_field('summary')
+
+    if 'keywords' in msg:
+        self.keywords = _read_field('keywords').split(',')
+
+    self.platforms = _read_list('platform')
+    self.classifiers = _read_list('classifier')
+
+    # PEP 314 - these fields only exist in 1.1
+    if metadata_version == '1.1':
+        self.requires = _read_list('requires')
+        self.provides = _read_list('provides')
+        self.obsoletes = _read_list('obsoletes')
+    else:
+        self.requires = None
+        self.provides = None
+        self.obsoletes = None
+
+
 # Based on Python 3.5 version
 def write_pkg_file(self, file):
     """Write the PKG-INFO format data to a file object.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -10,7 +10,11 @@ import distutils.core
 import distutils.cmd
 import distutils.dist
 import itertools
+
+
 from collections import defaultdict
+from email import message_from_file
+
 from distutils.errors import (
     DistutilsOptionError, DistutilsPlatformError, DistutilsSetupError,
 )
@@ -69,7 +73,7 @@ def read_pkg_file(self, file):
             return None
         return values
 
-    metadata_version = msg['metadata-version']
+    self.metadata_version = StrictVersion(msg['metadata-version'])
     self.name = _read_field('name')
     self.version = _read_field('version')
     self.description = _read_field('summary')
@@ -96,7 +100,7 @@ def read_pkg_file(self, file):
     self.classifiers = _read_list('classifier')
 
     # PEP 314 - these fields only exist in 1.1
-    if metadata_version == '1.1':
+    if metadata_version == StrictVersion('1.1'):
         self.requires = _read_list('requires')
         self.provides = _read_list('provides')
         self.obsoletes = _read_list('obsoletes')

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -84,7 +84,7 @@ def patch_all():
         warehouse = 'https://upload.pypi.org/legacy/'
         distutils.config.PyPIRCCommand.DEFAULT_REPOSITORY = warehouse
 
-    _patch_distribution_metadata_write_pkg_file()
+    _patch_distribution_metadata()
 
     # Install Distribution throughout the distutils
     for module in distutils.dist, distutils.core, distutils.cmd:
@@ -101,11 +101,11 @@ def patch_all():
     patch_for_msvc_specialized_compiler()
 
 
-def _patch_distribution_metadata_write_pkg_file():
-    """Patch write_pkg_file to also write Requires-Python/Requires-External"""
-    distutils.dist.DistributionMetadata.write_pkg_file = (
-        setuptools.dist.write_pkg_file
-    )
+def _patch_distribution_metadata():
+    """Patch write_pkg_file and read_pkg_file for higher metadata standards"""
+    for attr in ('write_pkg_file', 'read_pkg_file', 'get_metadata_version'):
+        new_val = getattr(setuptools.dist, attr)
+        setattr(distutils.dist.DistributionMetadata, attr, new_val)
 
 
 def patch_func(replacement, target_mod, func_name):

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -59,6 +59,102 @@ def test_dist_fetch_build_egg(tmpdir):
 def test_dist__get_unpatched_deprecated():
     pytest.warns(DistDeprecationWarning, _get_unpatched, [""])
 
+
+def __read_test_cases():
+    # Metadata version 1.0
+    base_attrs = {
+        "name": "package",
+        "version": "0.0.1",
+        "author": "Foo Bar",
+        "author_email": "foo@bar.net",
+        "long_description": "Long\ndescription",
+        "description": "Short description",
+        "keywords": ["one", "two"]
+    }
+
+    def merge_dicts(d1, d2):
+        d1 = d1.copy()
+        d1.update(d2)
+
+        return d1
+
+    test_cases = [
+        ('Metadata version 1.0', base_attrs.copy()),
+        ('Metadata version 1.1: Provides', merge_dicts(base_attrs, {
+            'provides': ['package']
+        })),
+        ('Metadata version 1.1: Obsoletes', merge_dicts(base_attrs, {
+            'obsoletes': ['foo']
+        })),
+        ('Metadata version 1.1: Classifiers', merge_dicts(base_attrs, {
+            'classifiers': [
+                'Programming Language :: Python :: 3',
+                'Programming Language :: Python :: 3.7',
+                'License :: OSI Approved :: MIT License'
+        ]})),
+        ('Metadata version 1.1: Download URL', merge_dicts(base_attrs, {
+            'download_url': 'https://example.com'
+        })),
+        ('Metadata Version 1.2: Requires-Python', merge_dicts(base_attrs, {
+            'python_requires': '>=3.7'
+        })),
+        pytest.param('Metadata Version 1.2: Project-Url',
+            merge_dicts(base_attrs, {
+                'project_urls': {
+                    'Foo': 'https://example.bar'
+                }
+            }), marks=pytest.mark.xfail(
+                reason="Issue #1578: project_urls not read"
+        )),
+        ('Metadata Version 2.1: Long Description Content Type',
+         merge_dicts(base_attrs, {
+             'long_description_content_type': 'text/x-rst; charset=UTF-8'
+         })),
+        pytest.param('Metadata Version 2.1: Provides Extra',
+            merge_dicts(base_attrs, {
+                'provides_extras': ['foo', 'bar']
+        }), marks=pytest.mark.xfail(reason="provides_extras not read")),
+    ]
+
+    return test_cases
+
+
+@pytest.mark.parametrize('name,attrs', __read_test_cases())
+def test_read_metadata(name, attrs, tmpdir):
+    dist = Distribution(attrs)
+    metadata_out = dist.metadata
+    dist_class = metadata_out.__class__
+
+    # Write to PKG_INFO and then load into a new metadata object
+    fn = tmpdir.mkdir('pkg_info')
+    fn_s = str(fn)
+
+    metadata_out.write_pkg_info(fn_s)
+
+    metadata_in = dist_class()
+    with io.open(str(fn.join('PKG-INFO')), 'r', encoding='utf-8') as f:
+        metadata_in.read_pkg_file(f)
+
+    tested_attrs = [
+        ('name', dist_class.get_name),
+        ('version', dist_class.get_version),
+        ('metadata_version', dist_class.get_metadata_version),
+        ('provides', dist_class.get_provides),
+        ('description', dist_class.get_description),
+        ('download_url', dist_class.get_download_url),
+        ('keywords', dist_class.get_keywords),
+        ('platforms', dist_class.get_platforms),
+        ('obsoletes', dist_class.get_obsoletes),
+        ('requires', dist_class.get_requires),
+        ('classifiers', dist_class.get_classifiers),
+        ('project_urls', lambda s: getattr(s, 'project_urls', {})),
+        ('provides_extras', lambda s: getattr(s, 'provides_extras', set())),
+    ]
+
+    for attr, getter in tested_attrs:
+        assert getter(metadata_in) == getter(metadata_out)
+
+
 def __maintainer_test_cases():
     attrs = {"name": "package",
              "version": "1.0",

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -203,26 +203,6 @@ class TestUploadTest:
         entries = patched_upload.get_uploaded_metadata()
         assert entries['gpg_signature'] == 'signed-data'
 
-    @pytest.mark.parametrize('bdist', ['bdist_rpm', 'bdist_dumb'])
-    @mock.patch('setuptools.command.upload.platform')
-    def test_bdist_rpm_upload(self, platform, bdist, patched_upload):
-        # Set the upload command to include bdist_rpm
-        cmd = patched_upload.cmd
-        dist_files = cmd.distribution.dist_files
-        dist_files = [(bdist,) + dist_files[0][1:]]
-        cmd.distribution.dist_files = dist_files
-
-        # Mock out the platform commands to make this platform-independent
-        platform.dist.return_value = ('redhat', '', '')
-
-        cmd.ensure_finalized()
-        cmd.run()
-
-        entries = patched_upload.get_uploaded_metadata()
-
-        assert entries['comment'].startswith(u'built for')
-        assert len(entries['comment']) > len(u'built for')
-
     def test_show_response_no_error(self, patched_upload):
         # This test is just that show_response doesn't throw an error
         # It is not really important what the printed response looks like

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -223,3 +223,12 @@ class TestUploadTest:
         assert entries['comment'].startswith(u'built for')
         assert len(entries['comment']) > len(u'built for')
 
+    def test_show_response_no_error(self, patched_upload):
+        # This test is just that show_response doesn't throw an error
+        # It is not really important what the printed response looks like
+        # in a deprecated command, but we don't want to introduce new
+        # errors when importing this function from distutils
+
+        patched_upload.cmd.show_response = True
+        patched_upload.cmd.ensure_finalized()
+        patched_upload.cmd.run()

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -95,7 +95,6 @@ class TestUploadTest:
         entries = patched_upload.get_uploaded_metadata()
         assert entries['metadata_version'] == '2.1'
 
-
     def test_warns_deprecation(self):
         dist = Distribution()
         dist.dist_files = [(mock.Mock(), mock.Mock(), mock.Mock())]
@@ -129,3 +128,21 @@ class TestUploadTest:
             "upload instead (https://pypi.org/p/twine/)",
             log.WARN
         )
+
+    @pytest.mark.parametrize('url', [
+        'https://example.com/a;parameter',    # Has parameters
+        'https://example.com/a?query',        # Has query
+        'https://example.com/a#fragment',     # Has fragment
+        'ftp://example.com',                  # Invalid scheme
+
+    ])
+    def test_upload_file_invalid_url(self, url, patched_upload):
+        patched_upload.urlopen.side_effect = Exception("Should not be reached")
+
+        cmd = patched_upload.cmd
+        cmd.repository = url
+
+        cmd.ensure_finalized()
+        with pytest.raises(AssertionError):
+            cmd.run()
+

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -166,3 +166,13 @@ class TestUploadTest:
             'Upload failed (404): File not found',
             log.ERROR)
 
+    def test_upload_file_os_error(self, patched_upload):
+        patched_upload.urlopen.side_effect = OSError("Invalid")
+
+        cmd = patched_upload.cmd
+        cmd.ensure_finalized()
+
+        with pytest.raises(OSError):
+            cmd.run()
+
+        cmd.announce.assert_any_call('Invalid', log.ERROR)

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -1,13 +1,72 @@
 import mock
+import os
+import re
+
 from distutils import log
+from distutils.version import StrictVersion
 
 import pytest
+import six
 
 from setuptools.command.upload import upload
 from setuptools.dist import Distribution
 
 
+def _parse_upload_body(body):
+    boundary = u'\r\n----------------GHSKFJDLGDS7543FJKLFHRE75642756743254'
+    entries = []
+    name_re = re.compile(u'^Content-Disposition: form-data; name="([^\"]+)"')
+
+    for entry in body.split(boundary):
+        pair = entry.split(u'\r\n\r\n')
+        if not len(pair) == 2:
+            continue
+
+        key, value = map(six.text_type.strip, pair)
+        m = name_re.match(key)
+        if m is not None:
+            key = m.group(1)
+
+        entries.append((key, value))
+
+    return entries
+
+
 class TestUploadTest:
+    @pytest.mark.xfail(reason='Issue #1381')
+    @mock.patch('setuptools.command.upload.urlopen')
+    def test_upload_metadata(self, patch, tmpdir):
+        dist = Distribution()
+        dist.metadata.metadata_version = StrictVersion('2.1')
+
+        content = os.path.join(str(tmpdir), "test_upload_metadata_content")
+
+        with open(content, 'w') as f:
+            f.write("Some content")
+
+        dist.dist_files = [('xxx', '3.7', content)]
+
+        patch.return_value = mock.Mock()
+        patch.return_value.getcode.return_value = 200
+
+        cmd = upload(dist)
+        cmd.announce = mock.Mock()
+        cmd.username = 'user'
+        cmd.password = 'hunter2'
+        cmd.ensure_finalized()
+        cmd.run()
+
+        # Make sure we did the upload
+        patch.assert_called_once()
+
+        # Make sure the metadata version is correct in the headers
+        request = patch.call_args_list[0][0][0]
+        body = request.data.decode('utf-8')
+
+        entries = dict(_parse_upload_body(body))
+        assert entries['metadata_version'] == '2.1'
+
+
     def test_warns_deprecation(self):
         dist = Distribution()
         dist.dist_files = [(mock.Mock(), mock.Mock(), mock.Mock())]

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -33,7 +33,6 @@ def _parse_upload_body(body):
 
 
 class TestUploadTest:
-    @pytest.mark.xfail(reason='Issue #1381')
     @mock.patch('setuptools.command.upload.urlopen')
     def test_upload_metadata(self, patch, tmpdir):
         dist = Distribution()


### PR DESCRIPTION
## Summary of changes

This PR adds `get_metadata_version` to `distutils.dist.DistributionMetadata` and also monkey patches `distutils.dist.DistributionMetadata.read_pkg_file` to populate the `metadata_version` attribute. We also have overridden  `distutils.command.upload.upload_file` so that the metadata version is retrieved from `get_metadata_version` rather than hard-coded as 1.0.

I felt that it would be preferable for `read_pkg_file` to actually store the specified metadata version rather than to infer it from the fields present (as is done when *writing* the metadata file), *however*, I think the bug I'm concerned about would still be fixed if we always had `get_metadata_version` infer the version from the keys present.

Closes #1381

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
