### PR TITLE
License_files improvements

### DIFF
--- a/changelog.d/2620.breaking.rst
+++ b/changelog.d/2620.breaking.rst
@@ -1,5 +1,4 @@
 If neither ``license_file`` nor ``license_files`` is specified, the ``sdist``
 option will now auto-include files that match the following patterns:
 ``LICEN[CS]E*``, ``COPYING*``, ``NOTICE*``, ``AUTHORS*``.
-This matches the behavior of ``bdist_wheel``.
-Any ``exclude`` in ``MANIFEST.in`` will overwrite it. -- by :user:`cdce8p`
+This matches the behavior of ``bdist_wheel``. -- by :user:`cdce8p`

--- a/changelog.d/2620.breaking.rst
+++ b/changelog.d/2620.breaking.rst
@@ -1,0 +1,5 @@
+If neither ``license_file`` nor ``license_files`` is specified, the ``sdist``
+option will now auto-include files that match the following patterns:
+``LICEN[CS]E*``, ``COPYING*``, ``NOTICE*``, ``AUTHORS*``.
+This matches the behavior of ``bdist_wheel``.
+Any ``exclude`` in ``MANIFEST.in`` will overwrite it. -- by :user:`cdce8p`

--- a/changelog.d/2620.change.rst
+++ b/changelog.d/2620.change.rst
@@ -1,0 +1,1 @@
+The ``license_file`` and ``license_files`` options now support glob patterns. -- by :user:`cdce8p`

--- a/changelog.d/2620.deprecation.rst
+++ b/changelog.d/2620.deprecation.rst
@@ -1,0 +1,2 @@
+The ``license_file`` option is now marked as deprecated.
+Use ``license_files`` instead. -- by :user:`cdce8p`

--- a/changelog.d/2620.doc.rst
+++ b/changelog.d/2620.doc.rst
@@ -1,0 +1,1 @@
+Added documentation for the ``license_files`` option. -- by :user:`cdce8p`

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -76,6 +76,18 @@ Keywords
 ``license``
     A string specifying the license of the package.
 
+``license_file``
+
+    .. warning::
+        ``license_file`` is deprecated. Use ``license_files`` instead.
+
+``license_files``
+
+    A list of glob patterns for license related files that should be included.
+    If neither ``license_file`` nor ``license_files`` is specified, this option
+    defaults to ``LICEN[CS]E*``, ``COPYING*``, ``NOTICE*``, and ``AUTHORS*``.
+    Any ``exclude`` specified in ``MANIFEST.in`` will overwrite it.
+
 ``keywords``
     A list of strings or a comma-separated string providing descriptive
     meta-data. See: `PEP 0314`_.

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -86,7 +86,6 @@ Keywords
     A list of glob patterns for license related files that should be included.
     If neither ``license_file`` nor ``license_files`` is specified, this option
     defaults to ``LICEN[CS]E*``, ``COPYING*``, ``NOTICE*``, and ``AUTHORS*``.
-    Any ``exclude`` specified in ``MANIFEST.in`` will overwrite it.
 
 ``keywords``
     A list of strings or a comma-separated string providing descriptive

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -184,7 +184,7 @@ maintainer_email                maintainer-email   str
 classifiers                     classifier         file:, list-comma
 license                                            str
 license_file                                       str
-license_files                                      list-comma
+license_files                                      list-comma         42.0.0
 description                     summary            file:, str
 long_description                long-description   file:, str
 long_description_content_type                      str                38.6.0

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -213,6 +213,9 @@ class sdist(sdist_add_defaults, orig.sdist):
             patterns.append(opts['license_file'][1])
 
         if 'license_file' not in opts and 'license_files' not in opts:
+            # Default patterns match the ones wheel uses
+            # See https://wheel.readthedocs.io/en/stable/user_guide.html
+            # -> 'Including license files in the generated wheel file'
             patterns = ('LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*')
 
         for pattern in patterns:

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -4,6 +4,8 @@ import os
 import sys
 import io
 import contextlib
+import warnings
+from glob import iglob
 
 from setuptools.extern import ordered_set
 
