### PR TITLE
Reconstruct changelog with categories from history

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,7 @@ v50.3.2
 -------
 
 
+
 Documentation changes
 ^^^^^^^^^^^^^^^^^^^^^
 * #2394: Extended towncrier news template to include change note categories.
@@ -23,12 +24,19 @@ Misc
 v50.3.1
 -------
 
+
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #2093: Finalized doc revamp.
 * #2097: doc: simplify index and group deprecated files
 * #2102: doc overhaul step 2: break main doc into multiple sections
 * #2111: doc overhaul step 3: update userguide
 * #2395: Added a ``:user:`` role to Sphinx config -- by :user:`webknjaz`
 * #2395: Added an illustrative explanation about the change notes to fragments dir -- by :user:`webknjaz`
+
+Misc
+^^^^
 * #2379: Travis CI test suite now tests against PPC64.
 * #2413: Suppress EOF errors (and other exceptions) when importing lib2to3.
 
@@ -36,12 +44,20 @@ v50.3.1
 v50.3.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2368: In distutils, restore support for monkeypatched CCompiler.spawn per pypa/distutils#15.
 
 
 v50.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2355: When pip is imported as part of a build, leave distutils patched.
 * #2380: There are some setuptools specific changes in the
   ``setuptools.command.bdist_rpm`` module that are no longer needed, because
@@ -52,24 +68,40 @@ v50.2.0
 v50.1.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2350: Setuptools reverts using the included distutils by default. Platform maintainers and system integrators and others are *strongly* encouraged to set ``SETUPTOOLS_USE_DISTUTILS=local`` to help identify and work through the reported issues with distutils adoption, mainly to file issues and pull requests with pypa/distutils such that distutils performs as needed across every supported environment.
 
 
 v50.0.3
 -------
 
+
+
+Misc
+^^^^
 * #2363: Restore link_libpython support on Python 3.7 and earlier (see pypa/distutils#9).
 
 
 v50.0.2
 -------
 
+
+
+Misc
+^^^^
 * #2352: In distutils hack, use absolute import rather than relative to avoid bpo-30876.
 
 
 v50.0.1
 -------
 
+
+
+Misc
+^^^^
 * #2357: Restored Python 3.5 support in distutils.util for missing ``subprocess._optim_args_from_interpreter_flags``.
 * #2358: Restored AIX support on Python 3.8 and earlier.
 * #2361: Add Python 3.10 support to _distutils_hack. Get the 'Loader' abstract class
@@ -80,19 +112,34 @@ v50.0.1
 v50.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #2232: Once again, Setuptools overrides the stdlib distutils on import. For environments or invocations where this behavior is undesirable, users are provided with a temporary escape hatch. If the environment variable ``SETUPTOOLS_USE_DISTUTILS`` is set to ``stdlib``, Setuptools will fall back to the legacy behavior. Use of this escape hatch is discouraged, but it is provided to ease the transition while proper fixes for edge cases can be addressed.
+
+Changes
+^^^^^^^
 * #2334: In MSVC module, refine text in error message.
 
 
 v49.6.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2129: In pkg_resources, no longer detect any pathname ending in .egg as a Python egg. Now the path must be an unpacked egg or a zip file.
 
 
 v49.5.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2306: When running as a PEP 517 backend, setuptools does not try to install
   ``setup_requires`` itself. They are reported as build requirements for the
   frontend to install.
@@ -101,43 +148,74 @@ v49.5.0
 v49.4.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2310: Updated vendored packaging version to 20.4.
 
 
 v49.3.2
 -------
 
+
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #2300: Improve the ``safe_version`` function documentation
+
+Misc
+^^^^
 * #2297: Once again, in stubs prefer exec_module to the deprecated load_module.
 
 
 v49.3.1
 -------
 
+
+
+Changes
+^^^^^^^
 * #2316: Removed warning when ``distutils`` is imported before ``setuptools`` when ``distutils`` replacement is not enabled.
 
 
 v49.3.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2259: Setuptools now provides a .pth file (except for editable installs of setuptools) to the target environment to ensure that when enabled, the setuptools-provided distutils is preferred before setuptools has been imported (and even if setuptools is never imported). Honors the SETUPTOOLS_USE_DISTUTILS environment variable.
 
 
 v49.2.1
 -------
 
