### PR TITLE
Link to build_meta documentation

### DIFF
--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -10,6 +10,15 @@ packages.
 Packages built and distributed using ``setuptools`` look to the user like
 ordinary Python packages based on the ``distutils``.
 
+Transition to PEP517
+====================
+
+Since setuptools no longer serves as the default build tool, one must explicitly
+opt in (by providing a ``pyproject.toml`` file) to use this library. The user
+facing part is provided by `PEP517 <https://pypi.org/project/pep517/>`_ and
+backend interface is described :ref:`in this document <../build_meta>`. The
+quickstart provides an overview of the new workflow.
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -16,7 +16,7 @@ Transition to PEP517
 Since setuptools no longer serves as the default build tool, one must explicitly
 opt in (by providing a :file:`pyproject.toml` file) to use this library. The user
 facing part is provided by tools such as pip and
-backend interface is described :ref:`in this document <../build_meta>`. The
+backend interface is described :doc:`in this document <../build_meta>`. The
 quickstart provides an overview of the new workflow.
 
 .. toctree::

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -14,8 +14,8 @@ Transition to PEP517
 ====================
 
 Since setuptools no longer serves as the default build tool, one must explicitly
-opt in (by providing a ``pyproject.toml`` file) to use this library. The user
-facing part is provided by `PEP517 <https://pypi.org/project/pep517/>`_ and
+opt in (by providing a :file:`pyproject.toml` file) to use this library. The user
+facing part is provided by tools such as pip and
 backend interface is described :ref:`in this document <../build_meta>`. The
 quickstart provides an overview of the new workflow.
 


### PR DESCRIPTION
## Summary of changes

I added a paragraph of text in the index that briefly mentions how setuptools works under pep517,  and provided a link to the build_meta document as mentioned in (#1698 ). 

At first I thought the quickstart has already covered this document, but judging from the discussion, it seems like it still deserves its own page. It appears that the quickstart should target the end users that are not concerned about this internal module.


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
