### PR TITLE
Use license classifiers rather than the license field.

### DIFF
--- a/changelog.d/1776.doc.rst
+++ b/changelog.d/1776.doc.rst
@@ -1,0 +1,1 @@
+Use license classifiers rather than the license field.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -136,16 +136,18 @@ dependencies, and perhaps some data files and scripts::
         author="Me",
         author_email="me@example.com",
         description="This is an Example Package",
-        license="PSF",
         keywords="hello world example examples",
         url="http://example.com/HelloWorld/",   # project home page, if any
         project_urls={
             "Bug Tracker": "https://bugs.example.com/HelloWorld/",
             "Documentation": "https://docs.example.com/HelloWorld/",
             "Source Code": "https://code.example.com/HelloWorld/",
-        }
+        },
+        classifiers=[
+            'License :: OSI Approved :: Python Software Foundation License'
+        ]
 
-        # could also include long_description, download_url, classifiers, etc.
+        # could also include long_description, download_url, etc.
     )
 
 In the sections that follow, we'll explain what most of these ``setup()``
@@ -2234,6 +2236,7 @@ boilerplate code in some cases.
     license = BSD 3-Clause License
     classifiers =
         Framework :: Django
+        License :: OSI Approved :: BSD License
         Programming Language :: Python :: 3
         Programming Language :: Python :: 3.5
 


### PR DESCRIPTION
The license field has a 'free' format, while the classifiers are unique
identifiers, similar to SPDX identifiers. In the documentation, we
should therefore showcase the use of classifiers.