### PR TITLE
Deprecate bdist_wininst

### DIFF
--- a/changelog.d/2040.change.rst
+++ b/changelog.d/2040.change.rst
@@ -1,0 +1,1 @@
+Deprecated the ``bdist_wininst`` command. Binary packages should be built as wheels instead.

--- a/setuptools/command/bdist_wininst.py
+++ b/setuptools/command/bdist_wininst.py
@@ -1,4 +1,7 @@
 import distutils.command.bdist_wininst as orig
+import warnings
+
+from setuptools import SetuptoolsDeprecationWarning
 
 
 class bdist_wininst(orig.bdist_wininst):
@@ -14,6 +17,12 @@ class bdist_wininst(orig.bdist_wininst):
         return cmd
 
     def run(self):
+        warnings.warn(
+            "bdist_wininst is deprecated and will be removed in a future "
+            "version. Use bdist_wheel (wheel packages) instead.",
+            SetuptoolsDeprecationWarning
+        )
+
         self._is_running = True
         try:
             orig.bdist_wininst.run(self)

--- a/setuptools/tests/test_bdist_deprecations.py
+++ b/setuptools/tests/test_bdist_deprecations.py
@@ -1,0 +1,23 @@
+"""develop tests
+"""
+import mock
+
+import pytest
+
+from setuptools.dist import Distribution
+from setuptools import SetuptoolsDeprecationWarning
+
+
+@mock.patch("distutils.command.bdist_wininst.bdist_wininst")
+def test_bdist_wininst_warning(distutils_cmd):
+    dist = Distribution(dict(
+        script_name='setup.py',
+        script_args=['bdist_wininst'],
+        name='foo',
+        py_modules=['hi'],
+    ))
+    dist.parse_command_line()
+    with pytest.warns(SetuptoolsDeprecationWarning):
+        dist.run_commands()
+
+    distutils_cmd.run.assert_called_once()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Deprecate bdist_wininst

<!-- Summary goes here -->

For #1988.

Already deprecated in CPython 3.8's `distutils`.

The deprecation method, message and tests are modelled on the recent https://github.com/pypa/setuptools/pull/1764 (deprecate "eggsecutable" scripts).

I had a go at the other bdists mentioned in #1988, but had a hard time with the tests, so here's just one to be getting on with.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details

