### PR TITLE
Document using asterisk in package_data section

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2416,7 +2416,7 @@ tests_require            list-semi
 include_package_data     bool
 packages                 find:, find_namespace:, list-comma
 package_dir              dict
-package_data             section
+package_data             section                                              (1)
 exclude_package_data     section
 namespace_packages       list-comma
 py_modules               list-comma
@@ -2432,6 +2432,10 @@ data_files               dict                                 40.6.0
     ``where``, ``include``, and ``exclude``.
 
     **find_namespace directive** - The ``find_namespace:`` directive is supported since Python >=3.3.
+
+Notes:
+1. In the `package_data` section, a key named with a single asterisk (`*`)
+refers to all packages, in lieu of the empty string used in `setup.py`.
 
 
 Configuration API


### PR DESCRIPTION
## Summary of changes

While the use of an asterisk key in the `package_data` section of `setup.cfg` is shown in an example, I couldn’t see it documented anywhere in reference material. As I was looking for reference material, not an example, I missed it for quite a while. Add a note to the table.

### Pull Request Checklist
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
  - I thought this was sufficiently trivial as to not require a changelog entry; I will make one if you think otherwise.