### PR TITLE
Reduce scope of dash deprecation warning. Fixes #2595

### DIFF
--- a/changelog.d/2595.misc.rst
+++ b/changelog.d/2595.misc.rst
@@ -1,0 +1,1 @@
+Reduced scope of dash deprecation warning to Setuptools/distutils only -- by :user:`melissa-kun-li`

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -600,7 +600,7 @@ class Distribution(_Distribution):
                         continue
 
                     val = parser.get(section, opt)
-                    opt = self.dash_to_underscore_warning(opt, section)
+                    opt = self.warn_dash_deprecation(opt, section)
                     opt = self.make_option_lowercase(opt, section)
                     opt_dict[opt] = (filename, val)
 
@@ -626,7 +626,7 @@ class Distribution(_Distribution):
             except ValueError as e:
                 raise DistutilsOptionError(e) from e
 
-    def dash_to_underscore_warning(self, opt, section):
+    def warn_dash_deprecation(self, opt, section):
         if section in (
             'options.extras_require', 'options.data_files',
         ):

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -11,6 +11,7 @@ import distutils.log
 import distutils.core
 import distutils.cmd
 import distutils.dist
+import distutils.command
 from distutils.util import strtobool
 from distutils.debug import DEBUG
 from distutils.fancy_getopt import translate_longopt
@@ -29,6 +30,7 @@ from setuptools.extern import ordered_set
 from . import SetuptoolsDeprecationWarning
 
 import setuptools
+import setuptools.command
 from setuptools import windows_support
 from setuptools.monkey import get_unpatched
 from setuptools.config import parse_configuration
@@ -629,7 +631,13 @@ class Distribution(_Distribution):
             'options.extras_require', 'options.data_files',
         ):
             return opt
+
         underscore_opt = opt.replace('-', '_')
+        commands = distutils.command.__all__ + setuptools.command.__all__
+        if (not section.startswith('options') and section != 'metadata'
+                and section not in commands):
+            return underscore_opt
+
         if '-' in opt:
             warnings.warn(
                 "Usage of dash-separated '%s' will not be supported in future "

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -507,10 +507,9 @@ class TestMetadata:
             with get_dist(tmpdir):
                 pass
 
-    def test_dash_to_underscore_warning(self, tmpdir):
-        # dash_to_underscore_warning() is a method in setuptools.dist
-        # remove this test and method when dash convert to underscore in setup.cfg
-        # is no longer supported
+    def test_warn_dash_deprecation(self, tmpdir):
+        # warn_dash_deprecation() is a method in setuptools.dist
+        # remove this test and the method when no longer needed
         fake_env(
             tmpdir,
             '[metadata]\n'
@@ -523,11 +522,12 @@ class TestMetadata:
         with pytest.warns(UserWarning, match=msg):
             with get_dist(tmpdir) as dist:
                 metadata = dist.metadata
-                assert metadata.author_email == 'test@test.com'
-                assert metadata.maintainer_email == 'foo@foo.com'
 
-    def test_uppercase_warning(self, tmpdir):
-        # remove this test and the method uppercase_warning() in setuptools.dist
+        assert metadata.author_email == 'test@test.com'
+        assert metadata.maintainer_email == 'foo@foo.com'
+
+    def test_make_option_lowercase(self, tmpdir):
+        # remove this test and the method make_option_lowercase() in setuptools.dist
         # when no longer needed
         fake_env(
             tmpdir,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #2595

This change limits the scope of the dash deprecation warning to sections which Setuptools/distutils uses in `setup.cfg` 

### Pull Request Checklist
~~- [ ] Changes have tests~~ Change was tested locally
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
