### PR TITLE
Always use latest metadata version for PKG-INFO

### DIFF
--- a/changelog.d/2641.change.rst
+++ b/changelog.d/2641.change.rst
@@ -1,0 +1,2 @@
+Setuptools will now always try to use the latest supported
+metadata version for ``PKG-INFO``. - by :user:`cdce8p`

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -52,23 +52,9 @@ def _get_unpatched(cls):
 
 def get_metadata_version(self):
     mv = getattr(self, 'metadata_version', None)
-
     if mv is None:
-        if self.long_description_content_type or self.provides_extras:
-            mv = StrictVersion('2.1')
-        elif (self.maintainer is not None or
-              self.maintainer_email is not None or
-              getattr(self, 'python_requires', None) is not None or
-              self.project_urls):
-            mv = StrictVersion('1.2')
-        elif (self.provides or self.requires or self.obsoletes or
-                self.classifiers or self.download_url):
-            mv = StrictVersion('1.1')
-        else:
-            mv = StrictVersion('1.0')
-
+        mv = StrictVersion('2.1')
         self.metadata_version = mv
-
     return mv
 
 
@@ -171,22 +157,17 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     write_field('Summary', single_line(self.get_description()))
     write_field('Home-page', self.get_url())
 
-    if version < StrictVersion('1.2'):
-        write_field('Author', self.get_contact())
-        write_field('Author-email', self.get_contact_email())
-    else:
-        optional_fields = (
-            ('Author', 'author'),
-            ('Author-email', 'author_email'),
-            ('Maintainer', 'maintainer'),
-            ('Maintainer-email', 'maintainer_email'),
-        )
+    optional_fields = (
+        ('Author', 'author'),
+        ('Author-email', 'author_email'),
+        ('Maintainer', 'maintainer'),
+        ('Maintainer-email', 'maintainer_email'),
+    )
 
-        for field, attr in optional_fields:
-            attr_val = getattr(self, attr)
-
-            if attr_val is not None:
-                write_field(field, attr_val)
+    for field, attr in optional_fields:
+        attr_val = getattr(self, attr, None)
+        if attr_val is not None:
+            write_field(field, attr_val)
 
     write_field('License', self.get_license())
     if self.download_url:
@@ -201,11 +182,8 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     if keywords:
         write_field('Keywords', keywords)
 
-    if version >= StrictVersion('1.2'):
-        for platform in self.get_platforms():
-            write_field('Platform', platform)
-    else:
-        self._write_list(file, 'Platform', self.get_platforms())
+    for platform in self.get_platforms():
+        write_field('Platform', platform)
 
     self._write_list(file, 'Classifier', self.get_classifiers())
 

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -84,14 +84,8 @@ def __read_test_cases():
 
     test_cases = [
         ('Metadata version 1.0', params()),
-        ('Metadata version 1.1: Provides', params(
-            provides=['package'],
-        )),
         ('Metadata Version 1.0: Short long description', params(
             long_description='Short long description',
-        )),
-        ('Metadata version 1.1: Obsoletes', params(
-            obsoletes=['foo'],
         )),
         ('Metadata version 1.1: Classifiers', params(
             classifiers=[

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -5,6 +5,7 @@ import glob
 import re
 import stat
 import time
+from typing import List, Tuple
 
 import pytest
 from jaraco import path
@@ -44,6 +45,11 @@ class TestEggInfo:
                     print('hello')
                 """)
         })
+
+    @staticmethod
+    def _extract_mv_version(pkg_info_lines: List[str]) -> Tuple[int, int]:
+        version_str = pkg_info_lines[0].split(' ')[1]
+        return tuple(map(int, version_str.split('.')[:2]))
 
     @pytest.fixture
     def env(self):
@@ -829,6 +835,20 @@ class TestEggInfo:
         for lf in excl_licenses:
             assert sources_lines.count(lf) == 0
 
+    def test_metadata_version(self, tmpdir_cwd, env):
+        """Make sure latest metadata version is used by default."""
+        self._setup_script_with_requires("")
+        code, data = environment.run_setup_py(
+            cmd=['egg_info'],
+            pypath=os.pathsep.join([env.paths['lib'], str(tmpdir_cwd)]),
+            data_stream=1,
+        )
+        egg_info_dir = os.path.join('.', 'foo.egg-info')
+        with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
+            pkg_info_lines = pkginfo_file.read().split('\n')
+        # Update metadata version if changed
+        assert self._extract_mv_version(pkg_info_lines) == (2, 1)
+
     def test_long_description_content_type(self, tmpdir_cwd, env):
         # Test that specifying a `long_description_content_type` keyword arg to
         # the `setup` function results in writing a `Description-Content-Type`
@@ -884,7 +904,7 @@ class TestEggInfo:
         assert expected_line in pkg_info_lines
         expected_line = 'Project-URL: Link Two, https://example.com/two/'
         assert expected_line in pkg_info_lines
-        assert 'Metadata-Version: 1.2' in pkg_info_lines
+        assert self._extract_mv_version(pkg_info_lines) >= (1, 2)
 
     def test_python_requires_egg_info(self, tmpdir_cwd, env):
         self._setup_script_with_requires(
@@ -902,7 +922,7 @@ class TestEggInfo:
         with open(os.path.join(egg_info_dir, 'PKG-INFO')) as pkginfo_file:
             pkg_info_lines = pkginfo_file.read().split('\n')
         assert 'Requires-Python: >=2.7.12' in pkg_info_lines
-        assert 'Metadata-Version: 1.2' in pkg_info_lines
+        assert self._extract_mv_version(pkg_info_lines) >= (1, 2)
 
     def test_manifest_maker_warning_suppression(self):
         fixtures = [


### PR DESCRIPTION
## Summary of changes

`setuptools` should always try to use the latest supported metadata version when writing the `PKG-INFO` file.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
