### PR TITLE
Deprecate the test command

### DIFF
--- a/changelog.d/1878.change.rst
+++ b/changelog.d/1878.change.rst
@@ -1,0 +1,1 @@
+Formally deprecated the ``test`` command, with the recommendation that users migrate to ``tox``.

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -346,6 +346,8 @@ unless you need the associated ``setuptools`` feature.
     specified test suite, e.g. via ``setup.py test``.  See the section on the
     `test`_ command below for more details.
 
+    New in 41.5.0: Deprecated the test command.
+
 ``tests_require``
     If your project's tests need one or more additional packages besides those
     needed to install it, you can use this option to specify them.  It should
@@ -356,6 +358,8 @@ unless you need the associated ``setuptools`` feature.
     required projects will *not* be installed on the system where the tests
     are run, but only downloaded to the project's setup directory if they're
     not already installed locally.
+
+    New in 41.5.0: Deprecated the test command.
 
 .. _test_loader:
 
@@ -379,6 +383,8 @@ unless you need the associated ``setuptools`` feature.
     The module and class you specify here may be contained in another package,
     as long as you use the ``tests_require`` option to ensure that the package
     containing the loader class is available when the ``test`` command is run.
+
+    New in 41.5.0: Deprecated the test command.
 
 ``eager_resources``
     A list of strings naming resources that should be extracted together, if
@@ -2142,6 +2148,11 @@ distutils configuration file the option will be added to (or removed from).
 ``test`` - Build package and run a unittest suite
 =================================================
 
+.. warning::
+    ``test`` is deprecated and will be removed in a future version. Users
+    looking for a generic test entry point independent of test runner are
+    encouraged to use `tox <https://tox.readthedocs.io>`_.
+
 When doing test-driven development, or running automated builds that need
 testing before they are deployed for downloading or use, it's often useful
 to be able to run a project's unit tests without actually deploying the project
@@ -2186,6 +2197,8 @@ available:
 
     If you did not set a ``test_suite`` in your ``setup()`` call, and do not
     provide a ``--test-suite`` option, an error will occur.
+
+New in 41.5.0: Deprecated the test command.
 
 
 .. _upload:

--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -74,7 +74,7 @@ class NonDataProperty:
 class test(Command):
     """Command to run unit tests after in-place build"""
 
-    description = "run unit tests after in-place build"
+    description = "run unit tests after in-place build (deprecated)"
 
     user_options = [
         ('test-module=', 'm', "Run 'test_suite' in specified module"),
@@ -214,6 +214,14 @@ class test(Command):
         return itertools.chain(ir_d, tr_d, er_d)
 
     def run(self):
+        self.announce(
+            "WARNING: Testing via this command is deprecated and will be "
+            "removed in a future version. Users looking for a generic test "
+            "entry point independent of test runner are encouraged to use "
+            "tox.",
+            log.WARN,
+        )
+
         installed_dists = self.install_dists(self.distribution)
 
         cmd = ' '.join(self._argv)


### PR DESCRIPTION
Refs #1684

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
