### PR TITLE
Undo preserve_mode=False in order to preserve execute permission

### DIFF
--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -120,8 +120,7 @@ class build_py(orig.build_py, Mixin2to3):
                 target = os.path.join(build_dir, filename)
                 self.mkpath(os.path.dirname(target))
                 srcfile = os.path.join(src_dir, filename)
-                outf, copied = self.copy_file(
-                    srcfile, target, preserve_mode=False)
+                outf, copied = self.copy_file(srcfile, target)
                 srcfile = os.path.abspath(srcfile)
                 if (copied and
                         srcfile in self.distribution.convert_2to3_doctests):


### PR DESCRIPTION
Fixes [#2041](https://github.com/pypa/setuptools/issues/2041)

@dhallam @tibdex @tgaddair @mattclay @pselden @jaraco @KOLANICH