### PR TITLE
Add tests/test*.py to sdist default inclusion list

### DIFF
--- a/changelog.d/2494.change.rst
+++ b/changelog.d/2494.change.rst
@@ -1,0 +1,2 @@
+Add tests/test*.py to sdist default inclusion list.
+-- by :user:`tomchen`

--- a/setuptools/_distutils/command/sdist.py
+++ b/setuptools/_distutils/command/sdist.py
@@ -211,7 +211,7 @@ class sdist(Command):
         """Add all the default files to self.filelist:
           - README or README.txt
           - setup.py
-          - test/test*.py
+          - tests/test*.py and test/test*.py
           - all pure Python modules mentioned in setup script
           - all files pointed by package_data (build_py)
           - all files defined in data_files.
@@ -268,7 +268,7 @@ class sdist(Command):
                     self.warn("standard file '%s' not found" % fn)
 
     def _add_defaults_optional(self):
-        optional = ['test/test*.py', 'setup.cfg']
+        optional = ['tests/test*.py', 'test/test*.py', 'setup.cfg']
         for pattern in optional:
             files = filter(os.path.isfile, glob(pattern))
             self.filelist.extend(files)

--- a/setuptools/command/py36compat.py
+++ b/setuptools/command/py36compat.py
@@ -17,7 +17,7 @@ class sdist_add_defaults:
         """Add all the default files to self.filelist:
           - README or README.txt
           - setup.py
-          - test/test*.py
+          - tests/test*.py and test/test*.py
           - all pure Python modules mentioned in setup script
           - all files pointed by package_data (build_py)
           - all files defined in data_files.
@@ -74,7 +74,7 @@ class sdist_add_defaults:
                     self.warn("standard file '%s' not found" % fn)
 
     def _add_defaults_optional(self):
-        optional = ['test/test*.py', 'setup.cfg']
+        optional = ['tests/test*.py', 'test/test*.py', 'setup.cfg']
         for pattern in optional:
             files = filter(os.path.isfile, glob(pattern))
             self.filelist.extend(files)


### PR DESCRIPTION
## Summary of changes

By default, all files matching the pattern **test**/test*.py (not **tests**/test*.py) are included in the source distribution (sdist). This is documented in [Python Packaging User Guide's "Including files in source distributions with MANIFEST.in" page](https://packaging.python.org/guides/using-manifest-in/?highlight=test#how-files-are-included-in-an-sdist).

But, both [pypa/sampleproject](https://github.com/pypa/sampleproject) and [Python Packaging User Guide's "Packaging Python Projects" page](https://packaging.python.org/tutorials/packaging-projects/?highlight=test#creating-the-package-files) suggest the unit test folder be named `tests`.

I opened the issue pypa/sampleproject#133, it looks clear that `tests` is a more common name than `test`, and it may avoid conflicting with the [test](https://docs.python.org/3/library/test.html) standard library module according to some.

Therefore, I request to add "tests/test*.py" to sdist default inclusion list. And "test/test*.py" should be kept for compatibility with old repos.

### Pull Request Checklist
- [x] News fragment added in [`changelog.d/`]

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