+
+
+Misc
+^^^^
 * #2257: Fixed two flaws in distutils._msvccompiler.MSVCCompiler.spawn.
 
 
 v49.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2230: Now warn the user when setuptools is imported after distutils modules have been loaded (exempting PyPy for 3.6), directing the users of packages to import setuptools first.
 
 
 v49.1.3
 -------
 
+
+
+Misc
+^^^^
 * #2212: (Distutils) Allow spawn to accept environment. Avoid monkey-patching global state.
 * #2249: Fix extension loading technique in stubs.
 
@@ -145,39 +223,69 @@ v49.1.3
 v49.1.2
 -------
 
+
+
+Changes
+^^^^^^^
 * #2232: In preparation for re-enabling a local copy of distutils, Setuptools now honors an environment variable, SETUPTOOLS_USE_DISTUTILS. If set to 'stdlib' (current default), distutils will be used from the standard library. If set to 'local' (default in a imminent backward-incompatible release), the local copy of distutils will be used.
 
 
 v49.1.1
 -------
 
+
+
+Misc
+^^^^
 * #2094: Removed pkg_resources.py2_warn module, which is no longer reachable.
 
 
 v49.0.1
 -------
 
+
+
+Misc
+^^^^
 * #2228: Applied fix for pypa/distutils#3, restoring expectation that spawn will raise a DistutilsExecError when attempting to execute a missing file.
 
 
 v49.1.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2228: Disabled distutils adoption for now while emergent issues are addressed.
 
 
 v49.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #2165: Setuptools no longer installs a site.py file during easy_install or develop installs. As a result, .eggs on PYTHONPATH will no longer take precedence over other packages on sys.path. If this issue affects your production environment, please reach out to the maintainers at #2165.
+
+Changes
+^^^^^^^
 * #2137: Removed (private) pkg_resources.RequirementParseError, now replaced by packaging.requirements.InvalidRequirement. Kept the name for compatibility, but users should catch InvalidRequirement instead.
 * #2180: Update vendored packaging in pkg_resources to 19.2.
+
+Misc
+^^^^
 * #2199: Fix exception causes all over the codebase by using ``raise new_exception from old_exception``
 
 
 v48.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #2143: Setuptools adopts distutils from the Python 3.9 standard library and no longer depends on distutils in the standard library. When importing ``setuptools`` or ``setuptools.distutils_patch``, Setuptools will expose its bundled version as a top-level ``distutils`` package (and unload any previously-imported top-level distutils package), retaining the expectation that ``distutils``' objects are actually Setuptools objects.
   To avoid getting any legacy behavior from the standard library, projects are advised to always "import setuptools" prior to importing anything from distutils. This behavior happens by default when using ``pip install`` or ``pep517.build``. Workflows that rely on ``setup.py (anything)`` will need to first ensure setuptools is imported. One way to achieve this behavior without modifying code is to invoke Python thus: ``python -c "import setuptools; exec(open('setup.py').read())" (anything)``.
 
@@ -185,12 +293,20 @@ v48.0.0
 v47.3.2
 -------
 
+
+
+Misc
+^^^^
 * #2071: Replaced references to the deprecated imp package with references to importlib
 
 
 v47.3.1
 -------
 
+
+
+Misc
+^^^^
 * #1973: Removed ``pkg_resources.py31compat.makedirs`` in favor of the stdlib. Use ``os.makedirs()`` instead.
 * #2198: Restore ``__requires__`` directive in easy-install wrapper scripts.
 
@@ -198,22 +314,38 @@ v47.3.1
 v47.3.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2197: Console script wrapper for editable installs now has a unified template and honors importlib_metadata if present for faster script execution on older Pythons.
+
+Misc
+^^^^
 * #2195: Fix broken entry points generated by easy-install (pip editable installs).
 
 
 v47.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2194: Editable-installed entry points now load significantly faster on Python versions 3.8+.
 
 
 v47.1.1
 -------
 
+
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #2156: Update mailing list pointer in developer docs
 
 Incorporate changes from v44.1.1:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * #2158: Avoid loading working set during ``Distribution.finalize_options`` prior to invoking ``_install_setup_requires``, broken since v42.0.0.
 
