### PR TITLE
Fix tests with pytest 6.2

### DIFF
--- a/changelog.d/2487.misc.rst
+++ b/changelog.d/2487.misc.rst
@@ -1,0 +1,2 @@
+ Fix tests with pytest 6.2
+-- by :user:`yan12125`

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -773,7 +773,7 @@ class TestNamespaces:
 
     ns_str = "__import__('pkg_resources').declare_namespace(__name__)\n"
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def symlinked_tmpdir(self, tmpdir):
         """
         Where available, return the tempdir as a symlink,
@@ -791,7 +791,7 @@ class TestNamespaces:
         finally:
             os.unlink(link_name)
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def patched_path(self, tmpdir):
         """
         Patch sys.path to include the 'site-pkgs' dir. Also

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -3,7 +3,7 @@ import pytest
 from . import contexts
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def user_override(monkeypatch):
     """
     Override site.USER_BASE and site.USER_SITE with temporary directories in
@@ -17,7 +17,7 @@ def user_override(monkeypatch):
                 yield
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def tmpdir_cwd(tmpdir):
     with tmpdir.as_cwd() as orig:
         yield orig

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -31,7 +31,7 @@ INIT_PY = """print "foo"
 """
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def temp_user(monkeypatch):
     with contexts.tempdir() as user_base:
         with contexts.tempdir() as user_site:
@@ -40,7 +40,7 @@ def temp_user(monkeypatch):
             yield
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def test_env(tmpdir, temp_user):
     target = tmpdir
     foo = target.mkdir('foo')

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -305,7 +305,7 @@ class TestPTHFileWriter:
         assert not pth.dirty
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def setup_context(tmpdir):
     with (tmpdir / 'setup.py').open('w') as f:
         f.write(SETUP_PY)
@@ -361,7 +361,7 @@ class TestUserInstallTest:
             f.write('Name: foo\n')
         return str(tmpdir)
 
-    @pytest.yield_fixture()
+    @pytest.fixture()
     def install_target(self, tmpdir):
         target = str(tmpdir)
         with mock.patch('sys.path', sys.path + [target]):
@@ -406,7 +406,7 @@ class TestUserInstallTest:
         )
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def distutils_package():
     distutils_setup_py = SETUP_PY.replace(
         'from setuptools import setup',

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -45,7 +45,7 @@ class TestEggInfo:
                 """)
         })
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def env(self):
         with contexts.tempdir(prefix='setuptools-test.') as env_dir:
             env = Environment(env_dir)

--- a/setuptools/tests/test_msvc.py
+++ b/setuptools/tests/test_msvc.py
@@ -88,7 +88,7 @@ class TestModulePatch:
                     assert isinstance(exc, expected)
                     assert 'aka.ms/vcpython27' in str(exc)
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def user_preferred_setting(self):
         """
         Set up environment with different install dirs for user vs. system
@@ -116,7 +116,7 @@ class TestModulePatch:
         expected = os.path.join(user_preferred_setting, 'vcvarsall.bat')
         assert expected == result
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def local_machine_setting(self):
         """
         Set up environment with only the system environment configured.
@@ -138,7 +138,7 @@ class TestModulePatch:
         expected = os.path.join(local_machine_setting, 'vcvarsall.bat')
         assert expected == result
 
-    @pytest.yield_fixture
+    @pytest.fixture
     def x64_preferred_setting(self):
         """
         Set up environment with 64-bit and 32-bit system settings configured

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -5,7 +5,6 @@ import sys
 import pathlib
 
 import pytest
-from pytest import yield_fixture
 from pytest_fixture_config import yield_requires_config
 
 import pytest_virtualenv
@@ -29,7 +28,7 @@ def pytest_virtualenv_works(virtualenv):
 
 
 @yield_requires_config(pytest_virtualenv.CONFIG, ['virtualenv_executable'])
-@yield_fixture(scope='function')
+@pytest.fixture(scope='function')
 def bare_virtualenv():
     """ Bare virtualenv (no pip/setuptools/wheel).
     """


### PR DESCRIPTION
## Summary of changes

The latest pytest deprecates `pytest.yield_fixture` in favor of 
`pytest.fixture` [1]. The changelog [2] says that both are the same.

[1] https://github.com/pytest-dev/pytest/pull/7988
[2] https://docs.pytest.org/en/stable/changelog.html#pytest-6-2-0-2020-12-12

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
