### PR TITLE
Improved ''setuptools.finalize_distribution_options'' hook.

### DIFF
--- a/changelog.d/2032.change.rst
+++ b/changelog.d/2032.change.rst
@@ -1,0 +1,7 @@
+Implemented some common facilities needed for further improvement of ''setuptools.finalize_distribution_options'' hook.
+
+* Implemented ''get_setup_py_path'' that allows to get a path of ''setup.py'' file.
+* Implemented ''get_setup_py_dir'' that allows to get a path of a dir where''setup.py'' file resides.
+* Implemented ''read_toml'' that just reads a TOML file. Neede ''toml' lib.
+* Implemented ''read_pyproject_toml'' that just reads ''pyproject'toml' file.
+* Implemented ''FinalizeDistributionOptionsHookArgsCache'' that does these operations lazily and caches their results, to use them for hooks in future.

--- a/changelog.d/2033.breaking.rst
+++ b/changelog.d/2033.breaking.rst
@@ -1,0 +1,1 @@
+* Improved entry points mechanism. Entry points now can contain JSON metadata appended to a ''name'' after ''@'' character. It is a backward-incompatible change, but the breakage will unlikely happen.

--- a/changelog.d/2034.change.rst
+++ b/changelog.d/2034.change.rst
@@ -1,0 +1,4 @@
+Now ''setuptools.finalize_distribution_options'' hook allows the implementers to ast setuptools to provide them various information by adding a parameter with a certain name into the function signature.
+Old behavior is also supported.
+
+For the list of args names see ''DistributionoptionsFinalizationRemap'' in ''dist.py''.

--- a/changelog.d/2036.change.rst
+++ b/changelog.d/2036.change.rst
@@ -1,0 +1,3 @@
+Improved ''setuptools.finalize_distribution_options'' hook.
+* Now it allows a hook only be called if it is mentioned in ''setup'' args or in ''pyproject.toml''. It can be done by adding ''{"only": ["toml"]}'' metadata. This should reduce breakage due to malfunctions in ''setuptools'' or hooks code. Use ''{"only": true}'' for system hooks that must be executed unconditionally.
+* Now it by default tolerates errors in hooks code, so a package with a broken hook doesn't prevent from updating itself. It can be overridden by adding Use ''{"fail": true}'' metadata. ''{"only": true}'' hooks have it by default, unless overridden.

--- a/changelog.d/2037.change.rst
+++ b/changelog.d/2037.change.rst
@@ -1,0 +1,4 @@
+A bit "cosmetic" changes though needed for implementing more advanced stuff.
+* Renamed args names params for some static methods and marked them with ''@staticmethod''.
+* Moved ''0'' into ''default_order_value" variable.
+* When an entry point now fails to be loaded, it doesn't disrupt building process.

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -430,6 +430,13 @@ class TestEntryPoints:
         assert ep.attrs == ("foo",)
         assert ep.extras == ()
 
+        ep = EntryPoint.parse('a @ {"aa:aa=b@ddd": {"bb:b@c=cc": 1}} =  b:c')
+        assert ep.name == "a"
+        assert ep.module_name == "b"
+        assert ep.attrs == ("c",)
+        assert ep.metadata["aa:aa=b@ddd"]["bb:b@c=cc"] == 1
+        assert ep.extras == ()
+
         # plus in the name
         spec = "html+mako = mako.ext.pygmentplugin:MakoHtmlLexer"
         ep = EntryPoint.parse(spec)
