### PR TITLE
Change exec_module to load_module

### DIFF
--- a/changelog.d/2249.misc.rst
+++ b/changelog.d/2249.misc.rst
@@ -1,0 +1,1 @@
+Fix extension loading technique in stubs.

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -59,7 +59,7 @@ def write_stub(resource, pyfile):
             from importlib.machinery import ExtensionFileLoader
             __file__ = pkg_resources.resource_filename(__name__, %r)
             __loader__ = None; del __bootstrap__, __loader__
-            ExtensionFileLoader(__name__,__file__).exec_module()
+            ExtensionFileLoader(__name__,__file__).load_module()
         __bootstrap__()
         """).lstrip()
     with open(pyfile, 'w') as f:

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -268,7 +268,7 @@ class build_ext(_build_ext):
                     "     os.chdir(os.path.dirname(__file__))",
                     if_dl("     sys.setdlopenflags(dl.RTLD_NOW)"),
                     "     ExtensionFileLoader(__name__,",
-                    "                         __file__).exec_module()",
+                    "                         __file__).load_module()",
                     "   finally:",
                     if_dl("     sys.setdlopenflags(old_flags)"),
                     "     os.chdir(old_dir)",


### PR DESCRIPTION
I originally wrote this code using `load_module` and then changed it to `exec_module` because [the documentation](https://docs.python.org/3/library/importlib.html#importlib.abc.Loader.load_module) says that `load_module` is deprecated, but I didn't notice that `exec_module` requires an argument. Since it's not clear from the documentation how `exec_module` is supposed to be used, and `load_module` doesn't actually emit a DeprecationWarning (fixing the warning was the original motivation for changing this code), I think we should just use `load_module` for now.