@@ -221,25 +353,44 @@ Incorporate changes from v44.1.1:
 v44.1.1
 -------
 
+
+
+Misc
+^^^^
 * #2158: Avoid loading working set during ``Distribution.finalize_options`` prior to invoking ``_install_setup_requires``, broken since v42.0.0.
 
 
 v47.1.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2070: In wheel-to-egg conversion, use simple pkg_resources-style namespace declaration for packages that declare namespace_packages.
 
 
 v47.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #2094: Setuptools now actively crashes under Python 2. Python 3.5 or later is required. Users of Python 2 should use ``setuptools<45``.
+
+Changes
+^^^^^^^
 * #1700: Document all supported keywords by migrating the ones from distutils.
 
 
 v46.4.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1753: ``attr:`` now extracts variables through rudimentary examination of the AST,
   thereby supporting modules with third-party imports. If examining the AST
   fails to find the variable, ``attr:`` falls back to the old behavior of
@@ -255,7 +406,14 @@ No significant changes.
 v46.3.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2089: Package index functionality no longer attempts to remove an md5 fragment from the index URL. This functionality, added for distribute #163 is no longer relevant.
+
+Misc
+^^^^
 * #2041: Preserve file modes during pkg files copying, but clear read only flag for target afterwards.
 * #2105: Filter ``2to3`` deprecation warnings from ``TestDevelop.test_2to3_user_mode``.
 
@@ -263,11 +421,21 @@ v46.3.0
 v46.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #2040: Deprecated the ``bdist_wininst`` command. Binary packages should be built as wheels instead.
 * #2062: Change 'Mac OS X' to 'macOS' in code.
 * #2075: Stop recognizing files ending with ``.dist-info`` as distribution metadata.
 * #2086: Deprecate 'use_2to3' functionality. Packagers are encouraged to use single-source solutions or build tool chains to manage conversions outside of setuptools.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1698: Added documentation for ``build_meta`` (a bare minimum, not completed).
+
+Misc
+^^^^
 * #2082: Filter ``lib2to3`` ``PendingDeprecationWarning`` and ``DeprecationWarning`` in tests,
   because ``lib2to3`` is `deprecated in Python 3.9 <https://bugs.python.org/issue40360>`_.
 
@@ -281,6 +449,10 @@ No significant changes.
 v46.1.2
 -------
 
+
+
+Misc
+^^^^
 * #1458: Added template for reporting Python 2 incompatibilities.
 
 
@@ -293,12 +465,17 @@ No significant changes.
 v46.1.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #308: Allow version number normalization to be bypassed by wrapping in a 'setuptools.sic()' call.
 * #1424: Prevent keeping files mode for package_data build. It may break a build if user's package data has read only flag.
 * #1431: In ``easy_install.check_site_dir``, ensure the installation directory exists.
 * #1563: In ``pkg_resources`` prefer ``find_spec`` (PEP 451) to ``find_module``.
 
 Incorporate changes from v44.1.0:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * #1704: Set sys.argv[0] in setup script run by build_meta.__legacy__
 * #1959: Fix for Python 4: replace unsafe six.PY3 with six.PY2
@@ -308,6 +485,10 @@ Incorporate changes from v44.1.0:
 v44.1.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1704: Set sys.argv[0] in setup script run by build_meta.__legacy__
 * #1959: Fix for Python 4: replace unsafe six.PY3 with six.PY2
 * #1994: Fixed a bug in the "setuptools.finalize_distribution_options" hook that lead to ignoring the order attribute of entry points managed by this hook.
@@ -316,16 +497,33 @@ v44.1.0
 v46.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #65: Once again as in 3.0, removed the Features feature.
+
+Changes
+^^^^^^^
 * #1890: Fix vendored dependencies so importing ``setuptools.extern.some_module`` gives the same object as ``setuptools._vendor.some_module``. This makes Metadata picklable again.
 * #1899: Test suite now fails on warnings.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #2011: Fix broken link to distutils docs on package_data
+
+Misc
+^^^^
 * #1991: Include pkg_resources test data in sdist, so tests can be executed from it.
 
 
 v45.3.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1557: Deprecated eggsecutable scripts and updated docs.
 * #1904: Update msvc.py to use CPython 3.8.0 mechanism to find msvc 14+
 
