### PR TITLE
uniquify paths in PYTHONPATH

### DIFF
--- a/changelog.d/1709.bugfix.rst
+++ b/changelog.d/1709.bugfix.rst
@@ -1,0 +1,1 @@
+In test.paths_on_python_path, avoid adding unnecessary duplicates to the PYTHONPATH.

--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -15,6 +15,7 @@ from pkg_resources import (resource_listdir, resource_exists, normalize_path,
                            working_set, _namespace_packages, evaluate_marker,
                            add_activation_listener, require, EntryPoint)
 from setuptools import Command
+from .build_py import _unique_everseen
 
 __metaclass__ = type
 
@@ -186,12 +187,11 @@ class test(Command):
         orig_pythonpath = os.environ.get('PYTHONPATH', nothing)
         current_pythonpath = os.environ.get('PYTHONPATH', '')
         try:
-            to_join = []
-            for x in list(paths) + current_pythonpath.split(os.pathsep):
-                if x not in to_join:
-                    to_join.append(x)
-            if to_join:
-                os.environ['PYTHONPATH'] = os.pathsep.join(to_join)
+            prefix = os.pathsep.join(_unique_everseen(paths))
+            to_join = filter(None, [prefix, current_pythonpath])
+            new_path = os.pathsep.join(to_join)
+            if new_path:
+                os.environ['PYTHONPATH'] = new_path
             yield
         finally:
             if orig_pythonpath is nothing:

--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -186,11 +186,12 @@ class test(Command):
         orig_pythonpath = os.environ.get('PYTHONPATH', nothing)
         current_pythonpath = os.environ.get('PYTHONPATH', '')
         try:
-            prefix = os.pathsep.join(paths)
-            to_join = filter(None, [prefix, current_pythonpath])
-            new_path = os.pathsep.join(to_join)
-            if new_path:
-                os.environ['PYTHONPATH'] = new_path
+            to_join = []
+            for x in list(paths) + current_pythonpath.split(os.pathsep):
+                if x not in to_join:
+                    to_join.append(x)
+            if to_join:
+                os.environ['PYTHONPATH'] = os.pathsep.join(to_join)
             yield
         finally:
             if orig_pythonpath is nothing:


### PR DESCRIPTION
When running in a complex environment with lots of installed
packages, PYTHONPATH gets way too long. Instead, just make sure
that paths_on_pythonpath doesn't contain duplicates

I don't expect this to be accepted. Just letting you know there's a problem here and how to fix it.