### PR TITLE
DOC: Update mailing list link

### DIFF
--- a/changelog.d/2156.doc.rst
+++ b/changelog.d/2156.doc.rst
@@ -1,0 +1,1 @@
+Update mailing list pointer in developer docs

--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -23,16 +23,16 @@ contribution.
 Project Management
 ------------------
 
-Setuptools is maintained primarily in Github at `this home
+Setuptools is maintained primarily in GitHub at `this home
 <https://github.com/pypa/setuptools>`_. Setuptools is maintained under the
 Python Packaging Authority (PyPA) with several core contributors. All bugs
-for Setuptools are filed and the canonical source is maintained in Github.
+for Setuptools are filed and the canonical source is maintained in GitHub.
 
 User support and discussions are done through the issue tracker (for specific)
-issues, through the distutils-sig mailing list, or on IRC (Freenode) at
+issues, through the `distutils-sig mailing list <https://mail.python.org/mailman3/lists/distutils-sig.python.org/>`_, or on IRC (Freenode) at
 #pypa.
 
-Discussions about development happen on the pypa-dev mailing list or on
+Discussions about development happen on the distutils-sig mailing list or on
 `Gitter <https://gitter.im/pypa/setuptools>`_.
 
 -----------------
@@ -44,7 +44,7 @@ describing the motivation behind making changes. First search to see if a
 ticket already exists for your issue. If not, create one. Try to think from
 the perspective of the reader. Explain what behavior you expected, what you
 got instead, and what factors might have contributed to the unexpected
-behavior. In Github, surround a block of code or traceback with the triple
+behavior. In GitHub, surround a block of code or traceback with the triple
 backtick "\`\`\`" so that it is formatted nicely.
 
 Filing a ticket provides a forum for justification, discussion, and


### PR DESCRIPTION
## Summary of changes

Per https://groups.google.com/d/msg/pypa-dev/rUNsfIbruHM/LCEx-CB5AgAJ
the pypa-dev Google Group is now decommissioned.
Pointing to distutils-sig instead.

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>

### Pull Request Checklist
- [x] Changes have tests (**Not applicable**)
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
