### PR TITLE
Don't keep file modes for package data.

### DIFF
--- a/changelog.d/1424.change.rst
+++ b/changelog.d/1424.change.rst
@@ -1,0 +1,1 @@
+Prevent keeping files mode for package_data build. It may break a build if user's package data has read only flag.

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -120,7 +120,7 @@ class build_py(orig.build_py, Mixin2to3):
                 target = os.path.join(build_dir, filename)
                 self.mkpath(os.path.dirname(target))
                 srcfile = os.path.join(src_dir, filename)
-                outf, copied = self.copy_file(srcfile, target)
+                outf, copied = self.copy_file(srcfile, target, preserve_mode=False)
                 srcfile = os.path.abspath(srcfile)
                 if (copied and
                         srcfile in self.distribution.convert_2to3_doctests):


### PR DESCRIPTION
## Summary of changes

Prevent keeping files mode for package_data build. It may break a build if user's package data has read only flag. It will be copied to build folder and set RO flag again. Then at the clean up stage a script will not be able to remove this files, asserting Access denied.

Closes #1424 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
