### PR TITLE
Re-enable distutils adoption with escape hatch

### DIFF
--- a/changelog.d/2232.misc.patch
+++ b/changelog.d/2232.misc.patch
@@ -1,0 +1,1 @@
+In preparation for re-enabling a local copy of distutils, Setuptools now honors an environment variable, SETUPTOOLS_USE_DISTUTILS. If set to 'stdlib' (current default), distutils will be used from the standard library. If set to 'local' (default in a imminent backward-incompatible release), the local copy of distutils will be used.

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -4,7 +4,7 @@ import os
 import functools
 
 # Disabled for now due to: #2228, #2230
-# import setuptools.distutils_patch  # noqa: F401
+import setuptools.distutils_patch  # noqa: F401
 
 import distutils.core
 import distutils.filelist

--- a/setuptools/distutils_patch.py
+++ b/setuptools/distutils_patch.py
@@ -7,6 +7,7 @@ for more motivation.
 
 import sys
 import re
+import os
 import importlib
 import warnings
 
@@ -20,6 +21,13 @@ def clear_distutils():
         del sys.modules[name]
 
 
+def enabled():
+    """
+    Provide an escape hatch for environments wishing to opt out.
+    """
+    return 'SETUPTOOLS_DISTUTILS_ADOPTION_OPT_OUT' not in os.environ
+
+
 def ensure_local_distutils():
     clear_distutils()
     distutils = importlib.import_module('setuptools._distutils')
@@ -31,4 +39,5 @@ def ensure_local_distutils():
     assert '_distutils' in core.__file__, core.__file__
 
 
-ensure_local_distutils()
+if enabled():
+    ensure_local_distutils()

--- a/setuptools/distutils_patch.py
+++ b/setuptools/distutils_patch.py
@@ -23,9 +23,10 @@ def clear_distutils():
 
 def enabled():
     """
-    Provide an escape hatch for environments wishing to opt out.
+    Allow selection of distutils by environment variable.
     """
-    return 'SETUPTOOLS_DISTUTILS_ADOPTION_OPT_OUT' not in os.environ
+    which = os.environ.get('SETUPTOOLS_USE_DISTUTILS', 'stdlib')
+    return which == 'local'
 
 
 def ensure_local_distutils():


### PR DESCRIPTION
In preparation for re-enabling a local copy of distutils, Setuptools now honors an environment variable, SETUPTOOLS_USE_DISTUTILS. If set to 'stdlib' (current default), distutils will be used from the standard library. If set to 'local' (default in a imminent backward-incompatible release), the local copy of distutils will be used.
