### PR TITLE
Don't install setup_requires when run as a PEP-517 backend.

### DIFF
--- a/changelog.d/2306.change.rst
+++ b/changelog.d/2306.change.rst
@@ -1,0 +1,3 @@
+When running as a PEP 517 backend, setuptools does not try to install
+``setup_requires`` itself. They are reported as build requirements for the
+frontend to install.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -155,8 +155,7 @@ class _BuildMetaBackend(object):
         with _open_setup_script(__file__) as f:
             code = f.read().replace(r'\r\n', r'\n')
 
-        with no_install_setup_requires():
-            exec(compile(code, __file__, 'exec'), locals())
+        exec(compile(code, __file__, 'exec'), locals())
 
     def get_requires_for_build_wheel(self, config_settings=None):
         config_settings = self._fix_config(config_settings)
@@ -171,7 +170,8 @@ class _BuildMetaBackend(object):
                                          config_settings=None):
         sys.argv = sys.argv[:1] + ['dist_info', '--egg-base',
                                    _to_str(metadata_directory)]
-        self.run_setup()
+        with no_install_setup_requires():
+            self.run_setup()
 
         dist_info_directory = metadata_directory
         while True:
@@ -211,7 +211,8 @@ class _BuildMetaBackend(object):
             sys.argv = (sys.argv[:1] + setup_command +
                         ['--dist-dir', tmp_dist_dir] +
                         config_settings["--global-option"])
-            self.run_setup()
+            with no_install_setup_requires():
+                self.run_setup()
 
             result_basename = _file_with_extension(
                 tmp_dist_dir, result_extension)

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -436,7 +436,6 @@ class TestBuildMetaBackend:
         # setup_requires, it will fail.
         build_backend.prepare_metadata_for_build_wheel(dist_dir)
 
-
     _sys_argv_0_passthrough = {
         'setup.py': DALS("""
             import os


### PR DESCRIPTION
## Summary of changes

Under PEP 517, installing build dependencies is up to the frontend. `setup_requires` are already reported as build dependencies, but setuptools should not attempt to install them itself when used as a PEP 517 backend.

Closes #2303

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
