### PR TITLE
Fixed get_export_symbols for unicode filenames

### DIFF
--- a/changelog.d/2646.change.rst
+++ b/changelog.d/2646.change.rst
@@ -1,0 +1,1 @@
+Fixed the symbol name exported for the PyInit function for modules with unicode names -- by :user:`da-woods`

--- a/setuptools/_distutils/command/build_ext.py
+++ b/setuptools/_distutils/command/build_ext.py
@@ -690,13 +690,15 @@ class build_ext(Command):
         provided, "PyInit_" + module_name.  Only relevant on Windows, where
         the .pyd file (DLL) must export the module "PyInit_" function.
         """
-        suffix = '_' + ext.name.split('.')[-1]
+        name = ext.name.split('.')[-1]
         try:
             # Unicode module name support as defined in PEP-489
             # https://www.python.org/dev/peps/pep-0489/#export-hook-name
-            suffix.encode('ascii')
+            name.encode('ascii')
         except UnicodeEncodeError:
-            suffix = 'U' + suffix.encode('punycode').replace(b'-', b'_').decode('ascii')
+            suffix = 'U_' + name.encode('punycode').replace(b'-', b'_').decode('ascii')
+        else:
+            suffix = "_" + name
 
         initfunc_name = "PyInit" + suffix
         if initfunc_name not in ext.export_symbols:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The implementation of `get_export_symbols` from distutils doesn't quite conform to PEP-489 (because `"_<name>".encode('punycode') != "<name>".encode('punycode')`). This affects the linking of unicode modules on Windows

I'm afraid I don't immediately know to how this should be tested; I'm happy to write one if needed but I'll need a hint about where it should go.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
