### PR TITLE
[Demo] Add a tidelift footer block into the docs layout and a ToC link

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,31 @@
+{%- extends "!layout.html" %}
+
+{%- block footer %}
+  <div class="tidelift for-enterprise" style="margin: 0 auto; width: 940px;">
+	<h3 class="donation" style="font-size: 2em; font-weight: normal;">For Enterprise</h3>
+
+	<div style="float: left; padding-right: 10px;">
+	  <a href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs">
+		  <img alt="Tidelift" src="https://nedbatchelder.com/pix/Tidelift_Logos_RGB_Tidelift_Shorthand_On-White_small.png" style="height: 6rem">
+	  </a>
+	</div>
+
+	<p style="text-align: justify">
+	  Professional support for setuptools is available as part of the
+	  <a class="reference external" href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs |project|">Tidelift
+Subscription</a>.
+      Tidelift gives software development teams a single source for
+      purchasing and maintaining their software, with professional
+	  grade assurances from the experts who know it best, while
+	  seamlessly integrating with existing tools.
+	</p>
+
+	<p>
+	  <a style="background-color: rgb(246, 145, 77); border-radius: 5px; color: white; display: inline-block; font-family: sans; font-size: 1.2rem; font-weight: bolder; margin: 5px; padding: 15px 0; text-align: center; text-decoration: none; text-transform: uppercase; width: 40%;" href="https://tidelift.com/subscription/pkg/pypi-{{ project }}?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs">Learn more</a>
+	  <a style="background-color: rgb(246, 145, 77); border-radius: 5px; color: white; display: inline-block; font-family: sans; font-size: 1.2rem; font-weight: bolder; margin: 5px; padding: 15px 0; text-align: center; text-decoration: none; text-transform: uppercase; width: 41%;" href="https://tidelift.com/subscription/request-a-demo?utm_source=pypi-{{ project }}&utm_medium=referral&utm_campaign=docs">Request a Demo</a>
+	</p>
+  <div>
+
+  {{ super() }}
+
+{%- endblock %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,6 @@
+from sphinx.addnodes import toctree
+
+
 extensions = ['sphinx.ext.autodoc', 'jaraco.packaging.sphinx', 'rst.linker']
 
 master_doc = "index"
@@ -150,3 +153,26 @@ extensions += ['sphinxcontrib.towncrier']
 towncrier_draft_working_directory = '..'
 # Avoid an empty section for unpublished changes.
 towncrier_draft_include_empty = False
+
+
+def _doctree_read(app, doctree):
+    """Add a Tidelift link into the main ToC tree."""
+    if app.env.docname != 'index':
+        return
+
+    project = app.config.project
+
+    tidelift_toc_entry = (
+        # Text -> Link
+        'For Enterprise',
+        f'https://tidelift.com/subscription/pkg/pypi-{project}?'
+        f'utm_source=pypi-{project}&utm_medium=referral&utm_campaign=docs',
+    )
+
+    toc_node = doctree.traverse(toctree)[-1]
+    toc_node['entries'].append(tidelift_toc_entry)
+
+
+def setup(app):
+    """Add a callback for injecting a Tidefift link into ToC tree."""
+    app.connect('doctree-read', _doctree_read)


### PR DESCRIPTION
## Summary of changes

This is mainly a demo for @jaraco of how to solve problems raised in https://github.com/pypa/setuptools/pull/2465 and https://github.com/jaraco/tidelift/pull/2.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