@@ -333,6 +531,10 @@ v45.3.0
 v45.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1905: Fixed defect in _imp, introduced in 41.6.0 when the 'tests' directory is not present.
 * #1941: Improve editable installs with PEP 518 build isolation:
 
@@ -340,12 +542,19 @@ v45.2.0
   * The error shown when the install directory is not in ``PYTHONPATH`` has been turned into a warning.
 * #1981: Setuptools now declares its ``tests`` and ``docs`` dependencies in metadata (extras).
 * #1985: Add support for installing scripts in environments where bdist_wininst is missing (i.e. Python 3.9).
+
+Misc
+^^^^
 * #1968: Add flake8-2020 to check for misuse of sys.version or sys.version_info.
 
 
 v45.1.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1458: Add minimum sunset date and preamble to Python 2 warning.
 * #1704: Set sys.argv[0] in setup script run by build_meta.__legacy__
 * #1974: Add Python 3 Only Trove Classifier and remove universal wheel declaration for more complete transition from Python 2.
@@ -354,25 +563,46 @@ v45.1.0
 v45.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #1458: Drop support for Python 2. Setuptools now requires Python 3.5 or later. Install setuptools using pip >=9 or pin to Setuptools <45 to maintain 2.7 support.
+
+Changes
+^^^^^^^
 * #1959: Fix for Python 4: replace unsafe six.PY3 with six.PY2
 
 
 v44.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #1908: Drop support for Python 3.4.
 
 
 v43.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #1634: Include ``pyproject.toml`` in source distribution by default. Projects relying on the previous behavior where ``pyproject.toml`` was excluded by default should stop relying on that behavior or add ``exclude pyproject.toml`` to their MANIFEST.in file.
+
+Changes
+^^^^^^^
 * #1927: Setuptools once again declares 'setuptools' in the ``build-system.requires`` and adds PEP 517 build support by declaring itself as the ``build-backend``. It additionally specifies ``build-system.backend-path`` to rely on itself for those builders that support it.
 
 
 v42.0.2
 -------
+
+Changes
+^^^^^^^
 
 * #1921: Fix support for easy_install's ``find-links`` option in ``setup.cfg``.
 * #1922: Build dependencies (setup_requires and tests_require) now install transitive dependencies indicated by extras.
@@ -381,12 +611,20 @@ v42.0.2
 v42.0.1
 -------
 
+
+
+Changes
+^^^^^^^
 * #1918: Fix regression in handling wheels compatibility tags.
 
 
 v42.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #1830, #1909: Mark the easy_install script and setuptools command as deprecated, and use `pip <https://pip.pypa.io/en/stable/>`_ when available to fetch/build wheels for missing ``setup_requires``/``tests_require`` requirements, with the following differences in behavior:
    * support for ``python_requires``
    * better support for wheels (proper handling of priority with respect to PEP 425 tags)
@@ -395,6 +633,9 @@ v42.0.0
    * no support for the ``allow_hosts`` easy_install option (``index_url``/``find_links`` are still honored)
    * pip environment variables are honored (and take precedence over easy_install options)
 * #1898: Removed the "upload" and "register" commands in favor of `twine <https://pypi.org/p/twine>`_.
+
+Changes
+^^^^^^^
 * #1767: Add support for the ``license_files`` option in ``setup.cfg`` to automatically
   include multiple license files in a source distribution.
 * #1829: Update handling of wheels compatibility tags:
@@ -407,46 +648,82 @@ v42.0.0
 v41.6.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #479: Replace usage of deprecated ``imp`` module with local re-implementation in ``setuptools._imp``.
 
 
 v41.5.1
 -------
 
+
+
+Changes
+^^^^^^^
 * #1891: Fix code for detecting Visual Studio's version on Windows under Python 2.
 
 
 v41.5.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1811: Improve Visual C++ 14.X support, mainly for Visual Studio 2017 and 2019.
 * #1814: Fix ``pkg_resources.Requirement`` hash/equality implementation: take PEP 508 direct URL into account.
 * #1824: Fix tests when running under ``python3.10``.
 * #1878: Formally deprecated the ``test`` command, with the recommendation that users migrate to ``tox``.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1860: Update documentation to mention the egg format is not supported by pip and dependency links support was dropped starting with pip 19.0.
 * #1862: Drop ez_setup documentation: deprecated for some time (last updated in 2016), and still relying on easy_install (deprecated too).
 * #1868: Drop most documentation references to (deprecated) EasyInstall.
 * #1884: Added a trove classifier to document support for Python 3.8.
