### PR TITLE
ignore any exception when loading 2to3

### DIFF
--- a/changelog.d/2413.misc.rst
+++ b/changelog.d/2413.misc.rst
@@ -1,0 +1,1 @@
+Suppress EOF errors (and other exceptions) when importing lib2to3.

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -11,7 +11,7 @@ import stat
 
 try:
     from setuptools.lib2to3_ex import Mixin2to3
-except ImportError:
+except Exception:
 
     class Mixin2to3:
         def run_2to3(self, files, doctests=True):


### PR DESCRIPTION
## Summary of changes

Related to https://github.com/pypa/setuptools/issues/2086

lib2to3 appears to have a problem loading the pickled pgen files, when running in parallel on pypy: https://github.com/twisted/ldaptor/runs/1205572060#step:12:103 (raises EOFError)

Instead of catching the `EOFError` I catch any `Exception`, as that seems cleaner

I've not added tests yet, as I'd like a concept ACK first, eg, If you'd rather I just remove all use of lib2to3 from the codebase I could do that instead.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
