### PR TITLE
Programmatically disable coverage when running on PyPy.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,19 @@ collect_ignore = [
 ]
 
 
+def pytest_configure(config):
+    disable_coverage_on_pypy(config)
+
+
+def disable_coverage_on_pypy(config):
+    """
+    Coverage makes tests on PyPy unbearably slow, so disable it.
+    """
+    if '__pypy__' in sys.builtin_module_names:
+        # Recommended at pytest-dev/pytest-cov#418
+        config.pluginmanager.set_blocked('_cov')
+
+
 if sys.version_info < (3,):
     collect_ignore.append('setuptools/lib2to3_ex.py')
     collect_ignore.append('setuptools/_imp.py')

--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,6 @@ extras =
 	tests
 
 
-[testenv:pypy{,3}]
-commands = pytest --no-cov {posargs}
-
-
 [testenv:coverage]
 description=Combine coverage data and create report
 deps=coverage


### PR DESCRIPTION
Building on #2224 and using the advice from pytest-dev/pytest-cov#418, programmatically disable coverage.