### PR TITLE
change: Mac OS X -> macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ setuptools.egg-info
 .cache
 .idea/
 .pytest_cache/
+.mypy_cache/

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1519,7 +1519,7 @@ v21.1.0
 * #572: In build_ext, now always import ``_CONFIG_VARS``
   from ``distutils`` rather than from ``sysconfig``
   to allow ``distutils.sysconfig.customize_compiler``
-  configure the OS X compiler for ``-dynamiclib``.
+  configure the macOS compiler for ``-dynamiclib``.
 
 v21.0.0
 -------
@@ -1939,7 +1939,7 @@ v20.6.0
   require that Cython be present before building source distributions.
   However, for systems with this build of setuptools, Cython will be
   downloaded on demand.
-* Issue #396: Fixed test failure on OS X.
+* Issue #396: Fixed test failure on macOS.
 * BB Pull Request #136: Remove excessive quoting from shebang headers
   for Jython.
 
@@ -3136,7 +3136,7 @@ how it parses version numbers.
 * Distribute #306: Even if 2to3 is used, we build in-place under Python 2.
 * Distribute #307: Prints the full path when .svn/entries is broken.
 * Distribute #313: Support for sdist subcommands (Python 2.7)
-* Distribute #314: test_local_index() would fail an OS X.
+* Distribute #314: test_local_index() would fail an macOS.
 * Distribute #310: Non-ascii characters in a namespace __init__.py causes errors.
 * Distribute #218: Improved documentation on behavior of `package_data` and
   `include_package_data`. Files indicated by `package_data` are now included
@@ -4163,7 +4163,7 @@ easy_install
    based on a contribution by Kevin Dangoor.  You may wish to delete and
    reinstall any eggs whose filename includes "darwin" and "Power_Macintosh",
    because the format for this platform information has changed so that minor
-   OS X upgrades (such as 10.4.1 to 10.4.2) do not cause eggs built with a
+   macOS upgrades (such as 10.4.1 to 10.4.2) do not cause eggs built with a
    previous OS version to become obsolete.
 
  * easy_install's dependency processing algorithms have changed.  When using
@@ -4176,7 +4176,7 @@ easy_install
 
  * Added ``--site-dirs`` option to allow adding custom "site" directories.
    Made ``easy-install.pth`` work in platform-specific alternate site
-   directories (e.g. ``~/Library/Python/2.x/site-packages`` on Mac OS X).
+   directories (e.g. ``~/Library/Python/2.x/site-packages`` on macOS).
 
  * If you manually delete the current version of a package, the next run of
    EasyInstall against the target directory will now remove the stray entry

--- a/changelog.d/2062.change.rst
+++ b/changelog.d/2062.change.rst
@@ -1,0 +1,1 @@
+Change 'Mac OS X' to 'macOS' in code.

--- a/docs/history.txt
+++ b/docs/history.txt
@@ -12,7 +12,7 @@ Credits
 
 * The original design for the ``.egg`` format and the ``pkg_resources`` API was
   co-created by Phillip Eby and Bob Ippolito. Bob also implemented the first
-  version of ``pkg_resources``, and supplied the OS X operating system version
+  version of ``pkg_resources``, and supplied the macOS operating system version
   compatibility algorithm.
 
 * Ian Bicking implemented many early "creature comfort" features of

--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -1621,7 +1621,7 @@ Platform Utilities
 
 ``get_build_platform()``
     Return this platform's identifier string.  For Windows, the return value
-    is ``"win32"``, and for Mac OS X it is a string of the form
+    is ``"win32"``, and for macOS it is a string of the form
     ``"macosx-10.4-ppc"``.  All other platforms return the same uname-based
     string that the ``distutils.util.get_platform()`` function returns.
     This string is the minimum platform version required by distributions built
@@ -1641,7 +1641,7 @@ Platform Utilities
     considered a wildcard, and the platforms are therefore compatible.
     Likewise, if the platform strings are equal, they're also considered
     compatible, and ``True`` is returned.  Currently, the only non-equal
-    platform strings that are considered compatible are Mac OS X platform
+    platform strings that are considered compatible are macOS platform
     strings with the same hardware type (e.g. ``ppc``) and major version
     (e.g. ``10``) with the `provided` platform's minor version being less than
     or equal to the `required` platform's minor version.
@@ -1674,7 +1674,7 @@ File/Path Utilities
     the same filesystem location if they have equal ``normalized_path()``
     values.  Specifically, this is a shortcut for calling ``os.path.realpath``
     and ``os.path.normcase`` on `path`.  Unfortunately, on certain platforms
