### PR TITLE
Distr opts improvements base

### DIFF
--- a/changelog.d/2032.change.rst
+++ b/changelog.d/2032.change.rst
@@ -1,0 +1,7 @@
+Implemented some common facilities needed for further improvement of ''setuptools.finalize_distribution_options'' hook.
+
+* Implemented ''get_setup_py_path'' that allows to get a path of ''setup.py'' file.
+* Implemented ''get_setup_py_dir'' that allows to get a path of a dir where''setup.py'' file resides.
+* Implemented ''read_toml'' that just reads a TOML file. Neede ''toml' lib.
+* Implemented ''read_pyproject_toml'' that just reads ''pyproject'toml' file.
+* Implemented ''FinalizeDistributionOptionsHookArgsCache'' that does these operations lazily and caches their results, to use them for hooks in future.

--- a/changelog.d/2037.change.rst
+++ b/changelog.d/2037.change.rst
@@ -1,0 +1,4 @@
+A bit "cosmetic" changes though needed for implementing more advanced stuff.
+* Renamed args names params for some static methods and marked them with ''@staticmethod''.
+* Moved ''0'' into ''default_order_value" variable.
+* When an entry point now fails to be loaded, it doesn't disrupt building process.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -284,6 +284,7 @@ def check_requirements(dist, attr, value):
 
 def check_specifier(dist, attr, value):
     """Verify that value is a valid version specifier"""
+
     try:
         packaging.specifiers.SpecifierSet(value)
     except packaging.specifiers.InvalidSpecifier as error:
@@ -702,30 +703,45 @@ class Distribution(_Distribution):
         to influence the order of execution. Smaller numbers
         go first and the default is 0.
         """
+
+        default_order_value = 0
         hook_key = 'setuptools.finalize_distribution_options'
 
         def by_order(hook):
-            return getattr(hook, 'order', 0)
+            return getattr(hook, 'order', default_order_value)
+
         eps = pkg_resources.iter_entry_points(hook_key)
+
         for ep in sorted(eps, key=by_order):
-            ep.load()(self)
+            try:
+                f = ep.load()
+            except Exception as ex:
+                warnings.warn(
+                    "Cannot load " + hook_key + " entry point "
+                    + repr(ep) + ":\n" + str(ex)
+                )
+                continue
 
-    def _finalize_setup_keywords(self):
+            f(self)
+
+    @staticmethod
+    def _finalize_setup_keywords(dist):
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):
-            value = getattr(self, ep.name, None)
+            value = getattr(dist, ep.name, None)
             if value is not None:
-                ep.require(installer=self.fetch_build_egg)
-                ep.load()(self, ep.name, value)
+                ep.require(installer=dist.fetch_build_egg)
+                ep.load()(dist, ep.name, value)
 
-    def _finalize_2to3_doctests(self):
-        if getattr(self, 'convert_2to3_doctests', None):
+    @staticmethod
+    def _finalize_2to3_doctests(dist):
+        if getattr(dist, 'convert_2to3_doctests', None):
             # XXX may convert to set here when we can rely on set being builtin
-            self.convert_2to3_doctests = [
+            dist.convert_2to3_doctests = [
                 os.path.abspath(p)
-                for p in self.convert_2to3_doctests
+                for p in dist.convert_2to3_doctests
             ]
         else:
-            self.convert_2to3_doctests = []
+            dist.convert_2to3_doctests = []
 
     def get_egg_cache_dir(self):
         egg_cache_dir = os.path.join(os.curdir, '.eggs')


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Implemented some common facilities needed for further improvement of ''setuptools.finalize_distribution_options'' hook.

* Implemented ''get_setup_py_path'' that allows to get a path of ''setup.py'' file.
* Implemented ''get_setup_py_dir'' that allows to get a path of a dir where''setup.py'' file resides.
* Implemented ''read_toml'' that just reads a TOML file. Neede ''toml' lib.
* Implemented ''read_pyproject_toml'' that just reads ''pyproject'toml' file.
* Implemented ''FinalizeDistributionOptionsHookArgsCache'' that does these operations lazily and caches their results, to use them for hooks in future.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
