### PR TITLE
Support attr directive with static evaluation

### DIFF
--- a/changelog.d/1753.change.rst
+++ b/changelog.d/1753.change.rst
@@ -1,4 +1,4 @@
 ``attr:`` now extracts variables through rudimentary examination of the AST,
-thereby supporting modules with third-party imports.  If examining the AST
+thereby supporting modules with third-party imports. If examining the AST
 fails to find the variable, ``attr:`` falls back to the old behavior of
-importing the module.
+importing the module. Works on Python 3 only.

--- a/changelog.d/1753.change.rst
+++ b/changelog.d/1753.change.rst
@@ -1,0 +1,1 @@
+Added a ``literal_attr:`` config directive to support reading versions from attributes of modules that import third-party modules

--- a/changelog.d/1753.change.rst
+++ b/changelog.d/1753.change.rst
@@ -1,1 +1,4 @@
-Added a ``literal_attr:`` config directive to support reading versions from attributes of modules that import third-party modules
+``attr:`` now extracts variables through rudimentary examination of the AST,
+thereby supporting modules with third-party imports.  If examining the AST
+fails to find the variable, ``attr:`` falls back to the old behavior of
+importing the module.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2193,7 +2193,7 @@ Metadata and options are set in the config sections of the same name.
 * In some cases, complex values can be provided in dedicated subsections for
   clarity.
 
-* Some keys allow ``file:``, ``attr:``, and ``find:`` and ``find_namespace:`` directives in
+* Some keys allow ``file:``, ``attr:``, ``literal_attr:``, ``find:``, and ``find_namespace:`` directives in
   order to cover common usecases.
 
 * Unknown keys are ignored.
@@ -2290,6 +2290,15 @@ Special directives:
 
 * ``attr:`` - Value is read from a module attribute.  ``attr:`` supports
   callables and iterables; unsupported types are cast using ``str()``.
+
+* ``literal_attr:`` — Like ``attr:``, except that the value is parsed using
+  ``ast.literal_eval()`` instead of by importing the module.  This allows one
+  to specify an attribute of a module that imports one or more third-party
+  modules without having to install those modules first; as a downside,
+  ``literal_attr:`` only supports variables that are assigned constant
+  expressions, not more complex assignments like ``__version__ =
+  '.'.join(map(str, (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)))``.
+
 * ``file:`` - Value is read from a list of files and then concatenated
 
 
@@ -2305,14 +2314,14 @@ Metadata
     The aliases given below are supported for compatibility reasons,
     but their use is not advised.
 
-==============================  =================  =================  =============== =====
-Key                             Aliases            Type               Minimum Version Notes
-==============================  =================  =================  =============== =====
+==============================  =================  ================================  =============== =====
+Key                             Aliases            Type                              Minimum Version Notes
+==============================  =================  ================================  =============== =====
 name                                               str
-version                                            attr:, file:, str  39.2.0          (1)
+version                                            attr:, literal_attr:, file:, str  39.2.0          (1)
 url                             home-page          str
 download_url                    download-url       str
-project_urls                                       dict               38.3.0
+project_urls                                       dict                              38.3.0
 author                                             str
 author_email                    author-email       str
 maintainer                                         str
@@ -2323,13 +2332,13 @@ license_file                                       str
 license_files                                      list-comma
 description                     summary            file:, str
 long_description                long-description   file:, str
-long_description_content_type                      str                38.6.0
+long_description_content_type                      str                               38.6.0
 keywords                                           list-comma
 platforms                       platform           list-comma
 provides                                           list-comma
 requires                                           list-comma
 obsoletes                                          list-comma
-==============================  =================  =================  =============== =====
+==============================  =================  ================================  =============== =====
 
 .. note::
     A version loaded using the ``file:`` directive must comply with PEP 440.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2193,7 +2193,7 @@ Metadata and options are set in the config sections of the same name.
 * In some cases, complex values can be provided in dedicated subsections for
   clarity.
 
-* Some keys allow ``file:``, ``attr:``, ``literal_attr:``, ``find:``, and ``find_namespace:`` directives in
+* Some keys allow ``file:``, ``attr:``, ``find:``, and ``find_namespace:`` directives in
   order to cover common usecases.
 
 * Unknown keys are ignored.
