### PR TITLE
Docs: add a link to the "Development Mode" page in "`setuptools` Quickstart"

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -201,7 +201,7 @@ Then::
     pip install --editable .
 
 This creates a link file in your interpreter site package directory which
-associate with your source code. For more information, see: (WIP)
+associate with your source code. For more information, see :doc:`development_mode`.
 
 
 Uploading your package to PyPI


### PR DESCRIPTION
## Summary of changes

It seems that the content of the "Development Mode" page is already stable, so I added a link to it in the "`setuptools` Quickstart" page.

## Test

Generate the documentation with tox (build finished with problems, 2 warnings):

<details>
<summary>console output</summary>

```console
$ python3 -m tox -e docs
docs create: /home/ubuntu/setuptools/.tox/docs
docs installdeps: sphinx@git+https://github.com/sphinx-doc/sphinx; python_version>="3.10"
docs develop-inst: /home/ubuntu/setuptools
docs installed: alabaster==0.7.12,attrs==21.2.0,autocommand==2.2.1,Babel==2.9.1,backports.entry-points-selectable==1.1.0,beautifulsoup4==4.10.0,black==21.8b0,certifi==2021.5.30,cffi==1.14.6,charset-normalizer==2.0.4,click==8.0.1,click-default-group==1.2.2,contextlib2==21.6.0,coverage==5.5,cryptography==3.4.8,dataclasses==0.8,distlib==0.3.2,docutils==0.17.1,execnet==1.9.0,filelock==3.0.12,flake8==3.9.2,flake8-2020==1.6.0,furo==2021.9.8,idna==3.2,imagesize==1.2.0,importlib-metadata==4.8.1,importlib-resources==5.2.2,incremental==21.3.0,iniconfig==1.1.1,jaraco.context==4.0.0,jaraco.envs==2.1.1,jaraco.functools==3.3.0,jaraco.packaging==8.2.1,jaraco.path==3.3.1,jaraco.tidelift==1.4.0,jeepney==0.7.1,Jinja2==3.0.1,keyring==23.2.0,MarkupSafe==2.0.1,mccabe==0.6.1,mock==4.0.3,more-itertools==8.9.0,mypy==0.910,mypy-extensions==0.4.3,packaging==21.0,path==16.2.0,path.py==12.5.0,pathspec==0.9.0,Paver==1.3.4,pep517==0.11.0,platformdirs==2.3.0,pluggy==1.0.0,py==1.10.0,pycodestyle==2.7.0,pycparser==2.20,pyflakes==2.3.1,Pygments==2.10.0,pygments-github-lexers==0.0.5,pyparsing==2.4.7,pytest==6.2.5,pytest-black==0.3.12,pytest-checkdocs==2.7.1,pytest-cov==2.12.1,pytest-enabler==1.2.0,pytest-fixture-config==1.7.0,pytest-flake8==1.0.7,pytest-forked==1.3.0,pytest-mypy==0.8.1,pytest-shutil==1.7.0,pytest-virtualenv==1.7.0,pytest-xdist==2.3.0,python-dateutil==2.8.2,pytz==2021.1,regex==2021.8.28,requests==2.26.0,requests-toolbelt==0.9.1,rst.linker==2.2.0,SecretStorage==3.3.1,setuptools-bootstrap==1.0,singledispatch==3.7.0,six==1.16.0,snowballstemmer==2.1.0,soupsieve==2.2.1,Sphinx==4.2.0,sphinx_inline_tabs==2021.3.28b7,sphinxcontrib-applehelp==1.0.2,sphinxcontrib-devhelp==1.0.2,sphinxcontrib-htmlhelp==2.0.0,sphinxcontrib-jsmath==1.0.1,sphinxcontrib-qthelp==1.0.3,sphinxcontrib-serializinghtml==1.1.5,sphinxcontrib-towncrier==0.2.0a0,termcolor==1.1.0,toml==0.10.2,tomli==1.2.1,towncrier==21.3.0,tox==3.24.3,typed-ast==1.4.3,typing-extensions==3.10.0.2,urllib3==1.26.6,virtualenv==20.7.2,zipp==3.5.0
docs run-test-pre: PYTHONHASHSEED='3153524584'
docs run-test: commands[0] | python -m sphinx -W --keep-going . /home/ubuntu/setuptools/build/html
Running Sphinx v4.2.0
making output directory... done
loading intersphinx inventory from https://pypa-build.readthedocs.io/en/latest/objects.inv...
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://docs.python.org/2/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 43 source files that are out of date
updating environment: [new config] 43 added, 0 changed, 0 removed
reading sources... [  2%] build_meta
reading sources... [  4%] deprecated/distutils-legacy
reading sources... [  6%] deprecated/distutils/_setuptools_disclaimer
reading sources... [  9%] deprecated/distutils/apiref
reading sources... [ 11%] deprecated/distutils/builtdist
reading sources... [ 13%] deprecated/distutils/commandref
reading sources... [ 16%] deprecated/distutils/configfile
reading sources... [ 18%] deprecated/distutils/examples
reading sources... [ 20%] deprecated/distutils/extending
reading sources... [ 23%] deprecated/distutils/index
reading sources... [ 25%] deprecated/distutils/introduction
reading sources... [ 27%] deprecated/distutils/packageindex
reading sources... [ 30%] deprecated/distutils/setupscript
reading sources... [ 32%] deprecated/distutils/sourcedist
reading sources... [ 34%] deprecated/distutils/uploading
reading sources... [ 37%] deprecated/easy_install
reading sources... [ 39%] deprecated/functionalities
reading sources... [ 41%] deprecated/index
reading sources... [ 44%] deprecated/python_eggs
reading sources... [ 46%] development/developer-guide
reading sources... [ 48%] development/index
reading sources... [ 51%] development/releases
reading sources... [ 53%] history
Loading template...
Finding news fragments...
Rendering news fragments...
Draft only -- nothing has been written.
What is seen below is what would be written.

reading sources... [ 55%] index
reading sources... [ 58%] pkg_resources
reading sources... [ 60%] python 2 sunset
reading sources... [ 62%] references/keywords
reading sources... [ 65%] roadmap
reading sources... [ 67%] setuptools
reading sources... [ 69%] userguide/commands
reading sources... [ 72%] userguide/datafiles
reading sources... [ 74%] userguide/declarative_config
reading sources... [ 76%] userguide/dependency_management
reading sources... [ 79%] userguide/development_mode
reading sources... [ 81%] userguide/distribution
reading sources... [ 83%] userguide/entry_point
reading sources... [ 86%] userguide/extension
reading sources... [ 88%] userguide/functionalities_rewrite
reading sources... [ 90%] userguide/index
reading sources... [ 93%] userguide/keywords
reading sources... [ 95%] userguide/miscellaneous
reading sources... [ 97%] userguide/package_discovery
reading sources... [100%] userguide/quickstart

/home/ubuntu/setuptools/docs/deprecated/index.rst:13: WARNING: toctree contains reference to nonexisting document 'deprecated/python3'
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [  2%] build_meta
writing output... [  4%] deprecated/distutils-legacy
writing output... [  6%] deprecated/distutils/_setuptools_disclaimer
writing output... [  9%] deprecated/distutils/apiref
writing output... [ 11%] deprecated/distutils/builtdist
writing output... [ 13%] deprecated/distutils/commandref
writing output... [ 16%] deprecated/distutils/configfile
writing output... [ 18%] deprecated/distutils/examples
writing output... [ 20%] deprecated/distutils/extending
writing output... [ 23%] deprecated/distutils/index
writing output... [ 25%] deprecated/distutils/introduction
writing output... [ 27%] deprecated/distutils/packageindex
writing output... [ 30%] deprecated/distutils/setupscript
writing output... [ 32%] deprecated/distutils/sourcedist
writing output... [ 34%] deprecated/distutils/uploading
writing output... [ 37%] deprecated/easy_install
writing output... [ 39%] deprecated/functionalities
writing output... [ 41%] deprecated/index
writing output... [ 44%] deprecated/python_eggs
writing output... [ 46%] development/developer-guide
writing output... [ 48%] development/index
writing output... [ 51%] development/releases
writing output... [ 53%] history
writing output... [ 55%] index
writing output... [ 58%] pkg_resources
writing output... [ 60%] python 2 sunset
writing output... [ 62%] references/keywords
writing output... [ 65%] roadmap
writing output... [ 67%] setuptools
writing output... [ 69%] userguide/commands
writing output... [ 72%] userguide/datafiles
writing output... [ 74%] userguide/declarative_config
writing output... [ 76%] userguide/dependency_management
writing output... [ 79%] userguide/development_mode
writing output... [ 81%] userguide/distribution
writing output... [ 83%] userguide/entry_point
writing output... [ 86%] userguide/extension
writing output... [ 88%] userguide/functionalities_rewrite
writing output... [ 90%] userguide/index
writing output... [ 93%] userguide/keywords
writing output... [ 95%] userguide/miscellaneous
writing output... [ 97%] userguide/package_discovery
writing output... [100%] userguide/quickstart

../CHANGES (links).rst:68: WARNING: 'any' reference target not found: [options.data_files]
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build finished with problems, 2 warnings.
ERROR: InvocationError for command /home/ubuntu/setuptools/.tox/docs/bin/python -m sphinx -W --keep-going . /home/ubuntu/setuptools/build/html (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   docs: commands failed
```

</details>

Generated link (HTML):

```html
<a class="reference internal" href="development_mode.html"><span class="doc">“Development Mode”</span></a>
```

Screenshot:

![20210912-pypa-setuptools-PR-docs-quickstart-add-link-to-development-mode-page](https://user-images.githubusercontent.com/29089388/132984280-0eb02556-394e-4a1b-9045-1b07921e15c7.png)
