### PR TITLE
Deprecate support for commands inheriting from distutils

### DIFF
--- a/changelog.d/2856.deprecation.rst
+++ b/changelog.d/2856.deprecation.rst
@@ -1,0 +1,2 @@
+Support for custom commands that inherit directly from ``distutils`` is
+**deprecated**. Users should extend classes provided by setuptools instead.

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -621,10 +621,11 @@ class manifest_maker(sdist):
         if hasattr(build_py, 'get_data_files_without_manifest'):
             return build_py.get_data_files_without_manifest()
 
-        log.warn(
+        warnings.warn(
             "Custom 'build_py' does not implement "
             "'get_data_files_without_manifest'.\nPlease extend command classes"
-            " from setuptools instead of distutils."
+            " from setuptools instead of distutils.",
+            SetuptoolsDeprecationWarning
         )
         return build_py.get_data_files()
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This PR replaces the log messages introduced in #2849 about using custom commands that inherit directly from distutils classes, with an actual deprecation warning.

The main advantage of this approach is that warnings can be filtered.

Including this deprecation in the changelog is also positive.

Closes #2856

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
