### PR TITLE
Explicitly declare our build backend

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,4 +12,4 @@ include launcher.c
 include msvc-build-launcher.cmd
 include pytest.ini
 include tox.ini
-exclude pyproject.toml  # Temporary workaround for #1644.
+include pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["wheel"]
+requires = ["setuptools", "wheel"]
+build-backend="setuptools.build_meta"
 
 [tool.towncrier]
     package = "setuptools"


### PR DESCRIPTION
## Summary of changes
This change more accurately reflects that ``setuptools`` is intended to use the ``build_meta`` backend from a previous installation. This may cause some problems with source builds if existing wheels for ``wheel`` and ``setuptools`` are not available. In that event, manually building a source wheel is recommended.

This may break `pip install --no-binary :all:`, though it's not entirely clear that it will. I would take the position that that this is basically revealing a bug in `pip`, but we could also just call this a "breaking change".

Closes #1644

### Pull Request Checklist
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
