### PR TITLE
Use importlib instead of imp in __bootstrap__ functions

### DIFF
--- a/changelog.d/2071.misc.rst
+++ b/changelog.d/2071.misc.rst
@@ -1,0 +1,1 @@
+Replaced references to the deprecated imp package with references to importlib

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -55,10 +55,11 @@ def write_stub(resource, pyfile):
     _stub_template = textwrap.dedent("""
         def __bootstrap__():
             global __bootstrap__, __loader__, __file__
-            import sys, pkg_resources, imp
+            import sys, pkg_resources
+            from importlib.machinery import ExtensionFileLoader
             __file__ = pkg_resources.resource_filename(__name__, %r)
             __loader__ = None; del __bootstrap__, __loader__
-            imp.load_dynamic(__name__,__file__)
+            ExtensionFileLoader(__name__,__file__).exec_module()
         __bootstrap__()
         """).lstrip()
     with open(pyfile, 'w') as f:

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -254,7 +254,8 @@ class build_ext(_build_ext):
                 '\n'.join([
                     "def __bootstrap__():",
                     "   global __bootstrap__, __file__, __loader__",
-                    "   import sys, os, pkg_resources, imp" + if_dl(", dl"),
+                    "   import sys, os, pkg_resources" + if_dl(", dl"),
+                    "   from importlib.machinery import ExtensionFileLoader",
                     "   __file__ = pkg_resources.resource_filename"
                     "(__name__,%r)"
                     % os.path.basename(ext._file_name),
@@ -266,7 +267,8 @@ class build_ext(_build_ext):
                     "   try:",
                     "     os.chdir(os.path.dirname(__file__))",
                     if_dl("     sys.setdlopenflags(dl.RTLD_NOW)"),
-                    "     imp.load_dynamic(__name__,__file__)",
+                    "     ExtensionFileLoader(__name__,",
+                    "                         __file__).exec_module()",
                     "   finally:",
                     if_dl("     sys.setdlopenflags(old_flags)"),
                     "     os.chdir(old_dir)",


### PR DESCRIPTION
When the PYTHONWARNINGS environment variable is set, I often see the message `DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses` in conjuction with bootstrap files for compiled modules. This pull request fixes the code that triggers that warning.