### PR TITLE
tests: unpin pytest

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,8 +3,7 @@ pytest-flake8; python_version!="3.4"
 pytest-flake8<=1.0.0; python_version=="3.4"
 virtualenv>=13.0.0
 pytest-virtualenv>=1.2.7
-# pytest pinned to <4 due to #1638
-pytest>=3.7,<4
+pytest>=3.7
 wheel
 coverage>=4.5.1
 pytest-cov>=2.5.1


### PR DESCRIPTION
The new releases for pytest-fixture-config and pytest-shutil are compatible with pytest>=4.0.

Close  #1638.