### PR TITLE
Add ``License-File`` field to package metadata

### DIFF
--- a/changelog.d/2645.breaking.rst
+++ b/changelog.d/2645.breaking.rst
@@ -1,0 +1,3 @@
+License files excluded via the ``MANIFEST.in`` but matched by either
+the ``license_file`` (deprecated) or ``license_files`` options,
+will be nevertheless included in the source distribution. - by :user:`cdce8p`

--- a/changelog.d/2645.change.rst
+++ b/changelog.d/2645.change.rst
@@ -1,0 +1,4 @@
+Added ``License-File`` (multiple) to the output package metadata.
+The field will contain the path of a license file, matched by the
+``license_file`` (deprecated) and ``license_files`` options,
+relative to ``.dist-info``. - by :user:`cdce8p`

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -539,9 +539,9 @@ class manifest_maker(sdist):
         if not os.path.exists(self.manifest):
             self.write_manifest()  # it must exist so it'll get in the list
         self.add_defaults()
-        self.add_license_files()
         if os.path.exists(self.template):
             self.read_template()
+        self.add_license_files()
         self.prune_file_list()
         self.filelist.sort()
         self.filelist.remove_duplicates()

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -593,7 +593,7 @@ class manifest_maker(sdist):
         self.filelist.graft(ei_cmd.egg_info)
 
     def add_license_files(self):
-        license_files = self.distribution.metadata.license_files_computed
+        license_files = self.distribution.metadata.license_files or []
         for lf in license_files:
             log.info("adding license file '%s'", lf)
             pass

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -539,6 +539,7 @@ class manifest_maker(sdist):
         if not os.path.exists(self.manifest):
             self.write_manifest()  # it must exist so it'll get in the list
         self.add_defaults()
+        self.add_license_files()
         if os.path.exists(self.template):
             self.read_template()
         self.prune_file_list()
@@ -575,7 +576,6 @@ class manifest_maker(sdist):
 
     def add_defaults(self):
         sdist.add_defaults(self)
-        self.check_license()
         self.filelist.append(self.template)
         self.filelist.append(self.manifest)
         rcfiles = list(walk_revctrl())
@@ -591,6 +591,13 @@ class manifest_maker(sdist):
 
         ei_cmd = self.get_finalized_command('egg_info')
         self.filelist.graft(ei_cmd.egg_info)
+
+    def add_license_files(self):
+        license_files = self.distribution.metadata.license_files_computed
+        for lf in license_files:
+            log.info("adding license file '%s'", lf)
+            pass
+        self.filelist.extend(license_files)
 
     def prune_file_list(self):
         build = self.get_finalized_command('build')

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -520,6 +520,11 @@ class ConfigMetadataHandler(ConfigHandler):
             'obsoletes': parse_list,
             'classifiers': self._get_parser_compound(parse_file, parse_list),
             'license': exclude_files_parser('license'),
+            'license_file': self._deprecated_config_handler(
+                exclude_files_parser('license_file'),
+                "The license_file parameter is deprecated, "
+                "use license_files instead.",
+                DeprecationWarning),
             'license_files': parse_list,
             'description': parse_file,
             'long_description': parse_file,

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -142,7 +142,7 @@ def read_pkg_file(self, file):
         self.provides = None
         self.obsoletes = None
 
-    self.license_files_computed = _read_list_from_msg(msg, 'license-file')
+    self.license_files = _read_list_from_msg(msg, 'license-file')
 
 
 def single_line(val):
@@ -216,7 +216,7 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
         for extra in self.provides_extras:
             write_field('Provides-Extra', extra)
 
-    self._write_list(file, 'License-File', self.license_files_computed)
+    self._write_list(file, 'License-File', self.license_files or [])
 
     file.write("\n%s\n\n" % self.get_long_description())
 
@@ -421,7 +421,6 @@ class Distribution(_Distribution):
         'provides_extras': ordered_set.OrderedSet,
         'license_file': None,
         'license_files': None,
-        'license_files_computed': list,
     }
 
     _patched_dist = None
@@ -603,7 +602,7 @@ class Distribution(_Distribution):
                 if path not in files and os.path.isfile(path):
                     files.add(path)
 
-        self.metadata.license_files_computed = sorted(files)
+        self.metadata.license_files = sorted(files)
 
     # FIXME: 'Distribution._parse_config_files' is too complex (14)
     def _parse_config_files(self, filenames=None):  # noqa: C901

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -419,7 +419,6 @@ class Distribution(_Distribution):
         'long_description_content_type': lambda: None,
         'project_urls': dict,
         'provides_extras': ordered_set.OrderedSet,
-        'license_file': lambda: None,
         'license_files': lambda: None,
     }
 
@@ -585,7 +584,10 @@ class Distribution(_Distribution):
         license_files: Optional[List[str]] = self.metadata.license_files
         patterns: List[str] = license_files if license_files else []
 
