### PR TITLE
Preserve file modes during pkg files copying, but clear read only flag for target afterwards

### DIFF
--- a/changelog.d/2041.bugfix.rst
+++ b/changelog.d/2041.bugfix.rst
@@ -1,0 +1,1 @@
+Preserve file modes during pkg files copying, but clear read only flag for target afterwards.

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -7,6 +7,7 @@ import textwrap
 import io
 import distutils.errors
 import itertools
+import stat
 
 from setuptools.extern import six
 from setuptools.extern.six.moves import map, filter, filterfalse
@@ -120,8 +121,10 @@ class build_py(orig.build_py, Mixin2to3):
                 target = os.path.join(build_dir, filename)
                 self.mkpath(os.path.dirname(target))
                 srcfile = os.path.join(src_dir, filename)
-                outf, copied = self.copy_file(
-                    srcfile, target, preserve_mode=False)
+                outf, copied = self.copy_file(srcfile, target)
+                cur_mode = os.stat(target)[stat.ST_MODE]
+                target_mode = cur_mode | stat.S_IWRITE
+                os.chmod(target, target_mode)
                 srcfile = os.path.abspath(srcfile)
                 if (copied and
                         srcfile in self.distribution.convert_2to3_doctests):

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -43,7 +43,11 @@ def test_read_only(tmpdir_cwd):
     open('pkg/__init__.py', 'w').close()
     open('pkg/data.dat', 'w').close()
     os.chmod('pkg/__init__.py', stat.S_IREAD)
-    os.chmod('pkg/data.dat', stat.S_IREAD)
+    os.chmod('pkg/data.dat', stat.S_IREAD | stat.S_IEXEC)
+
     dist.parse_command_line()
     dist.run_commands()
+
+    if not (os.stat('build/lib/pkg/data.dat')[stat.ST_MODE] & stat.S_IEXEC):
+        raise Exception('Executable flag was cleared!')
     shutil.rmtree('build')


### PR DESCRIPTION
## Summary of changes

This PR is supposed to fix a regression caused by PR #1607 and initially explained in the issue #1424
Originally the issue #1424 was fixed by not preserving flags for package data, but this caused issues in many other projects described e.g. in #2043 
The new approach is that we again keep file flags as is, but set write permission flag for the target file afterwards. This should not clear eXecutable bit, but allow file deleting.
An updated test also sets eX bit for package file and checks that target file still has it. The test fails for current version of setuptools and passes for the proposed PR.
Closes #2041 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
