### PR TITLE
Ensure bdist_wheel no longer creates a universal wheel [remove bdist_wheel block], close #1976

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,9 +14,6 @@ repository = https://upload.pypi.org/legacy/
 [sdist]
 formats = zip
 
-[bdist_wheel]
-universal = 1
-
 [metadata]
 name = setuptools
 version = 45.0.0


### PR DESCRIPTION
### Summary of changes

v45 doesn't support Python 2 any more, but  [`setup.cfg`](https://github.com/pypa/setuptools/blob/master/setup.cfg) is still set to create a universal wheel. I've removed the `[bdist_wheel]` block.

Closes #1976 

Alternative solution to #1977 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details