### PR TITLE
Implement `find_spec` in vendored module importers

### DIFF
--- a/changelog.d/2632.change.rst
+++ b/changelog.d/2632.change.rst
@@ -1,0 +1,3 @@
+Implemented ``VendorImporter.find_spec()`` method to get rid
+of ``ImportWarning`` that Python 3.10 emits when only the old-style
+importer hooks are present -- by :user:`webknjaz`

--- a/pkg_resources/extern/__init__.py
+++ b/pkg_resources/extern/__init__.py
@@ -26,14 +26,6 @@ class VendorImporter:
         root, base, target = fullname.partition(self.root_name + '.')
         return not root and any(map(target.startswith, self.vendored_names))
 
-    def find_module(self, fullname, path=None):
-        """
-        Return self when fullname starts with root_name and the
-        target module is one vendored through this importer.
-        """
-        spec = self.find_spec(fullname, path)
-        return spec.loader if spec is not None else None
-
     def load_module(self, fullname):
         """
         Iterate over the search path to locate and load fullname.

--- a/pkg_resources/extern/__init__.py
+++ b/pkg_resources/extern/__init__.py
@@ -1,4 +1,4 @@
-import importlib.machinery
+import importlib.util
 import sys
 
 
@@ -57,7 +57,7 @@ class VendorImporter:
     def find_spec(self, fullname, path=None, target=None):
         """Return a module spec for vendored names."""
         return (
-            importlib.machinery.ModuleSpec(fullname, self)
+            importlib.util.spec_from_loader(fullname, self)
             if self._module_matches_namespace(fullname) else None
         )
 

--- a/setuptools/extern/__init__.py
+++ b/setuptools/extern/__init__.py
@@ -26,14 +26,6 @@ class VendorImporter:
         root, base, target = fullname.partition(self.root_name + '.')
         return not root and any(map(target.startswith, self.vendored_names))
 
-    def find_module(self, fullname, path=None):
-        """
-        Return self when fullname starts with root_name and the
-        target module is one vendored through this importer.
-        """
-        spec = self.find_spec(fullname, path)
-        return spec.loader if spec is not None else None
-
     def load_module(self, fullname):
         """
         Iterate over the search path to locate and load fullname.

--- a/setuptools/extern/__init__.py
+++ b/setuptools/extern/__init__.py
@@ -1,4 +1,4 @@
-import importlib.machinery
+import importlib.util
 import sys
 
 
@@ -57,7 +57,7 @@ class VendorImporter:
     def find_spec(self, fullname, path=None, target=None):
         """Return a module spec for vendored names."""
         return (
-            importlib.machinery.ModuleSpec(fullname, self)
+            importlib.util.spec_from_loader(fullname, self)
             if self._module_matches_namespace(fullname) else None
         )
 


### PR DESCRIPTION
## Summary of changes

This change makes the import warning emitted by Python 3.10 disappear
but implementing the hook that is supposed to replace the old import
mechanism.

Refs:
* https://bugs.python.org/issue42134
* https://bugs.python.org/issue43540
* https://github.com/pypa/setuptools/issues/2632#issuecomment-815701078

Fixes #2632

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
