### PR TITLE
Drop deprecated `issue_body` from the forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,7 +7,6 @@ title: '[BUG] '
 labels:
 - bug
 - Needs Triage
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation-report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation-report.yml
@@ -5,8 +5,6 @@ description: Ask us about docs
 labels:
 - documentation
 - Needs Triage
-# NOTE: issue body is enabled to allow screenshots
-issue_body: true  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown
@@ -64,6 +62,22 @@ body:
     placeholder: Fedora 33, Firefox etc.
 
 
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: >
+      Describe how this improves the documentation, e.g. before/after
+      situation or screenshots.
+
+
+      **HINT:** You can paste https://gist.github.com links for larger files.
+    placeholder: >-
+      When the improvement is applied, it makes it more straightforward
+      to understand X.
+  validations:
+    required: true
+
+
 - type: checkboxes
   attributes:
     label: Code of Conduct
@@ -74,20 +88,4 @@ body:
     options:
     - label: I agree to follow the PSF Code of Conduct
       required: true
-
-
-- type: markdown
-  attributes:
-    value: >
- 
-
-      ### Additional Information
-
-
-      Describe how this improves the documentation, e.g. before/after
-      situation or screenshots.
-
-
-      **HINT:** You can paste https://gist.github.com links for
-      larger files.
 ...

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -5,7 +5,6 @@ title: '[FR] '
 labels:
 - enhancement
 - Needs Triage
-issue_body: false  # default: true, adds a classic WSYWIG textarea, if on
 
 body:
 - type: markdown


### PR DESCRIPTION
## Summary of changes

This change drops deprecated options from the issue forms schema files.
@jaraco this must be merged ASAP to reenable the forms.