### PR TITLE
Checking for missing `convert_2to3_doctests` attribute.

### DIFF
--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -123,7 +123,7 @@ class build_py(orig.build_py, Mixin2to3):
                 outf, copied = self.copy_file(srcfile, target)
                 make_writable(target)
                 srcfile = os.path.abspath(srcfile)
-                if (copied and
+                if (copied and self.distribution.convert_2to3_doctests and
                         srcfile in self.distribution.convert_2to3_doctests):
                     self.__doctests_2to3.append(outf)
 


### PR DESCRIPTION
Small patch to fix this error:

```
  File "/usr/local/lib/python3.6/dist-packages/setuptools/command/build_py.py", line 56, in run
    self.build_package_data()
  File "/usr/local/lib/python3.6/dist-packages/setuptools/command/build_py.py", line 127, in build_package_data
    srcfile in self.distribution.convert_2to3_doctests):
TypeError: argument of type 'NoneType' is not iterable
```