### PR TITLE
Set max_line_length in .editorconfig file to 88 for Python files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ end_of_line = lf
 
 [*.py]
 indent_style = space
+max_line_length = 88
 
 [*.{yml,yaml}]
 indent_style = space

--- a/changelog.d/2743.doc.rst
+++ b/changelog.d/2743.doc.rst
@@ -1,0 +1,1 @@
+Set .editorconfig `max_line_length` property for Python files.

--- a/changelog.d/2743.doc.rst
+++ b/changelog.d/2743.doc.rst
@@ -1,1 +1,1 @@
-Set .editorconfig `max_line_length` property for Python files.
+Set :file:`.editorconfig` ``max_line_length`` property for Python files.


### PR DESCRIPTION
## Summary of changes

I was getting slapped with some line-too-long flake8 warnings and so I'm contributing a small modif to the `.editorconfig` to set the [max_line_length](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties#max_line_length) property for Python files.

I think it might help some future contributors to detect their line length violations _before_ a pull request happens.

### Pull Request Checklist
- ~[ ] Changes have tests~ Not applicable.
- [x] News fragment added in [`changelog.d/`].
