### PR TITLE
Use Visual Studio setup configuration API instead of vswhere.exe

### DIFF
--- a/changelog.d/2061.change.rst
+++ b/changelog.d/2061.change.rst
@@ -1,0 +1,1 @@
+Use the Visual Studio setup configuration API to find Visual Studio 2017 and newer installs

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -285,10 +285,11 @@ def _vs_setup_config_find_vc():
         https://github.com/microsoft/vs-setup-samples
     """
     try:
-        ole32 = ctypes.oledll.ole32
+        ole32 = ctypes.windll.ole32
+        ole32_hr = ctypes.oledll.ole32
 
         # initialize the COM library
-        ole32.CoInitialize(None)
+        ole32_hr.CoInitializeEx(None, 0)  # COINIT_MULTITHREADED
     except OSError:
         return None, None
 
@@ -297,7 +298,7 @@ def _vs_setup_config_find_vc():
     try:
         # create an instance of the ISetupConfiguration interface
         setup_configuration = ctypes.c_void_p()
-        ole32.CoCreateInstance(
+        ole32_hr.CoCreateInstance(
             ctypes.byref(CLSID_SetupConfiguration),
             None,
             1,  # CLSCTX_INPROC_SERVER

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -258,6 +258,7 @@ class GUID(ctypes.Structure):
         ('Data4', ctypes.c_char * 8),
     ]
 
+
 CLSID_SetupConfiguration = GUID(
     0x177f0c4a, 0x1cd3, 0x4de7, b'\xa3\x2c\x71\xdb\xbb\x9f\xa3\x6d'
 )
@@ -269,6 +270,7 @@ IID_ISetupConfiguration = GUID(
 IID_ISetupInstance2 = GUID(
     0x89143c9a, 0x05af, 0x49b0, b'\xb7\x17\x72\xe2\x18\xa2\x18\x5c'
 )
+
 
 def _vs_setup_config_find_vc():
     """Search Visual Studio instances and returns the latest version.
@@ -298,7 +300,7 @@ def _vs_setup_config_find_vc():
         ole32.CoCreateInstance(
             ctypes.byref(CLSID_SetupConfiguration),
             None,
-            1, # CLSCTX_INPROC_SERVER
+            1,  # CLSCTX_INPROC_SERVER
             ctypes.byref(IID_ISetupConfiguration),
             ctypes.byref(setup_configuration)
         )
@@ -359,7 +361,9 @@ def _vs_setup_config_find_vc():
         packages = ctypes.c_void_p()
 
         try:
-            while _next(enum_setup_instances, 1, ctypes.byref(setup_instance), None) == 0: # S_OK
+            while _next(
+                    enum_setup_instances, 1, ctypes.byref(setup_instance), None
+            ) == 0:  # S_OK
                 try:
                     # call IUnknown::QueryInterface and receive an
                     # instance of ISetupInstance2


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The current version of `_msvc14_find_vc2017` uses the `vswhere.exe` utility to locate an installation of the Visual C++ compiler, but not all types of Visual Studio installs include that utility. For example, Visual Studio 2019 C++ Build Tools does not include it.

The `vswhere.exe` utility uses the [Visual Studio setup configuration API](https://github.com/microsoft/vs-setup-samples) to locate installs of Visual Studio 2017 and above. These changes use that API directly instead of relying on the `vswhere.exe` utility.

Since it uses the same API, it should work exactly as the current version, except that it will also work in cases where the `vswhere.exe` utility is not available on the system. But the changes do add quite a bit of code since it's accessing a COM interface using `ctypes`.

Since I don't own any version of Windows, my only way to test has been in Wine. Also due to bugs in Wine, running `vcvarsall.bat` causes a page fault... so I really haven't been able to do any extensive testing. What I *have* been able to test is that my version of `_msvc14_find_vc2017` does return the correct path with Visual Studio 2019 C++ Build Tools installed.

Closes #2028

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
