### PR TITLE
Ensure .zip sdists are supported in build_meta.

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -175,8 +175,11 @@ def build_sdist(sdist_directory, config_settings=None):
         ["--dist-dir", sdist_directory]
     _run_setup()
 
-    sdists = [f for f in os.listdir(sdist_directory)
-              if f.endswith('.tar.gz')]
+    sdists = [
+        f for f in os.listdir(sdist_directory)
+        if f.endswith('.tar.gz')
+        or f.endswith('.zip')
+    ]
 
     assert len(sdists) == 1
     return sdists[0]


### PR DESCRIPTION
It's a shame the tests didn't already capture this behavior. Does that mean there isn't a test for this function at all (because it would have failed on Windows CI)?

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #1623

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details