### PR TITLE
Small documentation tweaks

### DIFF
--- a/changelog.d/1860.doc.rst
+++ b/changelog.d/1860.doc.rst
@@ -1,0 +1,1 @@
+Update documentation to mention the egg format is not supported by pip and dependency links support was dropped starting with pip 19.0.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -675,6 +675,10 @@ using ``setup.py develop``.)
 Dependencies that aren't in PyPI
 --------------------------------
 
+.. warning::
+    Dependency links support has been dropped by pip starting with version
+    19.0 (released 2019-01-22).
+
 If your project depends on packages that don't exist on PyPI, you may still be
 able to depend on them, as long as they are available for download as:
 

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -1693,6 +1693,9 @@ file locations.
 ``bdist_egg`` - Create a Python Egg for the project
 ===================================================
 
+.. warning::
+    **eggs** are deprecated in favor of wheels, and not supported by pip.
+
 This command generates a Python Egg (``.egg`` file) for the project.  Python
 Eggs are the preferred binary distribution format for EasyInstall, because they
 are cross-platform (for "pure" packages), directly importable, and contain


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
 
* mention dependency links support was dropped in pip 19.0
* mention eggs are deprecated and not supported by pip

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
