### PR TITLE
Fix syntax error in test_build_meta's pyproject.toml files

### DIFF
--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -167,7 +167,7 @@ class TestBuildMetaBackend:
             'pyproject.toml': DALS("""
                 [build-system]
                 requires = ["setuptools", "wheel"]
-                build-backend = "setuptools.build_meta
+                build-backend = "setuptools.build_meta"
             """),
         }
 
@@ -260,7 +260,7 @@ class TestBuildMetaBackend:
             'pyproject.toml': DALS("""
                 [build-system]
                 requires = ["setuptools", "wheel"]
-                build-backend = "setuptools.build_meta
+                build-backend = "setuptools.build_meta"
                 """),
         }
         path.build(files)


### PR DESCRIPTION
## Summary of changes

Fix missing closing quotes in pyproject.toml files used
in test_build_meta's tests.  This fixes the test failures due
to TOMLDecodeError.

### Pull Request Checklist
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
