### PR TITLE
fix: suggest PyPA build instead of pep517.build

### DIFF
--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -157,7 +157,7 @@ To use this feature:
       ]
       build-backend = "setuptools.build_meta"
 
-* Use a :pep:`517` compatible build frontend, such as ``pip >= 19`` or ``pep517``.
+* Use a :pep:`517` compatible build frontend, such as ``pip >= 19`` or ``build``.
 
   .. warning::
 


### PR DESCRIPTION
This is a minor docs edit to suggest PyPA-build instead of pep517.build, which is no longer intended as a public interface. See https://github.com/pypa/packaging.python.org/issues/770 (and others)

Edit: or more recently, https://github.com/pypa/setuptools/pull/2504 (Forgot it was in the same repo :flushed:)