@@ -2291,13 +2291,10 @@ Special directives:
 * ``attr:`` - Value is read from a module attribute.  ``attr:`` supports
   callables and iterables; unsupported types are cast using ``str()``.
 
-* ``literal_attr:`` — Like ``attr:``, except that the value is parsed using
-  ``ast.literal_eval()`` instead of by importing the module.  This allows one
-  to specify an attribute of a module that imports one or more third-party
-  modules without having to install those modules first; as a downside,
-  ``literal_attr:`` only supports variables that are assigned constant
-  expressions, not more complex assignments like ``__version__ =
-  '.'.join(map(str, (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)))``.
+  In order to support the common case of a literal value assigned to a variable
+  in a module containing (directly or indirectly) third-party imports,
+  ``attr:`` first tries to read the value from the module by examining the
+  module's AST.  If that fails, ``attr:`` falls back to importing the module.
 
 * ``file:`` - Value is read from a list of files and then concatenated
 
@@ -2314,14 +2311,14 @@ Metadata
     The aliases given below are supported for compatibility reasons,
     but their use is not advised.
 
-==============================  =================  ================================  =============== =====
-Key                             Aliases            Type                              Minimum Version Notes
-==============================  =================  ================================  =============== =====
+==============================  =================  =================  =============== =====
+Key                             Aliases            Type               Minimum Version Notes
+==============================  =================  =================  =============== =====
 name                                               str
-version                                            attr:, literal_attr:, file:, str  39.2.0          (1)
+version                                            attr:, file:, str  39.2.0          (1)
 url                             home-page          str
 download_url                    download-url       str
-project_urls                                       dict                              38.3.0
+project_urls                                       dict               38.3.0
 author                                             str
 author_email                    author-email       str
 maintainer                                         str
@@ -2332,13 +2329,13 @@ license_file                                       str
 license_files                                      list-comma
 description                     summary            file:, str
 long_description                long-description   file:, str
-long_description_content_type                      str                               38.6.0
+long_description_content_type                      str                38.6.0
 keywords                                           list-comma
 platforms                       platform           list-comma
 provides                                           list-comma
 requires                                           list-comma
 obsoletes                                          list-comma
