### PR TITLE
Refactor ``read_pkg_file``

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -16,6 +16,7 @@ from distutils.util import strtobool
 from distutils.debug import DEBUG
 from distutils.fancy_getopt import translate_longopt
 import itertools
+from typing import List, Optional, TYPE_CHECKING
 
 from collections import defaultdict
 from email import message_from_file
@@ -35,6 +36,9 @@ from setuptools import windows_support
 from setuptools.monkey import get_unpatched
 from setuptools.config import parse_configuration
 import pkg_resources
+
+if TYPE_CHECKING:
+    from email.message import Message
 
 __import__('setuptools.extern.packaging.specifiers')
 __import__('setuptools.extern.packaging.version')
@@ -67,53 +71,57 @@ def get_metadata_version(self):
     return mv
 
 
+def _read_field_from_msg(msg: "Message", field: str) -> Optional[str]:
+    """Read Message header field."""
+    value = msg[field]
+    if value == 'UNKNOWN':
+        return None
+    return value
+
+
+def _read_list_from_msg(msg: "Message", field: str) -> Optional[List[str]]:
+    """Read Message header field and return all results as list."""
+    values = msg.get_all(field, None)
+    if values == []:
+        return None
+    return values
+
+
 def read_pkg_file(self, file):
     """Reads the metadata values from a file object."""
     msg = message_from_file(file)
 
-    def _read_field(name):
-        value = msg[name]
-        if value == 'UNKNOWN':
-            return None
-        return value
-
-    def _read_list(name):
-        values = msg.get_all(name, None)
-        if values == []:
-            return None
-        return values
-
     self.metadata_version = StrictVersion(msg['metadata-version'])
-    self.name = _read_field('name')
-    self.version = _read_field('version')
-    self.description = _read_field('summary')
+    self.name = _read_field_from_msg(msg, 'name')
+    self.version = _read_field_from_msg(msg, 'version')
+    self.description = _read_field_from_msg(msg, 'summary')
     # we are filling author only.
-    self.author = _read_field('author')
+    self.author = _read_field_from_msg(msg, 'author')
     self.maintainer = None
-    self.author_email = _read_field('author-email')
+    self.author_email = _read_field_from_msg(msg, 'author-email')
     self.maintainer_email = None
-    self.url = _read_field('home-page')
-    self.license = _read_field('license')
+    self.url = _read_field_from_msg(msg, 'home-page')
+    self.license = _read_field_from_msg(msg, 'license')
 
     if 'download-url' in msg:
-        self.download_url = _read_field('download-url')
+        self.download_url = _read_field_from_msg(msg, 'download-url')
     else:
         self.download_url = None
 
-    self.long_description = _read_field('description')
-    self.description = _read_field('summary')
+    self.long_description = _read_field_from_msg(msg, 'description')
+    self.description = _read_field_from_msg(msg, 'summary')
 
     if 'keywords' in msg:
-        self.keywords = _read_field('keywords').split(',')
+        self.keywords = _read_field_from_msg(msg, 'keywords').split(',')
 
-    self.platforms = _read_list('platform')
-    self.classifiers = _read_list('classifier')
+    self.platforms = _read_list_from_msg(msg, 'platform')
+    self.classifiers = _read_list_from_msg(msg, 'classifier')
 
     # PEP 314 - these fields only exist in 1.1
     if self.metadata_version == StrictVersion('1.1'):
-        self.requires = _read_list('requires')
-        self.provides = _read_list('provides')
-        self.obsoletes = _read_list('obsoletes')
+        self.requires = _read_list_from_msg(msg, 'requires')
+        self.provides = _read_list_from_msg(msg, 'provides')
+        self.obsoletes = _read_list_from_msg(msg, 'obsoletes')
     else:
         self.requires = None
         self.provides = None


### PR DESCRIPTION
## Summary of changes

Refactor `read_pkg_file` from `setuptools/dist.py` in preparation for #2628, see https://github.com/pypa/setuptools/pull/2628#discussion_r610941513
Additionally added `rfc822_unescape` function to reverse escaping which is applied to the `Description` field.
https://packaging.python.org/specifications/core-metadata/#description

/CC: @webknjaz 

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
