### PR TITLE
Fix broken link to distutils docs for package_data

### DIFF
--- a/changelog.d/2011.doc.rst
+++ b/changelog.d/2011.doc.rst
@@ -1,0 +1,1 @@
+Fix broken link to distutils docs on package_data

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -941,7 +941,7 @@ python.org website.  If using the setuptools-specific ``include_package_data``
 argument, files specified by ``package_data`` will *not* be automatically
 added to the manifest unless they are listed in the MANIFEST.in file.)
 
-__ http://docs.python.org/dist/node11.html
+__ https://docs.python.org/3/distutils/setupscript.html#installing-package-data
 
 Sometimes, the ``include_package_data`` or ``package_data`` options alone
 aren't sufficient to precisely define what files you want included.  For


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix a broken link that leads to `distutils` documentation for the `package_data` argument.
The broken link used to point to Python 2 docs (which has been moved).
Since Python 2 has reached its end-of-life, link to Python 3 docs instead.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