@@ -194,29 +196,38 @@ class sdist(sdist_add_defaults, orig.sdist):
         """Checks if license_file' or 'license_files' is configured and adds any
         valid paths to 'self.filelist'.
         """
-
-        files = ordered_set.OrderedSet()
-
         opts = self.distribution.get_option_dict('metadata')
 
-        # ignore the source of the value
-        _, license_file = opts.get('license_file', (None, None))
-
-        if license_file is None:
-            log.debug("'license_file' option was not specified")
-        else:
-            files.add(license_file)
-
+        files = ordered_set.OrderedSet()
         try:
-            files.update(self.distribution.metadata.license_files)
+            license_files = self.distribution.metadata.license_files
         except TypeError:
             log.warn("warning: 'license_files' option is malformed")
+            license_files = ordered_set.OrderedSet()
+        patterns = license_files if isinstance(license_files, ordered_set.OrderedSet) \
+            else ordered_set.OrderedSet(license_files)
 
-        for f in files:
-            if not os.path.exists(f):
-                log.warn(
-                    "warning: Failed to find the configured license file '%s'",
-                    f)
-                files.remove(f)
+        if 'license_file' in opts:
+            warnings.warn(
+                "The 'license_file' option is deprecated. Use 'license_files' instead.",
+                DeprecationWarning)
+            patterns.append(opts['license_file'][1])
 
-        self.filelist.extend(files)
+        if 'license_file' not in opts and 'license_files' not in opts:
+            patterns = ('LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*')
+
+        for pattern in patterns:
+            for path in iglob(pattern):
+                if path.endswith('~'):
+                    log.debug(
+                        "ignoring license file '%s' as it looks like a backup",
+                        path)
+                    continue
+
+                if path not in files and os.path.isfile(path):
+                    log.info(
+                        "adding license file '%s' (matched pattern '%s')",
+                        path, pattern)
+                    files.add(path)
+
+        self.filelist.extend(sorted(files))

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -4,7 +4,6 @@ import os
 import sys
 import io
 import contextlib
-import warnings
 from glob import iglob
 
 from setuptools.extern import ordered_set
@@ -208,9 +207,9 @@ class sdist(sdist_add_defaults, orig.sdist):
             else ordered_set.OrderedSet(license_files)
 
         if 'license_file' in opts:
