### PR TITLE
Add script to create a release on GitHub Actions from a tag

### DIFF
--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -1,0 +1,52 @@
+"""
+Create a release on GitHub Actions from a tag. Invokes bumpversion.
+"""
+
+__requires__ = ["bump2version"]
+
+import argparse
+import json
+import os
+from urllib.request import Request, urlopen
+
+from finalize import get_version
+
+
+def create_release(repo, tag):
+    """
+    Call the GitHub API to create a release from a tag.
+    """
+    token = os.environ["GITHUB_TOKEN"]
+
+    _json = json.loads(
+        urlopen(
+            Request(
+                "https://api.github.com/repos/" + repo + "/releases",
+                json.dumps({"tag_name": tag, "name": tag}).encode(),
+                headers={
+                    "Accept": "application/vnd.github.v3+json",
+                    "Authorization": "token " + token,
+                },
+            )
+        )
+        .read()
+        .decode()
+    )
+    print("Released to", _json["html_url"])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Create a release on GitHub Actions from a tag.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "repo", nargs="?", default="pypa/setuptools", help="Repo to release to"
+    )
+    parser.add_argument(
+        "tag", nargs="?", default="v" + get_version(), help="Tag to release"
+    )
+    args = parser.parse_args()
+
+    print("Creating release", args.tag, "at", args.repo)
+    create_release(args.repo, args.tag)

--- a/tox.ini
+++ b/tox.ini
@@ -67,9 +67,11 @@ deps =
 	twine[keyring]>=1.13
 	path
 	jaraco.tidelift
+	bump2version
 passenv =
 	TWINE_PASSWORD
 	TIDELIFT_TOKEN
+	GITHUB_TOKEN
 setenv =
 	TWINE_USERNAME = {env:TWINE_USERNAME:__token__}
 commands =
@@ -78,3 +80,4 @@ commands =
 	python setup.py release
 	python -m twine upload dist/*
 	python -m jaraco.tidelift.publish-release-notes
+	python tools/create_release.py


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Add a script to create a release on GitHub Actions from a tag.

Usage:

```console
$ python tools/create_release.py --help
usage: create_release.py [-h] [repo] [tag]

Create a release on GitHub Actions from a tag.

positional arguments:
  repo        Repo to release to (default: pypa/setuptools)
  tag         Tag to release (default: v49.7.0)

optional arguments:
  -h, --help  show this help message and exit
```
Calls `finalize.get_version` and prepends `v` to get the default tag.

Needs a `GITHUB_TOKEN` environment variable.

* How to create a token:
* https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token
* I think only the `public_repo` permission is needed

Example in my fork with explicit args:

```console
$ git tag v49.6.0.8
$ git push origin v49.6.0.8
Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
To https://github.com/hugovk/setuptools
 * [new tag]           v49.6.0.8 -> v49.6.0.8
$ python tools/create_release.py hugovk/setuptools v49.6.0.8
Creating release v49.6.0.8 at hugovk/setuptools
Released to https://github.com/hugovk/setuptools/releases/tag/v49.6.0.8
```

API docs: https://docs.github.com/en/rest/reference/repos#create-a-release

I'd need some guidance if this is to go in https://github.com/jaraco/skeleton first.

A `body` parameter can be used to add release notes, I'd suggest this be added in a follow-up once the general flow is working.

Closes #2328.

### Pull Request Checklist
- [n/a] Changes have tests
- [n/a] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
