### PR TITLE
Add ability to wrap project_url labels with quotation marks

### DIFF
--- a/changelog.d/2658.change.rst
+++ b/changelog.d/2658.change.rst
@@ -1,0 +1,1 @@
+Added ability wrap project_url labels with quotation marks. - by :user:`cdce8p`

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -269,7 +269,7 @@ class ConfigHandler:
             if sep != separator:
                 raise DistutilsOptionError(
                     'Unable to parse option value to dict: %s' % value)
-            result[key.strip()] = val.strip()
+            result[key.strip().strip('\"\'')] = val.strip()
 
         return result
 


### PR DESCRIPTION
## Summary of changes
To specify `project_urls` inside the `setup.cfg` file, a developer has to use a dictionary style.
```ini
project_urls =
    Bug tracker = https://github.com/...
```
This works and produces the desired output. However, many syntax highlight don't recognize this correctly (including Github). A reasonable next step would be to use quotation marks for the project_url label, like so
```ini
project_urls =
    "Bug tracker" = https://github.com/...
```
The issue this PR addresses is, that in the last case the quotation mark would be included in the final metadata and subsequently also be present on pypi.
```
Project-URL: "Bug tracker", https://github.com/...
```

**Links**
https://packaging.python.org/specifications/core-metadata/#project-url-multiple-use

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
