### PR TITLE
GHA: Replace 3.9 beta with 3.9 final

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,6 +16,7 @@ jobs:
       ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       # max-parallel: 5
       matrix:
         python-version:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,6 @@ jobs:
       ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       # max-parallel: 5
       matrix:
         python-version:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,6 +19,7 @@ jobs:
       # max-parallel: 5
       matrix:
         python-version:
+        - 3.9
         - 3.8
         - pypy3
         - 3.7
@@ -31,12 +32,6 @@ jobs:
         # - windows-2019
         # - windows-2016
         include:
-        # Pre-release versions (GH-shipped)
-        - os: ubuntu-20.04
-          python-version: 3.9.0-beta.4 - 3.9.0
-        # Pre-release versions (deadsnakes)
-        - os: ubuntu-20.04
-          python-version: 3.9-beta
         # Dev versions (deadsnakes)
         - os: ubuntu-20.04
           python-version: 3.9-dev

--- a/changelog.d/2420.misc.rst
+++ b/changelog.d/2420.misc.rst
@@ -1,0 +1,1 @@
+Replace Python 3.9.0 beta with 3.9.0 final on GitHub Actions.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The CI is failing because it's failing to set up 3.9-beta via deadsnakes.

```
  /usr/bin/python3.9 -mvenv /home/runner/venv-3.9
  Error: Command '['/home/runner/venv-3.9/bin/python3.9', '-Im', 'ensurepip', '--upgrade', '--default-pip']' returned non-zero exit status 1.
Error: The process '/usr/bin/python3.9' failed with exit code 1
```

* https://github.com/pypa/setuptools/runs/1239771433?check_suite_focus=true

Python 3.9.0 final is now available on GitHub Actions as `3.9`.

Let's add that, and we can remove the betas:

* `3.9.0-beta.4 - 3.9.0` from GHA
* `3.9-beta` from deadsnakes

I left in the `3.8-dev` and `3.9-dev` dev versions from deadsnakes. Still useful to keep them both?

I also left in the logic for checking `-beta`, will be useful for when 3.10 reaches beta (or to adapt for alpha). Let me know if you'd prefer it cleaned up.

---

Also we can see from the above that the single failing job caused all the other jobs to be auto-cancelled:

* https://github.com/pypa/setuptools/runs/1239771433?check_suite_focus=true

Instead, we can use `fail-fast: false` which allows the other jobs to run. For example:

* https://github.com/hugovk/setuptools/actions/runs/301588612


### Pull Request Checklist
- [x] Changes have tests [changes sort of _are_ tests]
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
