### PR TITLE
Include pkg_resources test data in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ recursive-include setuptools/tests *.html
 recursive-include docs *.py *.txt *.conf *.css *.css_t Makefile indexsidebar.html
 recursive-include setuptools/_vendor *.py *.txt
 recursive-include pkg_resources *.py *.txt
+recursive-include pkg_resources/tests/data *
 include *.py
 include *.rst
 include MANIFEST.in

--- a/changelog.d/1991.misc.rst
+++ b/changelog.d/1991.misc.rst
@@ -1,0 +1,1 @@
+Include pkg_resources test data in sdist, so tests can be executed from it.


### PR DESCRIPTION
This is the error otherwise:

```
_____________ TestFindDistributions.test_standalone_egg_directory ______________

self = <pkg_resources.tests.test_find_distributions.TestFindDistributions object at 0x7f17518a86d0>
target_dir = local('/tmp/pytest-of-mockbuild/pytest-0/test_standalone_egg_directory0/target')

    def test_standalone_egg_directory(self, target_dir):
        (TESTS_DATA_DIR / 'my-test-package_unpacked-egg').copy(target_dir)
        dists = pkg_resources.find_distributions(str(target_dir))
>       assert [dist.project_name for dist in dists] == ['my-test-package']
E       AssertionError: assert [] == ['my-test-package']
E         Right contains one more item: 'my-test-package'
E         Use -v to get the full diff

pkg_resources/tests/test_find_distributions.py:25: AssertionError
____________________ TestFindDistributions.test_zipped_egg _____________________

self = <module 'py.error'>, func = <built-in function listdir>
args = ('/builddir/build/BUILD/setuptools-45.2.0/pkg_resources/tests/data/my-test-package_zipped-egg',)
kwargs = {}, __tracebackhide__ = False, cls = <class 'py.error.ENOENT'>
value = FileNotFoundError(2, 'No such file or directory')
tb = <traceback object at 0x7f1751a6a7c0>, errno = 2

    def checked_call(self, func, *args, **kwargs):
        """ call a function and raise an errno-exception if applicable. """
        __tracebackhide__ = True
        try:
>           return func(*args, **kwargs)
E           FileNotFoundError: [Errno 2] No such file or directory: '/builddir/build/BUILD/setuptools-45.2.0/pkg_resources/tests/data/my-test-package_zipped-egg'

/usr/lib/python3.8/site-packages/py/_error.py:66: FileNotFoundError

During handling of the above exception, another exception occurred:

self = <pkg_resources.tests.test_find_distributions.TestFindDistributions object at 0x7f1751c8fe80>
target_dir = local('/tmp/pytest-of-mockbuild/pytest-0/test_zipped_egg0/target')

    def test_zipped_egg(self, target_dir):
>       (TESTS_DATA_DIR / 'my-test-package_zipped-egg').copy(target_dir)

pkg_resources/tests/test_find_distributions.py:30:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib/python3.8/site-packages/py/_path/local.py:437: in copy
    for x in self.visit(rec=rec):
/usr/lib/python3.8/site-packages/py/_path/common.py:377: in visit
    for x in Visitor(fil, rec, ignore, bf, sort).gen(self):
/usr/lib/python3.8/site-packages/py/_path/common.py:414: in gen
    entries = path.listdir()
/usr/lib/python3.8/site-packages/py/_path/local.py:392: in listdir
    names = py.error.checked_call(os.listdir, self.strpath)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <module 'py.error'>, func = <built-in function listdir>
args = ('/builddir/build/BUILD/setuptools-45.2.0/pkg_resources/tests/data/my-test-package_zipped-egg',)
kwargs = {}, __tracebackhide__ = False, cls = <class 'py.error.ENOENT'>
value = FileNotFoundError(2, 'No such file or directory')
tb = <traceback object at 0x7f1751a6a7c0>, errno = 2

    def checked_call(self, func, *args, **kwargs):
        """ call a function and raise an errno-exception if applicable. """
        __tracebackhide__ = True
        try:
            return func(*args, **kwargs)
        except self.Error:
            raise
        except (OSError, EnvironmentError):
            cls, value, tb = sys.exc_info()
            if not hasattr(value, 'errno'):
                raise
            __tracebackhide__ = False
            errno = value.errno
            try:
                if not isinstance(value, WindowsError):
                    raise NameError
            except NameError:
                # we are not on Windows, or we got a proper OSError
                cls = self._geterrnoclass(errno)
            else:
                try:
                    cls = self._geterrnoclass(_winerrnomap[errno])
                except KeyError:
                    raise value
>           raise cls("%s%r" % (func.__name__, args))
E           py.error.ENOENT: [No such file or directory]: listdir('/builddir/build/BUILD/setuptools-45.2.0/pkg_resources/tests/data/my-test-package_zipped-egg',)

/usr/lib/python3.8/site-packages/py/_error.py:86: ENOENT
```


### Pull Request Checklist
- [ ] Changes have tests - no idea how
- [x] News fragment added in changelog.d
