### PR TITLE
Copy docs requirements to a separate file due to RTD constraints.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,4 +2,5 @@ python:
   version: 3
   extra_requirements:
   - docs
-  pip_install: true
+  pip_install: false
+  requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# keep these in sync with setup.cfg
+sphinx
+jaraco.packaging>=6.1
+rst.linker>=1.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ tests =
     pip>=19.1 # For proper file:// URLs support.
 
 docs =
+    # Keep these in sync with docs/requirements.txt
     sphinx
     jaraco.packaging>=6.1
     rst.linker>=1.9


### PR DESCRIPTION
Fixes #2001 (option 2). Ref readthedocs/readthedocs.org#6662