### PR TITLE
Avoid installing setuptools 45 on Python 2.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,9 @@
 [build-system]
-requires = ["setuptools >= 40.8", "wheel"]
+requires = [
+    # avoid self install on Python 2; ref #1996
+    "setuptools >= 40.8; python_version > '3'",
+    "wheel",
+]
 build-backend = "setuptools.build_meta"
 backend-path = ["."]
 


### PR DESCRIPTION
Because Requires-Python is disabled for Python 2 to allow this declared-incompatible version to install on Python 2, the build-requirements must exclude installing setuptools 45 during the build-system setup.

Because Python 2 tests are only needed for internal validation, and because the latest pip is already installed, the build-system can rely on `backend-path = ["."]`.

Fixes #1996.