### PR TITLE
Simplified mechanized release process through tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ jobs:
     env: DISABLE_COVERAGE=1
   - python: 3.4
   - python: 3.5
-  - &default_py
-    python: 3.6
+  - python: 3.6
   - python: 3.7
   - &latest_py3
     python: 3.8
@@ -24,7 +23,7 @@ jobs:
   - python: 3.8-dev
   - <<: *latest_py3
     env: TOXENV=docs DISABLE_COVERAGE=1
-  - <<: *default_py
+  - <<: *latest_py3
     stage: deploy (to PyPI for tagged commits)
     if: tag IS present
     install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,25 +24,11 @@ jobs:
   - <<: *latest_py3
     env: TOXENV=docs DISABLE_COVERAGE=1
   - <<: *latest_py3
-    stage: deploy (to PyPI for tagged commits)
+    stage: deploy
     if: tag IS present
     install: skip
-    script: skip
-    after_success: true
-    before_deploy:
-      - python bootstrap.py
-      - "! grep pyc setuptools.egg-info/SOURCES.txt"
-    deploy:
-      provider: pypi
-      on:
-        tags: true
-        all_branches: true
-      user: __token__
-      password:
-        secure: FSp9KU+pdvWPxBOaxe6BNmcJ9y8259G3/NdTJ00r0qx/xMLpSneGjpuLqoD6BL2JoM6gRwurwakWoH/9Ah+Di7afETjMnL6WJKtDZ+Uu3YLx3ss7/FlhVz6zmVTaDJUzuo9dGr//qLBQTIxVjGYfQelRJyfMAXtrYWdeT/4489E45lMw+86Z/vnSBOxs4lWekeQW5Gem0cDViWu67RRiGkAEvrYVwuImMr2Dyhpv+l/mQGQIS/ezXuAEFToE6+q8VUVe/aK498Qovdc+O4M7OYk1JouFpffZ3tVZ6iWHQFcR11480UdI6VCIcFpPvGC/J8MWUWLjq7YOm0X9jPXgdYMUQLAP4clFgUr2qNoRSKWfuQlNdVVuS2htYcjJ3eEl90FhcIZKp+WVMrypRPOQJ8CBielZEs0dhytRrZSaJC1BNq25O/BPzws8dL8hYtoXsM6I3Zv5cZgdyqyq/eOEMCX7Cetv6do0U41VGEV5UohvyyuwH5l9GCuPREpY3sXayPg8fw7XcPjvvzSVyjcUT/ePW8sfnAyWZnngjweAn6dK8IFGPuSPQdlos78uxeUOvCVUW0xv/0m4lX73yoHdVVdLbu1MJTyibFGec86Bew9JqIcDlhHaIJ9ihZ9Z9tOtvp1cuNyKYE4kvmOtumDDicEw4DseYn2z5sZDTYTBsKY=
-      distributions: release
-      skip_cleanup: true
-      skip_upload_docs: true
+    script: tox -e release
+    after_success: skip
 
 cache: pip
 

--- a/tox.ini
+++ b/tox.ini
@@ -55,3 +55,18 @@ source=
 	setuptools
 omit=
 	*/_vendor/*
+
+[testenv:release]
+skip_install = True
+deps =
+	pep517>=0.5
+	twine[keyring]>=1.13
+	path
+passenv =
+	TWINE_PASSWORD
+setenv =
+	TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
+commands =
+	python -c "import path; path.Path('dist').rmtree_p()"
+	python -m pep517.build .
+	python -m twine upload dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ omit=
 [testenv:release]
 skip_install = True
 deps =
-	pep517>=0.5
+	wheel
 	twine[keyring]>=1.13
 	path
 passenv =
@@ -69,5 +69,5 @@ setenv =
 commands =
 	python -m bootstrap
 	python -c "import path; path.Path('dist').rmtree_p()"
-	python -m pep517.build .
+	python setup.py release
 	python -m twine upload dist/*

--- a/tox.ini
+++ b/tox.ini
@@ -67,6 +67,7 @@ passenv =
 setenv =
 	TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
 commands =
+	python -m bootstrap
 	python -c "import path; path.Path('dist').rmtree_p()"
 	python -m pep517.build .
 	python -m twine upload dist/*


### PR DESCRIPTION
This approach adopts the release process from jaraco/skeleton. This approach gives the project more control over the release process, decoupling from DPL (which has its own issues) and relies on tokens as installed to environment variables (as travis has issues with that).

This approach makes it possible to cut manual releases with `tox -e release` (assuming TWINE_PASSWORD is set to a valid token) as well as control other things about the release process (such as using pep517 to build the dists).

Compared to the attempt in #1925, this approach avoids switching to pep517 for the build. Even though that approach proved viable for cutting releases, it's not viable for the test environments.