### PR TITLE
Parallelize the test runs via pytest-xdist

### DIFF
--- a/changelog.d/2459.change.rst
+++ b/changelog.d/2459.change.rst
@@ -1,0 +1,1 @@
+Tests now run in parallel via pytest-xdist, completing in about half the time. Special thanks to :user:`webknjaz` for hard work implementing test isolation. To run without parallelization, disable the plugin with ``tox -- -p no:xdist``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ addopts = "--flake8"
 [pytest.enabler.cov]
 addopts = "--cov"
 
+[pytest.enabler.xdist]
+addopts = "-n auto"
+
 [tool.towncrier]
     package = "setuptools"
     package_dir = "setuptools"

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,9 @@ addopts=
 	--doctest-modules
 	--doctest-glob=pkg_resources/api_tests.txt
 	-r sxX
+
+	# `pytest-xdist`:
+	-n auto
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 # workaround for warning pytest-dev/pytest#6178
 junit_family=xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,9 +4,6 @@ addopts=
 	--doctest-modules
 	--doctest-glob=pkg_resources/api_tests.txt
 	-r sxX
-
-	# `pytest-xdist`:
-	-n auto
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 # workaround for warning pytest-dev/pytest#6178
 junit_family=xunit2

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ testing =
 	pytest-black >= 0.3.7; python_implementation != "PyPy"
 	pytest-cov
 	pytest-mypy; python_implementation != "PyPy"
-	pytest-enabler
+	pytest-enabler >= 1.0.1
 
 	# local
     mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ testing =
     paver
     pip>=19.1 # For proper file:// URLs support.
     jaraco.envs
+    pytest-xdist
 
 docs =
     # Keep these in sync with docs/requirements.txt

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -6,9 +6,6 @@ import pytest
 from . import contexts
 
 
-SRC_DIR = pathlib.Path(__file__).parents[2]
-
-
 @pytest.fixture
 def user_override(monkeypatch):
     """
@@ -32,7 +29,7 @@ def tmpdir_cwd(tmpdir):
 @pytest.fixture
 def src_dir():
     """The project source directory available via fixture."""
-    return SRC_DIR
+    return pathlib.Path(__file__).parents[2]
 
 
 @pytest.fixture

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -1,6 +1,12 @@
+import pathlib
+import shutil
+
 import pytest
 
 from . import contexts
+
+
+SRC_DIR = pathlib.Path(__file__).parents[2]
 
 
 @pytest.fixture
@@ -21,3 +27,25 @@ def user_override(monkeypatch):
 def tmpdir_cwd(tmpdir):
     with tmpdir.as_cwd() as orig:
         yield orig
+
+
+@pytest.fixture
+def src_dir():
+    """The project source directory available via fixture."""
+    return SRC_DIR
+
+
+@pytest.fixture
+def tmp_src(src_dir, tmp_path):
+    """Make a copy of the source dir under `$tmp/src`.
+
+    This fixture is useful whenever it's necessary to run `setup.py`
+    or `pip install` against the source directory when there's no
+    control over the number of simultaneous invocations. Such
+    concurrent runs create and delete directories with the same names
+    under the target directory and so they influence each other's runs
+    when they are not being executed sequentially.
+    """
+    tmp_src_path = tmp_path / 'src'
+    shutil.copytree(src_dir, tmp_src_path)
+    return tmp_src_path

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -1,4 +1,3 @@
-import pathlib
 import shutil
 
 import pytest
@@ -27,13 +26,7 @@ def tmpdir_cwd(tmpdir):
 
 
 @pytest.fixture
-def src_dir():
-    """The project source directory available via fixture."""
-    return pathlib.Path(__file__).parents[2]
-
-
-@pytest.fixture
-def tmp_src(src_dir, tmp_path):
+def tmp_src(request, tmp_path):
     """Make a copy of the source dir under `$tmp/src`.
 
     This fixture is useful whenever it's necessary to run `setup.py`
