### PR TITLE
📝 Update devguide links in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/developer-guide.html! -->
+<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
 <!-- Remove sections if not applicable -->
 
 ## Summary of changes
@@ -9,4 +9,10 @@ Closes <!-- issue number here -->
 
 ### Pull Request Checklist
 - [ ] Changes have tests
-- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
+- [ ] News fragment added in [`changelog.d/`].
+  _(See [documentation][PR docs] for details)_
+
+
+[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
+[PR docs]:
+https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request


### PR DESCRIPTION
## Summary of changes

$sbj. This is necessary because the document has been moved in PR #2426.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
