### PR TITLE
In distutils hack, use absolute import rather than relative to avoid bpo-30876.

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -80,7 +80,7 @@ class DistutilsMetaFinder:
         class DistutilsLoader(importlib.abc.Loader):
 
             def create_module(self, spec):
-                return importlib.import_module('._distutils', 'setuptools')
+                return importlib.import_module('setuptools._distutils')
 
             def exec_module(self, module):
                 pass

--- a/changelog.d/2352.misc.rst
+++ b/changelog.d/2352.misc.rst
@@ -1,0 +1,1 @@
+In distutils hack, use absolute import rather than relative to avoid bpo-30876.


### PR DESCRIPTION
Ref [bpo-30876](https://bugs.python.org/issue30876).

Fixes #2352.
