### PR TITLE
Update docs to contribute to #2093

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ setuptools.egg-info
 .idea/
 .pytest_cache/
 .mypy_cache/
+tags**
+tags{,.temp,.lock}

--- a/docs/build_meta.txt
+++ b/docs/build_meta.txt
@@ -7,31 +7,31 @@ What is it?
 
 Python packaging has come `a long way <https://www.bernat.tech/pep-517-518/>`_.
 
-The traditional ``setuptools`` way of packgaging Python modules
+The traditional ``setuptools`` way of packaging Python modules
 uses a ``setup()`` function within the ``setup.py`` script. Commands such as
-``python setup.py bdist`` or ``python setup.py bdist_wheel`` generate a 
-distribution bundle and ``python setup.py install`` installs the distribution. 
-This interface makes it difficult to choose other packaging tools without an 
+``python setup.py bdist`` or ``python setup.py bdist_wheel`` generate a
+distribution bundle and ``python setup.py install`` installs the distribution.
+This interface makes it difficult to choose other packaging tools without an
 overhaul. Because ``setup.py`` scripts allowed for arbitrary execution, it
 proved difficult to provide a reliable user experience across environments
 and history.
 
 `PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ therefore came to
-rescue and specified a new standard to 
+rescue and specified a new standard to
 package and distribute Python modules. Under PEP 517:
 
     a ``pyproject.toml`` file is used to specify what program to use
-    for generating distribution. 
+    for generating distribution.
 
-    Then, two functions provided by the program, ``build_wheel(directory: str)`` 
-    and ``build_sdist(directory: str)`` create the distribution bundle at the 
-    specified ``directory``. The program is free to use its own configuration 
-    script or extend the ``.toml`` file. 
+    Then, two functions provided by the program, ``build_wheel(directory: str)``
+    and ``build_sdist(directory: str)`` create the distribution bundle at the
+    specified ``directory``. The program is free to use its own configuration
+    script or extend the ``.toml`` file.
 
     Lastly, ``pip install *.whl`` or ``pip install *.tar.gz`` does the actual
     installation. If ``*.whl`` is available, ``pip`` will go ahead and copy
     the files into ``site-packages`` directory. If not, ``pip`` will look at
-    ``pyproject.toml`` and decide what program to use to 'build from source' 
+    ``pyproject.toml`` and decide what program to use to 'build from source'
     (the default is ``setuptools``)
 
 With this standard, switching between packaging tools becomes a lot easier. ``build_meta``
@@ -48,34 +48,34 @@ scripts, a ``pyproject.toml`` file and a ``setup.cfg`` file::
         setup.cfg
         meowpkg/__init__.py
 
-The pyproject.toml file is required to specify the build system (i.e. what is 
-being used to package your scripts and install from source). To use it with 
+The pyproject.toml file is required to specify the build system (i.e. what is
+being used to package your scripts and install from source). To use it with
 setuptools, the content would be::
 
     [build-system]
     requires = ["setuptools", "wheel"]
-    build-backend = "setuptools.build_meta" 
+    build-backend = "setuptools.build_meta"
 
-Use ``setuptools``' `declarative config`_ to specify the package information::
+Use ``setuptools``' :ref:`declarative config <declarative config>` to specify the package information::
 
     [metadata]
     name = meowpkg
     version = 0.0.1
     description = a package that meows
-    
+
     [options]
     packages = find:
 
 Now generate the distribution. Although the PyPA is still working to
 `provide a recommended tool <https://github.com/pypa/packaging-problems/issues/219>`_
-to build packages, the `pep517 package <https://pypi.org/project/pep517`_
+to build packages, the `pep517 package <https://pypi.org/project/pep517>`_
 provides this functionality. To build the package::
 
     $ pip install -q pep517
     $ mkdir dist
     $ python -m pep517.build .
 
-And now it's done! The ``.whl`` file  and ``.tar.gz`` can then be distributed 
+And now it's done! The ``.whl`` file  and ``.tar.gz`` can then be distributed
 and installed::
 
     dist/

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -14,10 +14,11 @@ designed to facilitate packaging Python projects, where packaging includes:
 Documentation content:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    setuptools
    pkg_resources
+   build_meta
    python3
    development
    roadmap

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Fix a broken link in build_meta, strip trailing whitespace, include it in the TOCTree and increase the maxdepth that Sphinx uses.

This is the copy pasted commit message.:

> Build meta was not included originally, emitting a warning from Sphinx
as a result.

> In addition, increase the max-depth to 3. As it stands the current table
> of contents is overwhelmingly populated from the changelog.

> By increasing the amount Sphinx recurses into each individual page, the
> content of the site is displayed much more prominently.


Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
