### PR TITLE
Upgrade GHA actions using deprecated env mechanism

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -50,6 +50,11 @@ jobs:
       if: >-
         endsWith(env.PYTHON_VERSION, '-beta') || 
         endsWith(env.PYTHON_VERSION, '-dev')
+      # FIXME: replace `set-env` with a newer alternative
+      # Refs:
+      # * github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: |
         from __future__ import print_function
         python_version = '${{ env.PYTHON_VERSION }}'.replace('-beta', '')
@@ -59,6 +64,12 @@ jobs:
     - name: Set up Python ${{ env.PYTHON_VERSION }} (deadsnakes)
       uses: deadsnakes/action@v1.0.0
       if: fromJSON(env.USE_DEADSNAKES) && true || false
+      # FIXME: drop once deadsnakes/action gets fixed
+      # Refs:
+      # * github.com/deadsnakes/issues/issues/135
+      # * github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Set up Python ${{ env.PYTHON_VERSION }}
@@ -99,6 +110,11 @@ jobs:
         python -m pip freeze --all
     - name: Adjust TOXENV for PyPy
       if: startsWith(env.PYTHON_VERSION, 'pypy')
+      # FIXME: replace `set-env` with a newer alternative
+      # Refs:
+      # * github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: >-
         echo "::set-env name=TOXENV::${{ env.PYTHON_VERSION }}"
     - name: Log env vars

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -62,7 +62,7 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     - name: Set up Python ${{ env.PYTHON_VERSION }}
-      uses: actions/setup-python@v2.1.1
+      uses: actions/setup-python@v2
       if: >-
         !fromJSON(env.USE_DEADSNAKES) && true || false
       with:
@@ -77,7 +77,7 @@ jobs:
       run: >-
         python -m sysconfig
     - name: Pip cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('setup.cfg') }}


### PR DESCRIPTION
## Summary of changes

This change effectively makes broken GHA work. They were broken because they
pinned old action versions that used a mechanism for setting env vars that
is now deprecated.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
