### PR TITLE
Fix typo in path to vendored.txt

### DIFF
--- a/docs/developer-guide.txt
+++ b/docs/developer-guide.txt
@@ -145,5 +145,5 @@ setuptools from source. Eventually, this limitation may be lifted as
 PEP 517/518 reach ubiquitous adoption, but for now, Setuptools
 cannot declare dependencies other than through
 ``setuptools/_vendor/vendored.txt`` and
-``pkg_reosurces/_vendor/vendored.txt`` and refreshed by way of
+``pkg_resources/_vendor/vendored.txt`` and refreshed by way of
 ``paver update_vendored`` (pavement.py).


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

I noticed a very minor typo in `docs/developer-guide.txt`. In the section _Vendored Dependencies_, the path to `vendored.txt` in `pkg_resources/` reads `pkg_reosurces/_vendor/vendored.txt`, where it should instead be `pkg_resources/_vendor/vendored.txt`. This was introduced in https://github.com/pypa/setuptools/commit/8aeff6b2c9a64e47ad2a22533d7e65c08cd4103f.


Because the change is so small, I haven't created an issue or a changelog entry. Previous corrected-typos-in-docs PRs that have been merged have done the same, so hopefully this is okay.