### PR TITLE
Added short license notice

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
 keywords = CPAN PyPI distutils eggs package management
 project_urls =
 	Documentation = https://setuptools.readthedocs.io/
+license = MIT
 
 [options]
 packages = find_namespace:


### PR DESCRIPTION
PyPI.org packages usually gives short license notice, but setuptools not.
In venv .../site-packages/setuptools-57.4.0.dist-info/METADATA  I can see just:

> License: UNKNOWN

Obviously - this amateur PR will fix it ;-).
Thank you for your work and time.
Pax et bonum.