-    (notably Cygwin and Mac OS X) the ``normcase`` function does not accurately
+    (notably Cygwin and macOS) the ``normcase`` function does not accurately
     reflect the platform's case-sensitivity, so there is always the possibility
     of two apparently-different paths being equal on such platforms.
 

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -179,10 +179,10 @@ def get_supported_platform():
     """Return this platform's maximum compatible version.
 
     distutils.util.get_platform() normally reports the minimum version
-    of Mac OS X that would be required to *use* extensions produced by
+    of macOS that would be required to *use* extensions produced by
     distutils.  But what we want when checking compatibility is to know the
-    version of Mac OS X that we are *running*.  To allow usage of packages that
-    explicitly require a newer version of Mac OS X, we must also know the
+    version of macOS that we are *running*.  To allow usage of packages that
+    explicitly require a newer version of macOS, we must also know the
     current version of the OS.
 
     If this condition occurs for any other platform with a version in its
@@ -192,9 +192,9 @@ def get_supported_platform():
     m = macosVersionString.match(plat)
     if m is not None and sys.platform == "darwin":
         try:
-            plat = 'macosx-%s-%s' % ('.'.join(_macosx_vers()[:2]), m.group(3))
+            plat = 'macosx-%s-%s' % ('.'.join(_macos_vers()[:2]), m.group(3))
         except ValueError:
-            # not Mac OS X
+            # not macOS
             pass
     return plat
 
@@ -365,7 +365,7 @@ def get_provider(moduleOrReq):
     return _find_adapter(_provider_factories, loader)(module)
 
 
-def _macosx_vers(_cache=[]):
+def _macos_vers(_cache=[]):
     if not _cache:
         version = platform.mac_ver()[0]
         # fallback for MacPorts
@@ -381,7 +381,7 @@ def _macosx_vers(_cache=[]):
     return _cache[0]
 
 
-def _macosx_arch(machine):
+def _macos_arch(machine):
     return {'PowerPC': 'ppc', 'Power_Macintosh': 'ppc'}.get(machine, machine)
 
 
@@ -389,18 +389,18 @@ def get_build_platform():
     """Return this platform's string for platform-specific distributions
 
     XXX Currently this is the same as ``distutils.util.get_platform()``, but it
-    needs some hacks for Linux and Mac OS X.
+    needs some hacks for Linux and macOS.
     """
     from sysconfig import get_platform
 
     plat = get_platform()
     if sys.platform == "darwin" and not plat.startswith('macosx-'):
         try:
-            version = _macosx_vers()
+            version = _macos_vers()
             machine = os.uname()[4].replace(" ", "_")
             return "macosx-%d.%d-%s" % (
                 int(version[0]), int(version[1]),
-                _macosx_arch(machine),
+                _macos_arch(machine),
             )
         except ValueError:
             # if someone is running a non-Mac darwin system, this will fall
@@ -426,7 +426,7 @@ def compatible_platforms(provided, required):
         # easy case
         return True
 
-    # Mac OS X special cases
+    # macOS special cases
     reqMac = macosVersionString.match(required)
     if reqMac:
         provMac = macosVersionString.match(provided)
@@ -435,7 +435,7 @@ def compatible_platforms(provided, required):
         if not provMac:
             # this is backwards compatibility for packages built before
             # setuptools 0.6. All packages built after this point will
-            # use the new macosx designation.
+            # use the new macOS designation.
             provDarwin = darwinVersionString.match(provided)
             if provDarwin:
                 dversion = int(provDarwin.group(1))
@@ -443,7 +443,7 @@ def compatible_platforms(provided, required):
                 if dversion == 7 and macosversion >= "10.3" or \
                         dversion == 8 and macosversion >= "10.4":
                     return True
-            # egg isn't macosx or legacy darwin
+            # egg isn't macOS or legacy darwin
             return False
 
         # are they the same major version and machine type?

--- a/pkg_resources/_vendor/appdirs.py
+++ b/pkg_resources/_vendor/appdirs.py
@@ -8,10 +8,9 @@
 See <http://github.com/ActiveState/appdirs> for details and usage.
 """
 # Dev Notes:
-# - MSDN on where to store app data files:
-#   http://support.microsoft.com/default.aspx?scid=kb;en-us;310294#XSLTH3194121123120121120120
-# - Mac OS X: http://developer.apple.com/documentation/MacOSX/Conceptual/BPFileSystem/index.html
-# - XDG spec for Un*x: http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+# - MSDN on where to store app data files: (TODO: needs new link)
+# - macOS: (TODO: needs new link)
+# - XDG spec for Un*x: https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
 
 __version_info__ = (1, 4, 3)
 __version__ = '.'.join(map(str, __version_info__))
@@ -64,7 +63,7 @@ def user_data_dir(appname=None, appauthor=None, version=None, roaming=False):
             for a discussion of issues.
 
     Typical user data directories are:
