### PR TITLE
Remove superfluous RequirementParseError

### DIFF
--- a/changelog.d/2137.change.rst
+++ b/changelog.d/2137.change.rst
@@ -1,0 +1,1 @@
+Removed (private) pkg_resources.RequirementParseError, now replaced by packaging.requirements.InvalidRequirement. Kept the name for compatibility, but users should catch InvalidRequirement instead.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -3068,11 +3068,6 @@ def issue_warning(*args, **kw):
     warnings.warn(stacklevel=level + 1, *args, **kw)
 
 
-class RequirementParseError(ValueError):
-    def __str__(self):
-        return ' '.join(self.args)
-
-
 def parse_requirements(strs):
     """Yield ``Requirement`` objects for each specification in `strs`
 
@@ -3098,10 +3093,7 @@ def parse_requirements(strs):
 class Requirement(packaging.requirements.Requirement):
     def __init__(self, requirement_string):
         """DO NOT CALL THIS UNDOCUMENTED METHOD; use Requirement.parse()!"""
-        try:
-            super(Requirement, self).__init__(requirement_string)
-        except packaging.requirements.InvalidRequirement as e:
-            raise RequirementParseError(str(e))
+        super(Requirement, self).__init__(requirement_string)
         self.unsafe_name = self.name
         project_name = safe_name(self.name)
         self.project_name, self.key = project_name, project_name.lower()

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -3090,6 +3090,10 @@ def parse_requirements(strs):
         yield Requirement(line)
 
 
+class RequirementParseError(packaging.requirements.InvalidRequirement):
+    "Compatibility wrapper for InvalidRequirement"
+
+
 class Requirement(packaging.requirements.Requirement):
     def __init__(self, requirement_string):
         """DO NOT CALL THIS UNDOCUMENTED METHOD; use Requirement.parse()!"""


### PR DESCRIPTION
In #1832, I learned that at least some users think the `RequirementParseError` should be exposed in `pkg_resources.__all__`. But diving into the history of that class, I don't think it was ever meant to be anything other than a nice error renderer. Can it just be removed?