@@ -44,5 +37,5 @@ def tmp_src(src_dir, tmp_path):
     when they are not being executed sequentially.
     """
     tmp_src_path = tmp_path / 'src'
-    shutil.copytree(src_dir, tmp_src_path)
+    shutil.copytree(request.config.rootdir, tmp_src_path)
     return tmp_src_path

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -349,6 +349,7 @@ class TestBuildMetaBackend:
         build_files(self._relative_path_import_files)
         build_backend = self.get_build_backend()
         with pytest.raises(ImportError):
+        with pytest.raises(ImportError, match="^No module named 'hello'$"):
             build_backend.build_sdist("temp")
 
     @pytest.mark.parametrize('setup_literal, requirements', [

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -1,10 +1,8 @@
 import os
 import shutil
-import sys
 import tarfile
 import importlib
 from concurrent import futures
-from contextlib import suppress
 
 import pytest
 
@@ -46,15 +44,6 @@ class BuildBackendCaller(BuildBackendBase):
 
     def __call__(self, name, *args, **kw):
         """Handles aribrary function invocations on the build backend."""
-        with suppress(ValueError):
-            # NOTE: pytest-xdist tends to inject '' into `sys.path` which
-            # NOTE: may break certain isolation expectations. To address
-            # NOTE: this, we remove this entry from there so the import
-            # NOTE: machinery behaves the same as in the default
-            # NOTE: sequential mode.
-            # Ref: https://github.com/pytest-dev/pytest-xdist/issues/376
-            sys.path.remove('')
-
         os.chdir(self.cwd)
         os.environ.update(self.env)
         mod = importlib.import_module(self.backend_name)

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -136,8 +136,10 @@ defns = [
 class TestBuildMetaBackend:
     backend_name = 'setuptools.build_meta'
 
-    def get_build_backend(self):
-        return BuildBackend(cwd='.', backend_name=self.backend_name)
+    def get_build_backend(self, cwd_path=None):
+        if cwd_path is None:
+            cwd_path = '.'
+        return BuildBackend(cwd=cwd_path, backend_name=self.backend_name)
 
     @pytest.fixture(params=defns)
     def build_backend(self, tmpdir, request):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -347,12 +347,11 @@ class TestBuildMetaBackend:
             """)
     }
 
-    def test_build_sdist_relative_path_import(self, tmpdir_cwd):
-        build_files(self._relative_path_import_files)
-        build_backend = self.get_build_backend()
-        with pytest.raises(ImportError):
+    def test_build_sdist_relative_path_import(self, tmp_path):
+        build_files(self._relative_path_import_files, prefix=str(tmp_path))
+        build_backend = self.get_build_backend(cwd_path=tmp_path)
         with pytest.raises(ImportError, match="^No module named 'hello'$"):
