### PR TITLE
Add setuptools to the build system requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,3 +12,4 @@ include launcher.c
 include msvc-build-launcher.cmd
 include pytest.ini
 include tox.ini
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["wheel"]
+requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.towncrier]


### PR DESCRIPTION
Without this, PEP 517 frontends will not be able to find the setuptools.build_meta backend, which exists only in the source tree.

This presents an obvious bootstrapping problem, in that building setuptools requires installing setuptools, but at the moment PEP 517 is read as only supporting build backends that are installable from wheels, and so we can use the most recent wheel to build this one.

Closes #1644, supercedes #1657.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
