### PR TITLE
sdist: Accept -u/--owner and -g/--group options

### DIFF
--- a/changelog.d/2800.change.rst
+++ b/changelog.d/2800.change.rst
@@ -1,0 +1,3 @@
+Added ``--owner`` and ``--group`` options to the ``sdist`` command,
+for specifying file ownership within the produced tarball (similarly
+to the corresponding distutils ``sdist`` options).

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -31,6 +31,10 @@ class sdist(sdist_add_defaults, orig.sdist):
         ('dist-dir=', 'd',
          "directory to put the source distribution archive(s) in "
          "[default: dist]"),
+        ('owner=', 'u',
+         "Owner name used when creating a tar file [default: current user]"),
+        ('group=', 'g',
+         "Group name used when creating a tar file [default: current group]"),
     ]
 
     negative_opt = {}


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Controlling the file ownership recorded in tar archives is useful for those striving towards reproducible builds, as discussed in #1893. These options are already understood by `distutils.command.sdist.sdist`, so just need to be accepted by `setuptools.command.sdist.sdist` to be propagated.

I didn't see any tests of the adjacent `sdist` options such as `--keep-temp` or `--dist-dir`, so as the change is to data only and effectively just forwards to already existing distutils code, I haven't added any additional tests. If there is somewhere appropriate to add a new test, please recommend where and I will add something appropriate. A similar comment applies to documentation.

Closes #1893.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
