### PR TITLE
need to strip the path seprator at the end of the path string

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2231,7 +2231,7 @@ register_namespace_handler(object, null_ns_handler)
 
 def normalize_path(filename):
     """Normalize a file/dir name for comparison purposes"""
-    return os.path.normcase(os.path.realpath(_cygwin_patch(filename)))
+    return os.path.normcase(os.path.realpath(_cygwin_patch(filename))).rstrip(os.sep)
 
 
 def _cygwin_patch(filename):  # pragma: nocover


### PR DESCRIPTION
On windows, to install a local pacakge through python setup.py develop, i was prompted:

("Can't get a consistent path to setup script from installation directory", 'd:\\devroot\\src\\gitee.com\\kadeem\\freeway\\', 'd:\\devroot\\src\\gitee.com\\kadeem\\freeway')

The difference is the trailing slashes, because os.path.normcase don't remove the trailing seprators

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
