### PR TITLE
Add support for setup.cfg-only projects

### DIFF
--- a/changelog.d/1675.change.rst
+++ b/changelog.d/1675.change.rst
@@ -1,0 +1,1 @@
+Added support for ``setup.cfg``-only projects when using the ``setuptools.build_meta`` backend. Projects that have enabled PEP 517 no longer need to have a ``setup.py`` and can use the purely declarative ``setup.cfg`` configuration file instead.

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -110,6 +110,21 @@ defns = [
                 print('hello')
             """),
     },
+    {
+        'setup.cfg': DALS("""
+        [metadata]
+        name = foo
+        version='0.0.0'
+
+        [options]
+        py_modules=hello
+        setup_requires=six
+        """),
+        'hello.py': DALS("""
+        def run():
+            print('hello')
+        """)
+    },
 ]
 
 
@@ -183,9 +198,13 @@ class TestBuildMetaBackend:
         # if the setup.py changes subsequent call of the build meta
         # should still succeed, given the
         # sdist_directory the frontend specifies is empty
-        with open(os.path.abspath("setup.py"), 'rt') as file_handler:
+        setup_loc = os.path.abspath("setup.py")
+        if not os.path.exists(setup_loc):
+            setup_loc = os.path.abspath("setup.cfg")
+
+        with open(setup_loc, 'rt') as file_handler:
             content = file_handler.read()
-        with open(os.path.abspath("setup.py"), 'wt') as file_handler:
+        with open(setup_loc, 'wt') as file_handler:
             file_handler.write(
                 content.replace("version='0.0.0'", "version='0.0.1'"))
 


### PR DESCRIPTION
Many projects can get away with an empty `setup.py` and use *only* the declarative `setup.cfg`. With the new PEP 517 backend, we can supply a default empty `setup.py` if one is not provided.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
