### PR TITLE
docs: Suggestion - Provide consistency in the description of setup.cfg

### DIFF
--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -1988,11 +1988,11 @@ boilerplate code in some cases.
     include_package_data = True
     packages = find:
     scripts =
-      bin/first.py
-      bin/second.py
+        bin/first.py
+        bin/second.py
     install_requires =
-      requests
-      importlib; python_version == "2.6"
+        requests
+        importlib; python_version == "2.6"
 
     [options.package_data]
     * = *.txt, *.rst
@@ -2028,8 +2028,8 @@ Metadata and options are set in the config sections of the same name.
 
       [metadata]
       keywords =
-        one
-        two
+          one
+          two
 
 * In some cases, complex values can be provided in dedicated subsections for
   clarity.


### PR DESCRIPTION
# Summary of changes

Hi, I moved the metadata description from `setup.py` to `setup.cfg`.

I found it desirable to have consistent indentation [in the documentation](https://setuptools.readthedocs.io/en/latest/setuptools.html).
![image](https://user-images.githubusercontent.com/221802/89709025-0b4c1700-d9b7-11ea-8563-f7f945ae1114.png)

Python programmers are familiar with 4 space indentation. I also prefer consistent indentation in the `setup.cfg` documentation. What do you think?

Thanks to the maintainers of the setuptools source code and documentation.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
