### PR TITLE
Release 40.6.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,23 @@
+v40.6.0
+-------
+
+* #1541: Officially deprecated the ``requires`` parameter in ``setup()``.
+* #1519: In ``pkg_resources.normalize_path``, additional path normalization is now performed to ensure path values to a directory is always the same, preventing false positives when checking scripts have a consistent prefix to set up on Windows.
+* #1545: Changed the warning class of all deprecation warnings; deprecation warning classes are no longer derived from ``DeprecationWarning`` and are thus visible by default.
+* #1554: ``build_meta.build_sdist`` now includes ``setup.py`` in source distributions by default.
+* #1576: Started monkey-patching ``get_metadata_version`` and ``read_pkg_file`` onto ``distutils.DistributionMetadata`` to retain the correct version on the ``PKG-INFO`` file in the (deprecated) ``upload`` command.
+* #1533: Restricted the ``recursive-include setuptools/_vendor`` to contain only .py and .txt files.
+* #1395: Changed Pyrex references to Cython in the documentation.
+* #1456: Documented that the ``rpmbuild`` packages is required for the ``bdist_rpm`` command.
+* #1537: Documented how to use ``setup.cfg`` for ``src/ layouts``
+* #1539: Added minimum version column in ``setup.cfg`` metadata table.
+* #1552: Fixed a minor typo in the python 2/3 compatibility documentation.
+* #1553: Updated installation instructions to point to ``pip install`` instead of ``ez_setup.py``.
+* #1560: Updated ``setuptools`` distribution documentation to remove some outdated information.
+* #1564: Documented ``setup.cfg`` minimum version for version and project_urls.
+* #1572: Added the ``concurrent.futures`` backport ``futures`` to the Python 2.7 test suite requirements.
+
+
 v40.5.0
 -------
 

--- a/changelog.d/1395.doc.rst
+++ b/changelog.d/1395.doc.rst
@@ -1,1 +1,0 @@
-Document building Cython projects instead of Pyrex

--- a/changelog.d/1456.doc.rst
+++ b/changelog.d/1456.doc.rst
@@ -1,1 +1,0 @@
-Documented that the ``rpmbuild`` packages is required for the ``bdist_rpm`` command.

--- a/changelog.d/1519.change.rst
+++ b/changelog.d/1519.change.rst
@@ -1,1 +1,0 @@
-In ``pkg_resources.normalize_path``, additional path normalization is now performed to ensure path values to a directory is always the same, preventing false positives when checking scripts have a consistent prefix to set up on Windows.

--- a/changelog.d/1531.misc.rst
+++ b/changelog.d/1531.misc.rst
@@ -1,1 +1,0 @@
-Converted Python version-specific tests to use ``skipif`` instead of ``xfail``, and removed Python 2.6-specific code from the tests.

--- a/changelog.d/1533.misc.rst
+++ b/changelog.d/1533.misc.rst
@@ -1,1 +1,0 @@
-Restrict the `recursive-include setuptools/_vendor` to contain only .py and .txt files

--- a/changelog.d/1537.doc.rst
+++ b/changelog.d/1537.doc.rst
@@ -1,1 +1,0 @@
-Document how to use setup.cfg for src/ layouts.

--- a/changelog.d/1539.doc.rst
+++ b/changelog.d/1539.doc.rst
@@ -1,1 +1,0 @@
-Added minumum version column in ``setup.cfg`` metadata table.

--- a/changelog.d/1541.deprecation.rst
+++ b/changelog.d/1541.deprecation.rst
@@ -1,1 +1,0 @@
-Officially deprecated the ``requires`` parameter in ``setup()``.

--- a/changelog.d/1545.feature.rst
+++ b/changelog.d/1545.feature.rst
@@ -1,1 +1,0 @@
-Changed the warning class of all deprecation warnings; deprecation warning classes are no longer derived from ``DeprecationWarning`` and are thus visible by default.

--- a/changelog.d/1552.doc.rst
+++ b/changelog.d/1552.doc.rst
@@ -1,1 +1,0 @@
-Fixed a minor typo in the python 2/3 compatibility documentation.

--- a/changelog.d/1553.doc.rst
+++ b/changelog.d/1553.doc.rst
@@ -1,1 +1,0 @@
-Update installation instructions to point to ``pip install`` instead of ``ez_setup.py``.

--- a/changelog.d/1554.change.rst
+++ b/changelog.d/1554.change.rst
@@ -1,1 +1,0 @@
-``build_meta.build_sdist`` now includes ``setup.py`` in source distributions by default

--- a/changelog.d/1560.doc.rst
+++ b/changelog.d/1560.doc.rst
@@ -1,1 +1,0 @@
-update ``setuptools`` distribution documentation to mimic packaging.python.org tutorial.

--- a/changelog.d/1564.doc.rst
+++ b/changelog.d/1564.doc.rst
@@ -1,1 +1,0 @@
-Document setup.cfg minimum version for version and project_urls

--- a/changelog.d/1572.misc.rst
+++ b/changelog.d/1572.misc.rst
@@ -1,1 +1,0 @@
-Added the ``concurrent.futures`` backport ``futures`` to the Python 2.7 test suite requirements.

--- a/changelog.d/1576.change.rst
+++ b/changelog.d/1576.change.rst
@@ -1,1 +1,0 @@
-Started monkey-patching ``get_metadata_version`` and ``read_pkg_file`` onto ``distutils.DistributionMetadata`` to retain the correct version on the ``PKG-INFO`` file in the (deprecated) ``upload`` command.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2416,7 +2416,7 @@ package_data             section
 exclude_package_data     section
 namespace_packages       list-comma
 py_modules               list-comma
-data_files               dict                                 40.5.0
+data_files               dict                                 40.6.0
 =======================  ===================================  =============== =====
 
 .. note::


### PR DESCRIPTION
Updating the news for the 40.6.0 release.

Doing this as a PR so I can see the netlify generated docs.