### PR TITLE
Fix case sensitivity of entry point names and keys in setup.cfg. Fixes #1937

### DIFF
--- a/changelog.d/1937.breaking.rst
+++ b/changelog.d/1937.breaking.rst
@@ -1,1 +1,0 @@
-Preserved case-sensitivity of keys in setup.cfg so that entry point names are case-sensitive. Changed sensitivity of configparser -- by :user:`melissa-kun-li`

--- a/changelog.d/1937.breaking.rst
+++ b/changelog.d/1937.breaking.rst
@@ -1,0 +1,1 @@
+Preserved case-sensitivity of keys in setup.cfg so that entry point names are case-sensitive. Changed sensitivity of configparser -- by :user:`melissa-kun-li`

--- a/changelog.d/1937.change.rst
+++ b/changelog.d/1937.change.rst
@@ -1,0 +1,1 @@
+Preserved case-sensitivity of keys in setup.cfg so that entry point names are case-sensitive. Changed sensitivity of configparser. NOTE: Any projects relying on case-insensitivity will need to adapt to accept the original case as published. -- by :user:`melissa-kun-li`

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -583,6 +583,7 @@ class Distribution(_Distribution):
             self.announce("Distribution.parse_config_files():")
 
         parser = ConfigParser()
+        parser.optionxform = str
         for filename in filenames:
             with io.open(filename, encoding='utf-8') as reader:
                 if DEBUG:

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -802,6 +802,40 @@ class TestOptions:
         with get_dist(tmpdir) as dist:
             assert dist.entry_points == expected
 
+    def test_case_sensitive_entry_points(self, tmpdir):
+        _, config = fake_env(
+            tmpdir,
+            '[options.entry_points]\n'
+            'GROUP1 = point1 = pack.module:func, '
+            '.point2 = pack.module2:func_rest [rest]\n'
+            'group2 = point3 = pack.module:func2\n'
+        )
+
+        with get_dist(tmpdir) as dist:
+            assert dist.entry_points == {
+                'GROUP1': [
+                    'point1 = pack.module:func',
+                    '.point2 = pack.module2:func_rest [rest]',
+                ],
+                'group2': ['point3 = pack.module:func2']
+            }
+
+        expected = (
+            '[blogtool.parsers]\n'
+            '.rst = some.nested.module:SomeClass.some_classmethod[reST]\n'
+        )
+
+        tmpdir.join('entry_points').write(expected)
+
+        # From file.
+        config.write(
+            '[options]\n'
+            'entry_points = file: entry_points\n'
+        )
+
+        with get_dist(tmpdir) as dist:
+            assert dist.entry_points == expected
+
     def test_data_files(self, tmpdir):
         fake_env(
             tmpdir,

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -820,22 +820,6 @@ class TestOptions:
                 'group2': ['point3 = pack.module:func2']
             }
 
-        expected = (
-            '[blogtool.parsers]\n'
-            '.rst = some.nested.module:SomeClass.some_classmethod[reST]\n'
-        )
-
-        tmpdir.join('entry_points').write(expected)
-
-        # From file.
-        config.write(
-            '[options]\n'
-            'entry_points = file: entry_points\n'
-        )
-
-        with get_dist(tmpdir) as dist:
-            assert dist.entry_points == expected
-
     def test_data_files(self, tmpdir):
         fake_env(
             tmpdir,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #1937

To address the bug of entry point names being made lower-case by Setuptools, this fix preserves case-sensitivity of keys in `setup.cfg` by changing`ConfigParser` to become case-sensitive. Edit: by extension this will also address any issues about keys in `setup.cfg` not retaining case-sensitivity such as in #2480

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
