### PR TITLE
Stop recognizing files ending with .dist-info as dist

### DIFF
--- a/changelog.d/2075.breaking.rst
+++ b/changelog.d/2075.breaking.rst
@@ -1,0 +1,1 @@
+Stop recognizing files ending with ``.dist-info`` as distribution metadata

--- a/changelog.d/2075.breaking.rst
+++ b/changelog.d/2075.breaking.rst
@@ -1,1 +1,0 @@
-Stop recognizing files ending with ``.dist-info`` as distribution metadata

--- a/changelog.d/2075.change.rst
+++ b/changelog.d/2075.change.rst
@@ -1,0 +1,1 @@
+Stop recognizing files ending with ``.dist-info`` as distribution metadata.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2071,16 +2071,18 @@ def find_on_path(importer, path_item, only=False):
 def dist_factory(path_item, entry, only):
     """Return a dist_factory for the given entry."""
     lower = entry.lower()
-    if lower.endswith('.egg-info'):
-        return distributions_from_metadata
-    elif lower.endswith('.dist-info') and os.path.isdir(entry):
-        return distributions_from_metadata
-    elif not only and _is_egg_path(entry):
-        return find_distributions
-    elif not only and lower.endswith('.egg-link'):
-        return resolve_egg_link
-    else:
-        return NoDists()
+    is_egg_info = lower.endswith('.egg-info')
+    is_dist_info = lower.endswith('.dist-info') and os.path.isdir(entry)
+    is_meta = is_egg_info or is_dist_info
+    return (
+        distributions_from_metadata
+        if is_meta else
+        find_distributions
+        if not only and _is_egg_path(entry) else
+        resolve_egg_link
+        if not only and lower.endswith('.egg-link') else
+        NoDists()
+    )
 
 
 class NoDists:

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2072,7 +2072,7 @@ def dist_factory(path_item, entry, only):
     """Return a dist_factory for the given entry."""
     lower = entry.lower()
     is_egg_info = lower.endswith('.egg-info')
-    is_dist_info = lower.endswith('.dist-info') and os.path.isdir(entry)
+    is_dist_info = lower.endswith('.dist-info') and not os.path.isfile(entry)
     is_meta = is_egg_info or is_dist_info
     return (
         distributions_from_metadata

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2072,7 +2072,10 @@ def dist_factory(path_item, entry, only):
     """Return a dist_factory for the given entry."""
     lower = entry.lower()
     is_egg_info = lower.endswith('.egg-info')
-    is_dist_info = lower.endswith('.dist-info') and not os.path.isfile(entry)
+    is_dist_info = (
+        lower.endswith('.dist-info') and
+        os.path.isdir(os.path.join(path_item, entry))
+    )
     is_meta = is_egg_info or is_dist_info
     return (
         distributions_from_metadata

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2056,19 +2056,19 @@ def find_on_path(importer, path_item, only=False):
     filtered = (
         entry
         for entry in entries
-        if dist_factory(entry, only)
+        if dist_factory(path_item, entry, only)
     )
 
     # scan for .egg and .egg-info in directory
     path_item_entries = _by_version_descending(filtered)
     for entry in path_item_entries:
         fullpath = os.path.join(path_item, entry)
-        factory = dist_factory(entry, only)
+        factory = dist_factory(path_item, entry, only)
         for dist in factory(fullpath):
             yield dist
 
 
-def dist_factory(entry, only):
+def dist_factory(path_item, entry, only):
     """Return a dist_factory for the given entry."""
     lower = entry.lower()
     if lower.endswith('.egg-info'):

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -335,7 +335,7 @@ def test_dist_info_is_not_dir(tmp_path, only):
     """Test path containing a file with dist-info extension."""
     dist_info = tmp_path / 'foobar.dist-info'
     dist_info.touch()
-    assert not pkg_resources.dist_factory(str(dist_info), only)
+    assert not pkg_resources.dist_factory(None, str(dist_info), only)
 
 
 class TestDeepVersionLookupDistutils:

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -335,7 +335,7 @@ def test_dist_info_is_not_dir(tmp_path, only):
     """Test path containing a file with dist-info extension."""
     dist_info = tmp_path / 'foobar.dist-info'
     dist_info.touch()
-    assert not pkg_resources.dist_factory(None, str(dist_info), only)
+    assert not pkg_resources.dist_factory(str(tmp_path), str(dist_info), only)
 
 
 class TestDeepVersionLookupDistutils:

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -330,6 +330,14 @@ def test_distribution_version_missing_undetected_path():
     assert msg == expected
 
 
+@pytest.mark.parametrize('only', [False, True])
+def test_dist_info_is_not_dir(tmp_path, only):
+    """Test path containing a file with dist-info extension."""
+    dist_info = tmp_path / 'foobar.dist-info'
+    dist_info.touch()
+    assert not pkg_resources.dist_factory(str(dist_info), only)
+
+
 class TestDeepVersionLookupDistutils:
     @pytest.fixture
     def env(self, tmpdir):


### PR DESCRIPTION
## Summary of changes
As proposed in [PEP 376](https://www.python.org/dev/peps/pep-0376/), dist-info distributions must be directories.

Closes pypa/pip#8122.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in `changelog.d`

Edit: apparently files with `dist-info` extension seems to be an supported behavior for `setuptools`.  I'll try to investigate why.