### PR TITLE
Add escaping to license field

### DIFF
--- a/changelog.d/2640.change.rst
+++ b/changelog.d/2640.change.rst
@@ -1,0 +1,1 @@
+Fixed handling of multiline license strings. - by :user:`cdce8p`

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -120,7 +120,7 @@ def read_pkg_file(self, file):
     self.author_email = _read_field_from_msg(msg, 'author-email')
     self.maintainer_email = None
     self.url = _read_field_from_msg(msg, 'home-page')
-    self.license = _read_field_from_msg(msg, 'license')
+    self.license = _read_field_unescaped_from_msg(msg, 'license')
 
     if 'download-url' in msg:
         self.download_url = _read_field_from_msg(msg, 'download-url')
@@ -188,7 +188,8 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
             if attr_val is not None:
                 write_field(field, attr_val)
 
-    write_field('License', self.get_license())
+    license = rfc822_escape(self.get_license())
+    write_field('License', license)
     if self.download_url:
         write_field('Download-URL', self.download_url)
     for project_url in self.project_urls.items():

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -116,6 +116,10 @@ def __read_test_cases():
         ('Metadata Version 2.1: Long Description Content Type', params(
             long_description_content_type='text/x-rst; charset=UTF-8',
         )),
+        ('License', params(license='MIT', )),
+        ('License multiline', params(
+            license='This is a long license \nover multiple lines',
+        )),
         pytest.param(
             'Metadata Version 2.1: Provides Extra',
             params(provides_extras=['foo', 'bar']),

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -886,6 +886,37 @@ class TestEggInfo:
         assert expected_line in pkg_info_lines
         assert 'Metadata-Version: 1.2' in pkg_info_lines
 
+    def test_license(self, tmpdir_cwd, env):
+        """Test single line license."""
+        self._setup_script_with_requires(
+            "license='MIT',"
+        )
+        code, data = environment.run_setup_py(
+            cmd=['egg_info'],
+            pypath=os.pathsep.join([env.paths['lib'], str(tmpdir_cwd)]),
+            data_stream=1,
+        )
+        egg_info_dir = os.path.join('.', 'foo.egg-info')
+        with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
+            pkg_info_lines = pkginfo_file.read().split('\n')
+        assert 'License: MIT' == pkg_info_lines[7]
+
+    def test_license_escape(self, tmpdir_cwd, env):
+        """Test license is escaped correctly if longer than one line."""
+        self._setup_script_with_requires(
+            "license='This is a long license text \\nover multiple lines',"
+        )
+        code, data = environment.run_setup_py(
+            cmd=['egg_info'],
+            pypath=os.pathsep.join([env.paths['lib'], str(tmpdir_cwd)]),
+            data_stream=1,
+        )
+        egg_info_dir = os.path.join('.', 'foo.egg-info')
+        with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
+            pkg_info_lines = pkginfo_file.read().split('\n')
+        assert 'License: This is a long license text ' == pkg_info_lines[7]
+        assert '        over multiple lines' == pkg_info_lines[8]
+
     def test_python_requires_egg_info(self, tmpdir_cwd, env):
         self._setup_script_with_requires(
             """python_requires='>=2.7.12',""")


### PR DESCRIPTION
## Summary of changes

Fix handling of multiline license string by adding rfc822 escaping.

The license is allowed to span over multiple lines, see [Metadata spec](https://packaging.python.org/specifications/core-metadata/#license). Currently, setuptools doesn't autoescape such inputs. The result of which is an `PKG-INFO` file that isn't parsed correctly by `importlib.metadata`.

```ini
# example setup.cfg
[metadata]
license = This is a pretty 
    long license
```

#### Current results
```
# PKG-INFO
...
Author: ...
License: This is a pretty
long license
Description: This is the package description
        that also spans multiple lines
...
```

```py
from importlib.metadata import metadata
metadata('custom-pkg')['License']      # -> 'This is a pretty'
metadata('custom-pkg')['Description']  # -> 'long license\nDescription: This ...\n        that ... lines'
```


#### With change
```
# PKG-INFO
...
Author: ...
License: This is a pretty
        long license
Description: This is the package description
        that also spans multiple lines
...
```

```py
# with change
from importlib.metadata import metadata
metadata('custom-pkg')['License']      # -> 'This is a pretty\n        long license'
metadata('custom-pkg')['Description']  # -> 'This ...\n        that ... lines'
```
Note that `importlib.metadata` doesn't remove the escaping. Neither for `Description` nor `License`.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
