### PR TITLE
pep425tags: don't append 'm' to ABI tag in Python 3.8

### DIFF
--- a/changelog.d/1822.change.rst
+++ b/changelog.d/1822.change.rst
@@ -1,0 +1,1 @@
+Fixed use of removed 'm' ABI flag in Python 3.8 on Windows

--- a/setuptools/pep425tags.py
+++ b/setuptools/pep425tags.py
@@ -93,7 +93,9 @@ def get_abi_tag():
             d = 'd'
         if get_flag('WITH_PYMALLOC',
                     lambda: impl == 'cp',
-                    warn=(impl == 'cp')):
+                    warn=(impl == 'cp' and
+                          sys.version_info < (3, 8))) \
+                and sys.version_info < (3, 8):
             m = 'm'
         if get_flag('Py_UNICODE_SIZE',
                     lambda: sys.maxunicode == 0x10ffff,

--- a/setuptools/tests/test_pep425tags.py
+++ b/setuptools/tests/test_pep425tags.py
@@ -29,6 +29,10 @@ class TestPEP425Tags:
         config_vars.update({'SOABI': None})
         base = pep425tags.get_abbr_impl() + pep425tags.get_impl_ver()
 
+        if sys.version_info >= (3, 8):
+            # Python 3.8 removes the m flag, so don't look for it.
+            flags = flags.replace('m', '')
+
         if sys.version_info < (3, 3):
             config_vars.update({'Py_UNICODE_SIZE': 2})
             mock_gcf = self.mock_get_config_var(**config_vars)


### PR DESCRIPTION
This makes changes to the `pep425tags` module following changes made in pip and wheel:
pypa/pip#6874
pypa/wheel#303

It fixes the `get_abi_tag()` function, which appended a `m` flag to the ABI tag on Windows despite this tag no longer existing in Python 3.8.  For more info see:
https://bugs.python.org/issue36707
https://docs.python.org/dev/whatsnew/3.8.html#build-and-c-api-changes

I'm not actually sure whether this function is used anywhere important; my testing was around building and installing wheels and this change didn't seem to be needed, but it is nonetheless good to ensure that the function does the right thing as long as it is there.  As such, I am not sure whether it is critical to get this change into the ensurepip shipped with Python 3.8.