### PR TITLE
travis: re-enable coverage for Python 3.8 job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ jobs:
   - <<: *latest_py3
     env: LANG=C
   - python: 3.8-dev
-    env: DISABLE_COVERAGE=1  # Ignore invalid coverage data.
   - <<: *default_py
     stage: deploy (to PyPI for tagged commits)
     if: tag IS present


### PR DESCRIPTION
Now that the issue with invalid coverage data has been fixed.