@@ -447,7 +454,7 @@ class TestEntryPoints:
         Allow any printable character in the name.
         """
         # Create a name with all printable characters; strip the whitespace.
-        name = string.printable.strip()
+        name = "".join(set(string.printable.strip()) - {"@"})
         spec = "{name} = module:attr".format(**locals())
         ep = EntryPoint.parse(spec)
         assert ep.name == name

--- a/setup.py
+++ b/setup.py
@@ -90,9 +90,9 @@ setup_params = dict(
             for cmd in read_commands()
         ],
         "setuptools.finalize_distribution_options": [
-            "parent_finalize = setuptools.dist:_Distribution.finalize_options",
-            "keywords = setuptools.dist:Distribution._finalize_setup_keywords",
-            "2to3_doctests = "
+            'parent_finalize  @ {"only": true} = setuptools.dist:_Distribution.finalize_options',
+            'keywords  @ {"only": true} = setuptools.dist:Distribution._finalize_setup_keywords',
+            '2to3_doctests @ {"only": true} = '
             "setuptools.dist:Distribution._finalize_2to3_doctests",
         ],
         "distutils.setup_keywords": [

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -284,6 +284,7 @@ def check_requirements(dist, attr, value):
 
 def check_specifier(dist, attr, value):
     """Verify that value is a valid version specifier"""
+
     try:
         packaging.specifiers.SpecifierSet(value)
     except packaging.specifiers.InvalidSpecifier as error:
@@ -702,30 +703,45 @@ class Distribution(_Distribution):
         to influence the order of execution. Smaller numbers
         go first and the default is 0.
         """
+
+        default_order_value = 0
         hook_key = 'setuptools.finalize_distribution_options'
 
         def by_order(hook):
-            return getattr(hook, 'order', 0)
+            return getattr(hook, 'order', default_order_value)
+
         eps = pkg_resources.iter_entry_points(hook_key)
+
         for ep in sorted(eps, key=by_order):
-            ep.load()(self)
+            try:
+                f = ep.load()
+            except Exception as ex:
+                warnings.warn(
+                    "Cannot load " + hook_key + " entry point "
+                    + repr(ep) + ":\n" + str(ex)
+                )
+                continue
 
-    def _finalize_setup_keywords(self):
+            f(self)
+
+    @staticmethod
+    def _finalize_setup_keywords(dist):
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
-            value = getattr(self, ep.name, None)
+            value = getattr(dist, ep.name, None)
             if value is not None:
-                ep.require(installer=self.fetch_build_egg)
-                ep.load()(self, ep.name, value)
+                ep.require(installer=dist.fetch_build_egg)
+                ep.load()(dist, ep.name, value)
 
-    def _finalize_2to3_doctests(self):
-        if getattr(self, 'convert_2to3_doctests', None):
+    @staticmethod
+    def _finalize_2to3_doctests(dist):
+        if getattr(dist, 'convert_2to3_doctests', None):
             # XXX may convert to set here when we can rely on set being builtin
-            self.convert_2to3_doctests = [
+            dist.convert_2to3_doctests = [
                 os.path.abspath(p)
-                for p in self.convert_2to3_doctests
+                for p in dist.convert_2to3_doctests
             ]
         else:
-            self.convert_2to3_doctests = []
+            dist.convert_2to3_doctests = []
 
     def get_egg_cache_dir(self):
         egg_cache_dir = os.path.join(os.curdir, '.eggs')


### PR DESCRIPTION
## Summary of changes
* Improved entry points mechanism. Entry points now can contain JSON metadata appended to a ''name'' after ''@'' character. It is a backward-incompatible change, but the breakage will unlikely happen.
* Now it allows the implementers to ast setuptools to provide them various information by adding a parameter with a certain name into the function signature. Old behavior is also supported. For the list of args names see ''DistributionoptionsFinalizationRemap'' in ''dist.py''.
* Now it tolerates errors in hooks code, so a package with a broken hook doesn't prevent from updating itself.
* Implemented ''setuptools.finalize_distribution_options'' hooks prioritization. A priority can be set as an integer or float metadata. Or, if you need to set other options via providing a ''dict'', it can be added into ''order'' key.
* Now it allows a hook only be called if it is mentioned in ''setup'' args or in ''pyproject.toml''. It can be done by adding ''{"only": ["toml"]}'' metadata. This should reduce breakage due to malfunctions in ''setuptools'' or hooks code.

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

Closes #2030

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
