### PR TITLE
Fix source typo

### DIFF
--- a/setuptools/_distutils/tests/test_build_ext.py
+++ b/setuptools/_distutils/tests/test_build_ext.py
@@ -139,7 +139,7 @@ class BuildExtTestCase(TempdirManager,
         cmd = self.build_ext(dist)
 
         # making sure the user option is there
-        options = [name for name, short, lable in
+        options = [name for name, short, label in
                    cmd.user_options]
         self.assertIn('user', options)
 

--- a/setuptools/_distutils/tests/test_install.py
+++ b/setuptools/_distutils/tests/test_install.py
@@ -101,7 +101,7 @@ class InstallTestCase(support.TempdirManager,
         cmd = install(dist)
 
         # making sure the user option is there
-        options = [name for name, short, lable in
+        options = [name for name, short, label in
                    cmd.user_options]
         self.assertIn('user', options)
 


### PR DESCRIPTION
Fixes a minor typo in a variable name. Note: this commit hasn't been tested.