### PR TITLE
improve pkg_resources.Distribution.hashcmp performance

### DIFF
--- a/changelog.d/2090.change.rst
+++ b/changelog.d/2090.change.rst
@@ -1,0 +1,1 @@
+Improve ``pkg_resources.Distribution.hashcmp`` performance.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2613,14 +2613,14 @@ class Distribution:
             self.platform or '',
         )
 
-    def get_location(self):
+    @property
+    def location(self):
         return self._location
 
-    def set_location(self, l):
-        self._location = l
-        self._location_without_md5 = _remove_md5_fragment(l)
-
-    location = property(get_location, set_location)
+    @location.setter
+    def location(self, location):
+        self._location = location
+        self._location_without_md5 = _remove_md5_fragment(location)
 
     def __hash__(self):
         return hash(self.hashcmp)

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2608,10 +2608,19 @@ class Distribution:
             self.parsed_version,
             self.precedence,
             self.key,
-            _remove_md5_fragment(self.location),
+            self._location_without_md5,
             self.py_version or '',
             self.platform or '',
         )
+
+    def get_location(self):
+        return self._location
+
+    def set_location(self, l):
+        self._location = l
+        self._location_without_md5 = _remove_md5_fragment(l)
+
+    location = property(get_location, set_location)
 
     def __hash__(self):
         return hash(self.hashcmp)


### PR DESCRIPTION
by storing location without md5.

Turns `Distribution.location` into a property to make `hashcmp` more performant.

Closes #2089

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