+
+Misc
+^^^^
 * #1886: Added Python 3.8 release to the Travis test matrix.
 
 
 v41.4.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1847: In declarative config, now traps errors when invalid ``python_requires`` values are supplied.
 
 
 v41.3.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1690: When storing extras, rely on OrderedSet to retain order of extras as indicated by the packager, which will also be deterministic on Python 2.7 (with PYTHONHASHSEED unset) and Python 3.6+.
+
+Misc
+^^^^
 * #1858: Fixed failing integration test triggered by 'long_description_content_type' in packaging.
 
 
 v41.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #479: Remove some usage of the deprecated ``imp`` module.
+
+Misc
+^^^^
 * #1565: Changed html_sidebars from string to list of string as per
   https://www.sphinx-doc.org/en/master/changes.html#id58
 
@@ -454,6 +731,10 @@ v41.2.0
 v41.1.0
 -------
 
+
+
+Misc
+^^^^
 * #1697: Moved most of the constants from setup.py to setup.cfg
 * #1749: Fixed issue with the PEP 517 backend where building a source distribution would fail if any tarball existed in the destination directory.
 * #1750: Fixed an issue with PEP 517 backend where wheel builds would fail if the destination directory did not already exist.
@@ -461,12 +742,19 @@ v41.1.0
 * #1769: Improve ``package_data`` check: ensure the dictionary values are lists/tuples of strings.
 * #1788: Changed compatibility fallback logic for ``html.unescape`` to avoid accessing ``HTMLParser.unescape`` when not necessary. ``HTMLParser.unescape`` is deprecated and will be removed in Python 3.9.
 * #1790: Added the file path to the error message when a ``UnicodeDecodeError`` occurs while reading a metadata file.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1776: Use license classifiers rather than the license field.
 
 
 v41.0.1
 -------
 
+
+
+Changes
+^^^^^^^
 * #1671: Fixed issue with the PEP 517 backend that prevented building a wheel when the ``dist/`` directory contained existing ``.whl`` files.
 * #1709: In test.paths_on_python_path, avoid adding unnecessary duplicates to the PYTHONPATH.
 * #1741: In package_index, now honor "current directory" during a checkout of git and hg repositories under Windows
@@ -475,22 +763,37 @@ v41.0.1
 v41.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #1735: When parsing setup.cfg files, setuptools now requires the files to be encoded as UTF-8. Any other encoding will lead to a UnicodeDecodeError. This change removes support for specifying an encoding using a 'coding: ' directive in the header of the file, a feature that was introduces in 40.7. Given the recent release of the aforementioned feature, it is assumed that few if any projects are utilizing the feature to specify an encoding other than UTF-8.
 
 
 v40.9.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1675: Added support for ``setup.cfg``-only projects when using the ``setuptools.build_meta`` backend. Projects that have enabled PEP 517 no longer need to have a ``setup.py`` and can use the purely declarative ``setup.cfg`` configuration file instead.
 * #1720: Added support for ``pkg_resources.parse_requirements``-style requirements in ``setup_requires`` when ``setup.py`` is invoked from the ``setuptools.build_meta`` build backend.
 * #1664: Added the path to the ``PKG-INFO`` or ``METADATA`` file in the exception
   text when the ``Version:`` header can't be found.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1705: Removed some placeholder documentation sections referring to deprecated features.
 
 
 v40.8.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1652: Added the ``build_meta:__legacy__`` backend, a "compatibility mode" PEP 517 backend that can be used as the default when ``build-backend`` is left unspecified in ``pyproject.toml``.
 * #1635: Resource paths are passed to ``pkg_resources.resource_string`` and similar no longer accept paths that traverse parents, that begin with a leading ``/``. Violations of this expectation raise DeprecationWarnings and will become errors. Additionally, any paths that are absolute on Windows are strictly disallowed and will raise ValueErrors.
 * #1536: ``setuptools`` will now automatically include licenses if ``setup.cfg`` contains a ``license_file`` attribute, unless this file is manually excluded inside ``MANIFEST.in``.
