### PR TITLE
fix support for easy_install's find-links option in setup.cfg

### DIFF
--- a/changelog.d/1921.change.txt
+++ b/changelog.d/1921.change.txt
@@ -1,0 +1,1 @@
+Fix support for easy_install's ``find-links`` option in ``setup.cfg``. 

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -7,9 +7,18 @@ from distutils.errors import DistutilsError
 
 import pkg_resources
 from setuptools.command.easy_install import easy_install
+from setuptools.extern import six
 from setuptools.wheel import Wheel
 
 from .py31compat import TemporaryDirectory
+
+
+def _fixup_find_links(find_links):
+    """Ensure find-links option end-up being a list of strings."""
+    if isinstance(find_links, six.string_types):
+        return find_links.split()
+    assert isinstance(find_links, (tuple, list))
+    return find_links
 
 
 def _legacy_fetch_build_egg(dist, req):
@@ -31,7 +40,7 @@ def _legacy_fetch_build_egg(dist, req):
     if dist.dependency_links:
         links = dist.dependency_links[:]
         if 'find_links' in opts:
-            links = opts['find_links'][1] + links
+            links = _fixup_find_links(opts['find_links'][1]) + links
         opts['find_links'] = ('setup', links)
     install_dir = dist.get_egg_cache_dir()
     cmd = easy_install(
@@ -84,7 +93,7 @@ def fetch_build_egg(dist, req):
     else:
         index_url = None
     if 'find_links' in opts:
-        find_links = opts['find_links'][1][:]
+        find_links = _fixup_find_links(opts['find_links'][1])[:]
     else:
         find_links = []
     if dist.dependency_links:


### PR DESCRIPTION
###  Summary of changes

The easy_install's `find-links` option can sometime be a string (and not a list of string), e.g. when its value comes from `setup.cfg` (see handling in [easy_install own code](https://github.com/pypa/setuptools/blob/master/setuptools/command/easy_install.py#L345)).

Ensure it's similarly handled in `fetch_build_egg`.<!-- Summary goes here -->

Closes #1920, #1375, and probably #1880.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
