### PR TITLE
Publish draft change notes

### DIFF
--- a/changelog.d/2650.misc.rst
+++ b/changelog.d/2650.misc.rst
@@ -1,0 +1,3 @@
+Updated the docs build tooling to support the latest version of
+Towncrier and show the previews of not-yet-released setuptools versions
+in the changelog -- :user:`webknjaz`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+
 extensions = ['sphinx.ext.autodoc', 'jaraco.packaging.sphinx', 'rst.linker']
 
 master_doc = "index"
@@ -143,3 +146,16 @@ intersphinx_mapping.update(
     python=('https://docs.python.org/3', None),
     python2=('https://docs.python.org/2', None),
 )
+
+# Add support for the unreleased "next-version" change notes
+extensions += ['sphinxcontrib.towncrier']
+
+
+# -- Options for towncrier_draft extension --------------------------------------------
+
+PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
+
+towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-release', 'sphinx-version'
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = PROJECT_ROOT_DIR
+# Not yet supported: towncrier_draft_config_path = 'pyproject.toml'  # relative to cwd

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,3 +148,5 @@ intersphinx_mapping.update(
 extensions += ['sphinxcontrib.towncrier']
 # Extension needs a path from here to the towncrier config.
 towncrier_draft_working_directory = '..'
+# Avoid an empty section for unpublished changes.
+towncrier_draft_include_empty = False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-
 extensions = ['sphinx.ext.autodoc', 'jaraco.packaging.sphinx', 'rst.linker']
 
 master_doc = "index"
@@ -149,13 +146,5 @@ intersphinx_mapping.update(
 
 # Add support for the unreleased "next-version" change notes
 extensions += ['sphinxcontrib.towncrier']
-
-
-# -- Options for towncrier_draft extension --------------------------------------------
-
-PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
-
-towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-release', 'sphinx-version'
-towncrier_draft_include_empty = True
-towncrier_draft_working_directory = PROJECT_ROOT_DIR
-# Not yet supported: towncrier_draft_config_path = 'pyproject.toml'  # relative to cwd
+# Extension needs a path from here to the towncrier config.
+towncrier_draft_working_directory = '..'

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,8 @@
 History
 *******
 
+.. towncrier-draft-entries:: DRAFT, unreleased as on |today|
+
 .. include:: ../CHANGES (links).rst
 
 Credits

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,7 @@ docs =
 	# local
 	pygments-github-lexers==0.0.5
 	sphinx-inline-tabs
+	sphinxcontrib-towncrier
 
 ssl =
 	wincertstore==0.2; sys_platform=='win32'


### PR DESCRIPTION
A reprise of #2650 with a fix for publishing clean release notes when no changes are pending.