### PR TITLE
Add mapping for long_description_content_type

### DIFF
--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -486,6 +486,7 @@ class ConfigMetadataHandler(ConfigHandler):
             'license_files': parse_list,
             'description': parse_file,
             'long_description': parse_file,
+            'long_description_content_type': parse_file,
             'version': self._parse_version,
             'project_urls': parse_dict,
         }


### PR DESCRIPTION
I believe this is the right place to put this so here

## Summary of changes

Puts `long_description_content_type` in the mappings so IDEs can see it as a keyword argument

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
