### PR TITLE
Disallow parent path traversal in resource paths, part 1 (deprecation)

### DIFF
--- a/changelog.d/1635.change.rst
+++ b/changelog.d/1635.change.rst
@@ -1,0 +1,1 @@
+Resource paths are passed to ``pkg_resources.resource_string`` and similar no longer accept paths that traverse parents. Violations of this expectation raise DeprecationWarnings and will become errors.

--- a/changelog.d/1635.change.rst
+++ b/changelog.d/1635.change.rst
@@ -1,1 +1,1 @@
-Resource paths are passed to ``pkg_resources.resource_string`` and similar no longer accept paths that traverse parents or begin with a leading ``/``. Violations of this expectation raise DeprecationWarnings and will become errors.
+Resource paths are passed to ``pkg_resources.resource_string`` and similar no longer accept paths that traverse parents, that begin with a leading ``/``. Violations of this expectation raise DeprecationWarnings and will become errors. Additionally, any paths that are absolute on Windows are strictly disallowed and will raise ValueErrors.

--- a/changelog.d/1635.change.rst
+++ b/changelog.d/1635.change.rst
@@ -1,1 +1,1 @@
-Resource paths are passed to ``pkg_resources.resource_string`` and similar no longer accept paths that traverse parents. Violations of this expectation raise DeprecationWarnings and will become errors.
+Resource paths are passed to ``pkg_resources.resource_string`` and similar no longer accept paths that traverse parents or begin with a leading ``/``. Violations of this expectation raise DeprecationWarnings and will become errors.

--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -1133,8 +1133,7 @@ segment will be treated as a peer of the top-level modules or packages in the
 distribution.
 
 Note that resource names must be ``/``-separated paths rooted at the package,
-cannot contain relative names like ``".."``, and cannot begin with a
-leading ``/``.  Do *not* use
+cannot contain relative names like ``".."``, and cannot be absolute.  Do *not* use
 ``os.path`` routines to manipulate resource paths, as they are *not* filesystem
 paths.
 

--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -1132,8 +1132,9 @@ relative to the root of the identified distribution; i.e. its first path
 segment will be treated as a peer of the top-level modules or packages in the
 distribution.
 
-Note that resource names must be ``/``-separated paths rooted at the package
-and cannot contain relative names like ``".."``.  Do *not* use
+Note that resource names must be ``/``-separated paths rooted at the package,
+cannot contain relative names like ``".."``, and cannot begin with a
+leading ``/``.  Do *not* use
 ``os.path`` routines to manipulate resource paths, as they are *not* filesystem
 paths.
 

--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -1132,8 +1132,8 @@ relative to the root of the identified distribution; i.e. its first path
 segment will be treated as a peer of the top-level modules or packages in the
 distribution.
 
-Note that resource names must be ``/``-separated paths and cannot be absolute
-(i.e. no leading ``/``) or contain relative names like ``".."``.  Do *not* use
+Note that resource names must be ``/``-separated paths rooted at the package
+and cannot contain relative names like ``".."``.  Do *not* use
 ``os.path`` routines to manipulate resource paths, as they are *not* filesystem
 paths.
 

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1932,7 +1932,7 @@ def find_eggs_in_zip(importer, path_item, only=False):
     if only:
         # don't yield nested distros
         return
-    for subitem in metadata.resource_listdir('/'):
+    for subitem in metadata.resource_listdir(''):
         if _is_egg_path(subitem):
             subpath = os.path.join(path_item, subitem)
             dists = find_eggs_in_zip(zipimport.zipimporter(subpath), subpath)

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1489,8 +1489,7 @@ class NullProvider:
         >>> warned.clear()
         >>> vrp('/foo/bar.txt')
         >>> bool(warned)
-        True
-        >>> warned.clear()
+        False
         >>> vrp('foo/../../bar.txt')
         >>> bool(warned)
         True
