### PR TITLE
docs: recommend pypa build instead of pep517.build

### DIFF
--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -67,14 +67,11 @@ specify the package information::
     [options]
     packages = find:
 
-Now generate the distribution. Although the PyPA is still working to
-`provide a recommended tool <https://github.com/pypa/packaging-problems/issues/219>`_
-to build packages, the `pep517 package <https://pypi.org/project/pep517>`_
-provides this functionality. To build the package::
+Now generate the distribution. To build the package, use
+`PyPA build <https://pypa-build.readthedocs.io/en/latest/>`_::
 
-    $ pip install -q pep517
-    $ mkdir dist
-    $ python -m pep517.build .
+    $ pip install -q build
+    $ python -m build
 
 And now it's done! The ``.whl`` file  and ``.tar.gz`` can then be distributed 
 and installed::


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Docs update to recommend PyPA build instead of pep517.build.

Closes #2503

