### PR TITLE
improve workaround for #1644

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts=--doctest-modules --doctest-glob=pkg_resources/api_tests.txt -r sxX
-norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern .*
+norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern tools .*
 flake8-ignore =
     setuptools/site-patch.py F821
     setuptools/py*compat.py F811

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -9,4 +9,3 @@ coverage>=4.5.1
 pytest-cov>=2.5.1
 paver; python_version>="3.6"
 futures; python_version=="2.7"
-pip==18.1  # Temporary workaround for #1644.

--- a/tools/tox_pip.py
+++ b/tools/tox_pip.py
@@ -1,0 +1,29 @@
+import os
+import shutil
+import subprocess
+import sys
+from glob import glob
+
+VIRTUAL_ENV = os.environ['VIRTUAL_ENV']
+TOX_PIP_DIR = os.path.join(VIRTUAL_ENV, 'pip')
+
+
+def pip(args):
+    # First things first, get a recent (stable) version of pip.
+    if not os.path.exists(TOX_PIP_DIR):
+        subprocess.check_call([sys.executable, '-m', 'pip',
+                               '--disable-pip-version-check',
+                               'install', '-t', TOX_PIP_DIR,
+                               'pip'])
+        shutil.rmtree(glob(os.path.join(TOX_PIP_DIR, 'pip-*.dist-info'))[0])
+    # And use that version.
+    for n, a in enumerate(args):
+        if not a.startswith('-'):
+            if a in 'install' and '-e' in args[n:]:
+                args.insert(n + 1, '--no-use-pep517')
+            break
+    subprocess.check_call([sys.executable, os.path.join(TOX_PIP_DIR, 'pip')] + args)
+
+
+if __name__ == '__main__':
+    pip(sys.argv[1:])

--- a/tox.ini
+++ b/tox.ini
@@ -7,14 +7,16 @@
 [tox]
 envlist=python
 
+[helpers]
+# Wrapper for calls to pip that make sure the version being used is a
+# up-to-date, and to prevent the current working directory from being
+# added to `sys.path`.
+pip = python {toxinidir}/tools/tox_pip.py
+
 [testenv]
 deps=-rtests/requirements.txt
-# Changed from default (`python -m pip ...`)
-# to prevent the current working directory
-# from being added to `sys.path`.
-install_command=python -c 'import sys; sys.path.remove(""); from pkg_resources import load_entry_point; load_entry_point("pip", "console_scripts", "pip")()' install {opts} {packages}
-# Same as above.
-list_dependencies_command={envbindir}/pip freeze --all
+install_command = {[helpers]pip} install {opts} {packages}
+list_dependencies_command = {[helpers]pip} freeze --all
 setenv=COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 # TODO: The passed environment variables came from copying other tox.ini files
 # These should probably be individually annotated to explain what needs them.


### PR DESCRIPTION
Make it possible to use a more recent version of pip for tests. Necessary for #1830.