### PR TITLE
setuptools/_distutils/ccompiler.py (CCompiler.has_function): Do not f…

### DIFF
--- a/setuptools/_distutils/ccompiler.py
+++ b/setuptools/_distutils/ccompiler.py
@@ -802,7 +802,10 @@ int main (int argc, char **argv) {
         except (LinkError, TypeError):
             return False
         else:
-            os.remove("a.out")
+            output_dir = self.output_dir
+            if output_dir is None:
+                output_dir = ''
+            os.remove(os.path.join(output_dir, "a.out"))
         finally:
             for fn in objects:
                 os.remove(fn)


### PR DESCRIPTION
…ail if self.outputdir is set

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes https://github.com/pypa/distutils/issues/64  <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
