### PR TITLE
Ensure bdist_wheel no longer creates a universal wheel [set universal = 0], close #1976

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ repository = https://upload.pypi.org/legacy/
 formats = zip
 
 [bdist_wheel]
-universal = 1
+universal = 0
 
 [metadata]
 name = setuptools


### PR DESCRIPTION
### Summary of changes

v45 doesn't support Python 2 any more, but  [`setup.cfg`](https://github.com/pypa/setuptools/blob/master/setup.cfg) is still set to create a universal wheel. I've changed `universal = 0`.

Closes #1976 

Alternative solution to #1978 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details