### PR TITLE
Emit deprecation warning when 2to3 is used.

### DIFF
--- a/changelog.d/2086.change.rst
+++ b/changelog.d/2086.change.rst
@@ -1,0 +1,1 @@
+Deprecate 'use_2to3' functionality. Packagers are encouraged to use single-source solutions or build tool chains to manage conversions outside of setuptools.

--- a/setuptools/lib2to3_ex.py
+++ b/setuptools/lib2to3_ex.py
@@ -13,6 +13,7 @@ from distutils import log
 from lib2to3.refactor import RefactoringTool, get_fixers_from_package
 
 import setuptools
+from ._deprecation_warning import SetuptoolsDeprecationWarning
 
 
 class DistutilsRefactoringTool(RefactoringTool):
@@ -40,7 +41,7 @@ class Mixin2to3(_Mixin2to3):
             "requires Python 2 support, please migrate to "
             "a single-codebase solution or employ an "
             "independent conversion process.",
-            DeprecationWarning)
+            SetuptoolsDeprecationWarning)
         log.info("Fixing " + " ".join(files))
         self.__build_fixer_names()
         self.__exclude_fixers()

--- a/setuptools/lib2to3_ex.py
+++ b/setuptools/lib2to3_ex.py
@@ -36,9 +36,10 @@ class Mixin2to3(_Mixin2to3):
             return
 
         warnings.warn(
-            "2to3 support is deprecated. Please migrate to "
-            "a single-codebase solution or roll your own "
-            "conversion process.",
+            "2to3 support is deprecated. If the project still "
+            "requires Python 2 support, please migrate to "
+            "a single-codebase solution or employ an "
+            "independent conversion process.",
             DeprecationWarning)
         log.info("Fixing " + " ".join(files))
         self.__build_fixer_names()

--- a/setuptools/lib2to3_ex.py
+++ b/setuptools/lib2to3_ex.py
@@ -7,6 +7,7 @@ Customized Mixin2to3 support:
 This module raises an ImportError on Python 2.
 """
 
+import warnings
 from distutils.util import Mixin2to3 as _Mixin2to3
 from distutils import log
 from lib2to3.refactor import RefactoringTool, get_fixers_from_package
@@ -33,6 +34,12 @@ class Mixin2to3(_Mixin2to3):
             return
         if not files:
             return
+
+        warnings.warn(
+            "2to3 support is deprecated. Please migrate to "
+            "a single-codebase solution or roll your own "
+            "conversion process.",
+            DeprecationWarning)
         log.info("Fixing " + " ".join(files))
         self.__build_fixer_names()
         self.__exclude_fixers()

--- a/setuptools/tests/test_test.py
+++ b/setuptools/tests/test_test.py
@@ -73,7 +73,11 @@ def quiet_log():
     log.set_verbosity(0)
 
 
+ack_2to3 = pytest.mark.filterwarnings('ignore:2to3 support is deprecated')
+
+
 @pytest.mark.usefixtures('sample_test', 'quiet_log')
+@ack_2to3
 def test_test(capfd):
     params = dict(
         name='foo',
@@ -124,6 +128,7 @@ def test_tests_are_run_once(capfd):
 
 
 @pytest.mark.usefixtures('sample_test')
+@ack_2to3
 def test_warns_deprecation(capfd):
     params = dict(
         name='foo',
@@ -149,6 +154,7 @@ def test_warns_deprecation(capfd):
 
 
 @pytest.mark.usefixtures('sample_test')
+@ack_2to3
 def test_deprecation_stderr(capfd):
     params = dict(
         name='foo',


### PR DESCRIPTION
As discussed in #2086, and as planned for years, deprecate the 2to3 feature. Instead, packagers are encouraged to write single-source code or build a tool chain outside of setuptools to perform conversions.