### PR TITLE
Allow (and parse) `[options.cmdclass]` in setup.cfg

### DIFF
--- a/changelog.d/1828.change.rst
+++ b/changelog.d/1828.change.rst
@@ -1,0 +1,1 @@
+Add support for specifying cmdclass in setup.cfg.

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -654,3 +654,11 @@ class ConfigOptionsHandler(ConfigHandler):
         """
         parsed = self._parse_section_to_dict(section_options, self._parse_list)
         self['data_files'] = [(k, v) for k, v in parsed.items()]
+
+    def parse_section_cmdclass(self, section_options):
+        """Parses `cmdclass` configuration file section.
+
+        :param dict section_options:
+        """
+        parsed = self._parse_section_to_dict(section_options, self._parse_attr)
+        self['cmdclass'] = parsed


### PR DESCRIPTION
## Summary of changes

Adds functionality to `ConfigOptionsHandler` to be able to parse `cmdclass` configurations.

I added a test, and you may notice that in my test I put the cmdclass into it's own file, this is because conventionally folks put their command classes into their setup.py, however if we want to specify one via setup.cfg, we must put it outside setup.py in order to reference it via the `attr:` specifier, or you end up invoking `setup()` twice (once during the attribute lookup, and again when it's actually invoked). I thought that this might be why cmdclass wasn't implemented in the first place, but I'm not sure. Let me know if this feature is problematic or warrants further discussion.

Thanks for looking!
