### PR TITLE
honor order attribute in "finalize_distibution_options" group of entrypoints

### DIFF
--- a/changelog.d/1994.change.rst
+++ b/changelog.d/1994.change.rst
@@ -1,0 +1,1 @@
+Fixed a bug in the "setuptools.finalize_distribution_options" hook that lead to ignoring the order attribute of entry points managed by this hook.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -731,13 +731,13 @@ class Distribution(_Distribution):
         to influence the order of execution. Smaller numbers
         go first and the default is 0.
         """
-        hook_key = 'setuptools.finalize_distribution_options'
+        group = 'setuptools.finalize_distribution_options'
 
         def by_order(hook):
             return getattr(hook, 'order', 0)
-        eps = pkg_resources.iter_entry_points(hook_key)
+        eps = map(lambda e: e.load(), pkg_resources.iter_entry_points(group))
         for ep in sorted(eps, key=by_order):
-            ep.load()(self)
+            ep(self)
 
     def _finalize_setup_keywords(self):
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):


### PR DESCRIPTION
## Summary of changes

The order attribute (if specified) is now honored for the targets of entrypoints in the `setuptools.finalize_distribution_options` group. Since introduction of these entrypoints in #1055 / #1877 there was a bug that caused the default `order` of `0` to be used regardless of what the target specified.

Closes  #1993

This is my first PR in setuptools. I will add a towncrier changelog file and maybe a test of entrypoint execution order as soon as I have the chance and people here agree that my change is acceptable.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