-==============================  =================  ================================  =============== =====
+==============================  =================  =================  =============== =====
 
 .. note::
     A version loaded using the ``file:`` directive must comply with PEP 440.

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -26,7 +26,7 @@ class StaticModule:
     Attempt to load the module by the name
     """
     def __init__(self, name):
-        spec = importlib.util.find_spec(module_name)
+        spec = importlib.util.find_spec(name)
         with open(spec.origin) as strm:
             src = strm.read()
         module = ast.parse(src)

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 from functools import partial
 from functools import wraps
 from importlib import import_module
+import contextlib
 
 from distutils.errors import DistutilsOptionError, DistutilsFileError
 from setuptools.extern.packaging.version import LegacyVersion, parse
@@ -18,6 +19,44 @@ from setuptools.extern.six import string_types, PY3
 
 
 __metaclass__ = type
+
+
+class StaticModule:
+    """
+    Attempt to load the module by the name
+    """
+    def __init__(self, name):
+        spec = importlib.util.find_spec(module_name)
+        with open(spec.origin) as strm:
+            src = strm.read()
+        module = ast.parse(src)
+        vars(self).update(locals())
+        del self.self
+
+    def __getattr__(self, attr):
+        try:
+            return next(
+                ast.literal_eval(statement.value)
+                for statement in self.module.body
+                if isinstance(statement, ast.Assign)
+                for target in statement.targets
+                if isinstance(target, ast.Name) and target.id == attr
+            )
+        except Exception:
+            raise AttributeError(
+                "{self.name} has no attribute {attr}".format(**locals()))
+
+
+@contextlib.contextmanager
+def patch_path(path):
+    """
+    Add path to front of sys.path for the duration of the context.
+    """
+    try:
+        sys.path.insert(0, path)
+        yield
+    finally:
+        sys.path.remove(path)
 
 
 def read_configuration(
@@ -346,50 +385,15 @@ class ConfigHandler:
                 # A custom parent directory was specified for all root modules
                 parent_path = os.path.join(os.getcwd(), package_dir[''])
 
-        fpath = os.path.join(parent_path, *module_name.split('.'))
-        if os.path.exists(fpath + '.py'):
-            fpath += '.py'
-        elif os.path.isdir(fpath):
-            fpath = os.path.join(fpath, '__init__.py')
-        else:
-            raise DistutilsOptionError('Could not find module ' + module_name)
-        with open(fpath, 'rb') as fp:
-            src = fp.read()
-        found = False
-        top_level = ast.parse(src)
-        for statement in top_level.body:
-            if isinstance(statement, ast.Assign):
-                for target in statement.targets:
-                    if isinstance(target, ast.Name) \
-                            and target.id == attr_name:
-                        try:
-                            value = ast.literal_eval(statement.value)
-                        except ValueError:
-                            found = False
-                        else:
-                            found = True
-                    elif isinstance(target, ast.Tuple) \
-                        and any(isinstance(t, ast.Name) and t.id == attr_name
-                                for t in target.elts):
-                        try:
-                            stmnt_value = ast.literal_eval(statement.value)
-                        except ValueError:
-                            found = False
-                        else:
-                            for t, v in zip(target.elts, stmnt_value):
-                                if isinstance(t, ast.Name) \
-                                        and t.id == attr_name:
-                                    value = v
-                                    found = True
-        if not found:
-            # Fall back to extracting attribute via importing
-            sys.path.insert(0, parent_path)
+        with patch_path(parent_path):
             try:
+                # attempt to load value statically
+                return getattr(StaticModule(module_name), attr_name)
+            except Exception:
+                # fallback to simple import
                 module = import_module(module_name)
-                value = getattr(module, attr_name)
-            finally:
-                sys.path = sys.path[1:]
-        return value
+
+        return getattr(module, attr_name)
 
     @classmethod
     def _get_parser_compound(cls, *parse_methods):

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -6,10 +6,10 @@ import sys
 
 import warnings
 import functools
+import importlib
 from collections import defaultdict
 from functools import partial
 from functools import wraps
-from importlib import import_module
 import contextlib
 
 from distutils.errors import DistutilsOptionError, DistutilsFileError
@@ -391,7 +391,7 @@ class ConfigHandler:
                 return getattr(StaticModule(module_name), attr_name)
             except Exception:
                 # fallback to simple import
-                module = import_module(module_name)
+                module = importlib.import_module(module_name)
 
         return getattr(module, attr_name)
 

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -317,22 +317,15 @@ class ConfigHandler:
         Examples:
             attr: package.attr
             attr: package.module.attr
-            literal_attr: package.attr
-            literal_attr: package.module.attr
 
         :param str value:
         :rtype: str
         """
         attr_directive = 'attr:'
-        literal_attr_directive = 'literal_attr:'
-        if value.startswith(attr_directive):
-            directive = attr_directive
-        elif value.startswith(literal_attr_directive):
-            directive = literal_attr_directive
-        else:
+        if not value.startswith(attr_directive):
             return value
 
-        attrs_path = value.replace(directive, '').strip().split('.')
+        attrs_path = value.replace(attr_directive, '').strip().split('.')
         attr_name = attrs_path.pop()
 
         module_name = '.'.join(attrs_path)
@@ -352,50 +345,50 @@ class ConfigHandler:
             elif '' in package_dir:
                 # A custom parent directory was specified for all root modules
                 parent_path = os.path.join(os.getcwd(), package_dir[''])
-        if directive == attr_directive:
+
+        fpath = os.path.join(parent_path, *module_name.split('.'))
+        if os.path.exists(fpath + '.py'):
+            fpath += '.py'
+        elif os.path.isdir(fpath):
+            fpath = os.path.join(fpath, '__init__.py')
+        else:
+            raise DistutilsOptionError('Could not find module ' + module_name)
+        with open(fpath, 'rb') as fp:
+            src = fp.read()
+        found = False
+        top_level = ast.parse(src)
+        for statement in top_level.body:
+            if isinstance(statement, ast.Assign):
+                for target in statement.targets:
+                    if isinstance(target, ast.Name) \
+                            and target.id == attr_name:
+                        try:
+                            value = ast.literal_eval(statement.value)
+                        except ValueError:
+                            found = False
+                        else:
+                            found = True
+                    elif isinstance(target, ast.Tuple) \
+                        and any(isinstance(t, ast.Name) and t.id == attr_name
+                                for t in target.elts):
+                        try:
+                            stmnt_value = ast.literal_eval(statement.value)
+                        except ValueError:
+                            found = False
+                        else:
+                            for t, v in zip(target.elts, stmnt_value):
+                                if isinstance(t, ast.Name) \
+                                        and t.id == attr_name:
+                                    value = v
+                                    found = True
+        if not found:
+            # Fall back to extracting attribute via importing
             sys.path.insert(0, parent_path)
             try:
                 module = import_module(module_name)
                 value = getattr(module, attr_name)
             finally:
                 sys.path = sys.path[1:]
