### PR TITLE
Improve coverage configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source=
+	pkg_resources
+	setuptools
+omit=
+	*/_vendor/*
+
+[report]

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -98,5 +98,3 @@ jobs:
         python -m
         tox
         --parallel auto
-        --
-        --cov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ jobs:
   fast_finish: true
   include:
   - python: pypy3
-    env: DISABLE_COVERAGE=1  # Don't run coverage on pypy (too slow).
   - python: 3.5
   - python: 3.6
   - python: 3.7
@@ -15,12 +14,12 @@ jobs:
     env: LANG=C
   - python: 3.8-dev
   - <<: *latest_py3
-    env: TOXENV=docs DISABLE_COVERAGE=1
+    env: TOXENV=docs
   allow_failures:
   # suppress failures due to pypa/setuptools#2000
   - python: pypy3
   - <<: *latest_py3
-    env: TOXENV=docs DISABLE_COVERAGE=1
+    env: TOXENV=docs
 
 cache: pip
 
@@ -39,22 +38,8 @@ install:
 
 script:
   - export NETWORK_REQUIRED=1
-  - |
-    ( # Run testsuite.
-      if [ -z "$DISABLE_COVERAGE" ]
-      then
-        tox -- --cov
-      else
-        tox
-      fi
-    )
+  - tox
 
 after_success:
-  - |
-    ( # Upload coverage data.
-      if [ -z "$DISABLE_COVERAGE" ]
-      then
-        export TRAVIS_JOB_NAME="${TRAVIS_PYTHON_VERSION} (LANG=$LANG)" CODECOV_ENV=TRAVIS_JOB_NAME
-        tox -e coverage,codecov
-      fi
-    )
+  - export TRAVIS_JOB_NAME="${TRAVIS_PYTHON_VERSION} (LANG=$LANG)" CODECOV_ENV=TRAVIS_JOB_NAME
+  - tox -e coverage,codecov

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts=--doctest-modules --flake8 --doctest-glob=pkg_resources/api_tests.txt -r sxX
+addopts=--doctest-modules --flake8 --doctest-glob=pkg_resources/api_tests.txt --cov -r sxX
 norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern pkg_resources/tests/data tools .* setuptools/_vendor pkg_resources/_vendor
 doctest_optionflags=ELLIPSIS ALLOW_UNICODE
 filterwarnings =

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ setenv =
 # TODO: The passed environment variables came from copying other tox.ini files
 # These should probably be individually annotated to explain what needs them.
 passenv=APPDATA HOMEDRIVE HOMEPATH windir Program* CommonProgram* VS* APPVEYOR APPVEYOR_* CI CODECOV_* TRAVIS TRAVIS_* NETWORK_REQUIRED
-commands=pytest --cov-config={toxinidir}/tox.ini --cov-report= {posargs}
+commands=pytest {posargs}
 usedevelop=True
 extras =
 	tests
@@ -52,13 +52,6 @@ extras =
 changedir = docs
 commands =
         python -m sphinx . {toxinidir}/build/html
-
-[coverage:run]
-source=
-	pkg_resources
-	setuptools
-omit=
-	*/_vendor/*
 
 [testenv:finalize]
 skip_install = True

--- a/tox.ini
+++ b/tox.ini
@@ -23,10 +23,14 @@ setenv =
 # TODO: The passed environment variables came from copying other tox.ini files
 # These should probably be individually annotated to explain what needs them.
 passenv=APPDATA HOMEDRIVE HOMEPATH windir Program* CommonProgram* VS* APPVEYOR APPVEYOR_* CI CODECOV_* TRAVIS TRAVIS_* NETWORK_REQUIRED
-commands=pytest {posargs}
+commands = pytest {posargs}
 usedevelop=True
 extras =
 	tests
+
+
+[testenv:pypy{,3}]
+commands = pytest --no-cov {posargs}
 
 
 [testenv:coverage]


### PR DESCRIPTION
In #2221, I learned a lot more about the coverage configuration.

There are settings around coverage scattered across CI invocations, tox configurations, etc. This approach instead attempts configure the coverage in one place, enable it in one place, and provide one workaround for PyPy slowness.