### PR TITLE
Docs: Fix typo in History

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,9 +8,9 @@ Changes
 
 Documentation changes
 ^^^^^^^^^^^^^^^^^^^^^
-* #2932: Removed the deprecated ``data_files`` option from the example in the
+* #2832: Removed the deprecated ``data_files`` option from the example in the
   declarative configuration docs -- by :user:`abravalheri`
-* #2932: Change type of ``data_files`` option from ``dict`` to ``section`` in
+* #2832: Change type of ``data_files`` option from ``dict`` to ``section`` in
   declarative configuration docs (to match previous example) -- by
   :user:`abravalheri`
 


### PR DESCRIPTION

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix a typo in the History changelog.

https://setuptools.pypa.io/en/latest/history.html#v58-4-0

Should be https://github.com/pypa/setuptools/issues/2832 not https://github.com/pypa/setuptools/issues/2932. 

<!-- Summary goes here -->



### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
