### PR TITLE
setuptools/dist: Fix reproducibility issue by sorting globbing

### DIFF
--- a/changelog.d/2692.change.rst
+++ b/changelog.d/2692.change.rst
@@ -1,0 +1,1 @@
+Globs are now sorted in 'license_files' restoring reproducibility by eliminating variance from disk order.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -15,7 +15,7 @@ import distutils.command
 from distutils.util import strtobool
 from distutils.debug import DEBUG
 from distutils.fancy_getopt import translate_longopt
-from glob import iglob
+from glob import glob
 import itertools
 import textwrap
 from typing import List, Optional, TYPE_CHECKING
@@ -603,7 +603,7 @@ class Distribution(_Distribution):
         return (
             path
             for pattern in patterns
-            for path in iglob(pattern)
+            for path in sorted(glob(pattern))
             if not path.endswith('~')
             and os.path.isfile(path)
         )

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -15,7 +15,7 @@ import distutils.command
 from distutils.util import strtobool
 from distutils.debug import DEBUG
 from distutils.fancy_getopt import translate_longopt
-from glob import glob
+from glob import iglob
 import itertools
 import textwrap
 from typing import List, Optional, TYPE_CHECKING
@@ -603,7 +603,7 @@ class Distribution(_Distribution):
         return (
             path
             for pattern in patterns
-            for path in sorted(glob(pattern))
+            for path in sorted(iglob(pattern))
             if not path.endswith('~')
             and os.path.isfile(path)
         )

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -600,6 +600,12 @@ class Distribution(_Distribution):
 
     @staticmethod
     def _expand_patterns(patterns):
+        """
+        >>> list(Distribution._expand_patterns(['LICENSE']))
+        ['LICENSE']
+        >>> list(Distribution._expand_patterns(['setup.cfg', 'LIC*']))
+        ['setup.cfg', 'LICENSE']
+        """
         return (
             path
             for pattern in patterns


### PR DESCRIPTION
globbing uses os.listdir() which returns order on disk which is unsorted.
Ultimately this leads to random ordering of License-File entries in PKG-INFO
and means the resulting output isn't deterministic.

Adding a sort fixes that. Switch to glob instead ot iglob since sorted()
removes the benefit of an iterator.

https://github.com/pypa/setuptools/issues/2691

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
