### PR TITLE
tests: fix some pytest warnings under Python 2

### DIFF
--- a/setuptools/tests/test_integration.py
+++ b/setuptools/tests/test_integration.py
@@ -64,7 +64,7 @@ def install_context(request, tmpdir, monkeypatch):
     monkeypatch.setattr('site.USER_BASE', user_base.strpath)
     monkeypatch.setattr('site.USER_SITE', user_site.strpath)
     monkeypatch.setattr('sys.path', sys.path + [install_dir.strpath])
-    monkeypatch.setenv('PYTHONPATH', os.path.pathsep.join(sys.path))
+    monkeypatch.setenv(str('PYTHONPATH'), str(os.path.pathsep.join(sys.path)))
 
     # Set up the command for performing the installation.
     dist = Distribution()


### PR DESCRIPTION
Fix those warnings:
```
setuptools/tests/test_integration.py:67: PytestWarning: Value of environment variable PYTHONPATH type should be str, but got u'...' (type: unicode); converted to str implicitly
    monkeypatch.setenv('PYTHONPATH', os.path.pathsep.join(sys.path))
```