### PR TITLE
launcher: Fix build with mingw-w64

### DIFF
--- a/launcher.c
+++ b/launcher.c
@@ -37,6 +37,7 @@
 #include <windows.h>
 #include <tchar.h>
 #include <fcntl.h>
+#include <process.h>
 
 int child_pid=0;
 


### PR DESCRIPTION
## Summary of changes

execv() requires process.h to be included according to the MSVC documentation
but for some reason it also works without it.

mingw-w64 on the other hand fails to build the launcher if the include isn't there,
so add it.