-        Mac OS X:               ~/Library/Application Support/<AppName>
+        macOS:                 ~/Library/Application Support/<AppName>
         Unix:                   ~/.local/share/<AppName>    # or in $XDG_DATA_HOME, if defined
         Win XP (not roaming):   C:\Documents and Settings\<username>\Application Data\<AppAuthor>\<AppName>
         Win XP (roaming):       C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>
@@ -118,7 +117,7 @@ def site_data_dir(appname=None, appauthor=None, version=None, multipath=False):
             if XDG_DATA_DIRS is not set
 
     Typical site data directories are:
-        Mac OS X:   /Library/Application Support/<AppName>
+        macOS:      /Library/Application Support/<AppName>
         Unix:       /usr/local/share/<AppName> or /usr/share/<AppName>
         Win XP:     C:\Documents and Settings\All Users\Application Data\<AppAuthor>\<AppName>
         Vista:      (Fail! "C:\ProgramData" is a hidden *system* directory on Vista.)
@@ -185,7 +184,7 @@ def user_config_dir(appname=None, appauthor=None, version=None, roaming=False):
             for a discussion of issues.
 
     Typical user config directories are:
-        Mac OS X:               same as user_data_dir
+        macOS:                  same as user_data_dir
         Unix:                   ~/.config/<AppName>     # or in $XDG_CONFIG_HOME, if defined
         Win *:                  same as user_data_dir
 
@@ -223,7 +222,7 @@ def site_config_dir(appname=None, appauthor=None, version=None, multipath=False)
             returned, or '/etc/xdg/<AppName>', if XDG_CONFIG_DIRS is not set
 
     Typical site config directories are:
-        Mac OS X:   same as site_data_dir
+        macOS:      same as site_data_dir
         Unix:       /etc/xdg/<AppName> or $XDG_CONFIG_DIRS[i]/<AppName> for each value in
                     $XDG_CONFIG_DIRS
         Win *:      same as site_data_dir
@@ -273,7 +272,7 @@ def user_cache_dir(appname=None, appauthor=None, version=None, opinion=True):
             discussion below.
 
     Typical user cache directories are:
-        Mac OS X:   ~/Library/Caches/<AppName>
+        macOS:     ~/Library/Caches/<AppName>
         Unix:       ~/.cache/<AppName> (XDG default)
         Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Cache
         Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Cache
@@ -333,7 +332,7 @@ def user_state_dir(appname=None, appauthor=None, version=None, roaming=False):
             for a discussion of issues.
 
     Typical user state directories are:
-        Mac OS X:  same as user_data_dir
+        macOS:     same as user_data_dir
         Unix:      ~/.local/state/<AppName>   # or in $XDG_STATE_HOME, if defined
         Win *:     same as user_data_dir
 
@@ -372,7 +371,7 @@ def user_log_dir(appname=None, appauthor=None, version=None, opinion=True):
             base cache dir for Unix. See discussion below.
 
     Typical user log directories are:
-        Mac OS X:   ~/Library/Logs/<AppName>
+        macOS:      ~/Library/Logs/<AppName>
         Unix:       ~/.cache/<AppName>/log  # or under $XDG_CACHE_HOME if defined
         Win XP:     C:\Documents and Settings\<username>\Local Settings\Application Data\<AppAuthor>\<AppName>\Logs
         Vista:      C:\Users\<username>\AppData\Local\<AppAuthor>\<AppName>\Logs

--- a/pkg_resources/api_tests.txt
+++ b/pkg_resources/api_tests.txt
@@ -290,8 +290,8 @@ Platform Compatibility Rules
 ----------------------------
 
 On the Mac, there are potential compatibility issues for modules compiled
-on newer versions of Mac OS X than what the user is running. Additionally,
-Mac OS X will soon have two platforms to contend with: Intel and PowerPC.
+on newer versions of macOS than what the user is running. Additionally,
+macOS will soon have two platforms to contend with: Intel and PowerPC.
 
 Basic equality works as on other platforms::
 

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1053,7 +1053,7 @@ def open_with_auth(url, opener=urllib.request.urlopen):
     parsed = urllib.parse.urlparse(url)
     scheme, netloc, path, params, query, frag = parsed
 
-    # Double scheme does not raise on Mac OS X as revealed by a
+    # Double scheme does not raise on macOS as revealed by a
     # failing test. We would expect "nonnumeric port". Refs #20.
     if netloc.endswith(':'):
         raise http_client.InvalidURL("nonnumeric port: ''")


### PR DESCRIPTION
Signed-off-by: Reece Dunham <me@rdil.rocks>

## Summary of changes

OS X isn't what macOS is called anymore.  This fixes it.

A couple other small fixes included aswell related.

### Pull Request Checklist
- [X] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
