### PR TITLE
pkg_resources: fix ``Requirement`` hash/equality implementation

### DIFF
--- a/changelog.d/1814.change.rst
+++ b/changelog.d/1814.change.rst
@@ -1,0 +1,1 @@
+Fix ``pkg_resources.Requirement`` hash/equality implementation: take PEP 508 direct URL into account.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -3109,6 +3109,7 @@ class Requirement(packaging.requirements.Requirement):
         self.extras = tuple(map(safe_extra, self.extras))
         self.hashCmp = (
             self.key,
+            self.url,
             self.specifier,
             frozenset(self.extras),
             str(self.marker) if self.marker else None,

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -520,6 +520,11 @@ class TestRequirements:
         assert r1 == r2
         assert str(r1) == str(r2)
         assert str(r2) == "Twisted==1.2c1,>=1.2"
+        assert (
+            Requirement("Twisted")
+            !=
+            Requirement("Twisted @ https://localhost/twisted.zip")
+        )
 
     def testBasicContains(self):
         r = Requirement("Twisted>=1.2")
@@ -546,8 +551,20 @@ class TestRequirements:
             ==
             hash((
                 "twisted",
+                None,
                 packaging.specifiers.SpecifierSet(">=1.2"),
                 frozenset(["foo", "bar"]),
+                None
+            ))
+        )
+        assert (
+            hash(Requirement.parse("Twisted @ https://localhost/twisted.zip"))
+            ==
+            hash((
+                "twisted",
+                "https://localhost/twisted.zip",
+                packaging.specifiers.SpecifierSet(),
+                frozenset(),
                 None
             ))
         )


### PR DESCRIPTION
## Summary of changes

Take PEP 508 direct URL into account.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