-        license_file: Optional[str] = self.metadata.license_file
+        license_file: Optional[str] = None
+        opts = self.get_option_dict('metadata')
+        if 'license_file' in opts:
+            license_file = opts['license_file'][1]
         if license_file and license_file not in patterns:
             patterns.append(license_file)
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -18,7 +18,7 @@ from distutils.fancy_getopt import translate_longopt
 from glob import iglob
 import itertools
 import textwrap
-from typing import List, Optional, Set, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 
 from collections import defaultdict
 from email import message_from_file
@@ -581,7 +581,6 @@ class Distribution(_Distribution):
 
     def _finalize_license_files(self):
         """Compute names of all license files which should be included."""
-        files: List[str] = []
         license_files: Optional[List[str]] = self.metadata.license_files
         patterns: List[str] = license_files if license_files else []
 
@@ -595,16 +594,18 @@ class Distribution(_Distribution):
             # -> 'Including license files in the generated wheel file'
             patterns = ('LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*')
 
-        for pattern in patterns:
-            files_pattern: Set[str] = set()
-            for path in iglob(pattern):
-                if path.endswith('~'):
-                    continue
-                if path not in files and os.path.isfile(path):
-                    files_pattern.add(path)
-            files.extend(sorted(files_pattern))
+        self.metadata.license_files = list(
+            unique_everseen(self._expand_patterns(patterns)))
 
-        self.metadata.license_files = files
+    @staticmethod
+    def _expand_patterns(patterns):
+        return (
+            path
+            for pattern in patterns
+            for path in iglob(pattern)
+            if not path.endswith('~')
+            and os.path.isfile(path)
+        )
 
     # FIXME: 'Distribution._parse_config_files' is too complex (14)
     def _parse_config_files(self, filenames=None):  # noqa: C901
@@ -1111,3 +1112,21 @@ class Distribution(_Distribution):
 class DistDeprecationWarning(SetuptoolsDeprecationWarning):
     """Class for warning about deprecations in dist in
     setuptools. Not ignored by default, unlike DeprecationWarning."""
+
+
+def unique_everseen(iterable, key=None):
+    "List unique elements, preserving order. Remember all elements ever seen."
+    # unique_everseen('AAAABBBCCDAABBB') --> A B C D
+    # unique_everseen('ABBCcAD', str.lower) --> A B C D
+    seen = set()
+    seen_add = seen.add
+    if key is None:
+        for element in itertools.filterfalse(seen.__contains__, iterable):
+            seen_add(element)
+            yield element
+    else:
+        for element in iterable:
+            k = key(element)
+            if k not in seen:
+                seen_add(k)
+                yield element

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -419,8 +419,8 @@ class Distribution(_Distribution):
         'long_description_content_type': lambda: None,
         'project_urls': dict,
         'provides_extras': ordered_set.OrderedSet,
-        'license_file': None,
-        'license_files': None,
+        'license_file': lambda: None,
+        'license_files': lambda: None,
     }
 
     _patched_dist = None

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -581,13 +581,13 @@ class Distribution(_Distribution):
 
     def _finalize_license_files(self):
         """Compute names of all license files which should be included."""
-        files = set()
+        files: List[str] = []
         license_files: Optional[List[str]] = self.metadata.license_files
-        patterns: Set[str] = set(license_files) if license_files else set()
+        patterns: List[str] = license_files if license_files else []
 
         license_file: Optional[str] = self.metadata.license_file
-        if license_file:
-            patterns.add(license_file)
+        if license_file and license_file not in patterns:
+            patterns.append(license_file)
 
         if license_files is None and license_file is None:
             # Default patterns match the ones wheel uses
@@ -596,13 +596,15 @@ class Distribution(_Distribution):
             patterns = ('LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*')
 
         for pattern in patterns:
+            files_pattern: Set[str] = set()
             for path in iglob(pattern):
                 if path.endswith('~'):
                     continue
                 if path not in files and os.path.isfile(path):
-                    files.add(path)
+                    files_pattern.add(path)
+            files.extend(sorted(files_pattern))
 
-        self.metadata.license_files = sorted(files)
+        self.metadata.license_files = files
 
     # FIXME: 'Distribution._parse_config_files' is too complex (14)
     def _parse_config_files(self, filenames=None):  # noqa: C901

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -419,6 +419,7 @@ class Distribution(_Distribution):
         'long_description_content_type': lambda: None,
         'project_urls': dict,
         'provides_extras': ordered_set.OrderedSet,
+        'license_file': lambda: None,
         'license_files': lambda: None,
     }
 
@@ -584,10 +585,7 @@ class Distribution(_Distribution):
         license_files: Optional[List[str]] = self.metadata.license_files
         patterns: List[str] = license_files if license_files else []
 
