### PR TITLE
Duplicate all of setuptools' entry points to simplify bootstrapping

### DIFF
--- a/bootstrap.egg-info/entry_points.txt
+++ b/bootstrap.egg-info/entry_points.txt
@@ -1,14 +1,60 @@
+# Keep this in sync with setup.cfg.
+
 [distutils.commands]
+alias = setuptools.command.alias:alias
+bdist_egg = setuptools.command.bdist_egg:bdist_egg
+bdist_rpm = setuptools.command.bdist_rpm:bdist_rpm
+build_clib = setuptools.command.build_clib:build_clib
+build_ext = setuptools.command.build_ext:build_ext
+build_py = setuptools.command.build_py:build_py
+develop = setuptools.command.develop:develop
+dist_info = setuptools.command.dist_info:dist_info
+easy_install = setuptools.command.easy_install:easy_install
 egg_info = setuptools.command.egg_info:egg_info
+install = setuptools.command.install:install
+install_egg_info = setuptools.command.install_egg_info:install_egg_info
+install_lib = setuptools.command.install_lib:install_lib
+install_scripts = setuptools.command.install_scripts:install_scripts
+rotate = setuptools.command.rotate:rotate
+saveopts = setuptools.command.saveopts:saveopts
+sdist = setuptools.command.sdist:sdist
+setopt = setuptools.command.setopt:setopt
+test = setuptools.command.test:test
+upload_docs = setuptools.command.upload_docs:upload_docs
+
+# From wheel.
+bdist_wheel = wheel.bdist_wheel:bdist_wheel
+
+[setuptools.finalize_distribution_options]
+parent_finalize = setuptools.dist:_Distribution.finalize_options
+keywords = setuptools.dist:Distribution._finalize_setup_keywords
 
 [distutils.setup_keywords]
-include_package_data = setuptools.dist:assert_bool
-install_requires = setuptools.dist:check_requirements
+eager_resources = setuptools.dist:assert_string_list
+namespace_packages = setuptools.dist:check_nsp
 extras_require = setuptools.dist:check_extras
+install_requires = setuptools.dist:check_requirements
+tests_require = setuptools.dist:check_requirements
+setup_requires = setuptools.dist:check_requirements
+python_requires = setuptools.dist:check_specifier
 entry_points = setuptools.dist:check_entry_points
+test_suite = setuptools.dist:check_test_suite
+zip_safe = setuptools.dist:assert_bool
+package_data = setuptools.dist:check_package_data
+exclude_package_data = setuptools.dist:check_package_data
+include_package_data = setuptools.dist:assert_bool
+packages = setuptools.dist:check_packages
+dependency_links = setuptools.dist:assert_string_list
+test_loader = setuptools.dist:check_importable
+test_runner = setuptools.dist:check_importable
+use_2to3 = setuptools.dist:invalid_unless_false
 
 [egg_info.writers]
 PKG-INFO = setuptools.command.egg_info:write_pkg_info
-dependency_links.txt = setuptools.command.egg_info:overwrite_arg
-entry_points.txt = setuptools.command.egg_info:write_entries
 requires.txt = setuptools.command.egg_info:write_requirements
+entry_points.txt = setuptools.command.egg_info:write_entries
+eager_resources.txt = setuptools.command.egg_info:overwrite_arg
+namespace_packages.txt = setuptools.command.egg_info:overwrite_arg
+top_level.txt = setuptools.command.egg_info:write_toplevel_names
+depends.txt = setuptools.command.egg_info:warn_depends_obsolete
+dependency_links.txt = setuptools.command.egg_info:overwrite_arg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "wheel",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta:_build_self"
 backend-path = ["."]
 
 [tool.black]

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -279,3 +279,6 @@ build_sdist = _BACKEND.build_sdist
 
 # The legacy backend
 __legacy__ = _BuildMetaLegacyBackend()
+
+# The backend used to build setuptools itself from path.
+_build_self = __legacy__


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Also adds `bdist_wheel`.

This is to obviate the intermediate `egg_info` step in both setuptools and wheel.

Closes #2828.<!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
