### PR TITLE
fix possible issue with transitive build dependencies

### DIFF
--- a/changelog.d/1922.change.rst
+++ b/changelog.d/1922.change.rst
@@ -1,1 +1,1 @@
-Fix possible issue with transitive build dependencies.
+Build dependencies (setup_requires and tests_require) now install transitive dependencies indicated by extras.

--- a/changelog.d/1922.change.rst
+++ b/changelog.d/1922.change.rst
@@ -1,0 +1,1 @@
+Fix possible issue with transitive build dependencies.

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -64,8 +64,11 @@ def fetch_build_egg(dist, req):
         pkg_resources.get_distribution('wheel')
     except pkg_resources.DistributionNotFound:
         dist.announce('WARNING: The wheel package is not available.', log.WARN)
-    if not isinstance(req, pkg_resources.Requirement):
-        req = pkg_resources.Requirement.parse(req)
+    # Ignore environment markers: if we're here, it's needed. This ensure
+    # we don't try to ask pip for something like `babel; extra == "i18n"`,
+    # which would always be ignored.
+    req = pkg_resources.Requirement.parse(str(req))
+    req.marker = None
     # Take easy_install options into account, but do not override relevant
     # pip environment variables (like PIP_INDEX_URL or PIP_QUIET); they'll
     # take precedence.

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -64,11 +64,8 @@ def fetch_build_egg(dist, req):
         pkg_resources.get_distribution('wheel')
     except pkg_resources.DistributionNotFound:
         dist.announce('WARNING: The wheel package is not available.', log.WARN)
-    # Ignore environment markers: if we're here, it's needed. This ensure
-    # we don't try to ask pip for something like `babel; extra == "i18n"`,
-    # which would always be ignored.
-    req = pkg_resources.Requirement.parse(str(req))
-    req.marker = None
+    # Ignore environment markers; if supplied, it is required.
+    req = strip_marker(req)
     # Take easy_install options into account, but do not override relevant
     # pip environment variables (like PIP_INDEX_URL or PIP_QUIET); they'll
     # take precedence.
@@ -130,3 +127,15 @@ def fetch_build_egg(dist, req):
         dist = pkg_resources.Distribution.from_filename(
             dist_location, metadata=dist_metadata)
         return dist
+
+
+def strip_marker(req):
+    """
+    Return a new requirement without the environment marker to avoid
+    calling pip with something like `babel; extra == "i18n"`, which
+    would always be ignored.
+    """
+    # create a copy to avoid mutating the input
+    req = pkg_resources.Requirement.parse(str(req))
+    req.marker = None
+    return req


### PR DESCRIPTION
Handle the case where a missing transitive build dependency is required by an extra for an already installed build dependency.

Example:
* a test package with a `setup.py` containing: `setup_requires=['dep[extra]']`
* `dep` is already installed, and the dependencies for `extra` are: `['extra_dep']`
* `extra_dep` is not already installed, and `fetch_build_egg('extra_dep; extra =="extra"')` is called

If the marker is not stripped, `pip wheel [...] 'extra_dep; extra =="extra"'` ignores the requirement, and does not build a wheel, but still returns with no error.

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes the second issue found in #1920.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
