### PR TITLE
build_meta: produce informative error when a dist is not found

### DIFF
--- a/changelog.d/2608.change.rst
+++ b/changelog.d/2608.change.rst
@@ -1,2 +1,2 @@
 Added informative error message to PEP 517 build failures owing to
-an empty ``setup.py`` -- by :user:layday
+an empty ``setup.py`` -- by :user:`layday`

--- a/changelog.d/2608.change.rst
+++ b/changelog.d/2608.change.rst
@@ -1,0 +1,2 @@
+Added informative error message to PEP 517 build failures owing to
+an empty ``setup.py`` -- by :user:layday

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -101,8 +101,12 @@ def _file_with_extension(directory, extension):
         f for f in os.listdir(directory)
         if f.endswith(extension)
     )
-    file, = matching
-    return file
+    try:
+        return next(matching)
+    except StopIteration:
+        raise ValueError('No distribution was found. The distribution was '
+                         'possibly not built. Ensure that your `setup.py` '
+                         'is not empty and that it calls `setup()`.')
 
 
 def _open_setup_script(setup_script):

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -107,8 +107,7 @@ def _file_with_extension(directory, extension):
         raise ValueError(
             'No distribution was found. Ensure that `setup.py` '
             'is not empty and that it calls `setup()`.')
-    else:
-        return file
+    return file
 
 
 def _open_setup_script(setup_script):

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -104,9 +104,9 @@ def _file_with_extension(directory, extension):
     try:
         return next(matching)
     except StopIteration:
-        raise ValueError('No distribution was found. The distribution was '
-                         'possibly not built. Ensure that your `setup.py` '
-                         'is not empty and that it calls `setup()`.')
+        raise ValueError(
+            'No distribution was found. Ensure that `setup.py` '
+            'is not empty and that it calls `setup()`.')
 
 
 def _open_setup_script(setup_script):

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -102,11 +102,13 @@ def _file_with_extension(directory, extension):
         if f.endswith(extension)
     )
     try:
-        return next(matching)
-    except StopIteration:
+        file, = matching
+    except ValueError:
         raise ValueError(
             'No distribution was found. Ensure that `setup.py` '
             'is not empty and that it calls `setup()`.')
+    else:
+        return file
 
 
 def _open_setup_script(setup_script):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -450,10 +450,7 @@ class TestBuildMetaBackend:
 
         with pytest.raises(
                 ValueError,
-                match=re.escape(
-                    'No distribution was found. The distribution was '
-                    'possibly not built. Ensure that your `setup.py` '
-                    'is not empty and that it calls `setup()`.')):
+                match=re.escape('No distribution was found.')):
             getattr(build_backend, build_hook)("temp")
 
 

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -3,6 +3,7 @@ import shutil
 import tarfile
 import importlib
 from concurrent import futures
+import re
 
 import pytest
 from jaraco import path
@@ -441,6 +442,19 @@ class TestBuildMetaBackend:
         build_backend = self.get_build_backend()
         with pytest.raises(AssertionError):
             build_backend.build_sdist("temp")
+
+    @pytest.mark.parametrize('build_hook', ('build_sdist', 'build_wheel'))
+    def test_build_with_empty_setuppy(self, build_backend, build_hook):
+        files = {'setup.py': ''}
+        path.build(files)
+
+        with pytest.raises(
+                ValueError,
+                match=re.escape(
+                    'No distribution was found. The distribution was '
+                    'possibly not built. Ensure that your `setup.py` '
+                    'is not empty and that it calls `setup()`.')):
+            getattr(build_backend, build_hook)("temp")
 
 
 class TestBuildMetaLegacyBackend(TestBuildMetaBackend):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Previously, when `build_sdist` or `build_wheel` were unable
to build a distribution (and were therefore unable to find the
distribution file), they would throw a

    ValueError: not enough values to unpack (expected 1, got 0)

which did not offer any clues as to where the issue might lie.

<!-- Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
