### PR TITLE
Description cannot contain a newline.

### DIFF
--- a/changelog.d/1390.change.rst
+++ b/changelog.d/1390.change.rst
@@ -1,0 +1,1 @@
+Newlines in metadata description/Summary now trigger a ValueError.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -118,6 +118,13 @@ def read_pkg_file(self, file):
         self.obsoletes = None
 
 
+def single_line(val):
+    # quick and dirty validation for description pypa/setuptools#1390
+    if '\n' in val:
+        raise ValueError("newlines not allowed")
+    return val
+
+
 # Based on Python 3.5 version
 def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     """Write the PKG-INFO format data to a file object.
@@ -130,7 +137,7 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     write_field('Metadata-Version', str(version))
     write_field('Name', self.get_name())
     write_field('Version', self.get_version())
-    write_field('Summary', self.get_description())
+    write_field('Summary', single_line(self.get_description()))
     write_field('Home-page', self.get_url())
 
     if version < StrictVersion('1.2'):


### PR DESCRIPTION
Quick fix for #1390.

This surgical fix addresses the reported and most common validation failure reported in that issue while a more complete solution is developed in pypa/packaging#147.

No tests are added, though I tested the behavior manually:

```
setuptools master $ .tox/python/bin/python -c "import setuptools; setuptools.setup(description='a\\nb')" egg_info
running egg_info
writing setuptools.egg-info/PKG-INFO
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Users/jaraco/code/public/pypa/setuptools/setuptools/__init__.py", line 153, in setup
    return distutils.core.setup(**attrs)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/Users/jaraco/code/public/pypa/setuptools/setuptools/command/egg_info.py", line 291, in run
    writer(self, ep.name, os.path.join(self.egg_info, ep.name))
  File "/Users/jaraco/code/public/pypa/setuptools/setuptools/command/egg_info.py", line 623, in write_pkg_info
    metadata.write_pkg_info(cmd.egg_info)
  File "/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/distutils/dist.py", line 1117, in write_pkg_info
    self.write_pkg_file(pkg_info)
  File "/Users/jaraco/code/public/pypa/setuptools/setuptools/dist.py", line 138, in write_pkg_file
    write_field('Summary', single_line(self.get_description()))
  File "/Users/jaraco/code/public/pypa/setuptools/setuptools/dist.py", line 123, in single_line
    raise ValueError("newlines not allowed")
ValueError: newlines not allowed
```

My main concern and reason for review is to determine:

- Should this change be backward-incompatible? It will break existing packages that have newlines in their descriptions.
- Perhaps instead of a hard error it should just emit a warning.

