### PR TITLE
Update setuptools.txt

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -62,7 +62,7 @@ Installing ``setuptools``
 
 To install the latest version of setuptools, use::
 
-    pip install -U setuptools
+    pip install --upgrade setuptools
 
 Refer to `Installing Packages`_ guide for more information.
 
@@ -1199,7 +1199,7 @@ command; see the section on the `develop`_ command below for more details.
 Note that you can also apply setuptools commands to non-setuptools projects,
 using commands like this::
 
-   python -c "import setuptools; execfile('setup.py')" develop
+   python -c "import setuptools; with open('setup.py') as f: exec(compile(f.read(), 'setup.py', 'exec'))" develop
 
 That is, you can simply list the normal setup commands and options following
 the quoted part.
@@ -1215,7 +1215,7 @@ Detailed instructions to distribute a setuptools project can be found at
 
 Before you begin, make sure you have the latest versions of setuptools and wheel::
 
-    python3 -m pip install --user --upgrade setuptools wheel
+    pip install --upgrade setuptools wheel
 
 To build a setuptools project, run this command from the same directory where
 setup.py is located::
@@ -1229,15 +1229,15 @@ https://test.pypi.org/account/register/. You will also need to verify your email
 to be able to upload any packages.
 You should install twine to be able to upload packages::
 
-    python3 -m pip install --user --upgrade setuptools wheel
+    pip install --upgrade twine
 
 Now, to upload these archives, run::
 
-    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+    twine upload --repository-url https://test.pypi.org/simple/ dist/*
 
 To install your newly uploaded package ``example_pkg``,  you can use pip::
 
-    python3 -m pip install --index-url https://test.pypi.org/simple/ example_pkg
+    pip install --index-url https://test.pypi.org/simple/ example_pkg
 
 If you have issues at any point, please refer to `Packaging project tutorials`_
 for clarification.


### PR DESCRIPTION
This PR:

- uses the long option `--upgrade` consistently;
- uses the built-in `exec` function instead of the Python 2-only `execfile`;
- fixes a command typo installing `setuptools `and `wheel `twice instead of `twine`;
- removes inconsistent `--user` options in some `pip install` commands;
- calls `pip install` from the PATH consistently instead of from the module namespace (`python -m pip install`) as we are not upgrading `pip` itself on Windows anywhere;
- fixes a URI.