### PR TITLE
Add flake8-2020 to tests/requirements.txt

### DIFF
--- a/changelog.d/1968.misc.rst
+++ b/changelog.d/1968.misc.rst
@@ -1,0 +1,1 @@
+Add flake8-2020 to check for misuse of sys.version or sys.version_info.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 mock
 pytest-flake8
+flake8-2020; python_version>="3.6"
 virtualenv>=13.0.0
 pytest-virtualenv>=1.2.7
 pytest>=3.7


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Add https://github.com/asottile/flake8-2020 plugin to Flake8.

To prevent regressions of things like https://github.com/pypa/setuptools/pull/1959 and make sure no problematic version comparisons are introduced which may break on Python 3.10, Python 4 or Python 10.

### Pull Request Checklist
- [x] Changes have tests [change *is* tests]
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
