### PR TITLE
fix find_packages glob doc

### DIFF
--- a/changelog.d/2333.doc.rst
+++ b/changelog.d/2333.doc.rst
@@ -1,0 +1,1 @@
+remove dots from `find_package(exclude=['*tests*'])` glob pattern examples

--- a/docs/setuptools.txt
+++ b/docs/setuptools.txt
@@ -256,14 +256,14 @@ patterns are applied to remove matching packages.
 
 Inclusion and exclusion patterns are package names, optionally including
 wildcards.  For
-example, ``find_packages(exclude=["*.tests"])`` will exclude all packages whose
-last name part is ``tests``.   Or, ``find_packages(exclude=["*.tests",
-"*.tests.*"])`` will also exclude any subpackages of packages named ``tests``,
+example, ``find_packages(exclude=["*tests"])`` will exclude all packages whose
+last name part is ``tests``.   Or, ``find_packages(exclude=["*tests",
+"*tests*"])`` will also exclude any subpackages of packages named ``tests``,
 but it still won't exclude a top-level ``tests`` package or the children
 thereof.  In fact, if you really want no ``tests`` packages at all, you'll need
 something like this::
 
-    find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"])
+    find_packages(exclude=["*tests", "*tests*", "tests*", "tests"])
 
 in order to cover all the bases.  Really, the exclusion patterns are intended
 to cover simpler use cases than this, like excluding a single, specified

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -51,7 +51,7 @@ class PackageFinder:
         be converted to the appropriate local path syntax.
 
         'exclude' is a sequence of package names to exclude; '*' can be used
-        as a wildcard in the names, such that 'foo.*' will exclude all
+        as a wildcard in the names, such that 'foo*' will exclude all
         subpackages of 'foo' (but not 'foo' itself).
 
         'include' is a sequence of package names to include.  If it's


### PR DESCRIPTION
## Summary of changes

The current documentation of `find_packages` incorrectly includes dots in the `exclude=` patterns. These are `fnmatch` patterns, not regexes.

See also https://github.com/pycroscopy/pyUSID/issues/50#issuecomment-674522758

I am not even sure if the statement "*but not 'foo' itself*" is true.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
