### PR TITLE
tests: improve `test_pip_upgrade_from_source`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,7 @@ install:
 - "! grep pyc setuptools.egg-info/SOURCES.txt"
 
 script:
+  - export NETWORK_REQUIRED=1
   - |
     ( # Run testsuite.
       if [ -z "$DISABLE_COVERAGE" ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ clone_depth: 50
 environment:
 
   APPVEYOR: True
+  NETWORK_REQUIRED: True
   CODECOV_ENV: APPVEYOR_JOB_NAME
 
   matrix:

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -52,10 +52,24 @@ def test_clean_env_install(bare_virtualenv):
     )).format(source=SOURCE_DIR))
 
 
-def test_pip_upgrade_from_source(virtualenv):
+@pytest.mark.parametrize('pip_version', (
+    'pip==9.0.3',
+    'pip==10.0.1',
+    'pip==18.1',
+    'pip==19.0.1',
+    'https://github.com/pypa/pip/archive/master.zip',
+))
+def test_pip_upgrade_from_source(virtualenv, pip_version):
     """
     Check pip can upgrade setuptools from source.
     """
+    # Install pip/wheel, and remove setuptools (as it
+    # should not be needed for bootstraping from source)
+    virtualenv.run(' && '.join((
+        'pip uninstall -y setuptools',
+        'pip install -U wheel',
+        'python -m pip install {pip_version}',
+    )).format(pip_version=pip_version))
     dist_dir = virtualenv.workspace
     # Generate source distribution / wheel.
     virtualenv.run(' && '.join((

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -52,24 +52,55 @@ def test_clean_env_install(bare_virtualenv):
     )).format(source=SOURCE_DIR))
 
 
-@pytest.mark.parametrize('pip_version', (
-    'pip==9.0.3',
-    'pip==10.0.1',
-    'pip==18.1',
-    'pip==19.0.1',
-    'https://github.com/pypa/pip/archive/master.zip',
-))
-def test_pip_upgrade_from_source(virtualenv, pip_version):
+def _get_pip_versions():
+    # This fixture will attempt to detect if tests are being run without
+    # network connectivity and if so skip some tests
+
+    network = True
+    if not os.environ.get('NETWORK_REQUIRED', False):  # pragma: nocover
+        try:
+            from urllib.request import urlopen
+            from urllib.error import URLError
+        except ImportError:
+            from urllib2 import urlopen, URLError # Python 2.7 compat
+
+        try:
+            urlopen('https://pypi.org', timeout=1)
+        except URLError:
+            # No network, disable most of these tests
+            network = False
+
+    network_versions = [
+        'pip==9.0.3',
+        'pip==10.0.1',
+        'pip==18.1',
+        'pip==19.0.1',
+        'https://github.com/pypa/pip/archive/master.zip',
+    ]
+
+    versions = [None] + [
+        pytest.param(v, **({} if network else {'marks': pytest.mark.skip}))
+        for v in network_versions
+    ]
+
+    return versions
+
+
+@pytest.mark.parametrize('pip_version', _get_pip_versions())
+def test_pip_upgrade_from_source(pip_version, virtualenv):
     """
     Check pip can upgrade setuptools from source.
     """
     # Install pip/wheel, and remove setuptools (as it
     # should not be needed for bootstraping from source)
+    if pip_version is None:
+        upgrade_pip = ()
+    else:
+        upgrade_pip = ('python -m pip install -U {pip_version} --retries=1',)
     virtualenv.run(' && '.join((
         'pip uninstall -y setuptools',
         'pip install -U wheel',
-        'python -m pip install {pip_version}',
-    )).format(pip_version=pip_version))
+    ) + upgrade_pip).format(pip_version=pip_version))
     dist_dir = virtualenv.workspace
     # Generate source distribution / wheel.
     virtualenv.run(' && '.join((

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ list_dependencies_command={envbindir}/pip freeze
 setenv=COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 # TODO: The passed environment variables came from copying other tox.ini files
 # These should probably be individually annotated to explain what needs them.
-passenv=APPDATA HOMEDRIVE HOMEPATH windir APPVEYOR APPVEYOR_* CI CODECOV_* TRAVIS TRAVIS_*
+passenv=APPDATA HOMEDRIVE HOMEPATH windir APPVEYOR APPVEYOR_* CI CODECOV_* TRAVIS TRAVIS_* NETWORK_REQUIRED
 commands=pytest --cov-config={toxinidir}/tox.ini --cov-report= {posargs}
 usedevelop=True
 


### PR DESCRIPTION
Parametrize the test to check different versions of pip (including master) are correctly supported. Fix #1649.