### PR TITLE
Add info message on package index auth error 

### DIFF
--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -348,6 +348,8 @@ class PackageIndex(Environment):
         f = self.open_url(url, tmpl % url)
         if f is None:
             return
+        if isinstance(f, urllib.error.HTTPError) and f.code == 401:
+            self.info("Authentication error: %s" % f.msg)
         self.fetched_urls[f.url] = True
         if 'html' not in f.headers.get('content-type', '').lower():
             f.close()  # not html, we can't process it


### PR DESCRIPTION
When an authentication error occurs fetching the package index, it's difficult to tell the cause of the error.  This PR adds a short error message that indicates an authentication error occured.

Before:

    Searching for flask
    Reading http://localhost:8081/repository/pypi-proxy/simple/flask/
    Couldn't find index page for 'flask' (maybe misspelled?)
    Scanning index of all packages (this may take a while)
    Reading http://localhost:8081/repository/pypi-proxy/simple/
    No local packages or working download links found for flask
    error: Could not find suitable distribution for Requirement.parse('flask')

After:

    Searching for flask
    Reading http://localhost:8081/repository/pypi-proxy/simple/flask/
    Authentication error: Unauthorized
    Couldn't find index page for 'flask' (maybe misspelled?)
    Scanning index of all packages (this may take a while)
    Reading http://localhost:8081/repository/pypi-proxy/simple/
    No local packages or working download links found for flask
    error: Could not find suitable distribution for Requirement.parse('flask')
