### PR TITLE
Restore testing on Python 2, bypassing the requires-python check when installing Setuptools.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ language: python
 jobs:
   fast_finish: true
   include:
+  - &latest_py2
+    python: 2.7
+  - <<: *latest_py2
+    env: LANG=C
   - python: pypy3
     env: DISABLE_COVERAGE=1  # Don't run coverage on pypy (too slow).
   - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ jobs:
   include:
   - &latest_py2
     python: 2.7
+    env: TOXENV=py27
   - <<: *latest_py2
-    env: LANG=C
+    env: LANG=C TOXENV=py27
   - python: pypy3
     env: DISABLE_COVERAGE=1  # Don't run coverage on pypy (too slow).
   - python: 3.5

--- a/tools/tox_pip.py
+++ b/tools/tox_pip.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 
@@ -14,6 +15,10 @@ def remove_setuptools():
 
 
 def pip(args):
+    # Honor requires-python when installing test suite dependencies
+    if any('-r' in arg for arg in args):
+        os.environ['PIP_IGNORE_REQUIRES_PYTHON'] = '0'
+
     # When installing '.', remove setuptools
     '.' in args and remove_setuptools()
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,9 @@ deps=-r{toxinidir}/tests/requirements.txt
 pip_version = pip
 install_command = {[helpers]pip} install {opts} {packages}
 list_dependencies_command = {[helpers]pip} freeze --all
-setenv=COVERAGE_FILE={toxworkdir}/.coverage.{envname}
+setenv =
+	COVERAGE_FILE={toxworkdir}/.coverage.{envname}
+	py27: PIP_IGNORE_REQUIRES_PYTHON=true
 # TODO: The passed environment variables came from copying other tox.ini files
 # These should probably be individually annotated to explain what needs them.
 passenv=APPDATA HOMEDRIVE HOMEPATH windir APPVEYOR APPVEYOR_* CI CODECOV_* TRAVIS TRAVIS_* NETWORK_REQUIRED


### PR DESCRIPTION
Follow-up to #1955, this change allows the tests to run on Python 2 even though the packages declares a requirement on Python 3.5 or later. This change will prevent the risk of bit-rot on the master and maintain the expectation that Python 2 compatibility is retained for those installers not honoring PEP 345.