### PR TITLE
Filter lib2to3 (Pending)DeprecationWarning in testes

### DIFF
--- a/changelog.d/2082.misc.rst
+++ b/changelog.d/2082.misc.rst
@@ -1,0 +1,2 @@
+Filter ``lib2to3`` ``PendingDeprecationWarning`` and ``DeprecationWarning`` in testes,
+because ``lib2to3`` is `deprecated in Python 3.9 <https://bugs.python.org/issue40360>`_.

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,3 +20,6 @@ filterwarnings =
     ignore:Unicode unequal comparison failed to convert:UnicodeWarning
     # https://github.com/pypa/setuptools/issues/2025
     ignore:direct construction of .*Item has been deprecated:DeprecationWarning
+    # https://github.com/pypa/setuptools/issues/2081
+    ignore:lib2to3 package is deprecated:PendingDeprecationWarning
+    ignore:lib2to3 package is deprecated:DeprecationWarning


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

lib2to3 is deprecated in Python 3.9: https://bugs.python.org/issue40360

Workarounds https://github.com/pypa/setuptools/issues/2081

### Pull Request Checklist
- [ ] Changes have tests: **not possible** unless we have metatests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
