### PR TITLE
Limit workers in ProcessPoolExecutor

### DIFF
--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -28,7 +28,7 @@ class BuildBackend(BuildBackendBase):
 
     def __init__(self, *args, **kwargs):
         super(BuildBackend, self).__init__(*args, **kwargs)
-        self.pool = futures.ProcessPoolExecutor()
+        self.pool = futures.ProcessPoolExecutor(max_workers=1)
 
     def __getattr__(self, name):
         """Handles aribrary function invocations on the build backend."""


### PR DESCRIPTION
As a mitigation for #1730, this commit limits the number of workers in the `ProcessPoolExecutor` to 1 (default is the number of CPUs). On PyPy, having a higher number of available workers dramatically increases the number of concurrent processes, leading to some resource exhaustion issues.

This does not address the root issue, but should improve the situation until the root issue is addressed.