### PR TITLE
Use `sphinx-inline-tabs` from PyPI in sphinx docs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ docs =
 
 	# local
 	pygments-github-lexers==0.0.5
-	sphinx-inline-tabs@git+https://github.com/pradyunsg/sphinx-inline-tabs@main
+	sphinx-inline-tabs
 
 ssl =
 	wincertstore==0.2; sys_platform=='win32'


### PR DESCRIPTION
## Summary of changes

This change reverts the workaround for installing a proper version of `sphinx-inline-tabs` since @pradyunsg published the new release today.

Fixes #2614

### Pull Request Checklist
- [x] Changes have tests
- [ ] ~News fragment added in [`changelog.d/`].~
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
