### PR TITLE
Don't distribute tests data for pkg_resources

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ exclude =
 	docs*
 	tests*
 	*.tests
+	*.tests.*
 	tools*
 
 [options.extras_require]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
OS distributions usually don't include tests and their data in
Python distro packages since they pull in extra tests
dependencies. But at the same time it is unlikely that end users
will run tests in production. In this case the tests data was
packaged without tests.
<!-- Summary goes here -->

Closes  #2624<!-- issue number here -->