### PR TITLE
Set sys.argv[0] in build scripts run by build_meta

### DIFF
--- a/changelog.d/1704.change.rst
+++ b/changelog.d/1704.change.rst
@@ -1,0 +1,1 @@
+Set sys.argv[0] in setup script run by build_meta.__legacy__

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -232,6 +232,12 @@ class _BuildMetaLegacyBackend(_BuildMetaBackend):
         if script_dir not in sys.path:
             sys.path.insert(0, script_dir)
 
+        # Some setup.py scripts (e.g. in pygame and numpy) use sys.argv[0] to
+        # get the directory of the source code. They expect it to refer to the
+        # setup.py script.
+        sys_argv_0 = sys.argv[0]
+        sys.argv[0] = setup_script
+
         try:
             super(_BuildMetaLegacyBackend,
                   self).run_setup(setup_script=setup_script)
@@ -242,6 +248,7 @@ class _BuildMetaLegacyBackend(_BuildMetaBackend):
             # the original path so that the path manipulation does not persist
             # within the hook after run_setup is called.
             sys.path[:] = sys_path
+            sys.argv[0] = sys_argv_0
 
 # The primary backend
 _BACKEND = _BuildMetaBackend()

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -385,6 +385,28 @@ class TestBuildMetaBackend:
 
         assert expected == sorted(actual)
 
+    _sys_argv_0_passthrough = {
+        'setup.py': DALS("""
+            import os
+            import sys
+
+            __import__('setuptools').setup(
+                name='foo',
+                version='0.0.0',
+            )
+
+            sys_argv = os.path.abspath(sys.argv[0])
+            file_path = os.path.abspath('setup.py')
+            assert sys_argv == file_path
+            """)
+    }
+
+    def test_sys_argv_passthrough(self, tmpdir_cwd):
+        build_files(self._sys_argv_0_passthrough)
+        build_backend = self.get_build_backend()
+        with pytest.raises(AssertionError):
+            build_backend.build_sdist("temp")
+
 
 class TestBuildMetaLegacyBackend(TestBuildMetaBackend):
     backend_name = 'setuptools.build_meta:__legacy__'
@@ -393,6 +415,12 @@ class TestBuildMetaLegacyBackend(TestBuildMetaBackend):
     def test_build_sdist_relative_path_import(self, tmpdir_cwd):
         # This must fail in build_meta, but must pass in build_meta_legacy
         build_files(self._relative_path_import_files)
+
+        build_backend = self.get_build_backend()
+        build_backend.build_sdist("temp")
+
+    def test_sys_argv_passthrough(self, tmpdir_cwd):
+        build_files(self._sys_argv_0_passthrough)
 
         build_backend = self.get_build_backend()
         build_backend.build_sdist("temp")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Some setup.py scripts, use sys.argv[0] to locate the source directory of a project. I only added this to build_meta.\_\_legacy__ since that is focused on backwards compatibility with old scripts. However, @pganssle said this behaviour should not be added to setuptools.build_meta. 

Closes #1628 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
