### PR TITLE
Fix typo in setup.py example in quickstart guide.

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -62,7 +62,7 @@ the minimum
         from setuptools import setup
 
         setup(
-            name='mypackage'
+            name='mypackage',
             version='0.0.1',
             packages=['mypackage'],
             install_requires=[

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -62,7 +62,7 @@ the minimum
         from setuptools import setup
 
         setup(
-            name='mypackage"'
+            name='mypackage'
             version='0.0.1',
             packages=['mypackage'],
             install_requires=[


### PR DESCRIPTION
Fix a small typo in the 'Basic Use' example of the Quickstart section of the User Guide.