-            warnings.warn(
-                "The 'license_file' option is deprecated. Use 'license_files' instead.",
-                DeprecationWarning)
+            log.warn(
+                "warning: the 'license_file' option is deprecated, "
+                "use 'license_files' instead")
             patterns.append(opts['license_file'][1])
 
         if 'license_file' not in opts and 'license_files' not in opts:

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -654,8 +654,7 @@ class TestEggInfo:
             'LICENSE-XYZ': "XYZ license"
         }, ['LICENSE-ABC'], ['LICENSE-XYZ']),  # subset is manually excluded
         pytest.param({
-            'setup.cfg': DALS("""
-                              """),
+            'setup.cfg': "",
             'LICENSE-ABC': "ABC license",
             'COPYING-ABC': "ABC copying",
             'NOTICE-ABC': "ABC notice",

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -537,7 +537,7 @@ class TestEggInfo:
             'setup.cfg': DALS("""
                               """),
             'LICENSE': "Test license"
-        }, False),  # no license_file attribute
+        }, True),  # no license_file attribute, LICENSE auto-included
         ({
             'setup.cfg': DALS("""
                               [metadata]
@@ -625,7 +625,7 @@ class TestEggInfo:
             'setup.cfg': DALS("""
                               """),
             'LICENSE': "Test license"
-        }, [], ['LICENSE']),  # no license_files attribute
+        }, ['LICENSE'], []),  # no license_files attribute, LICENSE auto-included
         ({
             'setup.cfg': DALS("""
                               [metadata]

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -545,7 +545,15 @@ class TestEggInfo:
                               """),
             'MANIFEST.in': "exclude LICENSE",
             'LICENSE': "Test license"
-        }, False)  # license file is manually excluded
+        }, False),  # license file is manually excluded
+        pytest.param({
+            'setup.cfg': DALS("""
+                              [metadata]
+                              license_file = LICEN[CS]E*
+                              """),
+            'LICENSE': "Test license",
+            }, True,
+            id="glob_pattern"),
     ])
     def test_setup_cfg_license_file(
             self, tmpdir_cwd, env, files, license_in_sources):
@@ -644,7 +652,37 @@ class TestEggInfo:
             'MANIFEST.in': "exclude LICENSE-XYZ",
             'LICENSE-ABC': "ABC license",
             'LICENSE-XYZ': "XYZ license"
-        }, ['LICENSE-ABC'], ['LICENSE-XYZ'])  # subset is manually excluded
+        }, ['LICENSE-ABC'], ['LICENSE-XYZ']),  # subset is manually excluded
+        pytest.param({
+            'setup.cfg': DALS("""
+                              """),
+            'LICENSE-ABC': "ABC license",
+            'COPYING-ABC': "ABC copying",
+            'NOTICE-ABC': "ABC notice",
+            'AUTHORS-ABC': "ABC authors",
+            'LICENCE-XYZ': "XYZ license",
+            'LICENSE': "License",
+            'INVALID-LICENSE': "Invalid license",
+            }, [
+            'LICENSE-ABC',
+            'COPYING-ABC',
+            'NOTICE-ABC',
+            'AUTHORS-ABC',
+            'LICENCE-XYZ',
+            'LICENSE',
+            ], ['INVALID-LICENSE'],
+            # ('LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*')
+            id="default_glob_patterns"),
+        pytest.param({
+            'setup.cfg': DALS("""
+                              [metadata]
+                              license_files =
+                                  LICENSE*
+                              """),
+            'LICENSE-ABC': "ABC license",
+            'NOTICE-XYZ': "XYZ notice",
+            }, ['LICENSE-ABC'], ['NOTICE-XYZ'],
+            id="no_default_glob_patterns"),
     ])
     def test_setup_cfg_license_files(
             self, tmpdir_cwd, env, files, incl_licenses, excl_licenses):
@@ -749,7 +787,28 @@ class TestEggInfo:
             'LICENSE-PQR': "PQR license",
             'LICENSE-XYZ': "XYZ license"
             # manually excluded
-        }, ['LICENSE-XYZ'], ['LICENSE-ABC', 'LICENSE-PQR'])
+        }, ['LICENSE-XYZ'], ['LICENSE-ABC', 'LICENSE-PQR']),
+        pytest.param({
+            'setup.cfg': DALS("""
+                              [metadata]
+                              license_file = LICENSE*
+                              """),
+            'LICENSE-ABC': "ABC license",
+            'NOTICE-XYZ': "XYZ notice",
+            }, ['LICENSE-ABC'], ['NOTICE-XYZ'],
+            id="no_default_glob_patterns"),
+        pytest.param({
+            'setup.cfg': DALS("""
+                              [metadata]
+                              license_file = LICENSE*
+                              license_files =
+                                NOTICE*
+                              """),
+            'LICENSE-ABC': "ABC license",
+            'NOTICE-ABC': "ABC notice",
+            'AUTHORS-ABC': "ABC authors",
+            }, ['LICENSE-ABC', 'NOTICE-ABC'], ['AUTHORS-ABC'],
+            id="combined_glob_patterrns"),
     ])
     def test_setup_cfg_license_file_license_files(
             self, tmpdir_cwd, env, files, incl_licenses, excl_licenses):

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -55,6 +55,7 @@ def touch(filename):
 default_files = frozenset(map(make_local_path, [
     'README.rst',
     'MANIFEST.in',
+    'LICENSE',
     'setup.py',
     'app.egg-info/PKG-INFO',
     'app.egg-info/SOURCES.txt',


### PR DESCRIPTION
## Summary of changes

- Add support for glob patterns in `license_file` and `license_files` options.
- Add default patterns if neither is specified to match behavior of `bdist_wheel`.
https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file
- Added deprecation warning if `license_file` file is used. `license_files` is a full replacement.
- Added additional documentation for the `license_files` option.

The implementation is similar to the one used by `wheel`: [wheel/bdist_wheel.py](https://github.com/pypa/wheel/blob/41b375ef33e3368f6f58c13f9649491d01c2ba5e/src/wheel/bdist_wheel.py#L410-L435)

Closes #2616

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
