### PR TITLE
📝 Enable showing news categories in towncrier log

### DIFF
--- a/changelog.d/2394.doc.rst
+++ b/changelog.d/2394.doc.rst
@@ -1,0 +1,3 @@
+Extended towncrier news template to include change note categories.
+This allows to see what types of changes a given version introduces
+-- by :user:`webknjaz`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ backend-path = ["."]
     title_format = "v{version}"
     issue_format = "#{issue}"
     template = "towncrier_template.rst"
-    underlines = ["-"]
+    underlines = ["-", "^"]
 
     [[tool.towncrier.type]]
         directory = "deprecation"

--- a/towncrier_template.rst
+++ b/towncrier_template.rst
@@ -1,10 +1,14 @@
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
 {{ underline * section|length }}
+{% set underline = underlines[1] %}
 {% endif %}
 
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
+
+{{ definitions[category]['name'] }}
+{{ underline * definitions[category]['name']|length }}
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
 * {{ values|join(', ') }}: {{ text }}


### PR DESCRIPTION
# Summary of changes

This change adds news categories into the rendered changelog entries
so that it's visible what types of changes a new version brings.

Fixes #2394

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