-        license_file: Optional[str] = None
-        opts = self.get_option_dict('metadata')
-        if 'license_file' in opts:
-            license_file = opts['license_file'][1]
+        license_file: Optional[str] = self.metadata.license_file
         if license_file and license_file not in patterns:
             patterns.append(license_file)
 

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -875,11 +875,9 @@ class TestEggInfo:
 
         # Only 'NOTICE', LICENSE-ABC', and 'LICENSE-XYZ' should have been matched
         # Also assert that order from license_files is keeped
-        assert license_file_lines == [
-            "License-File: NOTICE",
-            "License-File: LICENSE-ABC",
-            "License-File: LICENSE-XYZ",
-        ]
+        assert "License-File: NOTICE" == license_file_lines[0]
+        assert "License-File: LICENSE-ABC" in license_file_lines[1:]
+        assert "License-File: LICENSE-XYZ" in license_file_lines[1:]
 
     def test_metadata_version(self, tmpdir_cwd, env):
         """Make sure latest metadata version is used by default."""

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -551,7 +551,7 @@ class TestEggInfo:
                               """),
             'MANIFEST.in': "exclude LICENSE",
             'LICENSE': "Test license"
-        }, False),  # license file is manually excluded
+        }, True),  # manifest is overwritten by license_file
         pytest.param({
             'setup.cfg': DALS("""
                               [metadata]
@@ -647,7 +647,7 @@ class TestEggInfo:
                               """),
             'MANIFEST.in': "exclude LICENSE",
             'LICENSE': "Test license"
-        }, [], ['LICENSE']),  # license file is manually excluded
+        }, ['LICENSE'], []),  # manifest is overwritten by license_files
         ({
             'setup.cfg': DALS("""
                               [metadata]
@@ -658,7 +658,8 @@ class TestEggInfo:
             'MANIFEST.in': "exclude LICENSE-XYZ",
             'LICENSE-ABC': "ABC license",
             'LICENSE-XYZ': "XYZ license"
-        }, ['LICENSE-ABC'], ['LICENSE-XYZ']),  # subset is manually excluded
+            # manifest is overwritten by license_files
+        }, ['LICENSE-ABC', 'LICENSE-XYZ'], []),
         pytest.param({
             'setup.cfg': "",
             'LICENSE-ABC': "ABC license",
@@ -791,8 +792,8 @@ class TestEggInfo:
             'LICENSE-ABC': "ABC license",
             'LICENSE-PQR': "PQR license",
             'LICENSE-XYZ': "XYZ license"
-            # manually excluded
-        }, ['LICENSE-XYZ'], ['LICENSE-ABC', 'LICENSE-PQR']),
+            # manifest is overwritten
+        }, ['LICENSE-ABC', 'LICENSE-PQR', 'LICENSE-XYZ'], []),
         pytest.param({
             'setup.cfg': DALS("""
                               [metadata]

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -55,7 +55,6 @@ def touch(filename):
 default_files = frozenset(map(make_local_path, [
     'README.rst',
     'MANIFEST.in',
-    'LICENSE',
     'setup.py',
     'app.egg-info/PKG-INFO',
     'app.egg-info/SOURCES.txt',


### PR DESCRIPTION
## Summary of changes

This PR adds the ``License-File`` field to the package metadata. Although not yet part of the official metadata spec, including this field will enable third party tools easier access to all included license files through `importlib.metadata`. This is especially useful if a file doesn't have an easily recognizable name or is in an unusual location.

`setuptools` already parses the `license_file` and `license_files` options and cross-references them with all project files to see which ones should be included. With this change, the result of that would be made available for others to use as well.

Closes #2631

--
For reference: [PEP 639](https://www.python.org/dev/peps/pep-0639/), currently still in a draft, plans to add the `License-File` field to the metadata spec, [link](https://www.python.org/dev/peps/pep-0639/#license-file-multiple-use)

--
Example use case
```py
from importlib import metadata
meta = metadata.metadata('my-project')
project_files = metadata.files('my-project')

license_file_paths = [
    path for path in project_files
    if str(path) in meta.get_all('License-File')
]
```

## Open questions
**1. What should the value of `License-Path` be for files not in main project directory?**
From a technical standpoint it would probably be best to use the actual relative path and mirror that in the `.dist-info` directory. However, at the moment `wheel` flattens the folder structure and just puts all license files into `.dist-info`, AFAIK. This could lead to name conflicts.

**2. Should license files be copied into the `.egg-info` directory if the legacy install is used?**

**3. How should `license_files` and `MANIFEST.in` continue to work together?**
At the moment, the `MANIFEST.in` is parse at the end and thus overwrites all previous file includes. However, `license_files_computed` will only look at the `license_file` and `license_files` options (unless we parse the manifest there too). That means that the `License-File` field might contain files that are later excluded by the manifest.
-> I would recommend to change the behavior so that the `license_file` and `license_files` options take precedent over the manifest. A license file is most likely excluded by accident anyway. Additionally, specifying `license_files =` (without any values) won't add any default patterns and thus not match any license files.


## Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
