### PR TITLE
Corrected indent in setup.cfg example.

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -52,8 +52,8 @@ the minimum
         [options]
         packages = mypackage
         install_requires =
-        requests
-        importlib; python_version == "2.6"
+	        requests
+    	    importlib; python_version == "2.6"
 
 .. tab:: setup.py
 


### PR DESCRIPTION

## Summary of changes

The first `setup.cfg` example in the quickstart lacks indentation of the `install_requires` declaration: 

<img width="462" alt="Screenshot 2021-04-12 at 20 39 19" src="https://user-images.githubusercontent.com/64686/114444800-911c0400-9bcf-11eb-82dc-5f5464cd5cd7.png">

Not sure if it's valid or not, but it's certainly hard to visually parse. 

Later on it's better indented: 

<img width="441" alt="Screenshot 2021-04-12 at 20 39 26" src="https://user-images.githubusercontent.com/64686/114444861-a133e380-9bcf-11eb-86e5-3bd6eace2e97.png">

This adjusts the first example to add the indentation. 