### PR TITLE
Specify gpg --output option explicitly

### DIFF
--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -57,7 +57,7 @@ class upload(orig.upload):
 
         # Sign if requested
         if self.sign:
-            gpg_args = ["gpg", "--detach-sign", "-a", filename]
+            gpg_args = ["gpg", "--detach-sign", "-a", "--output", filename + ".asc", filename]
             if self.identity:
                 gpg_args[2:2] = ["--local-user", self.identity]
             spawn(gpg_args,

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -196,6 +196,7 @@ class TestUploadTest:
         # Make sure that GPG was called
         spawn.assert_called_once_with([
             "gpg", "--detach-sign", "--local-user", "Alice", "-a",
+            "--output", signed_file,
             content_fname
         ], dry_run=True)
 


### PR DESCRIPTION
Do not rely on obscure default behavior of gpg, which may not work with alternative implementations (like qubes-gpg-client-wrapper).

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Make it work with gpg that does not have default output file. See https://github.com/QubesOS/qubes-issues/issues/4612 for example.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
