### PR TITLE
Test - Fix url for pip download

### DIFF
--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -85,7 +85,7 @@ def _get_pip_versions():
         mark('pip==18.1', issue2599),
         mark('pip==19.3.1', pytest.mark.xfail(reason='pypa/pip#6599')),
         'pip==20.0.2',
-        'https://github.com/pypa/pip/archive/master.zip',
+        'https://github.com/pypa/pip/archive/main.zip',
     ]
 
     versions = itertools.chain(


### PR DESCRIPTION
## Summary of changes
pip changed its default branch to `main` which caused a test case to fail.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
