### PR TITLE
Force metadata-version = 1.2 when project urls are present.

### DIFF
--- a/changelog.d/1756.change.rst
+++ b/changelog.d/1756.change.rst
@@ -1,0 +1,1 @@
+Forse metadata-version >= 1.2. when project urls are present.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -54,7 +54,8 @@ def get_metadata_version(self):
             mv = StrictVersion('2.1')
         elif (self.maintainer is not None or
               self.maintainer_email is not None or
-              getattr(self, 'python_requires', None) is not None):
+              getattr(self, 'python_requires', None) is not None or
+              self.project_urls):
             mv = StrictVersion('1.2')
         elif (self.provides or self.requires or self.obsoletes or
                 self.classifiers or self.download_url):

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -622,6 +622,7 @@ class TestEggInfo:
         assert expected_line in pkg_info_lines
         expected_line = 'Project-URL: Link Two, https://example.com/two/'
         assert expected_line in pkg_info_lines
+        assert 'Metadata-Version: 1.2' in pkg_info_lines
 
     def test_python_requires_egg_info(self, tmpdir_cwd, env):
         self._setup_script_with_requires(


### PR DESCRIPTION
Closes: #1756

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Force `metadata_version` 1.2 in presence of project urls.

I'd have liked to add some tests, but looking at `test_dist.py`, I had no clue how to update any of the existing ones.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
