### PR TITLE
Make changelog tmpl compatible w/ new Towncrier

### DIFF
--- a/changelog.d/2654.misc.rst
+++ b/changelog.d/2654.misc.rst
@@ -1,0 +1,2 @@
+Made the changelog generator compatible
+with Towncrier >= 19.9 -- :user:`webknjaz`

--- a/towncrier_template.rst
+++ b/towncrier_template.rst
@@ -1,3 +1,7 @@
+{% if top_line %}
+{{ top_line }}
+{{ top_underline * ((top_line)|length)}}
+{% endif %}
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
 {{ underline * section|length }}


### PR DESCRIPTION
## Summary of changes

This change fulfills the expectation of the recent Towncrier versions that the changelog version title is generated within the corresponding Jinja2 template.

Ref: https://github.com/pypa/pip/issues/9815

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
