### PR TITLE
Handle AttributeError by raising DistutilsSetupError in check_specifier. Fixes #1932

### DIFF
--- a/changelog.d/1932.change.rst
+++ b/changelog.d/1932.change.rst
@@ -1,0 +1,1 @@
+Handled :code:`AttributeError` by raising :code:`DistutilsSetupError` in :code:`dist.check_specifier()` when specifier is not a string -- by :user:`melissa-kun-li`

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -292,7 +292,7 @@ def check_specifier(dist, attr, value):
     """Verify that value is a valid version specifier"""
     try:
         packaging.specifiers.SpecifierSet(value)
-    except packaging.specifiers.InvalidSpecifier as error:
+    except (packaging.specifiers.InvalidSpecifier, AttributeError) as error:
         tmpl = (
             "{attr!r} must be a string "
             "containing valid version specifiers; {error}"

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -9,6 +9,7 @@ from setuptools.dist import (
     _get_unpatched,
     check_package_data,
     DistDeprecationWarning,
+    check_specifier,
 )
 from setuptools import sic
 from setuptools import Distribution
@@ -323,3 +324,15 @@ def test_check_package_data(package_data, expected_message):
         with pytest.raises(
                 DistutilsSetupError, match=re.escape(expected_message)):
             check_package_data(None, str('package_data'), package_data)
+
+
+def test_check_specifier():
+    # valid specifier value
+    attrs = {'name': 'foo', 'python_requires': '>=3.0, !=3.1'}
+    dist = Distribution(attrs)
+    check_specifier(dist, attrs, attrs['python_requires'])
+
+    # invalid specifier value
+    attrs = {'name': 'foo', 'python_requires': ['>=3.0', '!=3.1']}
+    with pytest.raises(DistutilsSetupError):
+        dist = Distribution(attrs)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes  #1932

`Dist.check_specifier` verifies that the specifiers are valid and raises `DistutilsSetupError` if found invalid, however in the situation that the specifier is a non-string (e.g. a list with a string element) it would fail with an `AttributeError` because `SpecifierSet` from _vendor/packaging will assume that the specifier is a string. This fix will change `check_specifier` to handle the `AttributeError` by raising `DistutilsSetupError` when the situation of a non-string specifier occurs. 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
