### PR TITLE
fix: cannot set root package properly

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -218,8 +218,13 @@ class egg_info(InfoCommon, Command):
             ) from e
 
         if self.egg_base is None:
-            dirs = self.distribution.package_dir
-            self.egg_base = (dirs or {}).get('', os.curdir)
+            dirs = self.distribution.package_dir or {}
+            if '' in dirs:
+                self.egg_base = dirs['']
+            elif self.egg_name in dirs:
+                self.egg_base =os.path.dirname(dirs[self.egg_name])
+            else:
+                self.egg_base = os.curdir
 
         self.ensure_dirname('egg_base')
         self.egg_info = to_filename(self.egg_name) + '.egg-info'


### PR DESCRIPTION
According to https://docs.python.org/3/distutils/setupscript.html#listing-whole-packages, the root package can be set through `package_dir` by two ways:
1. `'': <root-path>`
2. `'<root-pkg>': <the-dirpath-of-its-init-file>`

However, the case is it only get changed if the key `''` in `package_dir`. Otherwise, it just use a default value: the distribution root (`os.cwd()`) .

This make errors for pkg without a standard source directory layout. 
E.g. when a pkg installed on develop mode, and with `package_dir` set not with a key `:`. Then the installed pkg wouldn't find itself with right root path.