### PR TITLE
Feature/faster distribution hashcmp no remove

### DIFF
--- a/changelog.d/2089.change.rst
+++ b/changelog.d/2089.change.rst
@@ -1,0 +1,1 @@
+Package index functionality no longer attempts to remove an md5 fragment from the index URL. This functionality, added for distribute #163 is no longer relevant.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -55,7 +55,7 @@ except NameError:
     FileExistsError = OSError
 
 from pkg_resources.extern import six
-from pkg_resources.extern.six.moves import urllib, map, filter
+from pkg_resources.extern.six.moves import map, filter
 
 # capture these to bypass sandboxing
 from os import utime
@@ -2546,15 +2546,6 @@ class EntryPoint:
         return maps
 
 
-def _remove_md5_fragment(location):
-    if not location:
-        return ''
-    parsed = urllib.parse.urlparse(location)
-    if parsed[-1].startswith('md5='):
-        return urllib.parse.urlunparse(parsed[:-1] + ('',))
-    return location
-
-
 def _version_from_file(lines):
     """
     Given an iterable of lines from a Metadata file, return
@@ -2611,7 +2602,7 @@ class Distribution:
             self.parsed_version,
             self.precedence,
             self.key,
-            _remove_md5_fragment(self.location),
+            self.location,
             self.py_version or '',
             self.platform or '',
         )

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -9,9 +9,7 @@ from setuptools.extern.six.moves import urllib, http_client
 import mock
 import pytest
 
-import pkg_resources
 import setuptools.package_index
-from setuptools.tests.server import IndexServer
 from .textwrap import DALS
 
 
@@ -113,43 +111,6 @@ class TestPackageIndex:
         )
         url = 'file:///tmp/test_package_index'
         assert index.url_ok(url, True)
-
-    def test_links_priority(self):
-        """
-        Download links from the pypi simple index should be used before
-        external download links.
-        https://bitbucket.org/tarek/distribute/issue/163
-
-        Usecase :
-        - someone uploads a package on pypi, a md5 is generated
-        - someone manually copies this link (with the md5 in the url) onto an
-          external page accessible from the package page.
-        - someone reuploads the package (with a different md5)
-        - while easy_installing, an MD5 error occurs because the external link
-          is used
-        -> Setuptools should use the link from pypi, not the external one.
-        """
-        if sys.platform.startswith('java'):
-            # Skip this test on jython because binding to :0 fails
-            return
-
-        # start an index server
-        server = IndexServer()
-        server.start()
-        index_url = server.base_url() + 'test_links_priority/simple/'
-
-        # scan a test index
-        pi = setuptools.package_index.PackageIndex(index_url)
-        requirement = pkg_resources.Requirement.parse('foobar')
-        pi.find_packages(requirement)
-        server.stop()
-
-        # the distribution has been found
-        assert 'foobar' in pi
-        # we have only one link, because links are compared without md5
-        assert len(pi['foobar']) == 1
-        # the link should be from the index
-        assert 'correct_md5' in pi['foobar'][0].location
 
     def test_parse_bdist_wininst(self):
         parse = setuptools.package_index.parse_bdist_wininst


### PR DESCRIPTION
Alternate to #2090 and #2098, fixes #2089 by just removing the slow function.