### PR TITLE
location of 'include' is changing for PyPy 3.8

### DIFF
--- a/setuptools/_distutils/sysconfig.py
+++ b/setuptools/_distutils/sysconfig.py
@@ -99,10 +99,13 @@ def get_python_inc(plat_specific=0, prefix=None):
     """
     if prefix is None:
         prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
-    if IS_PYPY:
-        return os.path.join(prefix, 'include')
-    elif os.name == "posix":
-        if python_build:
+    if os.name == "posix":
+        implementation = 'python'
+        if IS_PYPY:
+            if sys.version_info < (3, 8, 0):
+                return os.path.join(prefix, 'include')
+            implementation = 'pypy'
+        elif python_build:
             # Assume the executable is in the build directory.  The
             # pyconfig.h file should be in the same directory.  Since
             # the build directory may not be the source directory, we
@@ -113,7 +116,7 @@ def get_python_inc(plat_specific=0, prefix=None):
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
                 return os.path.normpath(incdir)
-        python_dir = 'python' + get_python_version() + build_flags
+        python_dir = implementation + get_python_version() + build_flags
         return os.path.join(prefix, "include", python_dir)
     elif os.name == "nt":
         if python_build:


### PR DESCRIPTION
## Summary of changes

The scheme for PyPy include files will change to be closer to CPython in the upcoming 3.8 release. Instead of `<prefix>/include`, they will be in `<prefix>/include/pypy3.8` on non-windows.

<!-- Summary goes here -->

Related to [PyPy 3540](https://foss.heptapod.net/pypy/pypy/-/issues/3540) and to issue #

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request

I am not sure what test hits this path. It seems it should be hit by `setuptools/_distutils/test/test_build_ext.py` but running `pypy3.8/bin/pypy3 -mpytest setuptools/_distutils/test/test_build_ext.py` does not seem to have an `import setuptools` so it uses the stdlib `distutils` not the `setuptools._distutils`. What am I doing wrong?
 