### PR TITLE
Add Python 3.10 support to _distutils_hack

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -74,9 +74,10 @@ class DistutilsMetaFinder:
         return method()
 
     def spec_for_distutils(self):
+        import importlib.abc
         import importlib.util
 
-        class DistutilsLoader(importlib.util.abc.Loader):
+        class DistutilsLoader(importlib.abc.Loader):
 
             def create_module(self, spec):
                 return importlib.import_module('._distutils', 'setuptools')

--- a/changelog.d/2361.change.rst
+++ b/changelog.d/2361.change.rst
@@ -1,0 +1,3 @@
+Add Python 3.10 support to _distutils_hack. Get the 'Loader' abstract class
+from importlib.abc rather than importlib.util.abc (alias removed in Python
+3.10).


### PR DESCRIPTION
Get the 'Loader' abstract class from importlib.abc rather than
importlib.util.abc (alias removed in Python 3.10).

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
