### PR TITLE
Support sic versions in pkg_resources.safe_version

### DIFF
--- a/changelog.d/2181.change.rst
+++ b/changelog.d/2181.change.rst
@@ -1,0 +1,1 @@
+Support 'setuptools.sic' class in 'pkg_resources.safe_version()' function to bypass version normalization.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1329,6 +1329,11 @@ def safe_version(version):
     Convert an arbitrary string to a standard version string
     """
     try:
+        # If this is a sic version bypass normalization. Unfortunately this
+        # module is loaded prior to sic being defined, so look for it by name.
+        if (type(version).__name__ == 'sic'):
+            return version
+
         # normalize the version
         return str(packaging.version.Version(version))
     except packaging.version.InvalidVersion:

--- a/pkg_resources/tests/test_safe_version.py
+++ b/pkg_resources/tests/test_safe_version.py
@@ -1,0 +1,27 @@
+# coding: utf-8
+
+from pkg_resources import safe_version
+from setuptools import sic
+
+
+class TestSafeVersion:
+
+    def test_safe_version_ok(self):
+        actual = '1.2.3'
+        safe = safe_version(actual)
+        assert safe == actual
+
+    def test_invalid_version_whitespace(self):
+        actual = '1 2 3'
+        safe = safe_version(actual)
+        assert safe == '1.2.3'
+
+    def test_invalid_version_regex(self):
+        actual = '1.2.3%4'
+        safe = safe_version(actual)
+        assert safe == '1.2.3-4'
+
+    def test_sic_version(self):
+        actual = sic('1.2.3.beta')
+        safe = safe_version(actual)
+        assert safe == actual


### PR DESCRIPTION
## Summary of changes

This builds upon https://github.com/pypa/setuptools/issues/308 and
https://github.com/pypa/setuptools/pull/2026 to extend support for sic versions (bypassing
normalization) into pkg_resources. I found this while trying to support versions such as
"1.2.3.alpha". While these worked for some setup.py commands, most continued to normalize the
version (egg_info, bdist_wheel for example). Both of those use safe_version in pkg_resources, so
figured extending support for sic there made the most sense.

Closes #2181

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d.