### PR TITLE
drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ jobs:
     env: DISABLE_COVERAGE=1  # Don't run coverage on pypy (too slow).
   - python: pypy3
     env: DISABLE_COVERAGE=1
-  - python: 3.4
   - python: 3.5
   - &default_py
     python: 3.6

--- a/changelog.d/1908.breaking.rst
+++ b/changelog.d/1908.breaking.rst
@@ -1,0 +1,1 @@
+Drop support for Python 3.4.

--- a/docs/easy_install.txt
+++ b/docs/easy_install.txt
@@ -41,7 +41,7 @@ Please see the `setuptools PyPI page <https://pypi.org/project/setuptools/>`_
 for download links and basic installation instructions for each of the
 supported platforms.
 
-You will need at least Python 3.4 or 2.7.  An ``easy_install`` script will be
+You will need at least Python 3.5 or 2.7.  An ``easy_install`` script will be
 installed in the normal location for Python scripts on your platform.
 
 Note that the instructions on the setuptools PyPI page assume that you are

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -88,8 +88,8 @@ __import__('pkg_resources.extern.packaging.markers')
 __metaclass__ = type
 
 
-if (3, 0) < sys.version_info < (3, 4):
-    raise RuntimeError("Python 3.4 or later is required")
+if (3, 0) < sys.version_info < (3, 5):
+    raise RuntimeError("Python 3.5 or later is required")
 
 if six.PY2:
     # Those builtin exceptions are only defined in Python 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ classifiers =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
@@ -50,7 +49,7 @@ classifiers =
 
 [options]
 zip_safe = True
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
 py_modules = easy_install
 packages = find:
 

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -77,11 +77,8 @@ def _get_pip_versions():
         'pip==10.0.1',
         'pip==18.1',
         'pip==19.0.1',
+        'https://github.com/pypa/pip/archive/master.zip',
     ]
-
-    # Pip's master dropped support for 3.4.
-    if not six.PY34:
-        network_versions.append('https://github.com/pypa/pip/archive/master.zip')
 
     versions = [None] + [
         pytest.param(v, **({} if network else {'marks': pytest.mark.skip}))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
 mock
-pytest-flake8; python_version!="3.4"
-pytest-flake8<=1.0.0; python_version=="3.4"
+pytest-flake8
 virtualenv>=13.0.0
 pytest-virtualenv>=1.2.7
 pytest>=3.7

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 #
 # To run Tox against all supported Python interpreters, you can set:
 #
-# export TOXENV='py27,py3{4,5,6},pypy,pypy3'
+# export TOXENV='py27,py3{5,6,7,8},pypy,pypy3'
 
 [tox]
 envlist=python


### PR DESCRIPTION
### Summary of changes

Drop support for Python 3.4, which reached end-of-life in March 2019.

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
