### PR TITLE
Require Python 3.5 or later, dropping support for Python 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,8 @@ language: python
 jobs:
   fast_finish: true
   include:
-  - &latest_py2
-    python: 2.7
-  - <<: *latest_py2
-    env: LANG=C
-  - python: pypy
-    env: DISABLE_COVERAGE=1  # Don't run coverage on pypy (too slow).
   - python: pypy3
-    env: DISABLE_COVERAGE=1
+    env: DISABLE_COVERAGE=1  # Don't run coverage on pypy (too slow).
   - python: 3.5
   - python: 3.6
   - python: 3.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ environment:
   matrix:
     - APPVEYOR_JOB_NAME: "python36-x64"
       PYTHON: "C:\\Python36-x64"
-    - APPVEYOR_JOB_NAME: "python27-x64"
-      PYTHON: "C:\\Python27-x64"
+    - APPVEYOR_JOB_NAME: "python37-x64"
+      PYTHON: "C:\\Python37-x64"
 
 install:
   # symlink python from a directory with a space

--- a/changelog.d/1458.breaking.rst
+++ b/changelog.d/1458.breaking.rst
@@ -1,0 +1,1 @@
+Drop support for Python 2. Setuptools now requires Python 3.5 or later. Install setuptools using pip >=9 or pin to Setuptools <45 to maintain 2.7 support.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -83,6 +83,7 @@ __import__('pkg_resources.extern.packaging.version')
 __import__('pkg_resources.extern.packaging.specifiers')
 __import__('pkg_resources.extern.packaging.requirements')
 __import__('pkg_resources.extern.packaging.markers')
+__import__('pkg_resources.py2_warn')
 
 
 __metaclass__ = type

--- a/pkg_resources/py2_warn.py
+++ b/pkg_resources/py2_warn.py
@@ -1,0 +1,19 @@
+import sys
+import warnings
+import textwrap
+
+
+msg = textwrap.dedent("""
+    You are running Setuptools on Python 2, which is no longer
+    supported and
+    >>> SETUPTOOLS WILL STOP WORKING <<<
+    in a subsequent release. Please ensure you are installing
+    Setuptools using pip 9.x or later or pin to `setuptools<45`
+    in your environment.
+    If you have done those things and are still encountering
+    this message, please comment in
+    https://github.com/pypa/setuptools/issues/1458
+    about the steps that led to this unsupported combination.
+    """)
+
+sys.version_info < (3,) and warnings.warn("*" * 60 + msg + "*" * 60)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
-    Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
@@ -49,7 +47,7 @@ classifiers =
 
 [options]
 zip_safe = True
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
+python_requires = >=3.5
 py_modules = easy_install
 packages = find:
 


### PR DESCRIPTION
This change does not yet remove any of the compatibility for Python 2, but only aims to declare the dropped support.

Closes #1458