### PR TITLE
Fix for Python 4: replace unsafe six.PY3 with PY2

### DIFF
--- a/changelog.d/1959.change.rst
+++ b/changelog.d/1959.change.rst
@@ -1,0 +1,1 @@
+Fix for Python 4: replace unsafe six.PY3 with six.PY2

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -113,7 +113,7 @@ class build_ext(_build_ext):
         if fullname in self.ext_map:
             ext = self.ext_map[fullname]
             use_abi3 = (
-                six.PY3
+                not six.PY2
                 and getattr(ext, 'py_limited_api')
                 and get_abi3_suffix()
             )

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -108,7 +108,7 @@ class develop(namespaces.DevelopInstaller, easy_install):
         return path_to_setup
 
     def install_for_development(self):
-        if six.PY3 and getattr(self.distribution, 'use_2to3', False):
+        if not six.PY2 and getattr(self.distribution, 'use_2to3', False):
             # If we run 2to3 we can not do this inplace:
 
             # Ensure metadata is up-to-date

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1567,7 +1567,7 @@ def get_exe_prefixes(exe_filename):
                 continue
             if parts[0].upper() in ('PURELIB', 'PLATLIB'):
                 contents = z.read(name)
-                if six.PY3:
+                if not six.PY2:
                     contents = contents.decode()
                 for pth in yield_lines(contents):
                     pth = pth.strip().replace('\\', '/')

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -266,7 +266,7 @@ class egg_info(InfoCommon, Command):
         to the file.
         """
         log.info("writing %s to %s", what, filename)
-        if six.PY3:
+        if not six.PY2:
             data = data.encode("utf-8")
         if not self.dry_run:
             f = open(filename, 'wb')

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -207,7 +207,7 @@ class sdist(sdist_add_defaults, orig.sdist):
         manifest = open(self.manifest, 'rb')
         for line in manifest:
             # The manifest must contain UTF-8. See #303.
-            if six.PY3:
+            if not six.PY2:
                 try:
                     line = line.decode('UTF-8')
                 except UnicodeDecodeError:

--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -129,7 +129,7 @@ class test(Command):
 
     @contextlib.contextmanager
     def project_on_sys_path(self, include_dists=[]):
-        with_2to3 = six.PY3 and getattr(self.distribution, 'use_2to3', False)
+        with_2to3 = not six.PY2 and getattr(self.distribution, 'use_2to3', False)
 
         if with_2to3:
             # If we run 2to3 we can not do this inplace:
@@ -240,7 +240,7 @@ class test(Command):
         # Purge modules under test from sys.modules. The test loader will
         # re-import them from the build location. Required when 2to3 is used
         # with namespace packages.
-        if six.PY3 and getattr(self.distribution, 'use_2to3', False):
+        if not six.PY2 and getattr(self.distribution, 'use_2to3', False):
             module = self.test_suite.split('.')[0]
             if module in _namespace_packages:
                 del_modules = []

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -24,7 +24,7 @@ from .upload import upload
 
 
 def _encode(s):
-    errors = 'surrogateescape' if six.PY3 else 'strict'
+    errors = 'strict' if six.PY2 else 'surrogateescape'
     return s.encode('utf-8', errors)
 
 
@@ -153,7 +153,7 @@ class upload_docs(upload):
         # set up the authentication
         credentials = _encode(self.username + ':' + self.password)
         credentials = standard_b64encode(credentials)
-        if six.PY3:
+        if not six.PY2:
             credentials = credentials.decode('ascii')
         auth = "Basic " + credentials
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -571,7 +571,7 @@ class Distribution(_Distribution):
         from setuptools.extern.six.moves.configparser import ConfigParser
 
         # Ignore install directory options if we have a venv
-        if six.PY3 and sys.prefix != sys.base_prefix:
+        if not six.PY2 and sys.prefix != sys.base_prefix:
             ignore_options = [
                 'install-base', 'install-platbase', 'install-lib',
                 'install-platlib', 'install-purelib', 'install-headers',
@@ -593,7 +593,7 @@ class Distribution(_Distribution):
             with io.open(filename, encoding='utf-8') as reader:
                 if DEBUG:
                     self.announce("  reading {filename}".format(**locals()))
-                (parser.read_file if six.PY3 else parser.readfp)(reader)
+                (parser.readfp if six.PY2 else parser.read_file)(reader)
             for section in parser.sections():
                 options = parser.options(section)
                 opt_dict = self.get_option_dict(section)
@@ -636,7 +636,7 @@ class Distribution(_Distribution):
 
         Ref #1653
         """
-        if six.PY3:
+        if not six.PY2:
             return val
         try:
             return val.encode()

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -95,7 +95,7 @@ class TestDevelop:
         with io.open(fn) as init_file:
             init = init_file.read().strip()
 
-        expected = 'print("foo")' if six.PY3 else 'print "foo"'
+        expected = 'print "foo"' if six.PY2 else 'print("foo")'
         assert init == expected
 
     def test_console_scripts(self, tmpdir):
@@ -161,7 +161,7 @@ class TestNamespaces:
         reason="https://github.com/pypa/setuptools/issues/851",
     )
     @pytest.mark.skipif(
-        platform.python_implementation() == 'PyPy' and six.PY3,
+        platform.python_implementation() == 'PyPy' and not six.PY2,
         reason="https://github.com/pypa/setuptools/issues/1202",
     )
     def test_namespace_package_importable(self, tmpdir):

--- a/setuptools/tests/test_setopt.py
+++ b/setuptools/tests/test_setopt.py
@@ -15,7 +15,7 @@ class TestEdit:
     def parse_config(filename):
         parser = configparser.ConfigParser()
         with io.open(filename, encoding='utf-8') as reader:
-            (parser.read_file if six.PY3 else parser.readfp)(reader)
+            (parser.readfp if six.PY2 else parser.read_file)(reader)
         return parser
 
     @staticmethod


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

We don't yet know if 3.10 or 4.0 will follow Python 3.9, but whichever it is, it will probably happen in [2020 when Python 3.9 reaches beta](https://www.python.org/dev/peps/pep-0596/#schedule) and work begins on Python 3.9+1.

There's some code which uses `six.PY3`:

```python
if six.PY3:
    print("Python 3+ code")
else:
    print "Python 2 code"
```

Where:

```python
PY3 = sys.version_info[0] == 3
```

When run on Python 4, this will run the Python 2 code! Instead, use `six.PY2`.

Found using https://github.com/asottile/flake8-2020

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
