### PR TITLE
Decrease start-up time of editable-installed entry points on newer versions of Python

### DIFF
--- a/changelog.d/2194.change.rst
+++ b/changelog.d/2194.change.rst
@@ -1,0 +1,1 @@
+Editable-installed entry points now load significantly faster on Python versions 3.8+.

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -2070,9 +2070,7 @@ class ScriptWriter:
     gui apps.
     """
 
-    try:
-        from importlib.metadata import distribution  # noqa: F401
-
+    if sys.version_info >= (3, 8):
         template = textwrap.dedent(r"""
             # EASY-INSTALL-ENTRY-SCRIPT: %(spec)r,%(group)r,%(name)r
             __requires__ = %(spec)r
@@ -2086,7 +2084,7 @@ class ScriptWriter:
                     if entry_point.group == %(group)r and entry_point.name == %(name)r:
                         sys.exit(entry_point.load()())
         """).lstrip()  # noqa: E501
-    except ImportError:
+    else:
         template = textwrap.dedent(r"""
             # EASY-INSTALL-ENTRY-SCRIPT: %(spec)r,%(group)r,%(name)r
             __requires__ = %(spec)r

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -2070,19 +2070,36 @@ class ScriptWriter:
     gui apps.
     """
 
-    template = textwrap.dedent(r"""
-        # EASY-INSTALL-ENTRY-SCRIPT: %(spec)r,%(group)r,%(name)r
-        __requires__ = %(spec)r
-        import re
-        import sys
-        from pkg_resources import load_entry_point
+    try:
+        from importlib.metadata import distribution  # noqa: F401
 
-        if __name__ == '__main__':
-            sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
-            sys.exit(
-                load_entry_point(%(spec)r, %(group)r, %(name)r)()
-            )
-    """).lstrip()
+        template = textwrap.dedent(r"""
+            # EASY-INSTALL-ENTRY-SCRIPT: %(spec)r,%(group)r,%(name)r
+            __requires__ = %(spec)r
+            import re
+            import sys
+            from importlib.metadata import distribution
+
+            if __name__ == '__main__':
+                sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+                for entry_point in distribution(%(spec)r).entry_points:
+                    if entry_point.group == %(group)r and entry_point.name == %(name)r:
+                        sys.exit(entry_point.load()())
+        """).lstrip()  # noqa: E501
+    except ImportError:
+        template = textwrap.dedent(r"""
+            # EASY-INSTALL-ENTRY-SCRIPT: %(spec)r,%(group)r,%(name)r
+            __requires__ = %(spec)r
+            import re
+            import sys
+            from pkg_resources import load_entry_point
+
+            if __name__ == '__main__':
+                sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+                sys.exit(
+                    load_entry_point(%(spec)r, %(group)r, %(name)r)()
+                )
+        """).lstrip()  # noqa: E501
 
     command_spec_class = CommandSpec
 

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -2073,7 +2073,6 @@ class ScriptWriter:
     if sys.version_info >= (3, 8):
         template = textwrap.dedent(r"""
             # EASY-INSTALL-ENTRY-SCRIPT: %(spec)r,%(group)r,%(name)r
-            __requires__ = %(spec)r
             import re
             import sys
             from importlib.metadata import distribution

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -74,7 +74,6 @@ class TestEasyInstallTest:
         if sys.version_info >= (3, 8):
             expected = header + DALS(r"""
                 # EASY-INSTALL-ENTRY-SCRIPT: 'spec','console_scripts','name'
-                __requires__ = 'spec'
                 import re
                 import sys
                 from importlib.metadata import distribution

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -71,9 +71,7 @@ class TestEasyInstallTest:
 
     def test_get_script_args(self):
         header = ei.CommandSpec.best().from_environment().as_header()
-        try:
-            from importlib.metadata import distribution  # noqa: F401
-
+        if sys.version_info >= (3, 8):
             expected = header + DALS(r"""
                 # EASY-INSTALL-ENTRY-SCRIPT: 'spec','console_scripts','name'
                 __requires__ = 'spec'
@@ -87,7 +85,7 @@ class TestEasyInstallTest:
                         if entry_point.group == 'console_scripts' and entry_point.name == 'name':
                             sys.exit(entry_point.load()())
                 """)  # noqa: E501
-        except ImportError:
+        else:
             expected = header + DALS(r"""
                 # EASY-INSTALL-ENTRY-SCRIPT: 'spec','console_scripts','name'
                 __requires__ = 'spec'

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -71,19 +71,37 @@ class TestEasyInstallTest:
 
     def test_get_script_args(self):
         header = ei.CommandSpec.best().from_environment().as_header()
-        expected = header + DALS(r"""
-            # EASY-INSTALL-ENTRY-SCRIPT: 'spec','console_scripts','name'
-            __requires__ = 'spec'
-            import re
-            import sys
-            from pkg_resources import load_entry_point
+        try:
+            from importlib.metadata import distribution  # noqa: F401
 
-            if __name__ == '__main__':
-                sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
-                sys.exit(
-                    load_entry_point('spec', 'console_scripts', 'name')()
-                )
-            """)  # noqa: E501
+            expected = header + DALS(r"""
+                # EASY-INSTALL-ENTRY-SCRIPT: 'spec','console_scripts','name'
+                __requires__ = 'spec'
+                import re
+                import sys
+                from importlib.metadata import distribution
+
+                if __name__ == '__main__':
+                    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+                    for entry_point in distribution('spec').entry_points:
+                        if entry_point.group == 'console_scripts' and entry_point.name == 'name':
+                            sys.exit(entry_point.load()())
+                """)  # noqa: E501
+        except ImportError:
+            expected = header + DALS(r"""
+                # EASY-INSTALL-ENTRY-SCRIPT: 'spec','console_scripts','name'
+                __requires__ = 'spec'
+                import re
+                import sys
+                from pkg_resources import load_entry_point
+
+                if __name__ == '__main__':
+                    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+                    sys.exit(
+                        load_entry_point('spec', 'console_scripts', 'name')()
+                    )
+                """)  # noqa: E501
+
         dist = FakeDist()
 
         args = next(ei.ScriptWriter.get_args(dist))


### PR DESCRIPTION
## Summary of changes

When `importlib.metadata` is present, the generated scripts will use that rather than the significantly slower `pkg_resources`.

Closes https://github.com/pypa/setuptools/issues/510 completely as editable installs are the final affected part (that is actionable) brought up in that issue and what I've been experiencing the last 2 weeks (it's indeed annoying)

The issue is locked, so here are some pings: @jaraco @scopatz @ninjaaron @untitaker @asottile @pganssle @gaborbernat @pfmoore @pradyunsg

### Benchmark

Before and after, using  [hyperfine](https://github.com/sharkdp/hyperfine):

![Capture](https://user-images.githubusercontent.com/9677399/84600100-0f3f3b00-ae45-11ea-8126-8cbfedbdf5f5.PNG)

### Pull Request Checklist

- [X] Changes have tests
- [X] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
