### PR TITLE
Include link to new developer guide in doc. Fixes #2456

### DIFF
--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -54,7 +54,7 @@ Feature Highlights:
 Developer's Guide
 -----------------
 
-The developer's guide has been updated. See the `most recent version. <https://setuptools.readthedocs.io/en/latest/userguide/index.html>`_
+The developer's guide has been updated. See the :doc:`most recent version <userguide/index>`.
 
 
 

--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -54,7 +54,7 @@ Feature Highlights:
 Developer's Guide
 -----------------
 
-
+The developer's guide has been updated. See the `most recent version. <https://setuptools.readthedocs.io/en/latest/userguide/index.html>`_
 
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The [former developer's guide](https://setuptools.readthedocs.io/en/latest/setuptools.html) in `setuptools.rst` has been updated, so that it points the user to the [new developer's guide](https://setuptools.readthedocs.io/en/latest/userguide/index.html) in `userguide/index`.

Closes #2456 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request