### PR TITLE
Reuse @ack_2to3 in TestDevelop.test_2to3_user_mode

### DIFF
--- a/changelog.d/2105.misc.rst
+++ b/changelog.d/2105.misc.rst
@@ -1,0 +1,1 @@
+Filter ``2to3`` deprecation warnings from ``TestDevelop.test_2to3_user_mode``.

--- a/setuptools/tests/__init__.py
+++ b/setuptools/tests/__init__.py
@@ -6,7 +6,7 @@ from setuptools.extern.six import PY2, PY3
 
 
 __all__ = [
-    'fail_on_ascii', 'py2_only', 'py3_only'
+    'fail_on_ascii', 'py2_only', 'py3_only', 'ack_2to3'
 ]
 
 
@@ -16,3 +16,5 @@ fail_on_ascii = pytest.mark.xfail(is_ascii, reason="Test fails in this locale")
 
 py2_only = pytest.mark.skipif(not PY2, reason="Test runs on Python 2 only")
 py3_only = pytest.mark.skipif(not PY3, reason="Test runs on Python 3 only")
+
+ack_2to3 = pytest.mark.filterwarnings('ignore:2to3 support is deprecated')

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -17,6 +17,7 @@ import pytest
 
 from setuptools.command.develop import develop
 from setuptools.dist import Distribution
+from setuptools.tests import ack_2to3
 from . import contexts
 from . import namespaces
 
@@ -65,6 +66,7 @@ class TestDevelop:
     @pytest.mark.skipif(
         in_virtualenv or in_venv,
         reason="Cannot run when invoked in a virtualenv or venv")
+    @ack_2to3
     def test_2to3_user_mode(self, test_env):
         settings = dict(
             name='foo',

--- a/setuptools/tests/test_test.py
+++ b/setuptools/tests/test_test.py
@@ -10,6 +10,7 @@ import pytest
 
 from setuptools.command.test import test
 from setuptools.dist import Distribution
+from setuptools.tests import ack_2to3
 
 from .textwrap import DALS
 
@@ -71,9 +72,6 @@ def quiet_log():
     # Running some of the other tests will automatically
     # change the log level to info, messing our output.
     log.set_verbosity(0)
-
-
-ack_2to3 = pytest.mark.filterwarnings('ignore:2to3 support is deprecated')
 
 
 @pytest.mark.usefixtures('sample_test', 'quiet_log')


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes https://github.com/pypa/setuptools/issues/2100

### Pull Request Checklist
- [x] Changes have tests -- it is tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
