### PR TITLE
Deprecate bdist_rpm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,10 @@ jobs:
     strategy:
       matrix:
         python:
+        - pypy3
         - 3.6
         - 3.9
         - 3.10.0-alpha - 3.10.99
-        - pypy3
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/build
 include
 lib
 distribute.egg-info
+foo.egg-info
 setuptools.egg-info
 .coverage
 .eggs

--- a/changelog.d/1988-change.rst
+++ b/changelog.d/1988-change.rst
@@ -1,2 +1,2 @@
-Deprecated the ``bdist_rom`` command. Binary packages should be built as wheels instead.
+Deprecated the ``bdist_rpm`` command. Binary packages should be built as wheels instead.
 -- by :user:`hugovk`

--- a/changelog.d/1988-change.rst
+++ b/changelog.d/1988-change.rst
@@ -1,0 +1,2 @@
+Deprecated the ``bdist_rom`` command. Binary packages should be built as wheels instead.
+-- by :user:`hugovk`

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,7 +4,6 @@ addopts=
 	--doctest-modules
 	--doctest-glob=pkg_resources/api_tests.txt
 	-r sxX
-	--color=yes
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 # workaround for warning pytest-dev/pytest#6178
 junit_family=xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,7 @@ addopts=
 	--doctest-modules
 	--doctest-glob=pkg_resources/api_tests.txt
 	-r sxX
+	--color=yes
 doctest_optionflags=ALLOW_UNICODE ELLIPSIS
 # workaround for warning pytest-dev/pytest#6178
 junit_family=xunit2

--- a/setuptools/command/bdist_rpm.py
+++ b/setuptools/command/bdist_rpm.py
@@ -1,4 +1,7 @@
 import distutils.command.bdist_rpm as orig
+import warnings
+
+from setuptools import SetuptoolsDeprecationWarning
 
 
 class bdist_rpm(orig.bdist_rpm):
@@ -11,6 +14,12 @@ class bdist_rpm(orig.bdist_rpm):
     """
 
     def run(self):
+        warnings.warn(
+            "bdist_rpm is deprecated and will be removed in a future "
+            "version. Use bdist_wheel (wheel packages) instead.",
+            SetuptoolsDeprecationWarning,
+        )
+
         # ensure distro name is up-to-date
         self.run_command('egg_info')
 

--- a/setuptools/tests/test_bdist_deprecations.py
+++ b/setuptools/tests/test_bdist_deprecations.py
@@ -1,0 +1,27 @@
+"""develop tests
+"""
+import mock
+import sys
+
+import pytest
+
+from setuptools.dist import Distribution
+from setuptools import SetuptoolsDeprecationWarning
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='non-Windows only')
+@mock.patch('distutils.command.bdist_rpm.bdist_rpm')
+def test_bdist_rpm_warning(distutils_cmd):
+    dist = Distribution(
+        dict(
+            script_name='setup.py',
+            script_args=['bdist_rpm'],
+            name='foo',
+            py_modules=['hi'],
+        )
+    )
+    dist.parse_command_line()
+    with pytest.warns(SetuptoolsDeprecationWarning):
+        dist.run_commands()
+
+    distutils_cmd.run.assert_called_once()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Similar to https://github.com/pypa/setuptools/pull/2040, deprecate `bdist_rpm`.

For #1988.

---

Also some test/CI improvements (please let me know if these should be in another PR):

* Ignore a generated file from running tox locally
* CI: test slower PyPy3 first, to make full use of parallel jobs to finish faster
* CI: turn on pytest colours for GitHub Actions logging, makes it more readable

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
