### PR TITLE
typo

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -71,7 +71,7 @@ file in the ``dist`` directory), which you can upload to PyPI!
 Of course, before you release your project to PyPI, you'll want to add a bit
 more information to your setup script to help people find or learn about your
 project.  And maybe your project will have grown by then to include a few
-dependencies, and perhaps some data files and scripts. In the next few section,
+dependencies, and perhaps some data files and scripts. In the next few sections,
 we will walk through those additional but essential information you need
 to specify to properly package your project.
 


### PR DESCRIPTION
## Summary of changes

Just fixes a small typo on the public docs from "In the next few section" to "In the next few section**s**".

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
