### PR TITLE
Correctly parse cmdclass in setup.cfg. Fixes #2570

### DIFF
--- a/changelog.d/2570.change.rst
+++ b/changelog.d/2570.change.rst
@@ -1,0 +1,1 @@
+Correctly parse cmdclass in setup.cfg.

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -1,3 +1,6 @@
+import types
+import sys
+
 import contextlib
 import configparser
 
@@ -7,6 +10,7 @@ from distutils.errors import DistutilsOptionError, DistutilsFileError
 from mock import patch
 from setuptools.dist import Distribution, _Distribution
 from setuptools.config import ConfigHandler, read_configuration
+from distutils.core import Command
 from .textwrap import DALS
 
 
@@ -852,6 +856,26 @@ class TestOptions:
         with pytest.raises(Exception):
             with get_dist(tmpdir) as dist:
                 dist.parse_config_files()
+
+    def test_cmdclass(self, tmpdir):
+        class CustomCmd(Command):
+            pass
+
+        m = types.ModuleType('custom_build', 'test package')
+
+        m.__dict__['CustomCmd'] = CustomCmd
+
+        sys.modules['custom_build'] = m
+
+        fake_env(
+            tmpdir,
+            '[options]\n'
+            'cmdclass =\n'
+            '    customcmd = custom_build.CustomCmd\n'
+        )
+
+        with get_dist(tmpdir) as dist:
+            assert dist.cmdclass == {'customcmd': CustomCmd}
 
 
 saved_dist_init = _Distribution.__init__


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #2570 <!-- issue number here -->


### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
