### PR TITLE
Add 'Programming Language :: Python :: 3 :: Only' trove classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7


### PR DESCRIPTION
The project has been Python 3 only since
a46a6bfd903ecc292fc3645c37c1b72781528095.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
