### PR TITLE
distutils 02e9f65ab0

### DIFF
--- a/changelog.d/2796.change.rst
+++ b/changelog.d/2796.change.rst
@@ -1,0 +1,1 @@
+Merge with pypa/distutils@02e9f65ab0

--- a/setuptools/_distutils/command/build_ext.py
+++ b/setuptools/_distutils/command/build_ext.py
@@ -220,7 +220,7 @@ class build_ext(Command):
         # For extensions under Cygwin, Python's library directory must be
         # appended to library_dirs
         if sys.platform[:6] == 'cygwin':
-            if sys.executable.startswith(os.path.join(sys.exec_prefix, "bin")):
+            if not sysconfig.python_build:
                 # building third party extensions
                 self.library_dirs.append(os.path.join(sys.prefix, "lib",
                                                       "python" + get_python_version(),

--- a/setuptools/_distutils/command/install.py
+++ b/setuptools/_distutils/command/install.py
@@ -470,6 +470,7 @@ class install(Command):
         """Sets the install directories by applying the install schemes."""
         # it's the caller's problem if they supply a bad name!
         if (hasattr(sys, 'pypy_version_info') and
+                sys.version_info < (3, 8) and
                 not name.endswith(('_user', '_home'))):
             if os.name == 'nt':
                 name = 'pypy_nt'

--- a/setuptools/_distutils/sysconfig.py
+++ b/setuptools/_distutils/sysconfig.py
@@ -99,9 +99,9 @@ def get_python_inc(plat_specific=0, prefix=None):
     """
     if prefix is None:
         prefix = plat_specific and BASE_EXEC_PREFIX or BASE_PREFIX
-    if IS_PYPY:
-        return os.path.join(prefix, 'include')
-    elif os.name == "posix":
+    if os.name == "posix":
+        if IS_PYPY and sys.version_info < (3, 8):
+            return os.path.join(prefix, 'include')
         if python_build:
             # Assume the executable is in the build directory.  The
             # pyconfig.h file should be in the same directory.  Since
@@ -113,7 +113,8 @@ def get_python_inc(plat_specific=0, prefix=None):
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
                 return os.path.normpath(incdir)
-        python_dir = 'python' + get_python_version() + build_flags
+        implementation = 'pypy' if IS_PYPY else 'python'
+        python_dir = implementation + get_python_version() + build_flags
         return os.path.join(prefix, "include", python_dir)
     elif os.name == "nt":
         if python_build:
@@ -142,7 +143,8 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
     If 'prefix' is supplied, use it instead of sys.base_prefix or
     sys.base_exec_prefix -- i.e., ignore 'plat_specific'.
     """
-    if IS_PYPY:
+
+    if IS_PYPY and sys.version_info < (3, 8):
         # PyPy-specific schema
         if prefix is None:
             prefix = PREFIX
@@ -164,8 +166,9 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
         else:
             # Pure Python
             libdir = "lib"
+        implementation = 'pypy' if IS_PYPY else 'python'
         libpython = os.path.join(prefix, libdir,
-                                 "python" + get_python_version())
+                                 implementation + get_python_version())
         if standard_lib:
             return libpython
         else:
@@ -211,10 +214,9 @@ def customize_compiler(compiler):
 
         if 'CC' in os.environ:
             newcc = os.environ['CC']
-            if (sys.platform == 'darwin'
-                    and 'LDSHARED' not in os.environ
+            if('LDSHARED' not in os.environ
                     and ldshared.startswith(cc)):
-                # On OS X, if CC is overridden, use that as the default
+                # If CC is overridden, use that as the default
                 #       command for LDSHARED as well
                 ldshared = newcc + ldshared[len(cc):]
             cc = newcc
@@ -251,6 +253,9 @@ def customize_compiler(compiler):
             linker_so=ldshared,
             linker_exe=cc,
             archiver=archiver)
+
+        if 'RANLIB' in os.environ and compiler.executables.get('ranlib', None):
+            compiler.set_executables(ranlib=os.environ['RANLIB'])
 
         compiler.shared_lib_extension = shlib_suffix
 

--- a/setuptools/_distutils/tests/test_unixccompiler.py
+++ b/setuptools/_distutils/tests/test_unixccompiler.py
@@ -140,6 +140,14 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sysconfig.get_config_var = gcv
         self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
 
+        def gcv(v):
+            if v == 'CC':
+                return 'gcc -pthread -B /bar'
+            elif v == 'GNULD':
+                return 'yes'
+        sysconfig.get_config_var = gcv
+        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
+
         # GCC non-GNULD
         sys.platform = 'bar'
         def gcv(v):
@@ -181,8 +189,8 @@ class UnixCCompilerTestCase(unittest.TestCase):
         sysconfig.get_config_var = gcv
         self.assertEqual(self.cc.rpath_foo(), '-R/foo')
 
-    @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for OS X')
-    def test_osx_cc_overrides_ldshared(self):
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
+    def test_cc_overrides_ldshared(self):
         # Issue #18080:
         # ensure that setting CC env variable also changes default linker
         def gcv(v):
@@ -202,8 +210,8 @@ class UnixCCompilerTestCase(unittest.TestCase):
             sysconfig.customize_compiler(self.cc)
         self.assertEqual(self.cc.linker_so[0], 'my_cc')
 
-    @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for OS X')
-    def test_osx_explicit_ldshared(self):
+    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
+    def test_explicit_ldshared(self):
         # Issue #18080:
         # ensure that setting CC env variable does not change
         #   explicit LDSHARED setting for linker

--- a/setuptools/_distutils/unixccompiler.py
+++ b/setuptools/_distutils/unixccompiler.py
@@ -13,7 +13,7 @@ the "typical" Unix-style command-line C compiler:
   * link shared library handled by 'cc -shared'
 """
 
-import os, sys, re
+import os, sys, re, shlex
 
 from distutils import sysconfig
 from distutils.dep_util import newer
@@ -231,7 +231,7 @@ class UnixCCompiler(CCompiler):
         # this time, there's no way to determine this information from
         # the configuration data stored in the Python installation, so
         # we use this hack.
-        compiler = os.path.basename(sysconfig.get_config_var("CC"))
+        compiler = os.path.basename(shlex.split(sysconfig.get_config_var("CC"))[0])
         if sys.platform[:6] == "darwin":
             from distutils.util import get_macosx_target_ver, split_version
             macosx_target_ver = get_macosx_target_ver()


### PR DESCRIPTION
- Prefer sysconfig.python_build
- adopt more standard schema for pypy3.8 (#51)
- Support overriding ranlib on macOS with env var
- override ldshared on non-macos platforms too if CC is overriden
- Split CC to make sure we get the correct basename of the compiler
- Use shlex

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
