### PR TITLE
Add 'sic' function to bypass version number normalization

### DIFF
--- a/changelog.d/308.change.rst
+++ b/changelog.d/308.change.rst
@@ -1,0 +1,1 @@
+Allow version number normalization to be bypassed by wrapping in a 'setuptools.sic()' call.

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -224,5 +224,9 @@ def findall(dir=os.curdir):
     return list(files)
 
 
+class sic(str):
+    """Treat this string as-is (https://en.wikipedia.org/wiki/Sic)"""
+
+
 # Apply monkey patches
 monkey.patch_all()

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -438,30 +438,35 @@ class Distribution(_Distribution):
                 value = default() if default else None
             setattr(self.metadata, option, value)
 
-        if isinstance(self.metadata.version, numbers.Number):
-            # Some people apparently take "version number" too literally :)
-            self.metadata.version = str(self.metadata.version)
+        self.metadata.version = self._validate_version(self.metadata.version)
+        self._finalize_requires()
 
-        if self.metadata.version is not None:
+    @staticmethod
+    def _validate_version(version):
+        if isinstance(version, numbers.Number):
+            # Some people apparently take "version number" too literally :)
+            version = str(version)
+
+        if version is not None:
             try:
-                ver = packaging.version.Version(self.metadata.version)
+                ver = packaging.version.Version(version)
                 normalized_version = str(ver)
-                if self.metadata.version != normalized_version:
+                if version != normalized_version:
                     warnings.warn(
                         "Normalizing '%s' to '%s'" % (
-                            self.metadata.version,
+                            version,
                             normalized_version,
                         )
                     )
-                    self.metadata.version = normalized_version
+                    version = normalized_version
             except (packaging.version.InvalidVersion, TypeError):
                 warnings.warn(
                     "The version specified (%r) is an invalid version, this "
                     "may not work as expected with newer versions of "
                     "setuptools, pip, and PyPI. Please see PEP 440 for more "
-                    "details." % self.metadata.version
+                    "details." % version
                 )
-        self._finalize_requires()
+        return version
 
     def _finalize_requires(self):
         """

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -137,7 +137,7 @@ def __read_test_cases():
         ('Bypass normalized version', dict(
             name='foo',
             version=sic('1.0.0a'),
-        )),      
+        )),
     ]
 
     return test_cases


### PR DESCRIPTION
## Summary of changes

As discussed in #308, this proposed change adds a simple API to bypass version number normalization, forcing the user to explicitly opt into this undesirable behavior. Now a user can specify:

```
from setuptools import setup, sic

setup(version=sic('1.0.0a'))
```

And version number normalization will be skipped.

### Pull Request Checklist
- [x] Changes have tests
- [X] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
