### PR TITLE
configparser: replace deprecated readfp with read_file

### DIFF
--- a/changelog.d/2785-change.rst
+++ b/changelog.d/2785-change.rst
@@ -1,0 +1,2 @@
+Replace confirparser's readfp with read_file, deprecated since Python 3.2.
+-- by :user:`hugovk`

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1508,7 +1508,7 @@ def extract_wininst_cfg(dist_filename):
             # Now the config is in bytes, but for RawConfigParser, it should
             #  be text, so decode it.
             config = config.decode(sys.getfilesystemencoding())
-            cfg.readfp(io.StringIO(config))
+            cfg.read_file(io.StringIO(config))
         except configparser.Error:
             return None
         if not cfg.has_section('metadata') or not cfg.has_section('Setup'):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

`configparser`: replace deprecated `readfp` with `read_file`, deprecated since Python 3.2 and potentially being removed in Python 3.11 (due for release October 2022).

* https://bugs.python.org/issue45173

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