@@ -499,25 +802,44 @@ v40.8.0
 v40.7.3
 -------
 
+
+
+Changes
+^^^^^^^
 * #1670: In package_index, revert to using a copy of splituser from Python 3.8. Attempts to use ``urllib.parse.urlparse`` led to problems as reported in #1663 and #1668. This change serves as an alternative to #1499 and fixes #1668.
 
 
 v40.7.2
 -------
 
+
+
+Changes
+^^^^^^^
 * #1666: Restore port in URL handling in package_index.
 
 
 v40.7.1
 -------
 
+
+
+Changes
+^^^^^^^
 * #1660: On Python 2, when reading config files, downcast options from text to bytes to satisfy distutils expectations.
 
 
 v40.7.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #1551: File inputs for the ``license`` field in ``setup.cfg`` files now explicitly raise an error.
+
+Changes
+^^^^^^^
 * #1180: Add support for non-ASCII in setup.cfg (#1062). Add support for native strings on some parameters (#1136).
 * #1499: ``setuptools.package_index`` no longer relies on the deprecated ``urllib.parse.splituser`` per Python #27485.
 * #1544: Added tests for PackageIndex.download (for git URLs).
@@ -527,30 +849,51 @@ v40.7.0
 v40.6.3
 -------
 
+
+
+Changes
+^^^^^^^
 * #1594: PEP 517 backend no longer declares setuptools as a dependency as it can be assumed.
 
 
 v40.6.2
 -------
 
+
+
+Changes
+^^^^^^^
 * #1592: Fix invalid dependency on external six module (instead of vendored version).
 
 
 v40.6.1
 -------
 
+
+
+Changes
+^^^^^^^
 * #1590: Fixed regression where packages without ``author`` or ``author_email`` fields generated malformed package metadata.
 
 
 v40.6.0
 -------
 
+
+
+Deprecations
+^^^^^^^^^^^^
 * #1541: Officially deprecated the ``requires`` parameter in ``setup()``.
+
+Changes
+^^^^^^^
 * #1519: In ``pkg_resources.normalize_path``, additional path normalization is now performed to ensure path values to a directory is always the same, preventing false positives when checking scripts have a consistent prefix to set up on Windows.
 * #1545: Changed the warning class of all deprecation warnings; deprecation warning classes are no longer derived from ``DeprecationWarning`` and are thus visible by default.
 * #1554: ``build_meta.build_sdist`` now includes ``setup.py`` in source distributions by default.
 * #1576: Started monkey-patching ``get_metadata_version`` and ``read_pkg_file`` onto ``distutils.DistributionMetadata`` to retain the correct version on the ``PKG-INFO`` file in the (deprecated) ``upload`` command.
-* #1533: Restricted the ``recursive-include setuptools/_vendor`` to contain only .py and .txt files.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1395: Changed Pyrex references to Cython in the documentation.
 * #1456: Documented that the ``rpmbuild`` packages is required for the ``bdist_rpm`` command.
 * #1537: Documented how to use ``setup.cfg`` for ``src/ layouts``
@@ -559,69 +902,115 @@ v40.6.0
 * #1553: Updated installation instructions to point to ``pip install`` instead of ``ez_setup.py``.
 * #1560: Updated ``setuptools`` distribution documentation to remove some outdated information.
 * #1564: Documented ``setup.cfg`` minimum version for version and project_urls.
+
+Misc
+^^^^
+* #1533: Restricted the ``recursive-include setuptools/_vendor`` to contain only .py and .txt files.
 * #1572: Added the ``concurrent.futures`` backport ``futures`` to the Python 2.7 test suite requirements.
 
 
 v40.5.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1335: In ``pkg_resources.normalize_path``, fix issue on Cygwin when cwd contains symlinks.
 * #1502: Deprecated support for downloads from Subversion in package_index/easy_install.
 * #1517: Dropped use of six.u in favor of ``u""`` literals.
 * #1520: Added support for ``data_files`` in ``setup.cfg``.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1525: Fixed rendering of the deprecation warning in easy_install doc.
 
 
 v40.4.3
 -------
 
