### PR TITLE
wheel: fix `is_compatible` implementation

### DIFF
--- a/changelog.d/1918.change.rst
+++ b/changelog.d/1918.change.rst
@@ -1,0 +1,1 @@
+Fix regression in handling wheels compatibility tags.

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -18,6 +18,7 @@ import pytest
 
 from pkg_resources import Distribution, PathMetadata, PY_MAJOR
 from setuptools.extern.packaging.utils import canonicalize_name
+from setuptools.extern.packaging.tags import parse_tag
 from setuptools.wheel import Wheel
 
 from .contexts import tempdir
@@ -571,3 +572,11 @@ def test_wheel_no_dist_dir():
                 _check_wheel_install(wheel_path, install_dir, None,
                                      project_name,
                                      version, None)
+
+
+def test_wheel_is_compatible(monkeypatch):
+    def sys_tags():
+        for t in parse_tag('cp36-cp36m-manylinux1_x86_64'):
+            yield t
+    monkeypatch.setattr('setuptools.wheel.sys_tags', sys_tags)
+    assert Wheel('onnxruntime-0.1.2-cp36-cp36m-manylinux1_x86_64.whl').is_compatible()

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -77,7 +77,7 @@ class Wheel:
 
     def is_compatible(self):
         '''Is the wheel is compatible with the current platform?'''
-        supported_tags = set(map(str, sys_tags()))
+        supported_tags = set((t.interpreter, t.abi, t.platform) for t in sys_tags())
         return next((True for t in self.tags() if t in supported_tags), False)
 
     def egg_name(self):


### PR DESCRIPTION
### Summary of changes

Fix `Wheel.is_compatible` implementation, which I bungled in #1829.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
