### PR TITLE
tweak #1644 workaround to fix `test_pip_upgrade_from_source`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ include launcher.c
 include msvc-build-launcher.cmd
 include pytest.ini
 include tox.ini
+exclude pyproject.toml  # Temporary workaround for #1644.


### PR DESCRIPTION
Explicitly exclude `pyproject.toml` so it's never added (e.g. because `setuptools_scm` is used).