### PR TITLE
Fix the specifier regexp.

### DIFF
--- a/pkg_resources/_vendor/packaging/specifiers.py
+++ b/pkg_resources/_vendor/packaging/specifiers.py
@@ -85,7 +85,7 @@ class _IndividualSpecifier(BaseSpecifier):
             raise InvalidSpecifier("Invalid specifier: '{0}'".format(spec))
 
         self._spec = (
-            match.group("operator").strip(),
+            (match.group("operator") or '').strip(),
             match.group("version").strip(),
         )
 
@@ -276,7 +276,7 @@ class Specifier(_IndividualSpecifier):
 
     _regex_str = (
         r"""
-        (?P<operator>(~=|==|!=|<=|>=|<|>|===))
+        (?P<operator>(~=|==|!=|<=|>=|<|>|===))?
         (?P<version>
             (?:
                 # The identity operators allow for an escape hatch that will

--- a/pkg_resources/tests/test_specifiers.py
+++ b/pkg_resources/tests/test_specifiers.py
@@ -1,0 +1,36 @@
+import pytest
+
+from pkg_resources.extern import packaging
+
+
+class TestSpecifier:
+    def testAllOperators(self):
+        for operator in ('', '~=', '==', '!=', '<=', '>=', '<', '>', '==='):
+            specifier = packaging.specifiers.Specifier(operator + '3.5')
+            assert(specifier.operator == operator)
+            assert(specifier.version == '3.5')
+
+    def testVersionFormats(self):
+        # A few versions found as examples in PEP440.
+        versions = [
+            '0.9', '0.9.1', '0.9.2',
+            '2012.04',
+            '1.0a1', '1.0a2', '1.0b1', '1.0rc1',
+            '1.0.dev1', '1.0.post1', '1.0b2.post345.dev456',
+            '1.4.*', '1.4.5.*',
+        ]
+        for version in versions:
+            specifier = packaging.specifiers.Specifier('==' + version)
+            assert(specifier.operator == '==')
+            assert(specifier.version == version)
+
+    def testInvalidSpecifier(self):
+        with pytest.raises(packaging.specifiers.InvalidSpecifier):
+            # This is a Twiddle Wakka operator, used in Ruby.
+            packaging.specifiers.Specifier('~> 2.5')
+
+    def testInvalidCompatibleClause(self):
+        with pytest.raises(packaging.specifiers.InvalidSpecifier):
+            # PEP440 states that "[The compatible release operator] MUST NOT be
+            # used with a single segment version number such as ~=1.
+            packaging.specifiers.Specifier('~= 1')


### PR DESCRIPTION
PEP345 states that the "Requires-Python" metadata field expects version
numbers in the format specified in Version Specifiers, such as:

	Requires-Python: 2.5
	Requires-Python: >2.1
	Requires-Python: >=2.3.4
	Requires-Python: >=2.5,<2.7

This commit makes sure version specifiers without an explicit operator
are valid.

Closes: packaging/issues#107