### PR TITLE
When pip is imported as part of a build, leave distutils patched.

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -92,8 +92,21 @@ class DistutilsMetaFinder:
         Ensure stdlib distutils when running under pip.
         See pypa/pip#8761 for rationale.
         """
+        if self.pip_imported_during_build():
+            return
         clear_distutils()
         self.spec_for_distutils = lambda: None
+
+    @staticmethod
+    def pip_imported_during_build():
+        """
+        Detect if pip is being imported in a build script. Ref #2355.
+        """
+        import traceback
+        return any(
+            frame.f_globals['__file__'].endswith('setup.py')
+            for frame, line in traceback.walk_stack(None)
+        )
 
 
 DISTUTILS_FINDER = DistutilsMetaFinder()

--- a/changelog.d/2355.change.rst
+++ b/changelog.d/2355.change.rst
@@ -1,0 +1,1 @@
+When pip is imported as part of a build, leave distutils patched.


### PR DESCRIPTION
Fixes #2355.
