### PR TITLE
Add "python -m setuptools" invocation method

### DIFF
--- a/changelog.d/2080.change.rst
+++ b/changelog.d/2080.change.rst
@@ -1,0 +1,1 @@
+Add support for running `python -m setuptools cmd` as a setup.py alternative.

--- a/setuptools/__main__.py
+++ b/setuptools/__main__.py
@@ -1,0 +1,10 @@
+"""
+Command-line interface for running setup.py or new-fashioned setup.cfg after
+setuptools is monkey-patched into distutils.
+"""
+
+if __name__ == '__main__':
+    import sys
+    from setuptools.launch import run_setup
+    sys.argv[0] = 'setuptools'
+    run_setup()

--- a/setuptools/launch.py
+++ b/setuptools/launch.py
@@ -11,6 +11,7 @@ import os
 import sys
 import tokenize
 
+
 def _open_setup_script(setup_script, fallback):
     if fallback and not os.path.exists(setup_script):
         # Supply a default setup.py
@@ -18,17 +19,19 @@ def _open_setup_script(setup_script, fallback):
 
     return getattr(tokenize, 'open', open)(setup_script)
 
+
 def run_setup(setup_script='setup.py', fallback=True):
     namespace = {
-        '__file__' : setup_script,
-        '__name__' : '__main__',
-        '__doc__' : None
+        '__file__': setup_script,
+        '__name__': '__main__',
+        '__doc__': None
     }
 
     with _open_setup_script(setup_script, fallback) as f:
         code = f.read().replace(r'\r\n', r'\n')
 
     exec(compile(code, setup_script, 'exec'), namespace)
+
 
 def run_script():
     """

--- a/setuptools/launch.py
+++ b/setuptools/launch.py
@@ -6,30 +6,40 @@ setuptools is bootstrapped via import.
 # Note that setuptools gets imported implicitly by the
 # invocation of this script using python -m setuptools.launch
 
-import tokenize
+import io
+import os
 import sys
+import tokenize
 
+def _open_setup_script(setup_script, fallback):
+    if fallback and not os.path.exists(setup_script):
+        # Supply a default setup.py
+        return io.StringIO(u"from setuptools import setup; setup()")
 
-def run():
+    return getattr(tokenize, 'open', open)(setup_script)
+
+def run_setup(setup_script='setup.py', fallback=True):
+    namespace = {
+        '__file__' : setup_script,
+        '__name__' : '__main__',
+        '__doc__' : None
+    }
+
+    with _open_setup_script(setup_script, fallback) as f:
+        code = f.read().replace(r'\r\n', r'\n')
+
+    exec(compile(code, setup_script, 'exec'), namespace)
+
+def run_script():
     """
     Run the script in sys.argv[1] as if it had
     been invoked naturally.
     """
-    __builtins__
     script_name = sys.argv[1]
-    namespace = dict(
-        __file__=script_name,
-        __name__='__main__',
-        __doc__=None,
-    )
     sys.argv[:] = sys.argv[1:]
 
-    open_ = getattr(tokenize, 'open', open)
-    script = open_(script_name).read()
-    norm_script = script.replace('\\r\\n', '\\n')
-    code = compile(norm_script, script_name, 'exec')
-    exec(code, namespace)
+    run_setup(script_name, fallback=False)
 
 
 if __name__ == '__main__':
-    run()
+    run_script()


### PR DESCRIPTION
## Summary of changes

This fully replaces the use of "python setup.py <cmd>" with the equivalent "python -m setuptools <cmd>". In the process, we guarantee that a setup.py which imported only distutils will still get the enhanced setuptools treatment previously provided only by pip install.

This opens the way for future improvements to setuptools, such as validating setup_requires (if listed in setup.cfg) before invoking the setup() function and running code.

It is also the only way to invoke setuptools to build and install packages which fully moved to setup.cfg and no longer provide a stub setup.py with the content:

```
from setuptool import setup
setup()
```

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details