### PR TITLE
Restore build-backend and remove switch to avoid pep517.

### DIFF
--- a/changelog.d/1927.change.rst
+++ b/changelog.d/1927.change.rst
@@ -1,0 +1,1 @@
+Setuptools once again declares 'setuptools' in the ``build-system.requires`` and adds PEP 517 build support by declaring itself as the ``build-backend``. It additionally specifies ``build-system.backend-path`` to rely on itself for those builders that support it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["wheel"]
+requires = ["setuptools >= 40.8", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.towncrier]
     package = "setuptools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = ["setuptools >= 40.8", "wheel"]
 build-backend = "setuptools.build_meta"
+backend-path = ["."]
 
 [tool.towncrier]
     package = "setuptools"

--- a/tools/tox_pip.py
+++ b/tools/tox_pip.py
@@ -21,12 +21,6 @@ def pip(args):
     pypath = pypath.split(os.pathsep) if pypath is not None else []
     pypath.insert(0, TOX_PIP_DIR)
     os.environ['PYTHONPATH'] = os.pathsep.join(pypath)
-    # Disable PEP 517 support when using editable installs.
-    for n, a in enumerate(args):
-        if not a.startswith('-'):
-            if a in 'install' and '-e' in args[n:]:
-                args.insert(n + 1, '--no-use-pep517')
-            break
     # Fix call for setuptools editable install.
     for n, a in enumerate(args):
         if a == '.':


### PR DESCRIPTION
Per Paul's [comment](https://github.com/pypa/setuptools/issues/1644#issuecomment-554677756) in #1644, this change restores the build backend and removes the workaround to avoid pep517.

Rather than selecting 40.0, I chose 40.8 based on the error message reported in #1923.