### PR TITLE
Fix the distutils hacking behavior with the environment variable SETU…

### DIFF
--- a/changelog.d/2370.change.rst
+++ b/changelog.d/2370.change.rst
@@ -1,0 +1,1 @@
+Fix the default distutils hatching behavior when environment variable SETUPTOOLS_USE_DISTUTILS is specified

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ class install_with_pth(install):
     _pth_contents = textwrap.dedent("""
         import os
         var = 'SETUPTOOLS_USE_DISTUTILS'
-        enabled = os.environ.get(var, 'local') == 'local'
+        enabled = os.environ.get(var, 'local') != 'stdlib'
         enabled and __import__('_distutils_hack').add_shim()
         """).lstrip().replace('\n', '; ')
 

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -67,3 +67,12 @@ def test_distutils_local(venv):
     preferred.
     """
     assert venv.name in find_distutils(venv, env=dict()).split(os.sep)
+
+
+@pytest.mark.xfail('IS_PYPY', reason='pypy imports distutils on startup')
+def test_distutils_invalid_option(venv):
+    """
+    Ensure local distutils is used even when an invalid option is provided.
+    """
+    env = dict(SETUPTOOLS_USE_DISTUTILS='xxx')
+    assert venv.name in find_distutils(venv, env=env).split(os.sep)


### PR DESCRIPTION
## Summary of changes

The change is to ensure the distutils hatching behavior works by default, except the environment variable SETUPTOOLS_USE_DISTUTILS is specified as "stdlib". 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