+
+
+Changes
+^^^^^^^
 * #1480: Bump vendored pyparsing in pkg_resources to 2.2.1.
 
 
 v40.4.2
 -------
 
+
+
+Misc
+^^^^
 * #1497: Updated gitignore in repo.
 
 
 v40.4.1
 -------
 
+
+
+Changes
+^^^^^^^
 * #1480: Bump vendored pyparsing to 2.2.1.
 
 
 v40.4.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1481: Join the sdist ``--dist-dir`` and the ``build_meta`` sdist directory argument to point to the same target (meaning the build frontend no longer needs to clean manually the dist dir to avoid multiple sdist presence, and setuptools no longer needs to handle conflicts between the two).
 
 
 v40.3.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1402: Fixed a bug with namespace packages under Python 3.6 when one package in
   current directory hides another which is installed.
 * #1427: Set timestamp of ``.egg-info`` directory whenever ``egg_info`` command is run.
 * #1474: ``build_meta.get_requires_for_build_sdist`` now does not include the ``wheel`` package anymore.
 * #1486: Suppress warnings in pkg_resources.handle_ns.
+
+Misc
+^^^^
 * #1479: Remove internal use of six.binary_type.
 
 
 v40.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1466: Fix handling of Unicode arguments in PEP 517 backend
 
 
 v40.1.1
 --------
 
+
+
+Changes
+^^^^^^^
 * #1465: Fix regression with ``egg_info`` command when tagging is used.
 
 
 v40.1.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1410: Deprecated ``upload`` and ``register`` commands.
 * #1312: Introduced find_namespace_packages() to find PEP 420 namespace packages.
 * #1420: Added find_namespace: directive to config parser.
@@ -631,24 +1020,44 @@ v40.1.0
 * #1388: Fixed "Microsoft Visual C++ Build Tools" link in exception when Visual C++ not found.
 * #1389: Added support for scripts which have unicode content.
 * #1416: Moved several Python version checks over to using ``six.PY2`` and ``six.PY3``.
+
+Misc
+^^^^
 * #1441: Removed spurious executable permissions from files that don't need them.
 
 
 v40.0.0
 -------
 
+
+
+Breaking Changes
+^^^^^^^^^^^^^^^^
 * #1342: Drop support for Python 3.3.
+
+Changes
+^^^^^^^
 * #1366: In package_index, fixed handling of encoded entities in URLs.
 * #1383: In pkg_resources VendorImporter, avoid removing packages imported from the root.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1379: Minor doc fixes after actually using the new release process.
 * #1385: Removed section on non-package data files.
 * #1403: Fix developer's guide.
+
+Misc
+^^^^
 * #1404: Fix PEP 518 configuration: set build requirements in ``pyproject.toml`` to ``["wheel"]``.
 
 
 v39.2.0
 -------
 
+
+
+Changes
+^^^^^^^
 * #1359: Support using "file:" to load a PEP 440-compliant package version from
   a text file.
 * #1360: Fixed issue with a mismatch between the name of the package and the
@@ -657,11 +1066,17 @@ v39.2.0
   includes the attributes in the ``_provider`` instance variable.
 * #1365: Take the package_dir option into account when loading the version from
   a module attribute.
+
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
 * #1353: Added coverage badge to README.
 * #1356: Made small fixes to the developer guide documentation.
 * #1357: Fixed warnings in documentation builds and started enforcing that the
   docs build without warnings in tox.
 * #1376: Updated release process docs.
+
+Misc
+^^^^
 * #1343: The ``setuptools`` specific ``long_description_content_type``,
   ``project_urls`` and ``provides_extras`` fields are now set consistently
   after any ``distutils`` ``setup_keywords`` calls, allowing them to override


### PR DESCRIPTION
## Summary of changes

This change injects change categories into the static changelog using the
historic data from Git as a follow-up for
https://github.com/pypa/setuptools/pull/2399#issuecomment-711014643.

I'm not sure if the script I used for the first data extraction step is
useful in the repo so I'm not enclosing it but you can find it attached
to https://github.com/pypa/setuptools/pull/2399#issuecomment-711104367.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
