### PR TITLE
Introduce issue forms in the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,130 @@
+---
+name: 🐛 Bug report
+description: >-
+  Create a report to help us improve when
+  something is not working correctly
+title: '[BUG] '
+labels:
+- bug
+- Needs Triage
+issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      **Thank you for wanting to report a bug in setuptools!**
+
+
+      ⚠
+      Verify first that your issue is not
+      [already reported on GitHub][issue search] and keep in mind and
+      keep in mind that we may have to keep the current behavior because
+      [every change breaks someone's workflow][XKCD 1172].
+      We try to be mindful about this.
+
+      Also test if the latest release and main branch are affected too.
+
+
+      If you are seeking community support, please consider
+      [starting a discussion][Discussions].
+
+
+      Thank you for your collaboration!
+
+
+      [Discussions]: https://github.com/pypa/setuptools/discussions
+
+      [issue search]: https://github.com/pypa/setuptools/search?q=is%3Aissue&type=issues
+
+      [XKCD 1172]: https://xkcd.com/1172/
+
+- type: markdown
+  attributes:
+    value: >-
+      **Environment**
+- type: input
+  attributes:
+    label: setuptools version
+    placeholder: For example, setuptools===60.4.2
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: Python version
+    placeholder: For example, Python 3.10
+  validations:
+    required: true
+- type: input
+  attributes:
+    label: OS
+    placeholder: For example, Gentoo Linux, RHEL 8, Arch Linux, macOS etc.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Additional environment information
+    description: >-
+      Feel free to add more information about your environment here.
+    placeholder: >-
+      This is only happening when I run setuptools on my fridge's patched firmware 🤯
+
+- type: textarea
+  attributes:
+    label: Description
+    description: >-
+      A clear and concise description of what the bug is.
+    placeholder: >-
+      I tried doing X and I expected it to result in Y because the docs
+      mentioned Z but what happened next what totally unexpected!
+      And here's why...
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Expected behavior
+    description: >-
+      A clear and concise description of what you expected to happen.
+    placeholder: >-
+      I tried doing X and I expected it to result in Y. I'm confused...
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: How to Reproduce
+    description: >-
+      Describe the steps to reproduce this bug.
+    placeholder: |
+      1. Integrate setuptools via '...'
+      2. Then run '...'
+      3. An error occurs.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Output
+    description: >-
+      Paste the output of the steps above, including the commands
+      themselves and setuptools' output/traceback etc.
+    value: |
+      ```console
+
+      ```
+  validations:
+    required: true
+
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [PSF Code of Conduct][CoC] first.
+
+      [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+    options:
+    - label: I agree to follow the PSF Code of Conduct
+      required: true
+...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+# Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: false  # default: true
+contact_links:
+- name: 🤔 Have questions or need support?
+  url: https://github.com/pypa/setuptools/discussions
+  about: This is a place for the community to exchange ideas and recipes
+- name: 💬 Discourse
+  url: https://discuss.python.org/c/packaging
+  about: |
+    Please ask typical Q&A here: general ideas for Python packaging,
+    questions about structuring projects and so on
+- name: >-
+    💬 IRC: #pypa @ Freenode
+  url: https://webchat.freenode.net/#pypa
+  about: Chat with devs

--- a/.github/ISSUE_TEMPLATE/documentation-report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-report.yml
@@ -1,0 +1,93 @@
+---
+name: 📝 Documentation Report
+title: '[Docs] '
+description: Ask us about docs
+labels:
+- documentation
+- Needs Triage
+# NOTE: issue body is enabled to allow screenshots
+issue_body: true  # default: true, adds a classic WSYWIG textarea, if on
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      **Thank you for wanting to report a problem with setuptools
+      documentation!**
+
+
+      Please fill out your suggestions below. If the problem seems
+      straightforward, feel free to go ahead and
+      submit a pull request instead!
+
+
+      ⚠
+      Verify first that your issue is not [already reported on
+      GitHub][issue search].
+
+
+      If you are seeking community support, please consider
+      [starting a discussion][Discussions].
+
+
+      Thank you for your collaboration!
+
+
+      [issue search]: https://github.com/pypa/setuptools/search?q=is%3Aissue&type=issues
+
+      [Discussions]: https://github.com/pypa/setuptools/discussions
+
+- type: textarea
+  attributes:
+    label: Summary
+    description: >
+      Explain the problem briefly below, add suggestions to wording
+      or structure.
+
+
+      **HINT:** Did you know the documentation has a `View on GitHub`
+      link on every page? Feel free to use it to start a pull request
+      right from the GitHub UI!
+    placeholder: >-
+      I was reading the setuptools documentation of version X and I'm
+      having problems understanding Y. It would be very helpful if that
+      got rephrased as Z.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: OS / Environment
+    description: >-
+      Provide all relevant information below, e.g. OS version,
+      browser, etc.
+    placeholder: Fedora 33, Firefox etc.
+
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [PSF Code of Conduct][CoC] first.
+
+      [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+    options:
+    - label: I agree to follow the PSF Code of Conduct
+      required: true
+
+
+- type: markdown
+  attributes:
+    value: >
+ 
+
+      ### Additional Information
+
+
+      Describe how this improves the documentation, e.g. before/after
+      situation or screenshots.
+
+
+      **HINT:** You can paste https://gist.github.com links for
+      larger files.
+...

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,105 @@
+---
+name: ✨ Feature request
+description: Suggest an idea for setuptools
+title: '[FR] '
+labels:
+- enhancement
+- Needs Triage
+issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
+
+body:
+- type: markdown
+  attributes:
+    value: >
+      **Thank you for wanting to suggest a feature for setuptools!**
+
+
+      💡
+      Before you go ahead with your request, please first consider if it
+      would be useful for majority of the setuptools users. As a general
+      rule of thumb, any feature that is only of interest to a small sub
+      group should be implemented in a third-party plugin or maybe even
+      just your project alone. Be mindful of the fact that the core
+      setuptools features have a broad impact.
+
+
+      <details>
+        <summary>
+          ❗ Every change breaks someone's workflow.
+        </summary>
+
+
+        [![❗ Every change breaks someone's workflow.](https://imgs.xkcd.com/comics/workflow.png)
+        ](https://xkcd.com/1172/)
+      </details>
+
+
+      ⚠
+      Verify first that your idea is not [already requested on GitHub][issue search].
+
+
+
+      [issue search]: https://github.com/pypa/setuptools/search?q=is%3Aissue&type=issues
+
+- type: textarea
+  attributes:
+    label: What's the problem this feature will solve?
+    description: >-
+      What are you trying to do, that you are unable to achieve
+      with setuptools as it currently stands?
+    placeholder: >-
+      I'm trying to do X and I'm missing feature Y for this to be
+      easily achievable.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Describe the solution you'd like
+    description: >
+      Clear and concise description of what you want to happen.
+
+
+      Provide examples of real world use cases that this would enable
+      and how it solves the problem described above.
+    placeholder: >-
+      When I do X, I want to achieve Y in a situation when Z.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Alternative Solutions
+    description: >-
+      Have you tried to workaround the problem using other tools? Or a
+      different approach to solving this issue? Please elaborate here.
+    placeholder: >-
+      I tried doing X, Y and Z. But they are subobpimal because of P.
+
+- type: textarea
+  attributes:
+    label: Additional context
+    description: >
+      Add any other context, links, etc. about the feature here.
+      Describe how the feature would be used, why it is needed and what
+      it would solve.
+
+
+      **HINT:** You can paste https://gist.github.com links for
+      larger files.
+    placeholder: >-
+      I asked on https://stackoverflow.com/.... and the community
+      advised me to do X, Y and Z.
+
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [PSF Code of Conduct][CoC] first.
+
+      [CoC]: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md
+    options:
+    - label: I agree to follow the PSF Code of Conduct
+      required: true
+...


### PR DESCRIPTION
## Summary of changes

This change makes the submitted GitHub issue structure predictable. The result of the submitted issue forms is saved as Markdown and can be freely edited later. The validation rules are only enforced on the initial issue creation.

Docs: https://gh-community.github.io/issue-template-feedback/structured/

I've made a demo repo with the configs from this PR. Check it out!

###### **[:point_right: ISSUE FORMS FROM THIS PR IN THE DEMO REPOSITORY :point_left:](/webknjaz/setuptools-issue-forms-demo/issues/new/choose)**

Resolves #2556

### Pull Request Checklist

N/A
