### PR TITLE
Allows to use files outside of the main directory in setup.cfg file

### DIFF
--- a/changelog.d/2701.change.rst
+++ b/changelog.d/2701.change.rst
@@ -1,0 +1,3 @@
+Allowed to copy the content of the file outside the main directory in the ``setup.cfg`` file.
+Example: ``long_description = file: ../../README.md``.
+-- by :user:`airvzxf`

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -308,11 +308,8 @@ class ConfigHandler:
         """Represents value as a string, allowing including text
         from nearest files using `file:` directive.
 
-        Directive is sandboxed and won't reach anything outside
-        directory with setup.py.
-
         Examples:
-            file: README.rst, CHANGELOG.md, src/file.txt
+            file: README.rst, CHANGELOG.md, src/file.txt ../file.txt
 
         :param str value:
         :rtype: str
@@ -330,15 +327,8 @@ class ConfigHandler:
         return '\n'.join(
             cls._read_file(path)
             for path in filepaths
-            if (cls._assert_local(path) or True)
-            and os.path.isfile(path)
+            if os.path.isfile(path)
         )
-
-    @staticmethod
-    def _assert_local(filepath):
-        if not filepath.startswith(os.getcwd()):
-            raise DistutilsOptionError(
-                '`file:` directive can not access %s' % filepath)
 
     @staticmethod
     def _read_file(filepath):

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -309,7 +309,7 @@ class ConfigHandler:
         from nearest files using `file:` directive.
 
         Examples:
-            file: README.rst, CHANGELOG.md, src/file.txt ../file.txt
+            file: README.rst, CHANGELOG.md, src/file.txt, ../file.txt
 
         :param str value:
         :rtype: str

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -193,7 +193,7 @@ class TestMetadata:
                 'changelog contents\nand stuff'
             )
 
-    def test_file_sandboxed(self, tmpdir):
+    def test_file_outside(self, tmpdir):
 
         fake_env(
             tmpdir,
@@ -201,9 +201,12 @@ class TestMetadata:
             'long_description = file: ../../README\n'
         )
 
-        with get_dist(tmpdir, parse=False) as dist:
-            with pytest.raises(DistutilsOptionError):
-                dist.parse_config_files()  # file: out of sandbox
+        tmpdir.join('../../README').write('readme contents\noutside of the sandbox')
+
+        with get_dist(tmpdir) as dist:
+            assert dist.metadata.long_description == (
+                'readme contents\noutside of the sandbox'
+            )
 
     def test_aliases(self, tmpdir):
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This change allows to use the file outside the main directory. For example, in the file `setup.cfg`, section `long_description` the user can use an outside file `file: ../README.md`.

Closes https://github.com/pypa/setuptools/issues/2699

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