@@ -1499,14 +1498,11 @@ class NullProvider:
         >>> bool(warned)
         False
         """
-        invalid = (
-            path.startswith('/') or
-            re.search(r'\B\.\.\B', path)
-        )
+        invalid = '..' in path.split('/')
         if not invalid:
             return
 
-        msg = "Use of .. or leading / in a resource path is not allowed."
+        msg = "Use of .. in a resource path is not allowed."
         # for compatibility, warn; in future
         # raise ValueError(msg)
         warnings.warn(

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1489,7 +1489,7 @@ class NullProvider:
         >>> warned.clear()
         >>> vrp('/foo/bar.txt')
         >>> bool(warned)
-        False
+        True
         >>> vrp('foo/../../bar.txt')
         >>> bool(warned)
         True
@@ -1498,11 +1498,14 @@ class NullProvider:
         >>> bool(warned)
         False
         """
-        invalid = '..' in path.split('/')
+        invalid = (
+            '..' in path.split('/') or
+            path.startswith('/')
+        )
         if not invalid:
             return
 
-        msg = "Use of .. in a resource path is not allowed."
+        msg = "Use of .. or leading '/' in a resource path is not allowed."
         # for compatibility, warn; in future
         # raise ValueError(msg)
         warnings.warn(

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1466,9 +1466,54 @@ class NullProvider:
         )
 
     def _fn(self, base, resource_name):
+        self._validate_resource_path(resource_name)
         if resource_name:
             return os.path.join(base, *resource_name.split('/'))
         return base
+
+    @staticmethod
+    def _validate_resource_path(path):
+        """
+        Validate the resource paths according to the docs.
+        https://setuptools.readthedocs.io/en/latest/pkg_resources.html#basic-resource-access
+
+        >>> warned = getfixture('recwarn')
+        >>> warnings.simplefilter('always')
+        >>> vrp = NullProvider._validate_resource_path
+        >>> vrp('foo/bar.txt')
+        >>> bool(warned)
+        False
+        >>> vrp('../foo/bar.txt')
+        >>> bool(warned)
+        True
+        >>> warned.clear()
+        >>> vrp('/foo/bar.txt')
+        >>> bool(warned)
+        True
+        >>> warned.clear()
+        >>> vrp('foo/../../bar.txt')
+        >>> bool(warned)
+        True
+        >>> warned.clear()
+        >>> vrp('foo/f../bar.txt')
+        >>> bool(warned)
+        False
+        """
+        invalid = (
+            path.startswith('/') or
+            re.search(r'\B\.\.\B', path)
+        )
+        if not invalid:
+            return
+
+        msg = "Use of .. or leading / in a resource path is not allowed."
+        # for compatibility, warn; in future
+        # raise ValueError(msg)
+        warnings.warn(
+            msg[:-1] + " and will raise exceptions in a future release.",
+            DeprecationWarning,
+            stacklevel=4,
+        )
 
     def _get(self, path):
         if hasattr(self.loader, 'get_data'):

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -93,7 +93,6 @@ class TestZipProvider:
 
         expected_root = ['data.dat', 'mod.py', 'subdir']
         assert sorted(zp.resource_listdir('')) == expected_root
-        assert sorted(zp.resource_listdir('/')) == expected_root
 
         expected_subdir = ['data2.dat', 'mod2.py']
         assert sorted(zp.resource_listdir('subdir')) == expected_subdir
@@ -106,7 +105,6 @@ class TestZipProvider:
         zp2 = pkg_resources.ZipProvider(mod2)
 
         assert sorted(zp2.resource_listdir('')) == expected_subdir
-        assert sorted(zp2.resource_listdir('/')) == expected_subdir
 
         assert zp2.resource_listdir('subdir') == []
         assert zp2.resource_listdir('subdir/') == []


### PR DESCRIPTION
## Summary of changes

Disallow parent path traversal in resource paths, part 1 (deprecation).

Reference #1635.

### Pull Request Checklist
- [X] Changes have tests
- [X] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details