### PR TITLE
Reduce size of setuptools' bdist_rpm._make_spec_file

### DIFF
--- a/changelog.d/2380.change.rst
+++ b/changelog.d/2380.change.rst
@@ -1,0 +1,4 @@
+There are some setuptools specific changes in the
+`setuptools.command.bdist_rpm` module that are no longer needed, because
+they are part of the `bdist_rpm` module in distutils in Python
+3.5.0. Therefore, code was removed from `setuptools.command.bdist_rpm`.

--- a/setuptools/command/bdist_rpm.py
+++ b/setuptools/command/bdist_rpm.py
@@ -8,8 +8,6 @@ class bdist_rpm(orig.bdist_rpm):
     1. Run egg_info to ensure the name and version are properly calculated.
     2. Always run 'install' using --single-version-externally-managed to
        disable eggs in RPM distributions.
-    3. Replace dash with underscore in the version numbers for better RPM
-       compatibility.
     """
 
     def run(self):
@@ -19,25 +17,15 @@ class bdist_rpm(orig.bdist_rpm):
         orig.bdist_rpm.run(self)
 
     def _make_spec_file(self):
-        version = self.distribution.get_version()
-        rpmversion = version.replace('-', '_')
         spec = orig.bdist_rpm._make_spec_file(self)
-        line23 = '%define version ' + version
-        line24 = '%define version ' + rpmversion
         spec = [
             line.replace(
-                "Source0: %{name}-%{version}.tar",
-                "Source0: %{name}-%{unmangled_version}.tar"
-            ).replace(
                 "setup.py install ",
                 "setup.py install --single-version-externally-managed "
             ).replace(
                 "%setup",
                 "%setup -n %{name}-%{unmangled_version}"
-            ).replace(line23, line24)
+            )
             for line in spec
         ]
-        insert_loc = spec.index(line24) + 1
-        unmangled_version = "%define unmangled_version " + version
-        spec.insert(insert_loc, unmangled_version)
         return spec


### PR DESCRIPTION
There are some setuptools specific changes in the bdist_rpm module that
are no longer needed, because the upstream/shipped version of distutils
already contains them. The code that is removed in this commit from
bdist_rpm is already part of the python-3.5 version of distutils.

Related: #2377

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