-            build_backend.build_sdist("temp")
+            build_backend.build_sdist(tmp_path / "temp")
 
     @pytest.mark.parametrize('setup_literal, requirements', [
         ("'foo'", ['foo']),

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -125,8 +125,8 @@ defns = [
 class TestBuildMetaBackend:
     backend_name = 'setuptools.build_meta'
 
-    def get_build_backend(self, **kwargs):
-        return BuildBackend(backend_name=self.backend_name, **kwargs)
+    def get_build_backend(self):
+        return BuildBackend(backend_name=self.backend_name)
 
     @pytest.fixture(params=defns)
     def build_backend(self, tmpdir, request):
@@ -334,11 +334,11 @@ class TestBuildMetaBackend:
             """)
     }
 
-    def test_build_sdist_relative_path_import(self, tmp_path):
-        build_files(self._relative_path_import_files, prefix=str(tmp_path))
-        build_backend = self.get_build_backend(cwd=tmp_path)
+    def test_build_sdist_relative_path_import(self, tmpdir_cwd):
+        build_files(self._relative_path_import_files)
+        build_backend = self.get_build_backend()
         with pytest.raises(ImportError, match="^No module named 'hello'$"):
-            build_backend.build_sdist(tmp_path / "temp")
+            build_backend.build_sdist("temp")
 
     @pytest.mark.parametrize('setup_literal, requirements', [
         ("'foo'", ['foo']),

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -1,8 +1,10 @@
 import os
 import shutil
+import sys
 import tarfile
 import importlib
 from concurrent import futures
+from contextlib import suppress
 
 import pytest
 
@@ -44,6 +46,15 @@ class BuildBackendCaller(BuildBackendBase):
 
     def __call__(self, name, *args, **kw):
         """Handles aribrary function invocations on the build backend."""
+        with suppress(ValueError):
+            # NOTE: pytest-xdist tends to inject '' into `sys.path` which
+            # NOTE: may break certain isolation expectations. To address
+            # NOTE: this, we remove this entry from there so the import
+            # NOTE: machinery behaves the same as in the default
+            # NOTE: sequential mode.
+            # Ref: https://github.com/pytest-dev/pytest-xdist/issues/376
+            sys.path.remove('')
+
         os.chdir(self.cwd)
         os.environ.update(self.env)
         mod = importlib.import_module(self.backend_name)

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -11,7 +11,7 @@ from .textwrap import DALS
 
 
 class BuildBackendBase:
-    def __init__(self, cwd=None, env={}, backend_name='setuptools.build_meta'):
+    def __init__(self, cwd='.', env={}, backend_name='setuptools.build_meta'):
         self.cwd = cwd
         self.env = env
         self.backend_name = backend_name
@@ -125,10 +125,8 @@ defns = [
 class TestBuildMetaBackend:
     backend_name = 'setuptools.build_meta'
 
-    def get_build_backend(self, cwd_path=None):
-        if cwd_path is None:
-            cwd_path = '.'
-        return BuildBackend(cwd=cwd_path, backend_name=self.backend_name)
+    def get_build_backend(self, **kwargs):
+        return BuildBackend(backend_name=self.backend_name, **kwargs)
 
     @pytest.fixture(params=defns)
     def build_backend(self, tmpdir, request):
@@ -338,7 +336,7 @@ class TestBuildMetaBackend:
 
     def test_build_sdist_relative_path_import(self, tmp_path):
         build_files(self._relative_path_import_files, prefix=str(tmp_path))
-        build_backend = self.get_build_backend(cwd_path=tmp_path)
+        build_backend = self.get_build_backend(cwd=tmp_path)
         with pytest.raises(ImportError, match="^No module named 'hello'$"):
             build_backend.build_sdist(tmp_path / "temp")
 

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -21,10 +21,10 @@ class VirtualEnv(jaraco.envs.VirtualEnv):
 
 
 @pytest.fixture
-def venv(tmpdir):
+def venv(tmp_path, tmp_src):
     env = VirtualEnv()
-    env.root = path.Path(tmpdir)
-    env.req = os.getcwd()
+    env.root = path.Path(tmp_path / 'venv')
+    env.req = str(tmp_src)
     return env.create()
 
 

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -43,11 +43,11 @@ def bare_virtualenv():
 SOURCE_DIR = os.path.join(os.path.dirname(__file__), '../..')
 
 
-def test_clean_env_install(bare_virtualenv):
+def test_clean_env_install(bare_virtualenv, tmp_src):
     """
     Check setuptools can be installed in a clean environment.
     """
-    bare_virtualenv.run(['python', 'setup.py', 'install'], cd=SOURCE_DIR)
+    bare_virtualenv.run(['python', 'setup.py', 'install'], cd=tmp_src)
 
 
 def _get_pip_versions():

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -85,7 +85,7 @@ def _get_pip_versions():
 
 
 @pytest.mark.parametrize('pip_version', _get_pip_versions())
-def test_pip_upgrade_from_source(pip_version, virtualenv):
+def test_pip_upgrade_from_source(pip_version, tmp_src, virtualenv):
     """
     Check pip can upgrade setuptools from source.
     """
@@ -104,7 +104,7 @@ def test_pip_upgrade_from_source(pip_version, virtualenv):
     virtualenv.run(' && '.join((
         'python setup.py -q sdist -d {dist}',
         'python setup.py -q bdist_wheel -d {dist}',
-    )).format(dist=dist_dir), cd=SOURCE_DIR)
+    )).format(dist=dist_dir), cd=tmp_src)
     sdist = glob.glob(os.path.join(dist_dir, '*.zip'))[0]
     wheel = glob.glob(os.path.join(dist_dir, '*.whl'))[0]
     # Then update from wheel.


### PR DESCRIPTION
## Summary of changes

This is a demo showing how using pytest-xdist affects the test runs.

Resolves #2458

### Performance improvements

Comparing before/after, this patch makes the jobs run 2x faster in the CI and 4x faster locally.

|                    |        main        |      this PR      |
|--------------------|--------------------|-------------------|
| py36/ubuntu-latest | 240.99s  (0:04:00) | 137.93s (0:02:17) |
| pypy3/macos-latest | 1642.34s (0:27:22) | 732.48s (0:12:12) |

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
