### PR TITLE
Implement #1681 (`glob:` directive for `[options.data_files]`)

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -68,6 +68,7 @@ boilerplate code in some cases.
         site.d/00_default.conf
         host.d/00_default.conf
     data = data/img/logo.png, data/svg/icon.svg
+    fonts = glob: data/fonts/*.ttf, glob: data/fonts/*.otf
 
 Metadata and options are set in the config sections of the same name.
 
@@ -156,6 +157,8 @@ Special directives:
       The ``file:`` directive is sandboxed and won't reach anything outside
       the directory containing ``setup.py``.
 
+* ``glob:`` - Value will be treated as a glob() pattern and expanded accordingly.
+
 
 Metadata
 --------
@@ -225,7 +228,7 @@ package_data             section                                              [#
 exclude_package_data     section
 namespace_packages       list-comma
 py_modules               list-comma
-data_files               dict                                 40.6.0
+data_files               glob:, dict                          40.6.0
 =======================  ===================================  =============== =========
 
 **Notes**:

--- a/setuptools/tests/test_config.py
+++ b/setuptools/tests/test_config.py
@@ -893,6 +893,41 @@ class TestOptions:
             ]
             assert sorted(dist.data_files) == sorted(expected)
 
+    def test_data_files_globby(self, tmpdir):
+        fake_env(
+            tmpdir,
+            '[options.data_files]\n'
+            'cfg =\n'
+            '      a/b.conf\n'
+            '      c/d.conf\n'
+            'data = glob: *.dat\n'
+            'icons = \n'
+            '      glob: *.ico\n'
+            'audio = \n'
+            '      glob:*.wav\n'
+            '      sounds.db\n'
+        )
+
+        # Create dummy files for glob()'s sake:
+        tmpdir.join('a.dat').write('')
+        tmpdir.join('b.dat').write('')
+        tmpdir.join('c.dat').write('')
+        tmpdir.join('a.ico').write('')
+        tmpdir.join('b.ico').write('')
+        tmpdir.join('c.ico').write('')
+        tmpdir.join('beep.wav').write('')
+        tmpdir.join('boop.wav').write('')
+        tmpdir.join('sounds.db').write('')
+
+        with get_dist(tmpdir) as dist:
+            expected = [
+                ('cfg', ['a/b.conf', 'c/d.conf']),
+                ('data', ['a.dat', 'b.dat', 'c.dat']),
+                ('icons', ['a.ico', 'b.ico', 'c.ico']),
+                ('audio', ['beep.wav', 'boop.wav', 'sounds.db']),
+            ]
+            assert sorted(dist.data_files) == sorted(expected)
+
     def test_python_requires_simple(self, tmpdir):
         fake_env(
             tmpdir,


### PR DESCRIPTION
## Summary of changes

Hello! 👋 First time contributor here.

This change (which closes #1681) introduces an optional new `glob:` directive just for values of `[options.data_files]` which will expand the given patterns to the corresponding relative paths.

It is also possible to do a mix of some regular strings and some using the new directive in the same dict. (See new unittest for an example.)

I took the liberty of updating `docs/userguide/declarative_config.rst` to mention the new directive. Please advise if it should be noted elsewhere in the documentation.

I tried to stay within the style of the file and added a new unittest for this new feature. Let me know what you think or if you wish to reword or adjust anything.

### Pull Request Checklist
- [✅] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
