### PR TITLE
Remove gcov exclusion. Defaults are fine.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,12 @@ jobs:
           python -m pip install tox
       - name: Run tests
         run: tox -- --cov-report xml
-      - name: Upload coverage to Codecov
+      - name: Publish coverage
         uses: codecov/codecov-action@v1
         with:
           flags: >-  # Mark which lines are covered by which envs
             ${{ runner.os }},
             ${{ matrix.python }}
-          functionalities: gcov  # disable C coverage autodiscovery
 
   release:
     needs: test


### PR DESCRIPTION
In #2693, I recommended to remove the `gcov` exclusion. When I did, I believe that the error message was modest and ignorable. It can't possibly be a good design that every non-C program is meant to add this line to their project. Let's keep it simple and rely on defaults where possible. Doing so would make this technique more applicable to other projects too.