### PR TITLE
Crash when invalid python_requires indicated in setup.cfg

### DIFF
--- a/changelog.d/1847.change.rst
+++ b/changelog.d/1847.change.rst
@@ -1,0 +1,1 @@
+Now traps errors when invalid ``python_requires`` values are supplied.

--- a/changelog.d/1847.change.rst
+++ b/changelog.d/1847.change.rst
@@ -1,1 +1,1 @@
-Now traps errors when invalid ``python_requires`` values are supplied.
+In declarative config, now traps errors when invalid ``python_requires`` values are supplied.

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -12,6 +12,7 @@ from importlib import import_module
 
 from distutils.errors import DistutilsOptionError, DistutilsFileError
 from setuptools.extern.packaging.version import LegacyVersion, parse
+from setuptools.extern.packaging.specifiers import SpecifierSet
 from setuptools.extern.six import string_types, PY3
 
 
@@ -554,6 +555,7 @@ class ConfigOptionsHandler(ConfigHandler):
             'packages': self._parse_packages,
             'entry_points': self._parse_file,
             'py_modules': parse_list,
+            'python_requires': SpecifierSet,
         }
 
     def _parse_packages(self, value):

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -819,6 +819,18 @@ class TestOptions:
             ]
             assert sorted(dist.data_files) == sorted(expected)
 
+    def test_python_requires_invalid(self, tmpdir):
+        fake_env(
+            tmpdir,
+            DALS("""
+            [options]
+            python_requires=invalid
+            """),
+        )
+        with pytest.raises(DistutilsOptionError):
+            with get_dist(tmpdir) as dist:
+                dist.parse_config_files()
+
 
 saved_dist_init = _Distribution.__init__
 

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -819,6 +819,28 @@ class TestOptions:
             ]
             assert sorted(dist.data_files) == sorted(expected)
 
+    def test_python_requires_simple(self, tmpdir):
+        fake_env(
+            tmpdir,
+            DALS("""
+            [options]
+            python_requires=>=2.7
+            """),
+        )
+        with get_dist(tmpdir) as dist:
+            dist.parse_config_files()
+
+    def test_python_requires_compound(self, tmpdir):
+        fake_env(
+            tmpdir,
+            DALS("""
+            [options]
+            python_requires=>=2.7,!=3.0.*
+            """),
+        )
+        with get_dist(tmpdir) as dist:
+            dist.parse_config_files()
+
     def test_python_requires_invalid(self, tmpdir):
         fake_env(
             tmpdir,
@@ -827,7 +849,7 @@ class TestOptions:
             python_requires=invalid
             """),
         )
-        with pytest.raises(DistutilsOptionError):
+        with pytest.raises(Exception):
             with get_dist(tmpdir) as dist:
                 dist.parse_config_files()
 


### PR DESCRIPTION
Closes #1787.

### Pull Request Checklist
- [X] Changes have tests
- [X] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
