### PR TITLE
distutils: pass -rpath on macOS when requested

### DIFF
--- a/changelog.d/2627.change.rst
+++ b/changelog.d/2627.change.rst
@@ -1,0 +1,1 @@
+Honor `runtime_library_dirs` on macOS by passing `-rpath` to the linker

--- a/setuptools/_distutils/unixccompiler.py
+++ b/setuptools/_distutils/unixccompiler.py
@@ -233,8 +233,7 @@ class UnixCCompiler(CCompiler):
         # we use this hack.
         compiler = os.path.basename(sysconfig.get_config_var("CC"))
         if sys.platform[:6] == "darwin":
-            # MacOSX's linker doesn't understand the -R flag at all
-            return "-L" + dir
+            return "-Wl,-rpath," + dir
         elif sys.platform[:7] == "freebsd":
             return "-Wl,-rpath=" + dir
         elif sys.platform[:5] == "hp-ux":


### PR DESCRIPTION
## Summary of changes

Resurrecting a patch to an old issue that is still relevant: distutils does not set the runtime search path when linking the shared object on macOS, passing a `-L`  argument instead of an `-rpath` argument, like on the other systems. The code in question states that OS X linker doesn't accept `-rpath`, but that code was written 19 years ago, and that comment is no longer true (certainly not on macOS 11.2, but I do not know what is the newest system version for which `-rpath` is not accepted, if any).

The `runtime_library_dirs` configuration option is vital for extensions that need to build against libraries that temporarily exist in a location different from their final installation location (such as during the build of a package for a distro).

Fix -R option of build_ext for OSX

Resolves this old bug against distutils that expired due to PIP 632:
https://bugs.python.org/issue36353

Applies patch originally submitted to CPython:
https://github.com/python/cpython/pull/12418

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
