### PR TITLE
Drop build-backend from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = ["wheel"]
-build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
     package = "setuptools"


### PR DESCRIPTION
Per @gaborbernat's suggestion, dropping the `build-backend`. I don't know if it makes sense to keep `build-system` at all, but this is the minimal change required to allow us to use `--no-use-pep517` (which is required on the current version of `pip` when building from the repo).

Bernat discovered this when building the first infrastructure for the integration testing repo.