### PR TITLE
Inject '' into sys.path in PEP 517 implementation

### DIFF
--- a/changelog.d/1642.change.rst
+++ b/changelog.d/1642.change.rst
@@ -1,0 +1,1 @@
+The current working directory is injected into `sys.path` when executing `setup.py`, maintaining compatibility to non-isolated projects where the module is imported in `setup.py`.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -82,7 +82,15 @@ def _run_setup(setup_script='setup.py'):
     f = getattr(tokenize, 'open', open)(__file__)
     code = f.read().replace('\\r\\n', '\\n')
     f.close()
+
+    # Execute setup.py. The current directory is added into sys.path to emulate
+    # the behavior when setup.py is run globally (i.e. no PEP 517 isolation)
+    # to maintain backward compatibility. (pypa/setuptools#1642)
+    sys_path = sys.path
+    if '' not in sys.path:
+        sys.path.insert(0, '')
     exec(compile(code, __file__, 'exec'), locals())
+    sys.path = sys_path
 
 
 def _fix_config(config_settings):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -236,3 +236,22 @@ def test_build_sdist_builds_targz_even_if_zip_indicated(tmpdir_cwd):
 
     build_files(files)
     build_sdist("temp")
+
+
+def test_build_sdist_with_pwd_in_sys_path(tmpdir_cwd):
+    files = {
+        'setup.py': DALS("""
+            __import__('setuptools').setup(
+                name='foo',
+                version=__import__('hello').__version__,
+                py_modules=['hello']
+            )"""),
+        'hello.py': '__version__ = "0.0.0"',
+        'setup.cfg': DALS("""
+            [sdist]
+            formats=zip
+            """)
+    }
+
+    build_files(files)
+    build_sdist("temp")


### PR DESCRIPTION
## Summary of changes

Injects `''` (current working directory) into `sys.path` if needed when running setup.py in the PEP 517 backend.

Closes #1642.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
