### PR TITLE
Fix error uploading Sphinx doc with upload_docs. Fixes #1060

### DIFF
--- a/changelog.d/2573.change.rst
+++ b/changelog.d/2573.change.rst
@@ -1,0 +1,2 @@
+Fixed error in uploading a Sphinx doc with the :code:`upload_docs` command. An html builder will be used. 
+Note: :code:`upload_docs` is deprecated for PyPi, but is supported for other sites -- by :user:`melissa-kun-li`

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ testing =
     pip>=19.1 # For proper file:// URLs support.
     jaraco.envs
     pytest-xdist
+    sphinx
 
 docs =
     # Keep these in sync with docs/requirements.txt

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -31,7 +31,7 @@ class upload_docs(upload):
     # supported by Warehouse (and won't be).
     DEFAULT_REPOSITORY = 'https://pypi.python.org/pypi/'
 
-    description = 'Upload documentation to PyPI'
+    description = 'Upload documentation to sites other than PyPi such as devpi'
 
     user_options = [
         ('repository=', 'r',
@@ -59,10 +59,7 @@ class upload_docs(upload):
         if self.upload_dir is None:
             if self.has_sphinx():
                 build_sphinx = self.get_finalized_command('build_sphinx')
-                for (builder, builder_dir) in build_sphinx.builder_target_dirs:
-                    if builder == "html":
-                        self.target_dir = builder_dir
-                        break
+                self.target_dir = dict(build_sphinx.builder_target_dirs)['html']
             else:
                 build = self.get_finalized_command('build')
                 self.target_dir = os.path.join(build.build_base, 'docs')
@@ -70,7 +67,7 @@ class upload_docs(upload):
             self.ensure_dirname('upload_dir')
             self.target_dir = self.upload_dir
         if 'pypi.python.org' in self.repository:
-            log.warn("Upload_docs command is deprecated. Use RTD instead.")
+            log.warn("Upload_docs command is deprecated for PyPi. Use RTD instead.")
         self.announce('Using upload directory %s' % self.target_dir)
 
     def create_zipfile(self, filename):

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -2,7 +2,7 @@
 """upload_docs
 
 Implements a Distutils 'upload_docs' subcommand (upload documentation to
-PyPI's pythonhosted.org).
+sites other than PyPi such as devpi).
 """
 
 from base64 import standard_b64encode
@@ -59,7 +59,10 @@ class upload_docs(upload):
         if self.upload_dir is None:
             if self.has_sphinx():
                 build_sphinx = self.get_finalized_command('build_sphinx')
-                self.target_dir = build_sphinx.builder_target_dir
+                for (builder, builder_dir) in build_sphinx.builder_target_dirs:
+                    if builder == "html":
+                        self.target_dir = builder_dir
+                        break
             else:
                 build = self.get_finalized_command('build')
                 self.target_dir = os.path.join(build.build_base, 'docs')

--- a/setuptools/tests/requirements.txt
+++ b/setuptools/tests/requirements.txt
@@ -11,3 +11,4 @@ paver; python_version>="3.6"
 futures; python_version=="2.7"
 pip>=19.1 # For proper file:// URLs support.
 jaraco.envs
+sphinx

--- a/setuptools/tests/test_sphinx_upload_docs.py
+++ b/setuptools/tests/test_sphinx_upload_docs.py
@@ -1,0 +1,42 @@
+import pytest
+import os
+
+from setuptools.command.upload_docs import upload_docs
+from setuptools.dist import Distribution
+
+
+@pytest.fixture
+def sphinx_doc_sample_project(tmpdir_cwd):
+    # setup.py
+    with open('setup.py', 'wt') as f:
+        f.write('from setuptools import setup; setup()\n')
+
+    os.makedirs('build/docs')
+
+    # A test conf.py for Sphinx
+    with open('build/docs/conf.py', 'w') as f:
+        f.write("project = 'test'")
+
+    # A test index.rst for Sphinx
+    with open('build/docs/index.rst', 'w') as f:
+        f.write(".. toctree::\
+                    :maxdepth: 2\
+                    :caption: Contents:")
+
+
+@pytest.mark.usefixtures('sphinx_doc_sample_project')
+@pytest.mark.usefixtures('user_override')
+class TestSphinxUploadDocs:
+    def test_sphinx_doc(self):
+        params = dict(
+            name='foo',
+            packages=['test'],
+        )
+        dist = Distribution(params)
+
+        cmd = upload_docs(dist)
+
+        cmd.initialize_options()
+        assert cmd.upload_dir is None
+        assert cmd.has_sphinx() is True
+        cmd.finalize_options()

--- a/setuptools/tests/test_sphinx_upload_docs.py
+++ b/setuptools/tests/test_sphinx_upload_docs.py
@@ -25,7 +25,6 @@ def sphinx_doc_sample_project(tmpdir_cwd):
 
 
 @pytest.mark.usefixtures('sphinx_doc_sample_project')
-@pytest.mark.usefixtures('user_override')
 class TestSphinxUploadDocs:
     def test_sphinx_doc(self):
         params = dict(


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Closes #1060

Sphinx now uses `builder_target_dirs` in replacement of `builder_target_dir`  https://github.com/sphinx-doc/sphinx/blob/3.x/sphinx/setup_command.py#L143-L145. This fix will set the `target_dir` in `upload_docs` to the path of the html builder. 

Note: `Upload_docs` was restored support for sites other than PyPi as noted here: https://github.com/pypa/setuptools/blob/e1ffc2abbae4f2aa78dd09ee9827d754b7702b7b/CHANGES.rst#v3610


### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
