### PR TITLE
Docs: Use license_files instead of license_file

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -183,8 +183,7 @@ maintainer                                         str
 maintainer_email                maintainer-email   str
 classifiers                     classifier         file:, list-comma
 license                                            str
-license_file                                       str
-license_files                                      list-comma         42.0.0
+license_files                   license_file       list-comma         42.0.0
 description                     summary            file:, str
 long_description                long-description   file:, str
 long_description_content_type                      str                38.6.0


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Since [v56.0.0](https://setuptools.readthedocs.io/en/latest/history.html#v56-0-0) / https://github.com/pypa/setuptools/pull/2620:

> The `license_file` option is now marked as deprecated. Use `license_files` instead.

So `license_file` (`str`) isn't _exactly_ the same as `license_files` (`list-comma`), but is it close enough to put it in this table? Would it need a note?

For example, if you have `license_file = LICENSE.txt`, you can replace that with `license_files = LICENSE.txt` 


### Pull Request Checklist
- [n/a] Changes have tests
- [n/a] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
