### PR TITLE
build_meta: Clarify the reasons for project requirements in pyproject…

### DIFF
--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -56,9 +56,9 @@ setuptools, the content would be::
     requires = ["setuptools", "wheel"]
     build-backend = "setuptools.build_meta"
 
-The ``setuptools`` package will implement the ``build_sdist``
-function and the ``wheel`` package will provide the ``build_wheel``
-function; both are required to be compliant with PEP 517.
+The ``setuptools`` package implements the ``build_sdist``
+command and the ``wheel`` package implements the ``build_wheel``
+command; both are required to be compliant with PEP 517.
 
 Use ``setuptools``' :ref:`declarative config <declarative config>` to
 specify the package information::

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -54,7 +54,11 @@ setuptools, the content would be::
 
     [build-system]
     requires = ["setuptools", "wheel"]
-    build-backend = "setuptools.build_meta" 
+    build-backend = "setuptools.build_meta"
+
+The ``setuptools`` package will implement the ``build_sdist``
+function and the ``wheel`` package will provide the ``build_wheel``
+function; both are required to be compliant with PEP 517.
 
 Use ``setuptools``' :ref:`declarative config <declarative config>` to
 specify the package information::


### PR DESCRIPTION
There was some discussion in a recent change adding ```pyproject.toml``` over the ```wheel``` requirement @ https://github.com/ProgVal/Limnoria/pull/1464#discussion_r684855320

From my reading, I think that this is required to be PEP 517 compliant and implement the ```build_wheel``` mandatory hook.  But it's probably worth clarifying why the extra project is a hard requirement here to avoid confusion.  This adds a small sentence explaining this.