### PR TITLE
Change coding cookie to use utf-8 (lowercase)

### DIFF
--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import contextlib

--- a/setuptools/tests/test_test.py
+++ b/setuptools/tests/test_test.py
@@ -1,4 +1,4 @@
-# -*- coding: UTF-8 -*-
+# -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
 


### PR DESCRIPTION
While perfectly valid, the encoding 'UTF-8' (uppercase) is not
recognized by the Emacs MULE system. As such, it displays the following
warning when opening a file with it used as an encoding cookie:

    Warning (mule): Invalid coding system ‘UTF-8’ is specified
    for the current buffer/file by the :coding tag.
    It is highly recommended to fix it before writing to a file.

Some discussion of this can be found at:

https://stackoverflow.com/questions/14031724/how-to-make-emacs-accept-utf-8-uppercase-encoding

While the post does offer a workaround for Emacs users, rather than ask
all to implement it, use the more typical utf-8 (lowercase).