### PR TITLE
In Distribution.finalize_options, suppress known removed entry points

### DIFF
--- a/changelog.d/2765.patch.rst
+++ b/changelog.d/2765.patch.rst
@@ -1,1 +1,1 @@
-In Distribution.finalize_options, suppress known removed entry points for a year to avoid issues with older Setuptools.
+In Distribution.finalize_options, suppress known removed entry points to avoid issues with older Setuptools.

--- a/changelog.d/2765.patch.rst
+++ b/changelog.d/2765.patch.rst
@@ -1,0 +1,1 @@
+In Distribution.finalize_options, suppress known removed entry points for a year to avoid issues with older Setuptools.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -5,6 +5,7 @@ import io
 import sys
 import re
 import os
+import datetime
 import warnings
 import numbers
 import distutils.log
@@ -817,9 +818,31 @@ class Distribution(_Distribution):
         def by_order(hook):
             return getattr(hook, 'order', 0)
 
-        eps = map(lambda e: e.load(), pkg_resources.iter_entry_points(group))
-        for ep in sorted(eps, key=by_order):
+        defined = pkg_resources.iter_entry_points(group)
+        filtered = self._suppress_removed_finalization_eps(defined)
+        loaded = map(lambda e: e.load(), filtered)
+        for ep in sorted(loaded, key=by_order):
             ep(self)
+
+    @staticmethod
+    def _suppress_removed_finalization_eps(defined):
+        """
+        When removing an entry point, if metadata is loaded
+        from an older version of Setuptools, that removed
+        entry point will attempt to be loaded and will fail.
+        See #2765 for more details. Remove these known
+        removed entry points for a year to limit the
+        disruption.
+        """
+        removed = {
+            '2to3_doctests': datetime.date(2021, 9, 5),
+        }
+        duration = datetime.timedelta(days=365)
+        today = datetime.date.today()
+
+        def suppress(ep):
+            return ep.name in removed and today - removed[ep.name] < duration
+        return itertools.filterfalse(suppress, defined)
 
     def _finalize_setup_keywords(self):
         for ep in pkg_resources.iter_entry_points('distutils.setup_keywords'):


### PR DESCRIPTION
...~~for a year~~ to avoid issues with older Setuptools. Fixes #2765.