### PR TITLE
Recover the changelog docs page link

### DIFF
--- a/changelog.d/2425.doc.rst
+++ b/changelog.d/2425.doc.rst
@@ -1,0 +1,2 @@
+Recovered the history of the changes_ page in Sphinx docs
+-- by :user:`webknjaz`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,3 +12,4 @@ Documentation content:
    User guide <userguide/index>
    Development guide <development>
    Backward compatibility & deprecated practice <deprecated/index>
+   Changelog <history>


### PR DESCRIPTION
## Summary of changes

This change makes the changelog webpage in docs recoverable again.

It's been lost as a part of https://github.com/pypa/setuptools/pull/2097

Ref #2424

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
