### PR TITLE
Give a less confusing example for requirements parsing

### DIFF
--- a/docs/pkg_resources.txt
+++ b/docs/pkg_resources.txt
@@ -594,7 +594,7 @@ Requirements Parsing
 
         FooProject >= 1.2
         Fizzy [foo, bar]
-        PickyThing<1.6,>1.9,!=1.9.6,<2.0a0,==2.4c1
+        PickyThing>1.6,<=1.9,!=1.8.6
         SomethingWhoseVersionIDontCareAbout
         SomethingWithMarker[foo]>1.0;python_version<"2.7"
 


### PR DESCRIPTION
In the API reference for requirements parsing:
https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirements-parsing

There is offered an example `PickyThing<1.6,>1.9,!=1.9.6,<2.0a0,==2.4c1` that strongly implies commas mean logical OR.  [But PEP440 says commas mean logical AND](https://www.python.org/dev/peps/pep-0440/#version-specifiers).

I've edited it into a more realistic example to avoid this potential confusion. 

Related is https://github.com/pypa/pip/issues/2744, which was promptly closed some time ago but never actually fixed (maybe just a simple oversight - ping @dstufft?)