### PR TITLE
Test Python 3.9-dev on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jobs:
   - <<: *latest_py3
     env: LANG=C
   - python: 3.8-dev
+  - python: 3.9-dev
   - <<: *latest_py3
     env: TOXENV=docs
   allow_failures:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Run tests on `3.9-dev`, the nightly build of the CPython 3.9 branch. 

Python 3.9 is in beta with final release due out in October. 

3.8-dev is already tested. 

This should help avoid regressions or bugs due to changes in 3.9, or even help find problems in CPython 3.9 itself.

The build currently passes, suggesting https://github.com/pypa/setuptools/issues/2246 isn't yet covered by tests. 

### Pull Request Checklist
- [x] Changes ~have~ *are* tests
- [n/a?] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
