### PR TITLE
Support overriding ranlib on macOS with env var

### DIFF
--- a/changelog.d/ranlib.rst
+++ b/changelog.d/ranlib.rst
@@ -1,0 +1,1 @@
+Added support to distutils to override ranlib on macos -- by :user:`isuruf`

--- a/setuptools/_distutils/sysconfig.py
+++ b/setuptools/_distutils/sysconfig.py
@@ -252,6 +252,9 @@ def customize_compiler(compiler):
             linker_exe=cc,
             archiver=archiver)
 
+        if 'RANLIB' in os.environ and compiler.executables.get('ranlib', None):
+            compiler.set_executables(ranlib=os.environ['RANLIB'])
+
         compiler.shared_lib_extension = shlib_suffix
 
 

--- a/setuptools/_distutils/tests/test_sysconfig.py
+++ b/setuptools/_distutils/tests/test_sysconfig.py
@@ -125,6 +125,7 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         os.environ['ARFLAGS'] = '--env-arflags'
         os.environ['CFLAGS'] = '--env-cflags'
         os.environ['CPPFLAGS'] = '--env-cppflags'
+        os.environ['RANLIB'] = 'env_ranlib'
 
         comp = self.customize_compiler()
         self.assertEqual(comp.exes['archiver'],
@@ -145,6 +146,12 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
                           ' --env-cppflags'))
         self.assertEqual(comp.shared_lib_extension, 'sc_shutil_suffix')
 
+        if sys.platform == "darwin":
+            self.assertEqual(comp.exes['ranlib'],
+                         'env_ranlib')
+        else:
+            self.assertTrue('ranlib' not in comp.exes)
+
         del os.environ['AR']
         del os.environ['CC']
         del os.environ['CPP']
@@ -154,6 +161,7 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         del os.environ['ARFLAGS']
         del os.environ['CFLAGS']
         del os.environ['CPPFLAGS']
+        del os.environ['RANLIB']
 
         comp = self.customize_compiler()
         self.assertEqual(comp.exes['archiver'],
@@ -171,6 +179,12 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertEqual(comp.exes['linker_so'],
                          'sc_ldshared')
         self.assertEqual(comp.shared_lib_extension, 'sc_shutil_suffix')
+        if sys.platform == "darwin":
+            self.assertEqual(comp.exes['ranlib'],
+                         'ranlib')
+        else:
+            # For platforms other than macOS, ranlib is not used
+            self.assertTrue('ranlib' not in comp.exes)
 
     def test_parse_makefile_base(self):
         self.makefile = TESTFN


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This adds support to distutils to override ranlib on macOS with an env var.
Before this, `ranlib` from PATH is used.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request

Fixes https://bugs.python.org/issue37916
