### PR TITLE
When an entry point now fails to be loaded, it doesn't disrupt building process.

### DIFF
--- a/changelog.d/distr_opts_improvements_graceful_load_fallback.change.rst
+++ b/changelog.d/distr_opts_improvements_graceful_load_fallback.change.rst
@@ -1,0 +1,2 @@
+* When an entry point now fails to be loaded, it doesn't disrupt building process.
+

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -285,6 +285,7 @@ def check_requirements(dist, attr, value):
 
 def check_specifier(dist, attr, value):
     """Verify that value is a valid version specifier"""
+
     try:
         packaging.specifiers.SpecifierSet(value)
     except packaging.specifiers.InvalidSpecifier as error:
@@ -712,7 +713,19 @@ class Distribution(_Distribution):
 
         def by_order(hook):
             return getattr(hook, 'order', 0)
-        eps = map(lambda e: e.load(), pkg_resources.iter_entry_points(group))
+
+        eps = []
+        for ep in  pkg_resources.iter_entry_points(group):
+            try:
+                f = ep.load()
+            except Exception as ex:
+                warnings.warn(
+                    "Cannot load " + hook_key + " entry point "
+                    + repr(ep) + ":\n" + str(ex)
+                )
+                continue
+            eps.append(f)
+
         for ep in sorted(eps, key=by_order):
             ep(self)
 


### PR DESCRIPTION
## Summary of changes
Splitted from #2037

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