-
-        elif directive == literal_attr_directive:
-            fpath = os.path.join(parent_path, *module_name.split('.'))
-            if os.path.exists(fpath + '.py'):
-                fpath += '.py'
-            elif os.path.isdir(fpath):
-                fpath = os.path.join(fpath, '__init__.py')
-            else:
-                raise DistutilsOptionError(
-                    'Could not find module ' + module_name
-                )
-            with open(fpath, 'rb') as fp:
-                src = fp.read()
-            found = False
-            top_level = ast.parse(src)
-            for statement in top_level.body:
-                if isinstance(statement, ast.Assign):
-                    for target in statement.targets:
-                        if isinstance(target, ast.Name) \
-                                and target.id == attr_name:
-                            value = ast.literal_eval(statement.value)
-                            found = True
-                        elif isinstance(target, ast.Tuple) \
-                            and any(isinstance(t, ast.Name) and t.id==attr_name
-                                    for t in target.elts):
-                                stmnt_value = ast.literal_eval(statement.value)
-                                for t,v in zip(target.elts, stmnt_value):
-                                    if isinstance(t, ast.Name) \
-                                            and t.id == attr_name:
-                                        value = v
-                                        found = True
-            if not found:
-                raise DistutilsOptionError(
-                    'No literal assignment to {!r} found in file'
-                    .format(attr_name)
-                )
-
         return value
 
     @classmethod

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -300,14 +300,14 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
-        subpack.join('submodule.py').write(
+        subpack.join('othersub.py').write(
             'import third_party_module\n'
             'VERSION = (2016, 11, 26)'
         )
 
         config.write(
             '[metadata]\n'
-            'version = attr: fake_package.subpackage.submodule.VERSION\n'
+            'version = attr: fake_package.subpackage.othersub.VERSION\n'
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -54,6 +54,7 @@ def fake_env(
         '    return [3, 4, 5, "dev"]\n'
         '\n'
     )
+
     return package_dir, config
 
 
@@ -268,11 +269,23 @@ class TestMetadata:
 
     def test_version(self, tmpdir):
 
-        _, config = fake_env(
+        package_dir, config = fake_env(
             tmpdir,
             '[metadata]\n'
             'version = attr: fake_package.VERSION\n'
         )
+
+        sub_a = package_dir.mkdir('subpkg_a')
+        sub_a.join('__init__.py').write('')
+        sub_a.join('mod.py').write('VERSION = (2016, 11, 26)')
+
+        sub_b = package_dir.mkdir('subpkg_b')
+        sub_b.join('__init__.py').write('')
+        sub_b.join('mod.py').write(
+            'import third_party_module\n'
+            'VERSION = (2016, 11, 26)'
+        )
+
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1.2.3'
 
@@ -290,23 +303,12 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1'
 
-        sub_a = tmpdir.join('fake_package').mkdir('subpkg_a')
-        sub_a.join('__init__.py').write('')
-        sub_a.join('mod.py').write('VERSION = (2016, 11, 26)')
-
         config.write(
             '[metadata]\n'
             'version = attr: fake_package.subpkg_a.mod.VERSION\n'
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
-
-        sub_b = tmpdir.join('fake_package').mkdir('subpkg_b')
-        sub_b.join('__init__.py').write('')
-        sub_b.join('mod.py').write(
-            'import third_party_module\n'
-            'VERSION = (2016, 11, 26)'
-        )
 
         config.write(
             '[metadata]\n'

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -103,7 +103,7 @@ class TestConfigurationReader:
             'version = attr: none.VERSION\n'
             'keywords = one, two\n'
         )
-        with pytest.raises(DistutilsOptionError):
+        with pytest.raises(ImportError):
             read_configuration('%s' % config)
 
         config_dict = read_configuration(

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import sys
 import contextlib
 
 import pytest
@@ -291,28 +290,27 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1'
 
-        subpack = tmpdir.join('fake_package').mkdir('subpackage')
-        subpack.join('__init__.py').write('')
-        subpack.join('submodule.py').write('VERSION = (2016, 11, 26)')
+        sub_a = tmpdir.join('fake_package').mkdir('subpkg_a')
+        sub_a.join('__init__.py').write('')
+        sub_a.join('mod.py').write('VERSION = (2016, 11, 26)')
 
         config.write(
             '[metadata]\n'
-            'version = attr: fake_package.subpackage.submodule.VERSION\n'
+            'version = attr: fake_package.subpkg_a.mod.VERSION\n'
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
-        del sys.modules['fake_package']
-        del sys.modules['fake_package.subpackage']
-
-        subpack.join('othersub.py').write(
+        sub_b = tmpdir.join('fake_package').mkdir('subpkg_b')
+        sub_b.join('__init__.py').write('')
+        sub_b.join('mod.py').write(
             'import third_party_module\n'
             'VERSION = (2016, 11, 26)'
         )
 
         config.write(
             '[metadata]\n'
-            'version = attr: fake_package.subpackage.othersub.VERSION\n'
+            'version = attr: fake_package.subpkg_b.mod.VERSION\n'
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -300,6 +300,37 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
+    def test_literal_version(self, tmpdir):
+
+        _, config = fake_env(
+            tmpdir,
+            '[metadata]\n'
+            'version = literal_attr: fake_package.VERSION\n'
+        )
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.version == '1.2.3'
+
+        config.write(
+            '[metadata]\n'
+            'version = literal_attr: fake_package.VERSION_MAJOR\n'
+        )
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.version == '1'
+
+        subpack = tmpdir.join('fake_package').mkdir('subpackage')
+        subpack.join('__init__.py').write('')
+        subpack.join('submodule.py').write(
+            'import third_party_module\n'
+            'VERSION = (2016, 11, 26)'
+        )
+
+        config.write(
+            '[metadata]\n'
+            'version = attr: fake_package.subpackage.submodule.VERSION\n'
+        )
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.version == '2016.11.26'
+
     def test_version_file(self, tmpdir):
 
         _, config = fake_env(
@@ -332,6 +363,17 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1.2.3'
 
+        config.write(
+            '[metadata]\n'
+            'version = literal_attr: fake_package_simple.VERSION\n'
+            '[options]\n'
+            'package_dir =\n'
+            '    = src\n'
+        )
+
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.version == '1.2.3'
+
     def test_version_with_package_dir_rename(self, tmpdir):
 
         _, config = fake_env(
@@ -347,6 +389,17 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1.2.3'
 
+        config.write(
+            '[metadata]\n'
+            'version = literal_attr: fake_package_rename.VERSION\n'
+            '[options]\n'
+            'package_dir =\n'
+            '    fake_package_rename = fake_dir\n'
+        )
+
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.version == '1.2.3'
+
     def test_version_with_package_dir_complex(self, tmpdir):
 
         _, config = fake_env(
@@ -357,6 +410,17 @@ class TestMetadata:
             'package_dir =\n'
             '    fake_package_complex = src/fake_dir\n',
             package_path='src/fake_dir'
+        )
+
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.version == '1.2.3'
+
+        config.write(
+            '[metadata]\n'
+            'version = literal_attr: fake_package_complex.VERSION\n'
+            '[options]\n'
+            'package_dir =\n'
+            '    fake_package_complex = src/fake_dir\n'
         )
 
         with get_dist(tmpdir) as dist:

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import sys
 import contextlib
+
 import pytest
 
 from distutils.errors import DistutilsOptionError, DistutilsFileError
@@ -299,6 +301,9 @@ class TestMetadata:
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
+
+        del sys.modules['fake_package']
+        del sys.modules['fake_package.subpackage']
 
         subpack.join('othersub.py').write(
             'import third_party_module\n'

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -103,7 +103,7 @@ class TestConfigurationReader:
             'version = attr: none.VERSION\n'
             'keywords = one, two\n'
         )
-        with pytest.raises(ImportError):
+        with pytest.raises(DistutilsOptionError):
             read_configuration('%s' % config)
 
         config_dict = read_configuration(
@@ -300,25 +300,6 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
-    def test_literal_version(self, tmpdir):
-
-        _, config = fake_env(
-            tmpdir,
-            '[metadata]\n'
-            'version = literal_attr: fake_package.VERSION\n'
-        )
-        with get_dist(tmpdir) as dist:
-            assert dist.metadata.version == '1.2.3'
-
-        config.write(
-            '[metadata]\n'
-            'version = literal_attr: fake_package.VERSION_MAJOR\n'
-        )
-        with get_dist(tmpdir) as dist:
-            assert dist.metadata.version == '1'
-
-        subpack = tmpdir.join('fake_package').mkdir('subpackage')
-        subpack.join('__init__.py').write('')
         subpack.join('submodule.py').write(
             'import third_party_module\n'
             'VERSION = (2016, 11, 26)'
@@ -363,17 +344,6 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1.2.3'
 
-        config.write(
-            '[metadata]\n'
-            'version = literal_attr: fake_package_simple.VERSION\n'
-            '[options]\n'
-            'package_dir =\n'
-            '    = src\n'
-        )
-
-        with get_dist(tmpdir) as dist:
-            assert dist.metadata.version == '1.2.3'
-
     def test_version_with_package_dir_rename(self, tmpdir):
 
         _, config = fake_env(
@@ -389,17 +359,6 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1.2.3'
 
-        config.write(
-            '[metadata]\n'
-            'version = literal_attr: fake_package_rename.VERSION\n'
-            '[options]\n'
-            'package_dir =\n'
-            '    fake_package_rename = fake_dir\n'
-        )
-
-        with get_dist(tmpdir) as dist:
-            assert dist.metadata.version == '1.2.3'
-
     def test_version_with_package_dir_complex(self, tmpdir):
 
         _, config = fake_env(
@@ -410,17 +369,6 @@ class TestMetadata:
             'package_dir =\n'
             '    fake_package_complex = src/fake_dir\n',
             package_path='src/fake_dir'
-        )
-
-        with get_dist(tmpdir) as dist:
-            assert dist.metadata.version == '1.2.3'
-
-        config.write(
-            '[metadata]\n'
-            'version = literal_attr: fake_package_complex.VERSION\n'
-            '[options]\n'
-            'package_dir =\n'
-            '    fake_package_complex = src/fake_dir\n'
         )
 
         with get_dist(tmpdir) as dist:

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -10,6 +10,7 @@ from mock import patch
 from setuptools.dist import Distribution, _Distribution
 from setuptools.config import ConfigHandler, read_configuration
 from setuptools.extern.six.moves import configparser
+from setuptools.extern import six
 from . import py2_only, py3_only
 from .textwrap import DALS
 
@@ -309,6 +310,10 @@ class TestMetadata:
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
+
+        if six.PY2:
+            # static version loading is unsupported on Python 2
+            return
 
         config.write(
             '[metadata]\n'


### PR DESCRIPTION
As I'm sure we all know, the `attr:` config directive for the `version` option in `setup.cfg` doesn't work when the specified module imports one or more third-party packages, thereby forcing package authors to [use a different strategy](https://packaging.python.org/guides/single-sourcing-package-version/).  Proposals have been made (#1316, #1679, others?) to add a function to `setuptools` that encapsulates the necessary code for strategy number 1, but these have been rejected, most recently with [the comment](https://github.com/pypa/setuptools/pull/1679#pullrequestreview-204563938):

> On the other hand, we're already discouraging use of imperative code in setup.py. Most importantly, this behavior doesn't have a comparable syntax in setup.cfg. That is, one cannot specify to load the version from a field in a file through setup.cfg (except for an empty file), meaning it becomes yet another feature that's preventing the adoption of declarative config.

This pull request attempts to address this criticism by implementing the relevant functionality as a `setup.cfg` directive instead of as a user-visible function.

## Summary of changes

- Implement a `literal_attr:` directive that can be used in `version` options in `setup.cfg`.  This directive is like `attr:`, except it extracts the variable assignment with the `ast` module, thereby supporting variables in modules with third-party imports at the cost of being unable to support variables that are not assigned constant expressions.

- Update documentation (The "Minimum Version" column for the `version` option in the table at <https://setuptools.readthedocs.io/en/latest/setuptools.html#metadata> has not been updated, as I'm not sure what the next version of `setuptools` is going to be.) 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details