### PR TITLE
Set up GHA to test on Python 3.9-beta and 3.8-dev

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -68,7 +68,7 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v2.1.1
       if: >-
         !fromJSON(env.USE_DEADSNAKES) && true || false
       with:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,6 +34,9 @@ jobs:
         # Pre-release versions (GH-shipped)
         - os: ubuntu-20.04
           python-version: 3.9.0-beta.4 - 3.9.0
+        # Pre-release versions (deadsnakes)
+        - os: ubuntu-20.04
+          python-version: 3.9-beta
         # Dev versions (deadsnakes)
         - os: ubuntu-20.04
           python-version: 3.9-dev
@@ -42,21 +45,34 @@ jobs:
 
     env:
       NETWORK_REQUIRED: 1
+      PYTHON_VERSION: ${{ matrix.python-version }}
       TOX_PARALLEL_NO_SPINNER: 1
       TOXENV: python
+      USE_DEADSNAKES: false
 
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python ${{ matrix.python-version }} (deadsnakes)
+    - name: Set flag to use deadsnakes
+      if: >-
+        endsWith(env.PYTHON_VERSION, '-beta') || 
+        endsWith(env.PYTHON_VERSION, '-dev')
+      run: |
+        from __future__ import print_function
+        python_version = '${{ env.PYTHON_VERSION }}'.replace('-beta', '')
+        print('::set-env name=PYTHON_VERSION::{ver}'.format(ver=python_version))
+        print('::set-env name=USE_DEADSNAKES::true')
+      shell: python
+    - name: Set up Python ${{ env.PYTHON_VERSION }} (deadsnakes)
       uses: deadsnakes/action@v1.0.0
-      if: endsWith(matrix.python-version, '-dev')
+      if: fromJSON(env.USE_DEADSNAKES) && true || false
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Set up Python ${{ matrix.python-version }}
+        python-version: ${{ env.PYTHON_VERSION }}
+    - name: Set up Python ${{ env.PYTHON_VERSION }}
       uses: actions/setup-python@v2
-      if: "!endsWith(matrix.python-version, '-dev')"
+      if: >-
+        !fromJSON(env.USE_DEADSNAKES) && true || false
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.PYTHON_VERSION }}
     - name: Log Python version
       run: >-
         python --version
@@ -88,9 +104,9 @@ jobs:
       run: >-
         python -m pip freeze --all
     - name: Adjust TOXENV for PyPy
-      if: startsWith(matrix.python-version, 'pypy')
+      if: startsWith(env.PYTHON_VERSION, 'pypy')
       run: >-
-        echo "::set-env name=TOXENV::${{ matrix.python-version }}"
+        echo "::set-env name=TOXENV::${{ env.PYTHON_VERSION }}"
     - name: Log env vars
       run: >-
         env

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -115,3 +115,5 @@ jobs:
         tox
         --parallel auto
         --parallel-live
+        --
+        -vvvvv

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -106,6 +106,7 @@ jobs:
         python -m
         tox
         --parallel auto
+        --parallel-live
         --notest
         --skip-missing-interpreters false
     - name: Test with tox
@@ -113,3 +114,4 @@ jobs:
         python -m
         tox
         --parallel auto
+        --parallel-live

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,14 +25,20 @@ jobs:
         - 3.6
         - 3.5
         os:
-        - ubuntu-latest
+        - ubuntu-18.04
         - ubuntu-16.04
         - macOS-latest
         # - windows-2019
         # - windows-2016
         include:
-        # Dev versions
-        - { python-version: 3.9-dev, os: ubuntu-20.04 }
+        # Pre-release versions (GH-shipped)
+        - os: ubuntu-20.04
+          python-version: 3.9.0-beta.4 - 3.9.0
+        # Dev versions (deadsnakes)
+        - os: ubuntu-20.04
+          python-version: 3.9-dev
+        - os: ubuntu-20.04
+          python-version: 3.8-dev
 
     env:
       NETWORK_REQUIRED: 1
@@ -47,7 +53,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1.1.1
+      uses: actions/setup-python@v2
       if: "!endsWith(matrix.python-version, '-dev')"
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
GHA has recently started shipping Python betas so I thought I'd add it.
`3.9.0-beta.4 - 3.9.0` is a semver range syntax that will get 3.9-beta set up in the worker.

I kept 3.9-dev and added 3.8-dev — these are still coming from deadsnakes PPA.

I've changed ubuntu-latest to concrete ubuntu-18.04 so that it's deterministic (at some point it'll be ubuntu-20.04 and that may come as a surprise).

I think it's possible to install the beta on macOS too but didn't know if that'd be wanted so I left it out.