### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/changelog.d/2644.misc.rst
+++ b/changelog.d/2644.misc.rst
@@ -1,0 +1,1 @@
+Fixed ``DeprecationWarning`` due to ``threading.Thread.setDaemon`` in tests -- by :user:`tirkarthi`

--- a/setuptools/tests/server.py
+++ b/setuptools/tests/server.py
@@ -65,7 +65,7 @@ class MockServer(http.server.HTTPServer, threading.Thread):
         http.server.HTTPServer.__init__(
             self, server_address, RequestHandlerClass)
         threading.Thread.__init__(self)
-        self.setDaemon(True)
+        self.daemon = True
         self.requests = []
 
     def run(self):


### PR DESCRIPTION
## Summary of changes

Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

Closes #2643 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
