### PR TITLE
Lint tox env

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,12 @@
 [flake8]
 exclude=
-    .tox
+    .*,
     setuptools/_vendor,
-    pkg_resources/_vendor
+    pkg_resources/_vendor,
+    setuptools/_distutils,
+    build/,
+    dist/,
+    venv/,
 ignore =
     # W503 violates spec https://github.com/PyCQA/pycodestyle/issues/513
     W503

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -133,3 +133,19 @@ jobs:
         --parallel-live
         --
         -vvvvv
+
+  lint:
+    runs-on: 'ubuntu-latest'
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install tox
+        run: python -m pip install --upgrade pip tox
+      - name: Prepare tox environment
+        run: tox -e lint --notest
+      - name: Run action
+        run: tox -e lint

--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -20,8 +20,8 @@ def warn_distutils_present():
         "also replaces the `distutils` module in `sys.modules`. This may lead "
         "to undesirable behaviors or errors. To avoid these issues, avoid "
         "using distutils directly, ensure that setuptools is installed in the "
-        "traditional way (e.g. not an editable install), and/or make sure that "
-        "setuptools is always imported before distutils.")
+        "traditional way (e.g. not an editable install), and/or make sure that"
+        " setuptools is always imported before distutils.")
 
 
 def clear_distutils():

--- a/changelog.d/2320.misc.rst
+++ b/changelog.d/2320.misc.rst
@@ -1,0 +1,1 @@
+The ``flake8`` linting check is now a separate ``tox`` test environment.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts=--doctest-modules --flake8 --doctest-glob=pkg_resources/api_tests.txt --cov -r sxX
+addopts=--doctest-modules --doctest-glob=pkg_resources/api_tests.txt --cov -r sxX
 norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern pkg_resources/tests/data tools .* setuptools/_vendor pkg_resources/_vendor
 doctest_optionflags=ELLIPSIS ALLOW_UNICODE
 filterwarnings =

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,8 +61,6 @@ certs =
 
 tests =
     mock
-    pytest-flake8
-    flake8-2020; python_version>="3.6"
     virtualenv>=13.0.0
     pytest-virtualenv>=1.2.7
     pytest>=3.7

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,16 @@ deps=codecov
 skip_install=True
 commands=codecov -X gcov --file {toxworkdir}/coverage.xml
 
+[testenv:lint]
+skip_install = True
+deps=
+    flake8
+    flake8-2020; python_version>="3.6"
+passenv = *
+commands =
+    python -m flake8 {posargs}
+
+
 [testenv:docs]
 extras =
         docs


### PR DESCRIPTION
# Summary of changes

Migrate the linting checks into their own dedicated `testenv`.

Closes #2317 

### Pull Request Checklist
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
