### PR TITLE
Fix comment in documentation

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -970,7 +970,7 @@ to do things like this::
         packages=find_packages('src'),  # include all packages under src
         package_dir={'':'src'},   # tell distutils packages are under src
 
-        include_package_data=True,    # include everything in source control
+        include_package_data=True,  # include package data as per MANIFEST.in
 
         # ...but exclude README.txt from all packages
         exclude_package_data={'': ['README.txt']},


### PR DESCRIPTION
Quoting from the same section as the example:

> The data files must be specified via the distutils’ MANIFEST.in file.

It is true that in principle `include_package_data` can also be used to
include files from source control, but to get that behavior you'd need
to configure the appropriate plugin, which is not done in the changed
example.