### PR TITLE
Change load_module to exec_module

### DIFF
--- a/changelog.d/2297.misc.rst
+++ b/changelog.d/2297.misc.rst
@@ -1,0 +1,1 @@
+Once again, in stubs prefer exec_module to the deprecated load_module.

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -55,11 +55,12 @@ def write_stub(resource, pyfile):
     _stub_template = textwrap.dedent("""
         def __bootstrap__():
             global __bootstrap__, __loader__, __file__
-            import sys, pkg_resources
-            from importlib.machinery import ExtensionFileLoader
+            import sys, pkg_resources, importlib.util
             __file__ = pkg_resources.resource_filename(__name__, %r)
             __loader__ = None; del __bootstrap__, __loader__
-            ExtensionFileLoader(__name__,__file__).load_module()
+            spec = importlib.util.spec_from_file_location(__name__,__file__)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
         __bootstrap__()
         """).lstrip()
     with open(pyfile, 'w') as f:

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -254,8 +254,8 @@ class build_ext(_build_ext):
                 '\n'.join([
                     "def __bootstrap__():",
                     "   global __bootstrap__, __file__, __loader__",
-                    "   import sys, os, pkg_resources" + if_dl(", dl"),
-                    "   from importlib.machinery import ExtensionFileLoader",
+                    "   import sys, os, pkg_resources, importlib.util" +
+                    if_dl(", dl"),
                     "   __file__ = pkg_resources.resource_filename"
                     "(__name__,%r)"
                     % os.path.basename(ext._file_name),
@@ -267,8 +267,10 @@ class build_ext(_build_ext):
                     "   try:",
                     "     os.chdir(os.path.dirname(__file__))",
                     if_dl("     sys.setdlopenflags(dl.RTLD_NOW)"),
-                    "     ExtensionFileLoader(__name__,",
-                    "                         __file__).load_module()",
+                    "     spec = importlib.util.spec_from_file_location(",
+                    "                __name__, __file__)",
+                    "     mod = importlib.util.module_from_spec(spec)",
+                    "     spec.loader.exec_module(mod)",
                     "   finally:",
                     if_dl("     sys.setdlopenflags(old_flags)"),
                     "     os.chdir(old_dir)",


### PR DESCRIPTION
#2249 changed back from `exec_module` to the deprecated `load_module` (so I'll cc @alexhenrie). This PR moves forward to `exec_module` again. Credit to posts like https://stackoverflow.com/a/41595552/4093019

Also fixes the Pillow compilation error reported in #2261.