### PR TITLE
fix: more focused output if setup.py is empty

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -97,16 +97,16 @@ def _get_immediate_subdirectories(a_dir):
 
 
 def _file_with_extension(directory, extension):
-    matching = (
+    matching = [
         f for f in os.listdir(directory)
         if f.endswith(extension)
-    )
+    ]
     try:
         file, = matching
     except ValueError:
-        raise ValueError(
-            'No distribution was found. Ensure that `setup.py` '
-            'is not empty and that it calls `setup()`.')
+        msg = ('No distribution was found. Ensure that `setup.py` '
+               'is not empty and that it calls `setup()`.')
+        raise ValueError(msg) from None
     return file
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Followup to #2608. Makes sure an unrelated ValueError is not caught by the try/except, then removes the extra exception printout. Also moves the msg to the line above to avoid a double message printout in the traceback.


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
