### PR TITLE
Fixes #2722 Adds an environment variable SETUPTOOLS_EXT_SUFFIX

### DIFF
--- a/changelog.d/2722.change.rst
+++ b/changelog.d/2722.change.rst
@@ -1,0 +1,1 @@
+Added support for ``SETUPTOOLS_EXT_SUFFIX`` environment variable to override the suffix normally detected from the ``sysconfig`` module.

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -104,14 +104,20 @@ class build_ext(_build_ext):
                 self.write_stub(package_dir or os.curdir, ext, True)
 
     def get_ext_filename(self, fullname):
-        filename = _build_ext.get_ext_filename(self, fullname)
+        so_ext = os.getenv('SETUPTOOLS_EXT_SUFFIX')
+        if so_ext:
+            filename = os.path.join(*fullname.split('.')) + so_ext
+        else:
+            filename = _build_ext.get_ext_filename(self, fullname)
+            so_ext = get_config_var('EXT_SUFFIX')
+
         if fullname in self.ext_map:
             ext = self.ext_map[fullname]
             use_abi3 = getattr(ext, 'py_limited_api') and get_abi3_suffix()
             if use_abi3:
-                so_ext = get_config_var('EXT_SUFFIX')
                 filename = filename[:-len(so_ext)]
-                filename = filename + get_abi3_suffix()
+                so_ext = get_abi3_suffix()
+                filename = filename + so_ext
             if isinstance(ext, Library):
                 fn, ext = os.path.splitext(filename)
                 return self.shlib_compiler.library_filename(fn, libtype)

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -72,7 +72,7 @@ class TestBuildExt:
         else:
             # PyPy builds do not use ABI3 tag, so they will
             # also get the overridden suffix.
-            expect = 'for_abi3.test_suffix'
+            expect = 'for_abi3.test-suffix'
 
         try:
             os.environ['SETUPTOOLS_EXT_SUFFIX'] = '.test-suffix'

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -13,6 +13,9 @@ from . import environment
 from .textwrap import DALS
 
 
+IS_PYPY = '__pypy__' in sys.builtin_module_names
+
+
 class TestBuildExt:
     def test_get_ext_filename(self):
         """
@@ -63,7 +66,14 @@ class TestBuildExt:
         )
         # Mock value needed to pass tests
         ext._links_to_dynamic = False
-        expect = cmd.get_ext_filename('for_abi3')
+
+        if not IS_PYPY:
+            expect = cmd.get_ext_filename('for_abi3')
+        else:
+            # PyPy builds do not use ABI3 tag, so they will
+            # also get the overridden suffix.
+            expect = 'for_abi3.test_suffix'
+
         try:
             os.environ['SETUPTOOLS_EXT_SUFFIX'] = '.test-suffix'
             res = cmd.get_ext_filename('normal')


### PR DESCRIPTION
Adds an environment variable SETUPTOOLS_EXT_SUFFIX to override the suffix inferred from the host Python runtime.

Closes #2722

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
