### PR TITLE
Upgrade setuptools.depends to importlib from depracated imp

### DIFF
--- a/changelog.d/479.bugfix.rst
+++ b/changelog.d/479.bugfix.rst
@@ -1,0 +1,1 @@
+Replace usage of deprecated ``imp`` module with local re-implementation in ``setuptools._imp``.

--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@ collect_ignore = [
 
 if sys.version_info < (3,):
     collect_ignore.append('setuptools/lib2to3_ex.py')
+    collect_ignore.append('setuptools/_imp.py')
 
 
 if sys.version_info < (3, 6):

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -73,4 +73,4 @@ def _resolve(spec):
 
 def get_module(module, paths, info):
     spec = importlib.util.find_spec(module, paths)
-    return importlib.util.module_from_spec(_resolve(spec))
+    return importlib.util.module_from_spec(spec)

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -4,6 +4,7 @@ from the deprecated imp module.
 """
 
 import os
+import sys
 import importlib.util
 import importlib.machinery
 
@@ -70,7 +71,12 @@ def _resolve(spec):
         else spec
     )
 
+def _module_from_spec(spec):
+    if sys.version_info >= (3, 5):
+        return importlib.util.module_from_spec(spec)
+    else:
+        return spec.loader.load_module(spec.name)
 
 def get_module(module, paths, info):
     spec = importlib.util.find_spec(module, paths)
-    return importlib.util.module_from_spec(spec)
+    return _module_from_spec(spec)

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -60,13 +60,17 @@ def find_module(module, paths=None):
 
 def get_frozen_object(module, paths):
     spec = importlib.util.find_spec(module, paths)
-    if hasattr(spec, 'submodule_search_locations'):
-        spec = importlib.util.spec_from_loader('__init__.py', spec.loader)
-    return spec.loader.get_code(module)
+    return spec.loader.get_code(_resolve(module))
+
+
+def _resolve(spec):
+    return (
+        importlib.util.spec_from_loader('__init__.py', spec.loader)
+        if hasattr(spec, 'submodule_search_locations')
+        else spec
+    )
 
 
 def get_module(module, paths, info):
     spec = importlib.util.find_spec(module, paths)
-    if hasattr(spec, 'submodule_search_locations'):
-        spec = importlib.util.spec_from_loader('__init__.py', spec.loader)
-    return importlib.util.module_from_spec(spec)
+    return importlib.util.module_from_spec(_resolve(spec))

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -60,11 +60,15 @@ def find_module(module, paths=None):
     return file, path, (suffix, mode, kind)
 
 
-def get_frozen_object(module, paths):
+def get_frozen_object(module, paths=None):
     spec = importlib.util.find_spec(module, paths)
-    return spec.loader.get_code(_resolve(module))
+    if not spec:
+        raise ImportError("Can't find %s" % module)
+    return spec.loader.get_code(module)
 
 
 def get_module(module, paths, info):
     spec = importlib.util.find_spec(module, paths)
+    if not spec:
+        raise ImportError("Can't find %s" % module)
     return module_from_spec(spec)

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -1,0 +1,72 @@
+"""
+Re-implementation of find_module and get_frozen_object
+from the deprecated imp module.
+"""
+
+import os
+import importlib.util
+import importlib.machinery
+
+
+PY_SOURCE = 1
+PY_COMPILED = 2
+C_EXTENSION = 3
+C_BUILTIN = 6
+PY_FROZEN = 7
+
+
+def find_module(module, paths=None):
+    """
+    """
+    spec = importlib.util.find_spec(module, paths)
+    if spec is None:
+        raise ImportError("Can't find %s" % module)
+    if not spec.has_location and hasattr(spec, 'submodule_search_locations'):
+        spec = importlib.util.spec_from_loader('__init__.py', spec.loader)
+
+    kind = -1
+    file = None
+    static = isinstance(spec.loader, type)
+    if spec.origin == 'frozen' or static and issubclass(
+            spec.loader, importlib.machinery.FrozenImporter):
+        kind = PY_FROZEN
+        path = None  # imp compabilty
+        suffix = mode = ''  # imp compability
+    elif spec.origin == 'built-in' or static and issubclass(
+            spec.loader, importlib.machinery.BuiltinImporter):
+        kind = C_BUILTIN
+        path = None  # imp compabilty
+        suffix = mode = ''  # imp compability
+    elif spec.has_location:
+        path = spec.origin
+        suffix = os.path.splitext(path)[1]
+        mode = 'r' if suffix in importlib.machinery.SOURCE_SUFFIXES else 'rb'
+
+        if suffix in importlib.machinery.SOURCE_SUFFIXES:
+            kind = PY_SOURCE
+        elif suffix in importlib.machinery.BYTECODE_SUFFIXES:
+            kind = PY_COMPILED
+        elif suffix in importlib.machinery.EXTENSION_SUFFIXES:
+            kind = C_EXTENSION
+
+        if kind in {PY_SOURCE, PY_COMPILED}:
+            file = open(path, mode)
+    else:
+        path = None
+        suffix = mode = ''
+
+    return file, path, (suffix, mode, kind)
+
+
+def get_frozen_object(module, paths):
+    spec = importlib.util.find_spec(module, paths)
+    if hasattr(spec, 'submodule_search_locations'):
+        spec = importlib.util.spec_from_loader('__init__.py', spec.loader)
+    return spec.loader.get_code(module)
+
+
+def get_module(module, paths, info):
+    spec = importlib.util.find_spec(module, paths)
+    if hasattr(spec, 'submodule_search_locations'):
+        spec = importlib.util.spec_from_loader('__init__.py', spec.loader)
+    return importlib.util.module_from_spec(spec)

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -63,13 +63,6 @@ def get_frozen_object(module, paths):
     return spec.loader.get_code(_resolve(module))
 
 
-def _resolve(spec):
-    return (
-        importlib.util.spec_from_loader('__init__.py', spec.loader)
-        if hasattr(spec, 'submodule_search_locations')
-        else spec
-    )
-
 def _module_from_spec(spec):
     if sys.version_info >= (3, 5):
         return importlib.util.module_from_spec(spec)

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -17,8 +17,7 @@ PY_FROZEN = 7
 
 
 def find_module(module, paths=None):
-    """
-    """
+    """Just like 'imp.find_module()', but with package support"""
     spec = importlib.util.find_spec(module, paths)
     if spec is None:
         raise ImportError("Can't find %s" % module)

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -4,7 +4,6 @@ from the deprecated imp module.
 """
 
 import os
-import sys
 import importlib.util
 import importlib.machinery
 

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -8,6 +8,8 @@ import sys
 import importlib.util
 import importlib.machinery
 
+from .py34compat import module_from_spec
+
 
 PY_SOURCE = 1
 PY_COMPILED = 2
@@ -63,12 +65,6 @@ def get_frozen_object(module, paths):
     return spec.loader.get_code(_resolve(module))
 
 
-def _module_from_spec(spec):
-    if sys.version_info >= (3, 5):
-        return importlib.util.module_from_spec(spec)
-    else:
-        return spec.loader.load_module(spec.name)
-
 def get_module(module, paths, info):
     spec = importlib.util.find_spec(module, paths)
-    return _module_from_spec(spec)
+    return module_from_spec(spec)

--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -1,22 +1,11 @@
 import sys
 import marshal
 from distutils.version import StrictVersion
-from setuptools.extern import six
 
 from .py33compat import Bytecode
 
-if six.PY2:
-    import imp
-    from imp import PKG_DIRECTORY, PY_COMPILED, PY_SOURCE, PY_FROZEN
-else:
-    import os.path
-    from importlib.util import find_spec, spec_from_loader
-    from importlib.machinery import SOURCE_SUFFIXES, BYTECODE_SUFFIXES, EXTENSION_SUFFIXES, BuiltinImporter, FrozenImporter
-    PY_SOURCE = 1
-    PY_COMPILED = 2
-    C_EXTENSION = 3
-    C_BUILTIN = 6
-    PY_FROZEN = 7
+from .py27compat import find_module, PY_COMPILED, PY_FROZEN, PY_SOURCE
+from . import py27compat
 
 
 __all__ = [
@@ -27,7 +16,8 @@ __all__ = [
 class Require:
     """A prerequisite to building or installing a distribution"""
 
-    def __init__(self, name, requested_version, module, homepage='',
+    def __init__(
+            self, name, requested_version, module, homepage='',
             attribute=None, format=None):
 
         if format is None and requested_version is not None:
@@ -91,63 +81,6 @@ class Require:
         return self.version_ok(version)
 
 
-def find_module(module, paths=None):
-    """Just like 'imp.find_module()', but with package support"""
-    if six.PY3:
-        spec = find_spec(module, paths)
-        if spec is None:
-            raise ImportError("Can't find %s" % module)
-        if not spec.has_location and hasattr(spec, 'submodule_search_locations'):
-            spec = spec_from_loader('__init__.py', spec.loader)
-
-        kind = -1
-        file = None
-        static = isinstance(spec.loader, type)
-        if spec.origin == 'frozen' or static and issubclass(spec.loader, FrozenImporter):
-            kind = PY_FROZEN
-            path = None # imp compabilty
-            suffix = mode = '' # imp compability
-        elif spec.origin == 'built-in' or static and issubclass(spec.loader, BuiltinImporter):
-            kind = C_BUILTIN
-            path = None # imp compabilty
-            suffix = mode = '' # imp compability
-        elif spec.has_location:
-            frozen = False
-            path = spec.origin
-            suffix = os.path.splitext(path)[1]
-            mode = 'r' if suffix in SOURCE_SUFFIXES else 'rb'
-
-            if suffix in SOURCE_SUFFIXES:
-                kind = PY_SOURCE
-            elif suffix in BYTECODE_SUFFIXES:
-                kind = PY_COMPILED
-            elif suffix in EXTENSION_SUFFIXES:
-                kind = C_EXTENSION
-
-            if kind in {PY_SOURCE, PY_COMPILED}:
-                file = open(path, mode)
-        else:
-            path = None
-            suffix = mode= ''
-
-        return file, path, (suffix, mode, kind)
-
-    else:
-        parts = module.split('.')
-        while parts:
-            part = parts.pop(0)
-            f, path, (suffix, mode, kind) = info = imp.find_module(part, paths)
-
-            if kind == PKG_DIRECTORY:
-                parts = parts or ['__init__']
-                paths = [path]
-
-            elif parts:
-                raise ImportError("Can't find %r in %s" % (parts, module))
-
-        return info
-
-
 def get_module_constant(module, symbol, default=-1, paths=None):
     """Find 'module' by searching 'paths', and extract 'symbol'
 
@@ -156,35 +89,23 @@ def get_module_constant(module, symbol, default=-1, paths=None):
     constant.  Otherwise, return 'default'."""
 
     try:
-        f, path, (suffix, mode, kind) = find_module(module, paths)
+        f, path, (suffix, mode, kind) = info = find_module(module, paths)
     except ImportError:
         # Module doesn't exist
         return None
-
-    if six.PY3:
-        spec = find_spec(module, paths)
-        if hasattr(spec, 'submodule_search_locations'):
-            spec = spec_from_loader('__init__.py', spec.loader)
 
     try:
         if kind == PY_COMPILED:
             f.read(8)  # skip magic & date
             code = marshal.load(f)
         elif kind == PY_FROZEN:
-            if six.PY2:
-                code = imp.get_frozen_object(module)
-            else:
-                code = spec.loader.get_code(module)
+            code = py27compat.get_frozen_object(module, paths)
         elif kind == PY_SOURCE:
             code = compile(f.read(), path, 'exec')
         else:
             # Not something we can parse; we'll have to import it.  :(
-            if module not in sys.modules:
-                if six.PY2:
-                    imp.load_module(module, f, path, (suffix, mode, kind))
-                else:
-                    sys.modules[module] = module_from_spec(spec)
-            return getattr(sys.modules[module], symbol, None)
+            imported = py27compat.get_module(module, paths, info)
+            return getattr(imported, symbol, None)
 
     finally:
         if f:

--- a/setuptools/py27compat.py
+++ b/setuptools/py27compat.py
@@ -2,6 +2,7 @@
 Compatibility Support for Python 2.7 and earlier
 """
 
+import sys
 import platform
 
 from setuptools.extern import six
@@ -26,3 +27,34 @@ linux_py2_ascii = (
 
 rmtree_safe = str if linux_py2_ascii else lambda x: x
 """Workaround for http://bugs.python.org/issue24672"""
+
+
+try:
+    from ._imp import find_module, PY_COMPILED, PY_FROZEN, PY_SOURCE
+    from ._imp import get_frozen_object, get_module
+except ImportError:
+    import imp
+    from imp import PY_COMPILED, PY_FROZEN, PY_SOURCE  # noqa
+
+    def find_module(module, paths=None):
+        """Just like 'imp.find_module()', but with package support"""
+        parts = module.split('.')
+        while parts:
+            part = parts.pop(0)
+            f, path, (suffix, mode, kind) = info = imp.find_module(part, paths)
+
+            if kind == imp.PKG_DIRECTORY:
+                parts = parts or ['__init__']
+                paths = [path]
+
+            elif parts:
+                raise ImportError("Can't find %r in %s" % (parts, module))
+
+        return info
+
+    def get_frozen_object(module, paths):
+        return imp.get_frozen_object(module)
+
+    def get_module(module, paths, info):
+        imp.load_module(*info)
+        return sys.modules[module]

--- a/setuptools/py27compat.py
+++ b/setuptools/py27compat.py
@@ -56,5 +56,5 @@ except ImportError:
         return imp.get_frozen_object(module)
 
     def get_module(module, paths, info):
-        imp.load_module(*info)
+        imp.load_module(module, *info)
         return sys.modules[module]

--- a/setuptools/py34compat.py
+++ b/setuptools/py34compat.py
@@ -1,4 +1,4 @@
-import importlib.util
+import importlib
 
 
 try:

--- a/setuptools/py34compat.py
+++ b/setuptools/py34compat.py
@@ -1,5 +1,10 @@
 import importlib
 
+try:
+    import importlib.util
+except ImportError:
+    pass
+
 
 try:
     module_from_spec = importlib.util.module_from_spec

--- a/setuptools/py34compat.py
+++ b/setuptools/py34compat.py
@@ -1,0 +1,8 @@
+import importlib.util
+
+
+try:
+    module_from_spec = importlib.util.module_from_spec
+except AttributeError:
+    def module_from_spec(spec):
+        return spec.loader.load_module(spec.name)

--- a/setuptools/tests/test_integration.py
+++ b/setuptools/tests/test_integration.py
@@ -143,6 +143,7 @@ def test_build_deps_on_distutils(request, tmpdir_factory, build_dep):
             'tests_require',
             'python_requires',
             'install_requires',
+            'long_description_content_type',
         ]
         assert not match or match.group(1).strip('"\'') in allowed_unknowns
 

--- a/setuptools/tests/test_integration.py
+++ b/setuptools/tests/test_integration.py
@@ -143,7 +143,6 @@ def test_build_deps_on_distutils(request, tmpdir_factory, build_dep):
             'tests_require',
             'python_requires',
             'install_requires',
-            'long_description_content_type',
         ]
         assert not match or match.group(1).strip('"\'') in allowed_unknowns
 


### PR DESCRIPTION
### Summary
Fix;
```console
(.venv) batuhan@x200-trisquel:~/astor$ python setup.py develop
/home/batuhan/.venv/lib/python3.8/site-packages/setuptools/depends.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details (already added about same subject
