### PR TITLE
[Docs] Remove data_files from declarative config example

### DIFF
--- a/changelog.d/2932.doc.1.rst
+++ b/changelog.d/2932.doc.1.rst
@@ -1,0 +1,2 @@
+Removed the deprecated ``data_files`` option from the example in the
+declarative configuration docs -- by :user:`abravalheri`

--- a/changelog.d/2932.doc.2.rst
+++ b/changelog.d/2932.doc.2.rst
@@ -1,0 +1,3 @@
+Change type of ``data_files`` option from ``dict`` to ``section`` in
+declarative configuration docs (to match previous example) -- by
+:user:`abravalheri`

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -63,13 +63,6 @@ boilerplate code in some cases.
         src.subpackage1
         src.subpackage2
 
-    [options.data_files]
-    /etc/my_package =
-        site.d/00_default.conf
-        host.d/00_default.conf
-    data = data/img/logo.png, data/svg/icon.svg
-    fonts = data/fonts/*.ttf, data/fonts/*.otf
-
 Metadata and options are set in the config sections of the same name.
 
 * Keys are the same as the keyword arguments one provides to the ``setup()``
@@ -222,7 +215,7 @@ package_data             section                                              [#
 exclude_package_data     section
 namespace_packages       list-comma
 py_modules               list-comma                            34.4.0
-data_files               dict                                 40.6.0
+data_files               section                              40.6.0          [#opt-4]_
 =======================  ===================================  =============== =========
 
 **Notes**:
@@ -249,6 +242,9 @@ data_files               dict                                 40.6.0
    ``where``, ``include``, and ``exclude``.
 
    The ``find_namespace:`` directive is supported since Python >=3.3.
+
+.. [#opt-4] ``data_files`` is deprecated and should be avoided.
+   Please check :doc:`/userguide/datafiles` for more information.
 
 
 Compatibility with other tools


### PR DESCRIPTION
### Motivation

According to the following references:

- https://setuptools.pypa.io/en/latest/references/keywords.html
- https://packaging.python.org/guides/distributing-packages-using-setuptools/#package-data

the usage of ``data_files`` is deprecated.

Therefore we should avoid having it in the main configuration example for declarative config to avoid causing confusion among users.

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Removed ``data_files`` from example
- Change the type of the ``data_files`` option from ``dict`` to ``section`` (to match previous example - by looking at the [config module]( https://github.com/pypa/setuptools/blob/4bce6d5a30accecc848d8e7f0dabd212bfea9475/setuptools/config.py#L743) that also seem to be the case).
- Added a note about deprecation and a link to the data files support docs.

Closes #2832 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request