### PR TITLE
Remove superfluous 'v' in CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-vv49.3.1
+v49.3.1
 --------
 
 * #2316: Removed warning when ``distutils`` is imported before ``setuptools`` when ``distutils`` replacement is not enabled.


### PR DESCRIPTION
This was an artifact of the fact that I did not use `tox -e finalize` to do the latest release in order to make a patch release.