### PR TITLE
bdist_rpm: add option to force version

### DIFF
--- a/changelog.d/2778.change.1.rst
+++ b/changelog.d/2778.change.1.rst
@@ -1,0 +1,1 @@
+* Added option to force RPM package version rather than inherit it

--- a/setuptools/_distutils/command/bdist_rpm.py
+++ b/setuptools/_distutils/command/bdist_rpm.py
@@ -120,6 +120,10 @@ class bdist_rpm(Command):
         ('force-arch=', None,
          "Force an architecture onto the RPM build process"),
 
+        # Allow a packager to explicitly force a version
+        ('force-version=', None,
+         "Force a version onto the RPM instead of using metadata"),
+
         ('quiet', 'q',
          "Run the INSTALL phase of RPM building in quiet mode"),
         ]
@@ -175,6 +179,7 @@ class bdist_rpm(Command):
         self.no_autoreq = 0
 
         self.force_arch = None
+        self.force_version = None
         self.quiet = 0
 
     def finalize_options(self):
@@ -252,6 +257,7 @@ class bdist_rpm(Command):
         self.ensure_string_list('obsoletes')
 
         self.ensure_string('force_arch')
+        self.ensure_string('force_version')
 
     def run(self):
         if DEBUG:
@@ -392,10 +398,14 @@ class bdist_rpm(Command):
         """Generate the text of an RPM spec file and return it as a
         list of strings (one per line).
         """
+        if self.force_version is None:
+            pkg_version = self.distribution.get_version()
+        else:
+            pkg_version = self.force_version
         # definitions and headers
         spec_file = [
             '%define name ' + self.distribution.get_name(),
-            '%define version ' + self.distribution.get_version().replace('-','_'),
+            '%define version ' + pkg_version.replace('-','_'),
             '%define unmangled_version ' + self.distribution.get_version(),
             '%define release ' + self.release.replace('-','_'),
             '',


### PR DESCRIPTION

## Summary of changes

The RPM versioning guidelines are slightly at odds with PEP440.
For example, RPM considers 1.1a1 to be a higher version than 1.1
where as PEP440 shows 1.1a1 to be an alpha and 1.1 to be the
official release. 
```shell
$ rpmdev-vercmp 1.1a1 1.1
1.1a1 > 1.1
```
Permitting specific override of the RPM version will allow a
maintainer to explicitly correct the version to fit their needs.


### Pull Request Checklist
- [X] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
