### PR TITLE
[Docs] Add reference and short description for Paver

### DIFF
--- a/docs/development/developer-guide.rst
+++ b/docs/development/developer-guide.rst
@@ -123,5 +123,14 @@ setuptools from source. Eventually, this limitation may be lifted as
 PEP 517/518 reach ubiquitous adoption, but for now, Setuptools
 cannot declare dependencies other than through
 ``setuptools/_vendor/vendored.txt`` and
-``pkg_resources/_vendor/vendored.txt`` and refreshed by way of
-``paver update_vendored`` (pavement.py).
+``pkg_resources/_vendor/vendored.txt``.
+
+All the dependencies specified in these files are "vendorized" using Paver_, a
+simple Python-based project scripting and task running tool.
+
+To refresh the dependencies, you can run the following command (defined in
+``pavement.py``)::
+
+    $ paver update_vendored
+
+.. _Paver: https://pythonhosted.org/Paver/


### PR DESCRIPTION
### Motivation

In the developer-guide [Paver] is very briefly mentioned.
The purpose of this change is to expand a little bit more the text to provide context and help the potential contributors find their way.

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

### Summary of changes

A URL reference and a short description for what is [Paver] were added to the developer-guide.

Closes #2834 


### Pull Request Checklist

- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`]
  _(See [documentation][PR docs] for details)_

Sorry for deviating a little bit of the procedure in the [PR docs]. These are the reasons behind it:

- Since it is a doc-only change, it is difficult to add tests...
- I felt like adding a news fragment was unnecessary (it is just a small change in the docs to clarify a particular aspect, and does not change the way setuptools work). But I could add one if the maintainers prefer...

Please let me know if I could improve this PR or do things differently.


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request

[Paver]: https://pythonhosted.org/Paver/
