### PR TITLE
pyproject.toml: add "setuptools>=40.8.0"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["wheel"]
+requires = ["wheel", "setuptools>=40.8.0"]
 
 [tool.towncrier]
     package = "setuptools"


### PR DESCRIPTION
Fixes:

    % pip install ~v/setuptools
    Looking in indexes: http://localhost:3141/root/pypi/+simple/
    Processing …/Vcs/setuptools
      Installing build dependencies ... done
      WARNING: Missing build requirements in pyproject.toml for file://…/Vcs/setuptools.
      WARNING: The project does not specify a build backend, and pip cannot fall back to setuptools without 'setuptools>=40.8.0'.
      Getting requirements to build wheel ... done
    ERROR: Exception:
    Traceback (most recent call last):
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/cli/base_command.py", line 153, in _main
        status = self.run(options, args)
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/commands/install.py", line 382, in run
        resolver.resolve(requirement_set)
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/legacy_resolve.py", line 201, in resolve
        self._resolve_one(requirement_set, req)
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/legacy_resolve.py", line 365, in _resolve_one
        abstract_dist = self._get_abstract_dist_for(req_to_install)
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/legacy_resolve.py", line 312, in _get_abstract_dist_for
        abstract_dist = self.preparer.prepare_linked_requirement(
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 223, in prepare_linked_requirement
        abstract_dist = _get_prepared_distribution(
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/operations/prepare.py", line 49, in _get_prepared_distribution
        abstract_dist.prepare_distribution_metadata(finder, build_isolation)
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/distributions/source/legacy.py", line 37, in prepare_distribution_metadata
        self._setup_isolation(finder)
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_internal/distributions/source/legacy.py", line 90, in _setup_isolation
        reqs = backend.get_requires_for_build_wheel()
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_vendor/pep517/wrappers.py", line 151, in get_requires_for_build_wheel
        return self._call_hook('get_requires_for_build_wheel', {
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_vendor/pep517/wrappers.py", line 255, in _call_hook
        raise BackendUnavailable(data.get('traceback', ''))
    pip._vendor.pep517.wrappers.BackendUnavailable: Traceback (most recent call last):
      File "/tmp/t/.venv/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 63, in _build_backend
        obj = import_module(mod_path)
      File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
        return _bootstrap._gcd_import(name[level:], package, level)
      File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
      File "<frozen importlib._bootstrap>", line 991, in _find_and_load
      File "<frozen importlib._bootstrap>", line 961, in _find_and_load_unlocked
      File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
      File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
      File "<frozen importlib._bootstrap>", line 991, in _find_and_load
      File "<frozen importlib._bootstrap>", line 973, in _find_and_load_unlocked
    ModuleNotFoundError: No module named 'setuptools'

Using pip 19.3.1.

Let me know if this needs a news fragment, since I'm not even sure this is correct and if using pip to install setuptools is supported etc.