### PR TITLE
quickstart: recommend PyPA build instead of pep517.build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,9 @@ link_files = {
     ),
 }
 
+intersphinx_mapping = {
+    'pypa-build': ('https://pypa-build.readthedocs.io/en/latest/', None)
+}
 
 # Add support for linking usernames
 github_url = 'https://github.com'
@@ -80,7 +83,7 @@ github_sponsors_url = f'{github_url}/sponsors'
 extlinks = {
     'user': (f'{github_sponsors_url}/%s', '@'),  # noqa: WPS323
 }
-extensions += ['sphinx.ext.extlinks']
+extensions += ['sphinx.ext.extlinks', 'sphinx.ext.intersphinx']
 
 # Be strict about any broken references:
 nitpicky = True

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -59,11 +59,11 @@ This is what your project would look like::
         setup.cfg
         mypackage/__init__.py
 
-Then, you need an installer, such as `pep517 <https://pypi.org/project/pep517/>`_
-which you can obtain via ``pip install pep517``. After downloading it, invoke
+Then, you need an installer, such as :std:doc:`PyPA build <pypa-build:index>`
+which you can obtain via ``pip install build``. After downloading it, invoke
 the installer::
 
-    python -m pep517.build .
+    python -m build
 
 You now have your distribution ready (e.g. a ``tar.gz`` file and a ``.whl``
 file in the ``dist`` directory), which you can upload to PyPI!


### PR DESCRIPTION
## Summary of changes

Docs update to recommend PyPA build instead of pep517.build (see https://github.com/pypa/pep517/issues/91). Similar to #2504 but for docs/userguide/quickstart.rst 
