### PR TITLE
Added some entry points required for bootstrapping from source.

### DIFF
--- a/bootstrap.egg-info/entry_points.txt
+++ b/bootstrap.egg-info/entry_points.txt
@@ -1,6 +1,10 @@
 [distutils.commands]
 egg_info = setuptools.command.egg_info:egg_info
-
+bdist_wheel = wheel.bdist_wheel:bdist_wheel
+easy_install = setuptools.command.easy_install:easy_install
+install = setuptools.command.install:install
+bdist_egg = setuptools.command.bdist_egg:bdist_egg
+ 
 [distutils.setup_keywords]
 include_package_data = setuptools.dist:assert_bool
 install_requires = setuptools.dist:check_requirements


### PR DESCRIPTION
## Summary of changes

<details>
<summary>Excerpt from a DOCKERFILE to bootstrap python packaging</summary>

```
	git clone --depth=50 https://github.com/pypa/setuptools.git;\
	git clone --depth=50 https://github.com/pypa/setuptools_scm.git;\
	git clone --depth=50 https://github.com/pypa/pip.git;\
	git clone --depth=50 https://github.com/pypa/wheel.git;\
	export SUDO=;\
	cd ./wheel;\
	python3 -c "import re;from pathlib import Path;f=Path('setup.cfg');f.write_text(re.subn('^setup_requires.+$', '', f.read_text(), flags=re.MULTILINE)[0])";\
	PYTHONPATH=../setuptools:./src $SUDO python3 ./setup.py install;\
	cd ../setuptools;\
	python3 ./setup.py install;\
	python3 ./setup.py bdist_wheel;\
	PYTHONPATH=../pip/src $SUDO python3 -m pip install --upgrade --force-reinstall ./dist/*.whl;\
	cd ../wheel;\
	PYTHONPATH=../setuptools python3 ./setup.py bdist_wheel;\
	PYTHONPATH=../pip/src $SUDO python3 -m pip install --upgrade --force-reinstall ./dist/*.whl;\
	cd ../pip;\
	python3 ./setup.py bdist_wheel;\
	PYTHONPATH=./src $SUDO python3 -m pip install --upgrade --force-reinstall ./dist/*.whl;\
	cd ../setuptools_scm;\
	python3 ./setup.py bdist_wheel;\
	$SUDO pip3 install --upgrade ./dist/*.whl;\
	cd ..;\
	rm -rf ./setuptools ./pip ./wheel;\
	git clone --depth=50 https://github.com/uiri/toml.git;\
	cd ./toml;\
	python3 ./setup.py bdist_wheel;\
	$SUDO pip3 install --upgrade ./dist/*.whl;\
	cd ..;\
	echo todo: $SUDO pip3 install --upgrade --force-reinstall ./setuptools_scm/dist/*.whl[toml];\
	rm -rf ./toml ./setuptools_scm;\
	\
	git clone --depth=50 https://github.com/pyparsing/pyparsing.git;\
	cd ./pyparsing;\
	python3 ./setup.py bdist_wheel;\
	$SUDO pip3 install --upgrade ./dist/*.whl;\
	cd ..;\
	rm -rf ./pyparsing;\
	\
	git clone --depth=50 https://github.com/takluyver/flit.git;\
	cd flit/flit_core;\
	python3 -c "from flit_core import build_thyself;build_thyself.build_wheel('./')";\
	$SUDO pip3 install --upgrade ./*.whl;\
	cd ../..;\
	rm -rf ./flit;\
	\
	git clone --depth=50 https://github.com/pypa/packaging.git;\
	git clone --depth=50 https://github.com/pypa/pep517.git;\
	git clone --depth=50 https://github.com/pypa/build.git;\
	\
	cd pep517;\
	PYTHONPATH=../build/src:../packaging python3 -m build -xnw .;\
	$SUDO pip3 install --upgrade ./dist/*.whl;\
	\
	cd ../packaging;\
	PYTHONPATH=../build/src python3 -m build -xnw .;\
	$SUDO pip3 install --upgrade ./dist/*.whl;\
	cd ..;\
	rm -rf ./packaging;\
	\
	cd ./build;\
	PYTHONPATH=./src python3 -m build -xnw .;\
	$SUDO pip3 install --upgrade ./dist/*.whl;\
	cd ..;\
	rm -rf ./pep517 ./build ./packaging;\
```

</details>

<details>
<summary>Log</summary>

1. First tried `bdist_wheel` for setuptools. Damn, it tries to install `wheel` with `pip` because it is a build dep. Trying to make use of non-installed `wheel` is unsuccesful.

2. OK, tried to build `wheel` with non-installed `setuptools` + non-installed `wheel`. No success. `wheel` needs installed `wheel`. OK, `wheel` uses `setup.cfg`, it's fairly easy to remove `install_requires`. `python3 -c import re;from pathlib import Path;f=Path('setup.cfg');f.write_text(re.subn('^setup_requires.+$', '', f.read_text(), flags=re.MULTILINE)[0])` Then `python ./setup.py install` succeeds (how? why?). `bdist_wheel` though doesn't IDK why, seems like just `install` doesn't register entry points.

3. OK, added an entry point for `bdist_wheel`. Damn, `error: cannot copy tree 'build/scripts-3.9': not a directory`. Trying to solve by installing setuptools.

4. trying to `python3 ./setup.py install` in setuptools dir. `error: invalid command 'easy_install'`. Why??? No entry point. Created a patch with them. Then install succeeds. 

5. then we can build a wheel for setuptools and install it

6. then we can go to `wheel` dir, set `PYTHONPATH` to `setuptools` dir to get a get the ehtry points for `bdist_wheel`, build a wheel for it and install.

</details>

Closes #2550

### Pull Request Checklist
- [ ] Changes have tests - not needed
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
