### PR TITLE
Fix issue with missing author metadata

### DIFF
--- a/changelog.d/1590.change.rst
+++ b/changelog.d/1590.change.rst
@@ -1,0 +1,1 @@
+Fixed regression where packages without ``author`` or ``author_email`` fields generated malformed package metadata.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -138,8 +138,8 @@ def write_pkg_file(self, file):
     write_field('Home-page', self.get_url())
 
     if version < StrictVersion('1.2'):
-        write_field('Author:', self.get_contact())
-        write_field('Author-email:', self.get_contact_email())
+        write_field('Author', self.get_contact())
+        write_field('Author-email', self.get_contact_email())
     else:
         optional_fields = (
             ('Author', 'author'),

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -115,6 +115,20 @@ def __read_test_cases():
             merge_dicts(base_attrs, {
                 'provides_extras': ['foo', 'bar']
         }), marks=pytest.mark.xfail(reason="provides_extras not read")),
+        ('Missing author, missing author e-mail',
+         {'name': 'foo', 'version': '1.0.0'}),
+        ('Missing author',
+         {'name': 'foo',
+          'version': '1.0.0',
+          'author_email': 'snorri@sturluson.name'}),
+        ('Missing author e-mail',
+         {'name': 'foo',
+          'version': '1.0.0',
+          'author': 'Snorri Sturluson'}),
+        ('Missing author',
+         {'name': 'foo',
+          'version': '1.0.0',
+          'author': 'Snorri Sturluson'}),
     ]
 
     return test_cases
@@ -141,6 +155,8 @@ def test_read_metadata(name, attrs):
     tested_attrs = [
         ('name', dist_class.get_name),
         ('version', dist_class.get_version),
+        ('author', dist_class.get_contact),
+        ('author_email', dist_class.get_contact_email),
         ('metadata_version', dist_class.get_metadata_version),
         ('provides', dist_class.get_provides),
         ('description', dist_class.get_description),


### PR DESCRIPTION
Prior to this patch, if the author or author_email were omitted from `setup`, a malformed `PKG-INFO` would be created.

Bug reported off-tracker by @dstufft.

Probably best to quickly merge this and cut a new patch release.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
