### PR TITLE
Avoid deprecated load_module() in pkg_resources namespace delaration

### DIFF
--- a/changelog.d/2493.change.rst
+++ b/changelog.d/2493.change.rst
@@ -1,0 +1,2 @@
+Use importlib.import_module() rather than the deprectated loader.load_module()
+in pkg_resources namespace delaration -- by :user:`encukou`

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -38,6 +38,7 @@ import itertools
 import inspect
 import ntpath
 import posixpath
+import importlib
 from pkgutil import get_importer
 
 try:
@@ -2209,7 +2210,7 @@ def _handle_ns(packageName, path_item):
     if subpath is not None:
         path = module.__path__
         path.append(subpath)
-        loader.load_module(packageName)
+        importlib.import_module(packageName)
         _rebuild_mod_path(path, packageName, module)
     return subpath
 


### PR DESCRIPTION

## Summary of changes

Fixes https://github.com/pypa/setuptools/issues/2493

As I said in the issue,
> As for the calling of load_module in `pkg_resources.__init__`, it seems to me that the only purpose of the call is to ensure the module is loaded, so that its `__path__` can be fixed up using `_rebuild_mod_path`. The call uses the default loader.
>
> So, it could be replaced by `importlib.import_module(packageName)`. From the load_module docs, the only thing it does in addition to what import_module does is reloading the module if it already exists. To me, that seems like an unintended side effect.
But I could also be off; the docs are written for implementing of loaders, not for calling them.


### Pull Request Checklist
- [x] Changes have tests (existing related tests no longer warn under Python 3.10; warnings are treated as errors by default)
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
