### PR TITLE
fix typo: above -> below

### DIFF
--- a/docs/userguide/distribution.rst
+++ b/docs/userguide/distribution.rst
@@ -25,7 +25,7 @@ the command line ahead of the ``sdist`` or ``bdist`` commands that you want
 to generate a daily build or snapshot for.  See the section below on the
 :ref:`egg_info <egg_info>` command for more details.
 
-(Also, before you release your project, be sure to see the section below on
+(Also, before you release your project, be sure to see the section on
 :ref:`Specifying Your Project's Version` for more information about how pre- and
 post-release tags affect how version numbers are interpreted.  This is
 important in order to make sure that dependency processing tools will know

--- a/docs/userguide/distribution.rst
+++ b/docs/userguide/distribution.rst
@@ -25,7 +25,7 @@ the command line ahead of the ``sdist`` or ``bdist`` commands that you want
 to generate a daily build or snapshot for.  See the section below on the
 :ref:`egg_info <egg_info>` command for more details.
 
-(Also, before you release your project, be sure to see the section above on
+(Also, before you release your project, be sure to see the section below on
 :ref:`Specifying Your Project's Version` for more information about how pre- and
 post-release tags affect how version numbers are interpreted.  This is
 important in order to make sure that dependency processing tools will know


### PR DESCRIPTION
## Summary of changes

"Above" here refers to a section further down the page.

I guess the sections may have been moved around at some point? 
That, or someone wrote it upside down, anyway this fixes the direction for most right-side-up readers :)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
