### PR TITLE
Enable flake8 and cov plugins only when installed.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ test_script:
   - python -m pip install --disable-pip-version-check --upgrade pip setuptools wheel
   - pip install --upgrade tox tox-venv virtualenv
   - pip freeze --all
-  - tox -- --cov
+  - tox
 
 after_test:
     - tox -e coverage,codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,18 +8,18 @@ environment:
 
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      APPVEYOR_JOB_NAME: "python35-x64-vs2015"
-      PYTHON: "C:\\Python35-x64"
+      APPVEYOR_JOB_NAME: "Python38-x64-vs2015"
+      PYTHON: "C:\\Python38-x64"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      APPVEYOR_JOB_NAME: "python35-x64-vs2017"
-      PYTHON: "C:\\Python35-x64"
+      APPVEYOR_JOB_NAME: "Python38-x64-vs2017"
+      PYTHON: "C:\\Python38-x64"
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      APPVEYOR_JOB_NAME: "python35-x64-vs2019"
-      PYTHON: "C:\\Python35-x64"
-    - APPVEYOR_JOB_NAME: "python36-x64"
-      PYTHON: "C:\\Python36-x64"
+      APPVEYOR_JOB_NAME: "Python38-x64-vs2019"
+      PYTHON: "C:\\Python38-x64"
     - APPVEYOR_JOB_NAME: "python37-x64"
       PYTHON: "C:\\Python37-x64"
+    - APPVEYOR_JOB_NAME: "python36-x64"
+      PYTHON: "C:\\Python36-x64"
 
 install:
   # symlink python from a directory with a space

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ environment:
       PYTHON: "C:\\Python37-x64"
     - APPVEYOR_JOB_NAME: "python36-x64"
       PYTHON: "C:\\Python36-x64"
+    - APPVEYOR_JOB_NAME: "python35-x64"
+      PYTHON: "C:\\Python35-x64"
+      PYTEST_ADDOPTS: "--cov"
+      TOX_TESTENV_PASSENV: "PYTEST_ADDOPTS"
 
 install:
   # symlink python from a directory with a space

--- a/conftest.py
+++ b/conftest.py
@@ -19,24 +19,6 @@ collect_ignore = [
 ]
 
 
-def pytest_configure(config):
-    disable_coverage_on_pypy(config)
-
-
-def disable_coverage_on_pypy(config):
-    """
-    Coverage makes tests on PyPy unbearably slow, so disable it.
-    """
-    if '__pypy__' not in sys.builtin_module_names:
-        return
-
-    # Recommended at pytest-dev/pytest-cov#418
-    cov = config.pluginmanager.get_plugin('_cov')
-    cov.options.no_cov = True
-    if cov.cov_controller:
-        cov.cov_controller.pause()
-
-
 if sys.version_info < (3,):
     collect_ignore.append('setuptools/lib2to3_ex.py')
     collect_ignore.append('setuptools/_imp.py')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,9 @@ backend-path = ["."]
         directory = "misc"
         name = "Misc"
         showcontent = true
+
+[tool.jaraco.pytest.plugins.flake8]
+addopts = "--flake8"
+
+[tool.jaraco.pytest.plugins.cov]
+addopts = "--cov"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts=--doctest-modules --flake8 --doctest-glob=pkg_resources/api_tests.txt --cov -r sxX
+addopts=--doctest-modules --doctest-glob=pkg_resources/api_tests.txt -r sxX
 norecursedirs=dist build *.egg setuptools/extern pkg_resources/extern pkg_resources/tests/data tools .* setuptools/_vendor pkg_resources/_vendor
 doctest_optionflags=ELLIPSIS ALLOW_UNICODE
 filterwarnings =

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ tests =
     paver; python_version>="3.6"
     pip>=19.1 # For proper file:// URLs support.
     jaraco.envs
-    jaraco.test >= 3.1.1
+    jaraco.test >= 3.1.1; python_version >= "3.6"
 
 docs =
     # Keep these in sync with docs/requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,10 +68,12 @@ tests =
     pytest>=3.7
     wheel
     coverage>=4.5.1
-    pytest-cov>=2.5.1
+    # Coverage is unbearably slow on PyPy
+    pytest-cov>=2.5.1; python_implementation != "PyPy"
     paver; python_version>="3.6"
     pip>=19.1 # For proper file:// URLs support.
     jaraco.envs
+    jaraco.test >= 3.1.1
 
 docs =
     # Keep these in sync with docs/requirements.txt


### PR DESCRIPTION
 Avoid installing in PyPy.
