### PR TITLE
Fixed quickstart packaging resources hyperlink.

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -22,7 +22,7 @@ be generated with whatever tools that provides a ``build sdist``-alike
 functionality. While this may appear cumbersome, given the added pieces,
 it in fact tremendously enhances the portability of your package. The
 change is driven under :pep:`PEP 517 <517#build-requirements>`. To learn more about Python packaging in general,
-navigate to the `bottom <Resources on python packaging>`_ of this page.
+navigate to the :ref:`bottom <packaging-resources>` of this page.
 
 
 Basic Use
@@ -215,13 +215,14 @@ basic use here.
 
 
 Transitioning from ``setup.py`` to ``setup.cfg``
-==================================================
+================================================
 To avoid executing arbitary scripts and boilerplate code, we are transitioning
 into a full-fledged ``setup.cfg`` to declare your package information instead
 of running ``setup()``. This inevitably brings challenges due to a different
 syntax. Here we provide a quick guide to understanding how ``setup.cfg`` is
 parsed by ``setuptool`` to ease the pain of transition.
 
+.. _packaging-resources:
 
 Resources on Python packaging
 =============================


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This link on [the quickstart page](https://setuptools.readthedocs.io/en/latest/userguide/quickstart.html#python-packaging-at-a-glance) is broken: 

![Screenshot 2021-04-10 at 10 15 04](https://user-images.githubusercontent.com/64686/114263653-37f17c00-99e7-11eb-840e-43b8fd89bed2.png)

The implicit link target that should have been created from the title was not
being detected correctly. This was causing the link to be interpreted as an
external hyperlink reference, resulting in a 404 in the rendered docs.

![Screenshot 2021-04-10 at 10 16 03](https://user-images.githubusercontent.com/64686/114263685-63746680-99e7-11eb-88f6-b5faf1e9d8c6.png)


Adding the explicit target and `ref` allows the link to resolve correctly.


<!-- Summary goes here -->

### Pull Request Checklist

I don't think these apply 🤔

- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
