### PR TITLE
Rely on tox-pip-version to upgrade pip

### DIFF
--- a/tools/tox_pip.py
+++ b/tools/tox_pip.py
@@ -1,31 +1,24 @@
-import os
-import shutil
 import subprocess
 import sys
-from glob import glob
 
-VIRTUAL_ENV = os.environ['VIRTUAL_ENV']
-TOX_PIP_DIR = os.path.join(VIRTUAL_ENV, 'pip')
+
+def remove_setuptools():
+    """
+    Remove setuptools from the current environment.
+    """
+    print("Removing setuptools")
+    cmd = [sys.executable, '-m', 'pip', 'uninstall', '-y', 'setuptools']
+    # set cwd to something other than '.' to avoid detecting
+    # '.' as the installed package.
+    subprocess.check_call(cmd, cwd='.tox')
 
 
 def pip(args):
-    # First things first, get a recent (stable) version of pip.
-    if not os.path.exists(TOX_PIP_DIR):
-        subprocess.check_call([sys.executable, '-m', 'pip',
-                               '--disable-pip-version-check',
-                               'install', '-t', TOX_PIP_DIR,
-                               'pip'])
-        shutil.rmtree(glob(os.path.join(TOX_PIP_DIR, 'pip-*.dist-info'))[0])
-    # And use that version.
-    pypath = os.environ.get('PYTHONPATH')
-    pypath = pypath.split(os.pathsep) if pypath is not None else []
-    pypath.insert(0, TOX_PIP_DIR)
-    os.environ['PYTHONPATH'] = os.pathsep.join(pypath)
-    # Fix call for setuptools editable install.
-    for n, a in enumerate(args):
-        if a == '.':
-            args[n] = os.getcwd()
-    subprocess.check_call([sys.executable, '-m', 'pip'] + args, cwd=TOX_PIP_DIR)
+    # When installing '.', remove setuptools
+    '.' in args and remove_setuptools()
+
+    cmd = [sys.executable, '-m', 'pip'] + args
+    subprocess.check_call(cmd)
 
 
 if __name__ == '__main__':

--- a/tox.ini
+++ b/tox.ini
@@ -6,15 +6,17 @@
 
 [tox]
 envlist=python
+minversion = 3.2
+requires =
+	tox-pip-version >= 0.0.6
 
 [helpers]
-# Wrapper for calls to pip that make sure the version being used is a
-# up-to-date, and to prevent the current working directory from being
-# added to `sys.path`.
+# Custom pip behavior
 pip = python {toxinidir}/tools/tox_pip.py
 
 [testenv]
 deps=-r{toxinidir}/tests/requirements.txt
+pip_version = pip
 install_command = {[helpers]pip} install {opts} {packages}
 list_dependencies_command = {[helpers]pip} freeze --all
 setenv=COVERAGE_FILE={toxworkdir}/.coverage.{envname}


### PR DESCRIPTION
Minimize the hook for removing setuptools from the environment.