### PR TITLE
Corrected tabs for spaces in quickstart example.

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -52,8 +52,8 @@ the minimum
         [options]
         packages = mypackage
         install_requires =
-	        requests
-    	    importlib; python_version == "2.6"
+            requests
+            importlib; python_version == "2.6"
 
 .. tab:: setup.py
 


### PR DESCRIPTION
Regression in 6f727262240e35e315a66ec0bbb845ad718be127, spotted by @mgorny