### PR TITLE
Migrate to `extend-exclude` in flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,7 @@
 [flake8]
 max-line-length = 88
 extend-exclude =
+	build/lib
 	setuptools/_vendor
 	pkg_resources/_vendor
 ignore =

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-exclude =
+extend-exclude =
 	setuptools/_vendor
 	pkg_resources/_vendor
 ignore =

--- a/.flake8
+++ b/.flake8
@@ -1,8 +1,9 @@
 [flake8]
 max-line-length = 88
 extend-exclude =
-	build/lib
+	build
 	setuptools/_vendor
+	setuptools/_distutils
 	pkg_resources/_vendor
 ignore =
 	# W503 violates spec https://github.com/PyCQA/pycodestyle/issues/513


### PR DESCRIPTION
## Summary of changes

This makes sure that flake8's defaults are in use. Specifically, it
excludes `.tox/` dir that is known to contain a lot of files in nested
folders that are not supposed to be linted.

Refs:
* https://github.com/pypa/setuptools/issues/2501#issuecomment-749144396
* https://github.com/pypa/setuptools/pull/2486/files#r546877674
* https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-extend-exclude
* https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-exclude

Ref #2501.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
