### PR TITLE
Patched sdist in PEP 517 to include pyproject.toml

### DIFF
--- a/changelog.d/1632.breaking
+++ b/changelog.d/1632.breaking
@@ -1,0 +1,1 @@
+Include ``pyproject.toml`` in sdist built with PEP 517 build hooks.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -36,6 +36,7 @@ import contextlib
 import setuptools
 import distutils
 from setuptools.py31compat import TemporaryDirectory
+from setuptools.command.sdist import sdist
 
 from pkg_resources import parse_requirements
 from pkg_resources.py31compat import makedirs
@@ -209,9 +210,13 @@ class _BuildMetaBackend(object):
                                          wheel_directory, config_settings)
 
     def build_sdist(self, sdist_directory, config_settings=None):
-        return self._build_with_temp_dir(['sdist', '--formats', 'gztar'],
-                                         '.tar.gz', sdist_directory,
-                                         config_settings)
+        orig, sdist.include_pyproject_toml = sdist.include_pyproject_toml, True
+        try:
+            return self._build_with_temp_dir(['sdist', '--formats', 'gztar'],
+                                             '.tar.gz', sdist_directory,
+                                             config_settings)
+        finally:
+            sdist.include_pyproject_toml = orig
 
 
 class _BuildMetaLegacyBackend(_BuildMetaBackend):

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -24,6 +24,8 @@ def walk_revctrl(dirname=''):
 class sdist(sdist_add_defaults, orig.sdist):
     """Smart sdist that finds anything supported by revision control"""
 
+    include_pyproject_toml = False
+
     user_options = [
         ('formats=', None,
          "formats for source distribution (comma-separated list)"),
@@ -45,6 +47,8 @@ class sdist(sdist_add_defaults, orig.sdist):
         ei_cmd = self.get_finalized_command('egg_info')
         self.filelist = ei_cmd.filelist
         self.filelist.append(os.path.join(ei_cmd.egg_info, 'SOURCES.txt'))
+        if self.include_pyproject_toml:
+            self.filelist.append('pyproject.toml')
         self.check_readme()
 
         # Run sub commands

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -262,6 +262,27 @@ class TestBuildMetaBackend:
         assert os.path.isfile(
             os.path.join(os.path.abspath("out_sdist"), sdist_name))
 
+    def test_build_sdist_pyproject_toml_exists(self, tmpdir_cwd):
+        files = {
+            'setup.py': DALS("""
+                __import__('setuptools').setup(
+                    name='foo',
+                    version='0.0.0',
+                    py_modules=['hello']
+                )"""),
+            'hello.py': '',
+            'pyproject.toml': DALS("""
+                [build-system]
+                requires = ["setuptools", "wheel"]
+                build-backend = "setuptools.build_meta
+                """),
+        }
+        build_files(files)
+        build_backend = self.get_build_backend()
+        targz_path = build_backend.build_sdist("temp")
+        with tarfile.open(os.path.join("temp", targz_path)) as tar:
+            assert any('pyproject.toml' in name for name in tar.getnames())
+
     def test_build_sdist_setup_py_exists(self, tmpdir_cwd):
         # If build_sdist is called from a script other than setup.py,
         # ensure setup.py is included


### PR DESCRIPTION
## Summary of changes

A flag is added to `setuptools.command.sdist.sdist` to include `pyproject.toml` if present. This flag is False by default, but set to True in PEP 517 build hooks, so the built sdist is compliant to the PEP.

Non-PEP 517 sdist builds remain the same as before (not including `pyproject.toml` unless explicitly included in `MANIFEST.in`).

Ref #1632

### Pull Request Checklist

- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
