### PR TITLE
Bugfix/downgrade pip

### DIFF
--- a/pip-wrapper.py
+++ b/pip-wrapper.py
@@ -12,7 +12,13 @@ import subprocess
 
 
 def ensure_pip_version(pip_bin, ver):
-    cmd = [pip_bin, 'install', 'pip ' + ver]
+    """
+    Ensure the pip version meets the specified version.
+
+    Use python -m pip to upgrade/downgrade, because for this operation,
+    on Windows, pip.exe must not be locked.
+    """
+    cmd = [sys.executable, '-m', 'pip', 'install', 'pip ' + ver]
     subprocess.check_call(cmd)
 
 

--- a/pip-wrapper.py
+++ b/pip-wrapper.py
@@ -3,6 +3,7 @@ Wrap the pip command to:
 
 - Avoid the default 'python -m pip' invocation, which causes the current
   working directory to be added to the path, which causes problems.
+- Ensure pip meets a requisite version.
 """
 
 
@@ -10,7 +11,15 @@ import sys
 import subprocess
 
 
+def ensure_pip_version(pip_bin, ver):
+    cmd = [pip_bin, 'install', 'pip ' + ver]
+    subprocess.check_call(cmd)
+
+
 def main():
+    pip_bin = sys.argv[1]
+    # workaround for #1644
+    ensure_pip_version(pip_bin, '<19')
     cmd = sys.argv[1:]
     subprocess.check_call(cmd)
 

--- a/pip-wrapper.py
+++ b/pip-wrapper.py
@@ -1,0 +1,18 @@
+"""
+Wrap the pip command to:
+
+- Avoid the default 'python -m pip' invocation, which causes the current
+  working directory to be added to the path, which causes problems.
+"""
+
+
+import sys
+import subprocess
+
+
+def main():
+    cmd = sys.argv[1:]
+    subprocess.check_call(cmd)
+
+
+__name__ == '__main__' and main()

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,8 @@ envlist=python
 
 [testenv]
 deps=-rtests/requirements.txt
-# Changed from default (`python -m pip ...`)
-# to prevent the current working directory
-# from being added to `sys.path`.
-install_command={envbindir}/pip install {opts} {packages}
-# Same as above.
-list_dependencies_command={envbindir}/pip freeze
+install_command = python ./pip-wrapper.py {envbindir}/pip install {opts} {packages}
+list_dependencies_command = python ./pip-wrapper.py {envbindir}/pip freeze
 setenv=COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 # TODO: The passed environment variables came from copying other tox.ini files
 # These should probably be individually annotated to explain what needs them.


### PR DESCRIPTION
As discussed in #1644, bootstrapping issues have emerged with the pep517 build support in pip 19. This change wraps the 'install' command from tox to ensure that a requisite version of pip is present for builds, unblocking testing/development until a more permanent solution can be devised.