### PR TITLE
Fix misplaced/mistyped per-file-ignores in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -10,5 +10,8 @@ ignore =
 	W504
 	# Black creates whitespace before colon
 	E203
-	setuptools/site-patch.py F821
-	setuptools/py*compat.py F811
+
+# Allow certain violations in certain files:
+per-file-ignores =
+	setuptools/site-patch.py: F821
+	setuptools/py*compat.py: F811

--- a/.flake8
+++ b/.flake8
@@ -13,5 +13,4 @@ ignore =
 
 # Allow certain violations in certain files:
 per-file-ignores =
-	setuptools/site-patch.py: F821
 	setuptools/py*compat.py: F811

--- a/.flake8
+++ b/.flake8
@@ -10,7 +10,3 @@ ignore =
 	W504
 	# Black creates whitespace before colon
 	E203
-
-# Allow certain violations in certain files:
-per-file-ignores =
-	setuptools/py*compat.py: F811


### PR DESCRIPTION
## Summary of changes

This PR gets rid of the invalid ignore entries in the flake8 config. They were introduced in https://github.com/pypa/setuptools/commit/313ac58f51c6ef92170647c4cc8626043f68a26b while being moved from the pytest config. The correct flake8 syntax is `per-file-ignores` with colon-separated entries.
I'm pretty sure this never worked.

Also, `setuptools/site-patch.py` doesn't even exist anymore + `setuptools/py*compat.py` matches `setuptools/py34compat.py` that doesn't generate any violations meaning that introducing the correct `per-file-ignores` is currently unnecessary.

Refs:
* https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-per-file-ignores
* #2501

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
