### PR TITLE
Merge two `intersphinx_mapping` vars in `conf.py`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,10 +73,6 @@ link_files = {
     ),
 }
 
-intersphinx_mapping = {
-    'pypa-build': ('https://pypa-build.readthedocs.io/en/latest/', None)
-}
-
 # Add support for linking usernames
 github_url = 'https://github.com'
 github_sponsors_url = f'{github_url}/sponsors'
@@ -140,6 +136,7 @@ nitpick_ignore = [
 
 # Allow linking objects on other Sphinx sites seamlessly:
 intersphinx_mapping = {
+    'pypa-build': ('https://pypa-build.rtfd.io/en/latest', None),
     'python': ('https://docs.python.org/3', None),
     'python2': ('https://docs.python.org/2', None),
 }


### PR DESCRIPTION
## Summary of changes

This change makes sure to preserve the intersphinx link against
`pypa/build` in the sphinx docs setup.

Ref: https://github.com/pypa/setuptools/pull/2657/files#r620240443

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
