### PR TITLE
Support requirement parsing in setuptools.build_meta

### DIFF
--- a/changelog.d/1720.change.rst
+++ b/changelog.d/1720.change.rst
@@ -1,0 +1,1 @@
+Added support for ``pkg_resources.parse_requirements``-style requirements in ``setup_requires`` when ``setup.py`` is invoked from the ``setuptools.build_meta`` build backend.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -36,7 +36,7 @@ import contextlib
 import setuptools
 import distutils
 
-from setuptools._vendor import six
+from pkg_resources import parse_requirements
 
 __all__ = ['get_requires_for_build_sdist',
            'get_requires_for_build_wheel',
@@ -53,7 +53,7 @@ class SetupRequirementsError(BaseException):
 
 class Distribution(setuptools.dist.Distribution):
     def fetch_build_eggs(self, specifiers):
-        specifier_list = self._parse_requirements(specifiers)
+        specifier_list = list(map(str, parse_requirements(specifiers)))
 
         raise SetupRequirementsError(specifier_list)
 
@@ -72,45 +72,6 @@ class Distribution(setuptools.dist.Distribution):
         finally:
             distutils.core.Distribution = orig
 
-    def _yield_lines(self, strs):
-        """Yield non-empty/non-comment lines of a string or sequence"""
-        if isinstance(strs, six.string_types):
-            for s in strs.splitlines():
-                s = s.strip()
-                # skip blank lines/comments
-                if s and not s.startswith('#'):
-                    yield s
-        else:
-            for ss in strs:
-                for s in self._yield_lines(ss):
-                    yield s
-
-    def _parse_requirements(self, strs):
-        """Parse requirement specifiers into a list of requirement strings
-
-        This is forked from pkg_resources.parse_requirements.
-
-        `strs` must be a string, or a (possibly-nested) iterable thereof.
-        """
-        # create a steppable iterator, so we can handle \-continuations
-        lines = iter(self._yield_lines(strs))
-
-        requirements = []
-
-        for line in lines:
-            # Drop comments -- a hash without a space may be in a URL.
-            if ' #' in line:
-                line = line[:line.find(' #')]
-            # If there is a line continuation, drop it, and append the next line.
-            if line.endswith('\\'):
-                line = line[:-2].strip()
-                try:
-                    line += next(lines)
-                except StopIteration:
-                    return
-            requirements.append(line)
-
-        return requirements
 
 def _to_str(s):
     """

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -288,21 +288,17 @@ class TestBuildMetaBackend:
             build_backend.build_sdist("temp")
 
     @pytest.mark.parametrize('setup_literal, requirements', [
-        pytest.param("'foo'", ['foo'], marks=pytest.mark.xfail),
+        ("'foo'", ['foo']),
         ("['foo']", ['foo']),
-        pytest.param(r"'foo\n'", ['foo'], marks=pytest.mark.xfail),
-        pytest.param(r"'foo\n\n'", ['foo'], marks=pytest.mark.xfail),
+        (r"'foo\n'", ['foo']),
+        (r"'foo\n\n'", ['foo']),
         ("['foo', 'bar']", ['foo', 'bar']),
-        pytest.param(r"'# Has a comment line\nfoo'",
-                     ['foo'], marks=pytest.mark.xfail),
-        pytest.param(r"'foo # Has an inline comment'",
-                     ['foo'], marks=pytest.mark.xfail),
-        pytest.param(r"'foo \\\n >=3.0'",
-                     ['foo>=3.0'], marks=pytest.mark.xfail),
-        pytest.param(r"'foo\nbar'", ['foo', 'bar'], marks=pytest.mark.xfail),
-        pytest.param(r"'foo\nbar\n'", ['foo', 'bar'], marks=pytest.mark.xfail),
-        pytest.param(r"['foo\n', 'bar\n']",
-                     ['foo', 'bar'], marks=pytest.mark.xfail),
+        (r"'# Has a comment line\nfoo'", ['foo']),
+        (r"'foo # Has an inline comment'", ['foo']),
+        (r"'foo \\\n >=3.0'", ['foo>=3.0']),
+        (r"'foo\nbar'", ['foo', 'bar']),
+        (r"'foo\nbar\n'", ['foo', 'bar']),
+        (r"['foo\n', 'bar\n']", ['foo', 'bar']),
     ])
     def test_setup_requires(self, setup_literal, requirements, tmpdir_cwd):
 

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -300,7 +300,9 @@ class TestBuildMetaBackend:
         (r"'foo\nbar\n'", ['foo', 'bar']),
         (r"['foo\n', 'bar\n']", ['foo', 'bar']),
     ])
-    def test_setup_requires(self, setup_literal, requirements, tmpdir_cwd):
+    @pytest.mark.parametrize('use_wheel', [True, False])
+    def test_setup_requires(self, setup_literal, requirements, use_wheel,
+                            tmpdir_cwd):
 
         files = {
             'setup.py': DALS("""
@@ -323,9 +325,16 @@ class TestBuildMetaBackend:
 
         build_backend = self.get_build_backend()
 
+        if use_wheel:
+            base_requirements = ['wheel']
+            get_requires = build_backend.get_requires_for_build_wheel
+        else:
+            base_requirements = []
+            get_requires = build_backend.get_requires_for_build_sdist
+
         # Ensure that the build requirements are properly parsed
-        expected = sorted(['wheel'] + requirements)
-        actual = build_backend.get_requires_for_build_wheel()
+        expected = sorted(base_requirements + requirements)
+        actual = get_requires()
 
         assert expected == sorted(actual)
 


### PR DESCRIPTION
## Summary of changes

In the original `setup.py` interface, `setup_requires` would also accept some newline-delimited string format (including comments), but `setuptools.build_meta` assumes that you have passed a `list` when converting `setup_require` to `get_requires_for_*`.

In this PR, I've added this behavior to `setuptools.build_meta`, but an argument could be made for restricting this to `setuptools.build_meta:__legacy__` and requiring a `setup_requires` to take a list in the main `build_meta`.

Closes #1682.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
