### PR TITLE
FIX: git and hg revision checkout under Windows

### DIFF
--- a/changelog.d/1741.change.rst
+++ b/changelog.d/1741.change.rst
@@ -1,1 +1,1 @@
-Fixed revision checkout routine of git and hg repositories under Windows
+In package_index, now honor "current directory" during a checkout of git and hg repositories under Windows

--- a/changelog.d/1741.change.rst
+++ b/changelog.d/1741.change.rst
@@ -1,0 +1,1 @@
+Fixed revision checkout routine of git and hg repositories under Windows

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -897,7 +897,7 @@ class PackageIndex(Environment):
 
         if rev is not None:
             self.info("Checking out %s", rev)
-            os.system("(cd %s && git checkout --quiet %s)" % (
+            os.system("git -C %s checkout --quiet %s" % (
                 filename,
                 rev,
             ))
@@ -913,7 +913,7 @@ class PackageIndex(Environment):
 
         if rev is not None:
             self.info("Updating to %s", rev)
-            os.system("(cd %s && hg up -C -r %s -q)" % (
+            os.system("hg --cwd %s up -C -r %s -q" % (
                 filename,
                 rev,
             ))

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -249,7 +249,7 @@ class TestPackageIndex:
         first_call_args = os_system_mock.call_args_list[0][0]
         assert first_call_args == (expected,)
 
-        tmpl = '(cd {expected_dir} && git checkout --quiet master)'
+        tmpl = 'git -C {expected_dir} checkout --quiet master'
         expected = tmpl.format(**locals())
         assert os_system_mock.call_args_list[1][0] == (expected,)
         assert result == expected_dir


### PR DESCRIPTION
Windows does not change the working directory for a process via `cd .. && <process>` (see e.g. this question: https://stackoverflow.com/q/55641332/8575607 ). This commit replaces the use of `(cd %s && <command>)` with arguments provided by `git` and `hg` respectively.

Closes #1740