### PR TITLE
Move version to declarative config

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,6 @@
+[bumpversion]
+current_version = 40.8.0
+commit = True
+tag = True
+
+[bumpversion:file:setup.cfg]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,3 @@
-[bumpversion]
-current_version = 40.8.0
-commit = True
-tag = True
-
 [egg_info]
 tag_build = .post
 tag_date = 1
@@ -25,6 +20,3 @@ universal = 1
 [metadata]
 license_file = LICENSE
 version = 40.8.0
-
-[bumpversion:file:setup.cfg]
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ universal = 1
 
 [metadata]
 license_file = LICENSE
+version = 40.8.0
 
-[bumpversion:file:setup.py]
+[bumpversion:file:setup.cfg]
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,6 @@ def pypi_link(pkg_filename):
 
 setup_params = dict(
     name="setuptools",
-    version="40.8.0",
     description=(
         "Easily download, build, install, upgrade, and uninstall "
         "Python packages"


### PR DESCRIPTION
This change moves the setuptools version to declarative config. In order to accomplish this, the bump2version config had to be moved to .bumpversion.cfg.

I'm creating this PR in light of #1679, which conflicts with this change, to highlight the direction that I'd prefer the setuptools project should move.