### PR TITLE
📝 Upgrade RTD config to v2

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,6 +1,23 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+# for details
+
+version: 2  # required
+
+sphinx:
+  builder: dirhtml
+  configuration: docs/conf.py  # build documentation in the docs/ dir
+  fail_on_warning: true  # https://github.com/pypa/setuptools/issues/2424
+
+formats:
+- epub
+- pdf
+- htmlzip
+
+build:
+  image: latest
+
 python:
-  version: 3
-  extra_requirements:
-  - docs
-  pip_install: false
-  requirements: docs/requirements.txt
+  version: 3  # availability depends on the image
+  install:
+  - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary of changes

This change makes the RTD config documented more explicitly and
migrates away from the legacy v1 schema.

Among other things, it enables Sphinx strict mode on RTD to support
the goal of https://github.com/pypa/setuptools/issues/2424.

It also switches the builder to `dirhtml` that resolves #2432.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in changelog.d. See [documentation](http://setuptools.readthedocs.io/en/latest/developer-guide.html#making-a-pull-request) for details
