### PR TITLE
Fix wrong issue number in CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ v58.5.1
 
 Misc
 ^^^^
-* #2486: Move PkgResourcesDeprecationWarning above implicitly-called function so that it's in the namespace when version warnings are generated in an environment that contains them.
+* #2846: Move PkgResourcesDeprecationWarning above implicitly-called function so that it's in the namespace when version warnings are generated in an environment that contains them.
 
 
 v58.5.0


### PR DESCRIPTION
## Summary of changes

Fix a typo in `CHANGES.rst`.

The line should have linked #2846, but it linked #2486 (middle two digits transposed) instead.