### PR TITLE
Use `extend-ignore` in flake8 config

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,11 +3,7 @@ max-line-length = 88
 exclude =
 	setuptools/_vendor
 	pkg_resources/_vendor
-ignore =
-	# W503 violates spec https://github.com/PyCQA/pycodestyle/issues/513
-	W503
-	# W504 has issues https://github.com/OCA/maintainer-quality-tools/issues/545
-	W504
+extend-ignore =
 	# Black creates whitespace before colon
 	E203
 	setuptools/site-patch.py F821


### PR DESCRIPTION
## Summary of changes

This option allows adding extra ignored rules to the default list
instead of replacing it.

The default exclusions are: E121, E123, E126, E226, E24, E704,
W503 and W504.

Refs:
* https://github.com/pypa/setuptools/pull/2486/files#r541943356
* https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-extend-ignore
* https://flake8.pycqa.org/en/latest/user/options.html#cmdoption-flake8-ignore
* #2501
* https://github.com//skeleton/issues/28

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
