### PR TITLE
Import internal version of six

### DIFF
--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -12,9 +12,9 @@ from distutils.spawn import spawn
 
 from distutils.errors import DistutilsError
 
-from six.moves.urllib.request import urlopen, Request
-from six.moves.urllib.error import HTTPError
-from six.moves.urllib.parse import urlparse
+from setuptools.extern.six.moves.urllib.request import urlopen, Request
+from setuptools.extern.six.moves.urllib.error import HTTPError
+from setuptools.extern.six.moves.urllib.parse import urlparse
 
 class upload(orig.upload):
     """

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -7,13 +7,12 @@ from setuptools.dist import DistDeprecationWarning, _get_unpatched
 from setuptools import Distribution
 from setuptools.extern.six.moves.urllib.request import pathname2url
 from setuptools.extern.six.moves.urllib_parse import urljoin
+from setuptools.extern import six
 
 from .textwrap import DALS
 from .test_easy_install import make_nspkg_sdist
 
 import pytest
-import six
-
 
 def test_dist_fetch_build_egg(tmpdir):
     """

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -7,10 +7,10 @@ from distutils.errors import DistutilsError
 from distutils.version import StrictVersion
 
 import pytest
-import six
 
 from setuptools.command.upload import upload
 from setuptools.dist import Distribution
+from setuptools.extern import six
 
 
 def _parse_upload_body(body):

--- a/tests/manual_test.py
+++ b/tests/manual_test.py
@@ -8,7 +8,7 @@ import subprocess
 from distutils.command.install import INSTALL_SCHEMES
 from string import Template
 
-from six.moves import urllib
+from setuptools.extern.six.moves import urllib
 
 
 def _system_call(*args):


### PR DESCRIPTION
## Summary of changes

Fix for usage external `six` module, that was added at #1576 (v.40.6.0).

Closes  #1592

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
