### PR TITLE
Clean up after :func:`CCompiler.has_function`. Fixes #2559.

### DIFF
--- a/setuptools/_distutils/ccompiler.py
+++ b/setuptools/_distutils/ccompiler.py
@@ -792,6 +792,8 @@ int main (int argc, char **argv) {
             objects = self.compile([fname], include_dirs=include_dirs)
         except CompileError:
             return False
+        finally:
+            os.remove(fname)
 
         try:
             self.link_executable(objects, "a.out",
@@ -799,6 +801,12 @@ int main (int argc, char **argv) {
                                  library_dirs=library_dirs)
         except (LinkError, TypeError):
             return False
+        else:
+            os.remove("a.out")
+        finally:
+            for fn in objects:
+                os.remove(fn)
+
         return True
 
     def find_library_file (self, dirs, lib, debug=0):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
CCompiler.has_function() does not delete temporary files. Depending on the
check result it leaves temporary C source, object and executable files.
This PR fixes that.

Closes #2559<!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
