### PR TITLE
Tweak "making a pull request" documentation

### DIFF
--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -68,7 +68,7 @@ changelog entry.
 
 ``setuptools`` uses `towncrier <https://pypi.org/project/towncrier/>`_
 for changelog management, so when making a PR, please add a news fragment in the
-``changelog.d/`` folder. Changelog files are written in Restructured Text and
+``changelog.d/`` folder. Changelog files are written in reStructuredText and
 should be a 1 or 2 sentence description of the substantive changes in the PR.
 They should be named ``<pr_number>.<category>.rst``, where the categories are:
 
@@ -76,7 +76,7 @@ They should be named ``<pr_number>.<category>.rst``, where the categories are:
 - ``breaking``: Any backwards-compatibility breaking change
 - ``doc``: A change to the documentation
 - ``misc``: Changes internal to the repo like CI, test and build changes
-- ``deprecation``: For deprecations of an existing feature of behavior
+- ``deprecation``: For deprecations of an existing feature or behavior
 
 A pull request may have more than one of these components, for example a code
 change may introduce a new feature that deprecates an old feature, in which


### PR DESCRIPTION
reStructuredText is how the name is commonly stylized (see Wikipedia), also fixed a typo in the "deprecation" description.
