### PR TITLE
Document support for Python 3.8 through a trove classifier

### DIFF
--- a/changelog.d/1884.doc.rst
+++ b/changelog.d/1884.doc.rst
@@ -1,0 +1,1 @@
+Added a trove classifier to document support for Python 3.8.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: System :: Archiving :: Packaging
     Topic :: System :: Systems Administration


### PR DESCRIPTION
Travis has official support for the Python 3.8 release, so can use that instead of 3.8-dev.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
