### PR TITLE
Tweak note about setup.cfg

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -2106,8 +2106,9 @@ Configuring setup() using setup.cfg files
 .. note:: New in 30.3.0 (8 Dec 2016).
 
 .. important::
-    A ``setup.py`` file containing a ``setup()`` function call is still
-    required even if your configuration resides in ``setup.cfg``.
+    If compatibility with legacy builds (i.e. those not using the :pep:`517`
+    build API) is desired, a ``setup.py`` file containing a ``setup()`` function
+    call is still required even if your configuration resides in ``setup.cfg``.
 
 ``Setuptools`` allows using configuration files (usually :file:`setup.cfg`)
 to define a package’s metadata and other options that are normally supplied


### PR DESCRIPTION
This note has gotten a bit out of date, since setup.py is no longer required.

### Pull Request Checklist
- N/A Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
