### PR TITLE
build_meta: fix 2 issues with `build_wheel` / `build_sdist`

### DIFF
--- a/changelog.d/1749.change.rst
+++ b/changelog.d/1749.change.rst
@@ -1,0 +1,1 @@
+Fixed issue with the PEP 517 backend where building a source distribution would fail if any tarball existed in the destination directory.

--- a/changelog.d/1750.change.rst
+++ b/changelog.d/1750.change.rst
@@ -1,0 +1,1 @@
+Fixed an issue with PEP 517 backend where wheel builds would fail if the destination directory did not already exist.


### PR DESCRIPTION
## Summary of changes

Fix the following cases:

* `build_sdist` is called with another sdist already present in the destination directory (#1749)

* `build_wheel` is called with the destination directory not already created


Closes #1749.

### Pull Request Checklist
- [X] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
