### PR TITLE
Relax MACOSX_DEPLOYMENT_TARGET check

### DIFF
--- a/setuptools/_distutils/spawn.py
+++ b/setuptools/_distutils/spawn.py
@@ -60,13 +60,17 @@ def spawn(cmd, search_path=1, verbose=0, dry_run=0, env=None):
             if _cfg_target:
                 _cfg_target_split = [int(x) for x in _cfg_target.split('.')]
         if _cfg_target:
-            # ensure that the deployment target of build process is not less
-            # than that used when the interpreter was built. This ensures
-            # extension modules are built with correct compatibility values
+            # Ensure that the deployment target of the build process is not
+            # less than 10.3 if the interpreter was built for 10.3 or later.
+            # This ensures extension modules are built with correct
+            # compatibility values, specifically LDSHARED which can use
+            # '-undefined dynamic_lookup' which only works on >= 10.3.
             cur_target = os.environ.get('MACOSX_DEPLOYMENT_TARGET', _cfg_target)
-            if _cfg_target_split > [int(x) for x in cur_target.split('.')]:
+            cur_target_split = [int(x) for x in cur_target.split('.')]
+            if _cfg_target_split[:2] >= [10, 3] and cur_target_split[:2] < [10, 3]:
                 my_msg = ('$MACOSX_DEPLOYMENT_TARGET mismatch: '
-                          'now "%s" but "%s" during configure'
+                          'now "%s" but "%s" during configure;'
+                          'must use 10.3 or later'
                                 % (cur_target, _cfg_target))
                 raise DistutilsPlatformError(my_msg)
             env.update(MACOSX_DEPLOYMENT_TARGET=cur_target)


### PR DESCRIPTION
Only complain if the config target is >= 10.3 and the current target is
< 10.3. The check was originally added to ensure that incompatible
LDSHARED flags are not used, because `-undefined dynamic_lookup` is
used when building for 10.3 and later, and is not supported on older OS
versions. Apart from that, there should be no problem in general with
using an older target.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_
