### PR TITLE
Pin pip to <19 until a more permanent solution can be devised.

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
+# workaround for #1644
+pip<19
 mock
 pytest-flake8; python_version!="3.4"
 pytest-flake8<=1.0.0; python_version=="3.4"


### PR DESCRIPTION
As @benoit-pierre suggested in #1645, try pinning pip in test requirements... since the build issue is only happening with the build of setuptools itself.