### PR TITLE
Add setuptools.get_version(path, field='__version__')

### DIFF
--- a/changelog.d/1679.change.rst
+++ b/changelog.d/1679.change.rst
@@ -1,0 +1,3 @@
+Add ``setuptools.get_version(path, field='__version__')``. It extracts version
+info from lines like ``__version__ = '0.12'"`` in text files and Python
+sources without importing them.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,5 +25,3 @@ universal = 1
 [metadata]
 license_file = LICENSE
 
-[bumpversion:file:setup.py]
-

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ def pypi_link(pkg_filename):
 
 setup_params = dict(
     name="setuptools",
-    version="40.8.0",
+    version=setuptools.get_version("setup.cfg", field="current_version"),
     description=(
         "Easily download, build, install, upgrade, and uninstall "
         "Python packages"

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -27,7 +27,7 @@ __metaclass__ = type
 __all__ = [
     'setup', 'Distribution', 'Feature', 'Command', 'Extension', 'Require',
     'SetuptoolsDeprecationWarning',
-    'find_packages'
+    'find_packages', 'get_version'
 ]
 
 if PY3:
@@ -222,6 +222,26 @@ def findall(dir=os.curdir):
         make_rel = functools.partial(os.path.relpath, start=dir)
         files = map(make_rel, files)
     return list(files)
+
+
+def get_version(path, field='__version__'):
+    """
+    Get version information from a text file. Version is extracted
+    from "key = value" format with key matched at the beginning of
+    a line and specified by `field` parameter. Returns string.
+    """
+    version_file = os.path.abspath(path)
+    # Using binary matching to avoid possible encoding problems
+    # when reading arbitrary text files
+    if type(field) is not bytes:
+        field = field.encode('utf-8')
+    for line in open(version_file, 'rb'):
+        if line.startswith(field):
+            # __version__ = "0.9"
+            # current_version = 4.8.0
+            _, value = line.split(b'=')
+            version = value.strip(b' \'\"').decode()
+            return version
 
 
 # Apply monkey patches

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -240,7 +240,7 @@ def get_version(path, field='__version__'):
             # __version__ = "0.9"
             # current_version = 4.8.0
             _, value = line.split(b'=')
-            version = value.strip(b' \n\t\'\"').decode()
+            version = value.strip(b' \r\n\t\'\"').decode()
             return version
 
 

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -240,7 +240,7 @@ def get_version(path, field='__version__'):
             # __version__ = "0.9"
             # current_version = 4.8.0
             _, value = line.split(b'=')
-            version = value.strip(b' \'\"').decode()
+            version = value.strip(b' \n\t\'\"').decode()
             return version
 
 

--- a/setuptools/tests/test_get_version.py
+++ b/setuptools/tests/test_get_version.py
@@ -26,23 +26,23 @@ class TestFiles:
     def setup_method(self, method):
         self.tmpdir = tempfile.mkdtemp()
 
-        self.file_python = os.path.join(self.tmpdir, 'version.py') 
-        with open(self.file_python, 'w') as fp:
-            fp.write('__version__ = "0.23beta"\n')
-
-        self.file_russian = os.path.join(self.tmpdir, 'russian.py') 
-        with open(self.file_russian, 'wb') as fp:
-            fp.write('# файл в русской кодировке\n\n'.encode('cp1251'))
-            fp.write('__version__ = "17.0"\n')
-
     def teardown_method(self, method):
-        shutil.rmtree(self.dist_dir)
+        shutil.rmtree(self.tmpdir)
 
     def test_python_file(self):
-        version = get_version(self.ver_python)
+        path = os.path.join(self.tmpdir, 'version.py')
+        with open(path, 'w') as fp:
+            fp.write('__version__ = "0.23beta"\n')
+
+        version = get_version(path)
         assert version == '0.23beta'
 
     def test_non_utf8_python_file(self):
-        version2 = get_version(self.ver_russian)
-        assert version2 == '17.0'
+        path = os.path.join(self.tmpdir, 'russian.py')
+        with open(path, 'wb') as fp:
+            fp.write(u'# файл в русской кодировке\n\n'.encode('cp1251'))
+            fp.write('__version__ = "17.0"\n')
+
+        version = get_version(path)
+        assert version == '17.0'
 

--- a/setuptools/tests/test_get_version.py
+++ b/setuptools/tests/test_get_version.py
@@ -1,0 +1,40 @@
+# -*- encoding: utf-8 -*-
+
+"""Tests for setuptools.get_version()."""
+import os
+import codecs
+import tempfile
+
+import pytest
+
+from setuptools import __version__, get_version
+
+
+def test_get_version():
+    version = get_version('setup.cfg', field='current_version')
+    assert version == __version__
+
+
+class TestFiles:
+    def setup_method(self, method):
+        self.tmpdir = tempfile.mkdtemp()
+
+        self.file_python = os.path.join(self.tmpdir, 'version.py') 
+        with open(self.file_python, 'w') as fp:
+            fp.write('__version__ = "0.23beta"\n')
+
+        self.file_russian = os.path.join(self.tmpdir, 'russian.py') 
+        with open(self.file_russian, 'wb') as fp:
+            fp.write('# файл в русской кодировке\n\n'.encode('cp1251'))
+            fp.write('__version__ = "17.0"\n')
+
+    def teardown_method(self, method):
+        shutil.rmtree(self.dist_dir)
+
+    def test_get_version_files(self):
+        version = get_version(self.ver_python)
+        assert version == '0.23beta'
+
+        version2 = get_version(self.ver_russian)
+        assert version2 == '17.0'
+

--- a/setuptools/tests/test_get_version.py
+++ b/setuptools/tests/test_get_version.py
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 """Tests for setuptools.get_version()."""
 import os
@@ -12,7 +12,14 @@ from setuptools import __version__, get_version
 
 def test_get_version():
     version = get_version('setup.cfg', field='current_version')
-    assert version == __version__
+
+    # `setup.py egg_info` which is run in bootstrap.py during package
+    # installation adds `.post` prefix to setuptools.__version__
+    # which becomes different from 'setup.cfg` file
+
+    # https://setuptools.readthedocs.io/en/latest/setuptools.html#egg-info
+
+    assert __version__.startswith(version + '.post')
 
 
 class TestFiles:

--- a/setuptools/tests/test_get_version.py
+++ b/setuptools/tests/test_get_version.py
@@ -3,6 +3,7 @@
 """Tests for setuptools.get_version()."""
 import os
 import codecs
+import shutil
 import tempfile
 
 import pytest
@@ -41,7 +42,7 @@ class TestFiles:
         path = os.path.join(self.tmpdir, 'russian.py')
         with open(path, 'wb') as fp:
             fp.write(u'# файл в русской кодировке\n\n'.encode('cp1251'))
-            fp.write('__version__ = "17.0"\n')
+            fp.write(u'__version__ = "17.0"\n'.encode('cp1251'))
 
         version = get_version(path)
         assert version == '17.0'

--- a/setuptools/tests/test_get_version.py
+++ b/setuptools/tests/test_get_version.py
@@ -10,7 +10,7 @@ import pytest
 from setuptools import __version__, get_version
 
 
-def test_get_version():
+def test_own_version():
     version = get_version('setup.cfg', field='current_version')
 
     # `setup.py egg_info` which is run in bootstrap.py during package
@@ -38,10 +38,11 @@ class TestFiles:
     def teardown_method(self, method):
         shutil.rmtree(self.dist_dir)
 
-    def test_get_version_files(self):
+    def test_python_file(self):
         version = get_version(self.ver_python)
         assert version == '0.23beta'
 
+    def test_non_utf8_python_file(self):
         version2 = get_version(self.ver_russian)
         assert version2 == '17.0'
 


### PR DESCRIPTION
## Summary of changes

This allows people who use setuptools to maintain project versions
in a single place, for example as attributes in their Python source.

Closes #1316
Closes https://github.com/pypa/pip/pull/6004
Closes https://github.com/pypa/python-packaging-user-guide/pull/571

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
