### PR TITLE
add pypy schemas to command/install.py

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1459,7 +1459,8 @@ class NullProvider:
         script_filename = self._fn(self.egg_info, script)
         namespace['__file__'] = script_filename
         if os.path.exists(script_filename):
-            source = open(script_filename).read()
+            with open(script_filename) as fid:
+                source = fid.read()
             code = compile(source, script_filename, 'exec')
             exec(code, namespace, namespace)
         else:

--- a/setuptools/launch.py
+++ b/setuptools/launch.py
@@ -25,7 +25,8 @@ def run():
     sys.argv[:] = sys.argv[1:]
 
     open_ = getattr(tokenize, 'open', open)
-    script = open_(script_name).read()
+    with open_(script_name) as fid:
+        script = fid.read()
     norm_script = script.replace('\\r\\n', '\\n')
     code = compile(norm_script, script_name, 'exec')
     exec(code, namespace)

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -42,7 +42,7 @@ class TestBuildExt:
         res = cmd.get_ext_filename('spam.eggs')
 
         if six.PY2 or not get_abi3_suffix():
-            assert res.endswith(get_config_var('SO'))
+            assert res.endswith(get_config_var('EXT_SUFFIX'))
         elif sys.platform == 'win32':
             assert res.endswith('eggs.pyd')
         else:


### PR DESCRIPTION
## Summary of changes

This is a start: there are still 3 pypy failures after this change.
I think they are related to sysconfig specifically finding `Python.h`, and one may be a bad test.
