### PR TITLE
Fix problems when sys.executable is slightly different to argv[0]

### DIFF
--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -42,7 +42,7 @@ class install_scripts(orig.install_scripts):
         if is_wininst:
             exec_param = "python.exe"
             writer = ei.WindowsScriptWriter
-        if exec_param == sys.executable:
+        if os.path.abspath(exec_param) == os.path.abspath(sys.executable):
             # In case the path to the Python executable contains a space, wrap
             # it so it's not split up.
             exec_param = [exec_param]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This patch fixes problems when Python is installed on a directory with spaces on Windows and the `sys.executable` variable doesn't exactly match `argv[0]`.

Closes #216   At least on my system this was the root of the problem.

