### PR TITLE
Show not-yet-released change notes in Sphinx docs

### DIFF
--- a/changelog.d/2650.misc.rst
+++ b/changelog.d/2650.misc.rst
@@ -1,0 +1,3 @@
+Updated the docs build tooling to support the latest version of
+Towncrier and show the previews of not-yet-released setuptools versions
+in the changelog -- :user:`webknjaz`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+
 extensions = ['sphinx.ext.autodoc', 'jaraco.packaging.sphinx', 'rst.linker']
 
 master_doc = "index"
@@ -143,3 +146,16 @@ intersphinx_mapping.update(
     python=('https://docs.python.org/3', None),
     python2=('https://docs.python.org/2', None),
 )
+
+# Add support for the unreleased "next-version" change notes
+extensions += ['sphinxcontrib.towncrier']
+
+
+# -- Options for towncrier_draft extension --------------------------------------------
+
+PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
+
+towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-release', 'sphinx-version'
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = PROJECT_ROOT_DIR
+# Not yet supported: towncrier_draft_config_path = 'pyproject.toml'  # relative to cwd

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-
 extensions = ['sphinx.ext.autodoc', 'jaraco.packaging.sphinx', 'rst.linker']
 
 master_doc = "index"
@@ -149,13 +146,5 @@ intersphinx_mapping.update(
 
 # Add support for the unreleased "next-version" change notes
 extensions += ['sphinxcontrib.towncrier']
-
-
-# -- Options for towncrier_draft extension --------------------------------------------
-
-PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
-
-towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-release', 'sphinx-version'
-towncrier_draft_include_empty = True
-towncrier_draft_working_directory = PROJECT_ROOT_DIR
-# Not yet supported: towncrier_draft_config_path = 'pyproject.toml'  # relative to cwd
+# Extension needs a path from here to the towncrier config.
+towncrier_draft_working_directory = '..'

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,8 @@
 History
 *******
 
+.. towncrier-draft-entries:: DRAFT, unreleased as on |today|
+
 .. include:: ../CHANGES (links).rst
 
 Credits

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ docs =
 	# local
 	pygments-github-lexers==0.0.5
 	sphinx-inline-tabs
+	sphinxcontrib-towncrier
 
 ssl =
 	wincertstore==0.2; sys_platform=='win32'


### PR DESCRIPTION
## Summary of changes

The recent towncrier release now requires a `{{ top_line }}` variable in the template (as discovered in https://github.com/pypa/pip/issues/9815). Without this change, the changelog updates will have no title when the new Towncrier is used and this will happen sooner or later because it's unpinned in the deps.

Also, besides fixing that problem above this change integrates an extension for showing the upcoming release change notes in the Sphinx docs whenever standalone fragments are present in the tree.

Blocked by: https://github.com/pypa/setuptools/pull/2651.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
Ref: https://github.com/pypa/pip/issues/9815