### PR TITLE
Pinned all requirements in requirements.txt

### DIFF
--- a/changelog.d/1566.change
+++ b/changelog.d/1566.change
@@ -1,0 +1,1 @@
+Pinned all requirements in tests/doc-requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
-sphinx!=1.8.0
-rst.linker>=1.9
-jaraco.packaging>=6.1
-
-setuptools>=34
+sphinx==2.0.1
+rst.linker==1.10
+jaraco.packaging==6.1
+setuptools==40.8.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==2.0.1
+sphinx==1.8.5
 rst.linker==1.10
 jaraco.packaging==6.1
 setuptools==40.8.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 mock==3.0.5
 pytest-flake8==1.0.4; python_version!="3.4"
 pytest-flake8==1.0.0; python_version=="3.4"
-virtualenv==13.0.0
+virtualenv==16.5.0
 pytest-virtualenv==1.6.0
 pytest==3.10.1
 wheel==0.33.4

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ mock==3.0.5
 pytest-flake8==1.0.4; python_version!="3.4"
 pytest-flake8==1.0.0; python_version=="3.4"
 virtualenv==13.0.0
-pytest-virtualenv==1.2.7
+pytest-virtualenv==1.6.0
 pytest==3.10.1
 wheel==0.33.4
 coverage==4.5.1

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,13 +1,12 @@
-mock
-pytest-flake8; python_version!="3.4"
-pytest-flake8<=1.0.0; python_version=="3.4"
-virtualenv>=13.0.0
-pytest-virtualenv>=1.2.7
-# pytest pinned to <4 due to #1638
-pytest>=3.7,<4
-wheel
-coverage>=4.5.1
-pytest-cov>=2.5.1
-paver; python_version>="3.6"
-futures; python_version=="2.7"
+mock==3.0.5
+pytest-flake8==1.0.4; python_version!="3.4"
+pytest-flake8==1.0.0; python_version=="3.4"
+virtualenv==13.0.0
+pytest-virtualenv==1.2.7
+pytest==3.10.1
+wheel==0.33.4
+coverage==4.5.1
+pytest-cov==2.5.1
+paver==1.3.4; python_version>="3.6"
+futures==3.1.1; python_version=="2.7"
 pip==18.1  # Temporary workaround for #1644.


### PR DESCRIPTION
Closes: #1566

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Pinned *all* requirements in the `requirements.txt` files, as per [offical recommendation](https://packaging.python.org/discussions/install-requires-vs-requirements/#install-requires-vs-requirements-files).

This will prevent us from random tests failing whenever one of the unpinned dependency makes an incompatible update. On the downside, one has to update the pinned dependencies every once in a while as a separate commit.


### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
