### PR TITLE
Align RTD config with skeleton

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,6 @@
 version: 2
 python:
   install:
-  - requirements: docs/requirements.txt
+  - path: .
+    extra_requirements:
+      - docs

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,0 @@
-# keep these in sync with setup.cfg
-sphinx
-jaraco.packaging>=6.1
-rst.linker>=1.9
-pygments-github-lexers==0.0.5
-sphinx-inline-tabs@git+https://github.com/pradyunsg/sphinx-inline-tabs@main
-
-setuptools>=34

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,10 +72,10 @@ docs =
 	sphinx
 	jaraco.packaging >= 8.2
 	rst.linker >= 1.9
-	sphinx-inline-tabs
 
 	# local
 	pygments-github-lexers==0.0.5
+	sphinx-inline-tabs@git+https://github.com/pradyunsg/sphinx-inline-tabs@main
 
 ssl =
 	wincertstore==0.2; sys_platform=='win32'


### PR DESCRIPTION
Now that Setuptools builds from git source without a bootstrap step, reset RTD config to match skeleton and rely on package metadata for docs build requirements. Eliminates duplication.

[Tested in this build](https://readthedocs.org/projects/setuptools/builds/13360943/).