### PR TITLE
Relax the distutils deprecation regex

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -9,7 +9,7 @@ is_pypy = '__pypy__' in sys.builtin_module_names
 
 
 warnings.filterwarnings('ignore',
-                        '.+ distutils .+ deprecated',
+                        r'.+ distutils\b.+ deprecated',
                         DeprecationWarning)
 
 

--- a/changelog.d/2664.misc.rst
+++ b/changelog.d/2664.misc.rst
@@ -1,0 +1,1 @@
+Relax the deprecation message in the distutils hack.


### PR DESCRIPTION
There is new message:

> The distutils.sysconfig module is deprecated, use sysconfig instead
