### PR TITLE
Fix Travis test for pyc files in egg-info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
     after_success: true
     before_deploy:
       - python bootstrap.py
-      - ! grep pyc setuptools.egg-info/SOURCES.txt
+      - "! grep pyc setuptools.egg-info/SOURCES.txt"
     deploy:
       provider: pypi
       on:
@@ -60,6 +60,7 @@ install:
 
 # update egg_info based on setup.py in checkout
 - python bootstrap.py
+- "! grep pyc setuptools.egg-info/SOURCES.txt"
 
 script:
   - |


### PR DESCRIPTION
This fixes the issue that prevented the initial `40.6.0` release.

The problem is that [`!` is a special character in YAML syntax](https://stackoverflow.com/questions/9664113/what-does-a-single-exclamation-mark-do-in-yaml/9703472#9703472).