### PR TITLE
Improved entry points mechanism. Entry points now can contain JSON metadata

### DIFF
--- a/changelog.d/2033.breaking.rst
+++ b/changelog.d/2033.breaking.rst
@@ -1,0 +1,1 @@
+* Improved entry points mechanism. Entry points now can contain JSON metadata appended to a ''name'' after ''@'' character. It is a backward-incompatible change, but the breakage will unlikely happen.

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -430,6 +430,13 @@ class TestEntryPoints:
         assert ep.attrs == ("foo",)
         assert ep.extras == ()
 
+        ep = EntryPoint.parse('a @ {"aa:aa=b@ddd": {"bb:b@c=cc": 1}} =  b:c')
+        assert ep.name == "a"
+        assert ep.module_name == "b"
+        assert ep.attrs == ("c",)
+        assert ep.metadata["aa:aa=b@ddd"]["bb:b@c=cc"] == 1
+        assert ep.extras == ()
+
         # plus in the name
         spec = "html+mako = mako.ext.pygmentplugin:MakoHtmlLexer"
         ep = EntryPoint.parse(spec)
@@ -447,7 +454,7 @@ class TestEntryPoints:
         Allow any printable character in the name.
         """
         # Create a name with all printable characters; strip the whitespace.
-        name = string.printable.strip()
+        name = "".join(set(string.printable.strip()) - {"@"})
         spec = "{name} = module:attr".format(**locals())
         ep = EntryPoint.parse(spec)
         assert ep.name == name


### PR DESCRIPTION
Improved entry points mechanism. Entry points now can contain JSON metadata appended to a ''name'' after ''@'' character. It is a backward-incompatible change, but the breakage will unlikely happen.

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

* Improved entry points mechanism. Entry points now can contain JSON metadata appended to a ''name'' after ''@'' character. It is a backward-incompatible change, but the breakage will unlikely happen.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
