### PR TITLE
Resolve exclude of setuptools.find_packages is no use

### DIFF
--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -72,7 +72,7 @@ class PackageFinder:
 
         return list(cls._find_packages_iter(
             convert_path(where),
-            cls._build_filter('ez_setup', '*__pycache__', *exclude),
+            cls._build_filter('ez_setup', '*__pycache__', exclude),
             cls._build_filter(*include)))
 
     @classmethod


### PR DESCRIPTION
Resolve: #2270

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
