### PR TITLE
Allow specifying the location of setup.cfg files

### DIFF
--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -16,6 +16,9 @@ def config_file(kind="local"):
 
     `kind` must be one of "local", "global", or "user"
     """
+    env_location = os.environ.get('SETUPTOOLS_CFG_FILE')
+    if env_location:
+        return os.path.normpath(env_location)
     if kind == 'local':
         return 'setup.cfg'
     if kind == 'global':


### PR DESCRIPTION
## Summary of changes

The file path resolver will first check for the `SETUPTOOLS_CFG_FILE` env var

### Motivation

The files in my case are dynamically generated at build time and this would remove the need to temporarily write them to the project directory