### PR TITLE
Add integration tests focusing on installing sdists via pip

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
@@ -67,7 +67,7 @@ jobs:
         - stdlib
         - local
     needs: test
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     # To avoid long times and high resource usage, we assume that:
     # 1. The setuptools APIs used by packages don't vary too much with OS or
     #    Python implementation

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,11 @@ jobs:
           C:\\tools\\cygwin\\bin\\bash -l -x -c 'cd $(cygpath -u "$GITHUB_WORKSPACE") && tox -- --cov-report xml'
 
   integration-test:
+    strategy:
+      matrix:
+        distutils:
+        - stdlib
+        - local
     needs: test
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     # To avoid long times and high resource usage, we assume that:
@@ -71,6 +76,8 @@ jobs:
     #    "integration")
     # With that in mind, the integration tests can run for a single setup
     runs-on: ubuntu-latest
+    env:
+      SETUPTOOLS_USE_DISTUTILS: ${{ matrix.distutils }}
     steps:
       - uses: actions/checkout@v2
       - name: Install OS-level dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,8 +59,36 @@ jobs:
         run: |
           C:\\tools\\cygwin\\bin\\bash -l -x -c 'cd $(cygpath -u "$GITHUB_WORKSPACE") && tox -- --cov-report xml'
 
-  release:
+  integration-test:
     needs: test
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    # To avoid long times and high resource usage, we assume that:
+    # 1. The setuptools APIs used by packages don't vary too much with OS or
+    #    Python implementation
+    # 2. Any circumstance for which the previous assumption is not valid is
+    #    already tested via unit tests (or other tests not classified here as
+    #    "integration")
+    # With that in mind, the integration tests can run for a single setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install OS-level dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential gfortran libopenblas-dev
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          # Use a release that is not very new but still have a long life:
+          python-version: "3.8"
+      - name: Install tox
+        run: |
+          python -m pip install tox
+      - name: Run integration tests
+        run: tox -e integration
+
+  release:
+    needs: [test, integration-test]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 

--- a/changelog.d/2862.misc.rst
+++ b/changelog.d/2862.misc.rst
@@ -1,0 +1,2 @@
+Added integration tests that focus on building and installing some packages in
+the Python ecosystem via ``pip`` -- by :user:`abravalheri`

--- a/conftest.py
+++ b/conftest.py
@@ -20,10 +20,6 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "integration: indicate integration tests")
 
-    if config.option.integration:
-        # Assume unit tests and flake already run
-        config.option.flake8 = False
-
 
 collect_ignore = [
     'tests/manual_test.py',

--- a/conftest.py
+++ b/conftest.py
@@ -18,7 +18,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    config.addinivalue_line("markers", "integration: indicate integration tests")
+    config.addinivalue_line("markers", "integration: integration tests")
 
 
 collect_ignore = [

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import sys
 
+import pytest
+
 
 pytest_plugins = 'setuptools.tests.fixtures'
 
@@ -9,6 +11,18 @@ def pytest_addoption(parser):
         "--package_name", action="append", default=[],
         help="list of package_name to pass to test functions",
     )
+    parser.addoption(
+        "--integration", action="store_true", default=False,
+        help="run integration tests (only)"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "integration: indicate integration tests")
+
+    if config.option.integration:
+        # Assume unit tests and flake already run
+        config.option.flake8 = False
 
 
 collect_ignore = [
@@ -27,3 +41,13 @@ collect_ignore = [
 if sys.version_info < (3, 6):
     collect_ignore.append('docs/conf.py')  # uses f-strings
     collect_ignore.append('pavement.py')
+
+
+@pytest.fixture(autouse=True)
+def _skip_integration(request):
+    running_integration_tests = request.config.getoption("--integration")
+    is_integration_test = request.node.get_closest_marker("integration")
+    if running_integration_tests and not is_integration_test:
+        pytest.skip("running integration tests only")
+    if not running_integration_tests and is_integration_test:
+        pytest.skip("skipping integration tests")

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ testing-integration:
 	pytest
 	pytest-xdist
 	pytest-enabler
+	virtualenv
 	tomli
 	wheel
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ testing =
 	sphinx
 	jaraco.path>=3.2.0
 
-testing-integration:
+testing-integration =
 	pytest
 	pytest-xdist
 	pytest-enabler

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,8 @@ testing =
 	sphinx
 	jaraco.path>=3.2.0
 
+	tomli  # used in integration test
+
 docs =
 	# upstream
 	sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,13 @@ testing =
 	sphinx
 	jaraco.path>=3.2.0
 
-	tomli  # used in integration test
+testing-integration:
+	pytest
+	pytest-xdist
+	pytest-enabler
+	tomli
+	wheel
+
 
 docs =
 	# upstream

--- a/setuptools/tests/integration/helpers.py
+++ b/setuptools/tests/integration/helpers.py
@@ -1,0 +1,61 @@
+"""Reusable functions and classes for different types of integration tests.
+
+For example ``Archive`` can be used to check the contents of distribution built
+with setuptools, and ``run`` will always try to be as verbose as possible to
+facilitate debugging.
+"""
+import os
+import subprocess
+import tarfile
+from zipfile import ZipFile
+
+
+def run(cmd, env=None):
+    r = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        env={**os.environ, **(env or {})}
+        # ^-- allow overwriting instead of discarding the current env
+    )
+
+    out = r.stdout + "\n" + r.stderr
+    # pytest omits stdout/err by default, if the test fails they help debugging
+    print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    print(f"Command: {cmd}\nreturn code: {r.returncode}\n\n{out}")
+
+    if r.returncode == 0:
+        return out
+    raise subprocess.CalledProcessError(r.returncode, cmd, r.stdout, r.stderr)
+
+
+class Archive:
+    """Compatibility layer for ZipFile/Info and TarFile/Info"""
+    def __init__(self, filename):
+        self._filename = filename
+        if filename.endswith("tar.gz"):
+            self._obj = tarfile.open(filename, "r:gz")
+        elif filename.endswith("zip"):
+            self._obj = ZipFile(filename)
+        else:
+            raise ValueError(f"{filename} doesn't seem to be a zip or tar.gz")
+
+    def __iter__(self):
+        if hasattr(self._obj, "infolist"):
+            return iter(self._obj.infolist())
+        return iter(self._obj)
+
+    def get_name(self, zip_or_tar_info):
+        if hasattr(zip_or_tar_info, "filename"):
+            return zip_or_tar_info.filename
+        return zip_or_tar_info.name
+
+    def get_content(self, zip_or_tar_info):
+        if hasattr(self._obj, "extractfile"):
+            content = self._obj.extractfile(zip_or_tar_info)
+            if content is None:
+                msg = f"Invalid {zip_or_tar_info.name} in {self._filename}"
+                raise ValueError(msg)
+            return str(content.read(), "utf-8")
+        return str(self._obj.read(zip_or_tar_info), "utf-8")

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -24,7 +24,6 @@ from urllib.request import urlopen
 from zipfile import ZipFile
 
 import pytest
-import tomli as toml
 from packaging.requirements import Requirement
 
 
@@ -223,6 +222,10 @@ def build_deps(package, sdist_file):
     We need to "manually" install them, since pip will not install build
     deps with `--no-build-isolation`.
     """
+    import tomli as toml
+    # delay importing, since pytest discovery phase may hit this file from a
+    # testenv without tomli
+
     archive = Archive(sdist_file)
     pyproject = _read_pyproject(archive)
 

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -12,6 +12,7 @@ their build process may require changes in the tests).
 """
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -22,9 +23,9 @@ from urllib.request import urlopen
 from zipfile import ZipFile
 
 import pytest
-import setuptools
 from packaging.requirements import Requirement
 
+import setuptools
 
 pytestmark = pytest.mark.integration
 
@@ -89,7 +90,8 @@ SDIST_OPTIONS = (
 @pytest.fixture
 def venv_python(tmp_path):
     run_command([*VIRTUALENV, str(tmp_path / ".venv")])
-    return str(next(tmp_path.glob(".venv/*/python")))
+    possible_path = (str(p.parent) for p in tmp_path.glob(".venv/*/python*"))
+    return shutil.which("python", path=os.pathsep.join(possible_path))
 
 
 @pytest.fixture(autouse=True)
@@ -221,6 +223,7 @@ def build_deps(package, sdist_file):
     deps with `--no-build-isolation`.
     """
     import tomli as toml
+
     # delay importing, since pytest discovery phase may hit this file from a
     # testenv without tomli
 

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -1,0 +1,272 @@
+"""Integration tests for setuptools that focus on building packages via pip.
+
+The idea behind these tests is not to exhaustively check all the possible
+combinations of packages, operating systems, supporting libraries, etc, but
+rather check a limited number of popular packages and how they interact with
+the exposed public API. This way if any change in API is introduced, we hope to
+identify backward compatibility problems before publishing a release.
+
+The number of tested packages is purposefully kept small, to minimise duration
+and the associated maintenance cost (changes in the way these packages define
+their build process may require changes in the tests).
+"""
+import importlib
+import json
+import os
+import subprocess
+import sys
+import tarfile
+from enum import Enum
+from glob import glob
+from hashlib import md5
+from itertools import chain
+from urllib.request import urlopen
+from zipfile import ZipFile
+
+import pytest
+import tomli as toml
+from packaging.requirements import Requirement
+
+
+pytestmark = pytest.mark.integration
+
+
+LATEST, = list(Enum("v", "LATEST"))
+"""Default version to be checked"""
+# There are positive and negative aspects of checking the latest version of the
+# packages.
+# The main positive aspect is that the latest version might have already
+# removed the use of APIs deprecated in previous releases of setuptools.
+
+
+# Packages to be tested:
+# (Please notice the test environment cannot support EVERY library required for
+# compiling binary extensions. In Ubuntu/Debian nomenclature, we only assume
+# that `build-essential`, `gfortran` and `libopenblas-dev` are installed,
+# due to their relevance to the numerical/scientific programming ecosystem)
+EXAMPLES = [
+    ("numpy", LATEST),  # custom distutils-based commands
+    ("pandas", LATEST),  # cython + custom build_ext
+    ("sphinx", LATEST),  # custom setup.py
+    ("pip", LATEST),  # just in case...
+    ("pytest", LATEST),  # uses setuptools_scm
+    ("mypy", LATEST),  # custom build_py + ext_modules
+
+    # --- Popular packages: https://hugovk.github.io/top-pypi-packages/ ---
+    ("botocore", LATEST),
+    ("kiwisolver", "1.3.2"),  # build_ext, version pinned due to setup_requires
+    ("brotli", LATEST),  # not in the list but used by urllib3
+]
+
+
+# Some packages have "optional" dependencies that modify their build behaviour
+# and are not listed in pyproject.toml, others still use `setup_requires`
+EXTRA_BUILD_DEPS = {
+    "sphinx": ("babel>=1.3",),
+    "kiwisolver": ("cppy>=1.1.0",)
+}
+
+
+# By default, pip will try to build packages in isolation (PEP 517), which
+# means it will download the previous stable version of setuptools.
+# `pip` flags can avoid that (the version of setuptools under test
+# should be the one to be used)
+PIP = (sys.executable, "-m", "pip")
+SDIST_OPTIONS = (
+    "--ignore-installed",
+    "--no-build-isolation",
+    # We don't need "--no-binary :all:" since we specify the path to the sdist.
+    # It also helps with performance, since dependencies can come from wheels.
+)
+# The downside of `--no-build-isolation` is that pip will not download build
+# dependencies. The test script will have to also handle that.
+
+
+@pytest.fixture(autouse=True)
+def _prepare(tmp_path, monkeypatch, request):
+    (tmp_path / "lib").mkdir(exist_ok=True)
+    download_path = os.getenv("DOWNLOAD_PATH", str(tmp_path))
+    os.makedirs(download_path, exist_ok=True)
+
+    # Environment vars used for building some of the packages
+    monkeypatch.setenv("USE_MYPYC", "1")
+
+    def _debug_info():
+        # Let's provide the maximum amount of information possible in the case
+        # it is necessary to debug the tests directly from the CI logs.
+        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+        print("Temporary directory:")
+        for entry in chain(tmp_path.glob("*"), tmp_path.glob("lib/*")):
+            print(entry)
+    request.addfinalizer(_debug_info)
+
+
+ALREADY_LOADED = ("pytest", "mypy")  # loaded by pytest/pytest-enabler
+
+
+@pytest.mark.parametrize('package, version', EXAMPLES)
+def test_install_sdist(package, version, tmp_path, monkeypatch):
+    lib = tmp_path / "lib"
+    sdist = retrieve_sdist(package, version, tmp_path)
+    deps = build_deps(package, sdist)
+    if deps:
+        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+        print("Dependencies:", deps)
+        pip_install(*deps, target=lib)
+
+    pip_install(*SDIST_OPTIONS, sdist, target=lib)
+
+    if package in ALREADY_LOADED:
+        # We cannot import packages already in use from a different location
+        assert (lib / package).exists()
+        return
+
+    # Make sure the package was installed correctly
+    with monkeypatch.context() as m:
+        m.syspath_prepend(str(lib))  # add installed packages to path
+        pkg = importlib.import_module(package)
+        if hasattr(pkg, '__version__'):
+            print(pkg.__version__)
+        for path in getattr(pkg, '__path__', []):
+            assert os.path.abspath(path).startswith(os.path.abspath(tmp_path))
+
+
+# ---- Helper Functions ----
+
+
+def pip_install(*args, target):
+    """Install packages in the ``target`` directory"""
+    cmd = [*PIP, 'install', '--target', str(target), *args]
+    env = {**os.environ, "PYTHONPATH": str(target)}
+    # ^-- use libs installed in the target for build, but keep
+    #     compiling/build-related env variables
+
+    try:
+        subprocess.run(
+            cmd,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            env=env
+        )
+    except subprocess.CalledProcessError as ex:
+        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+        print("Command", repr(ex.cmd), "failed with code", ex.returncode)
+        print(ex.stdout)
+        print(ex.stderr)
+        raise
+
+
+def retrieve_sdist(package, version, tmp_path):
+    """Either use cached sdist file or download it from PyPI"""
+    # `pip download` cannot be used due to
+    # https://github.com/pypa/pip/issues/1884
+    # https://discuss.python.org/t/pep-625-file-name-of-a-source-distribution/4686
+    # We have to find the correct distribution file and download it
+    download_path = os.getenv("DOWNLOAD_PATH", str(tmp_path))
+    dist = retrieve_pypi_sdist_metadata(package, version)
+
+    # Remove old files to prevent cache to grow indefinitely
+    for file in glob(os.path.join(download_path, f"{package}*")):
+        if dist["filename"] != file:
+            os.unlink(file)
+
+    dist_file = os.path.join(download_path, dist["filename"])
+    if not os.path.exists(dist_file):
+        download(dist["url"], dist_file, dist["md5_digest"])
+    return dist_file
+
+
+def retrieve_pypi_sdist_metadata(package, version):
+    # https://warehouse.pypa.io/api-reference/json.html
+    id_ = package if version is LATEST else f"{package}/{version}"
+    with urlopen(f"https://pypi.org/pypi/{id_}/json") as f:
+        metadata = json.load(f)
+
+    if metadata["info"]["yanked"]:
+        raise ValueError(f"Release for {package} {version} was yanked")
+
+    version = metadata["info"]["version"]
+    release = metadata["releases"][version]
+    dists = [d for d in release if d["packagetype"] == "sdist"]
+    if len(dists) == 0:
+        raise ValueError(f"No sdist found for {package} {version}")
+
+    for dist in dists:
+        if dist["filename"].endswith(".tar.gz"):
+            return dist
+
+    # Not all packages are publishing tar.gz, e.g. numpy==1.21.4
+    return dist
+
+
+def download(url, dest, md5_digest):
+    with urlopen(url) as f:
+        data = f.read()
+
+    assert md5(data).hexdigest() == md5_digest
+
+    with open(dest, "wb") as f:
+        f.write(data)
+
+    assert os.path.exists(dest)
+
+
+IN_TEST_VENV = ("setuptools", "wheel", "packaging")
+"""Don't re-install"""
+
+
+def build_deps(package, sdist_file):
+    """Find out what are the build dependencies for a package.
+
+    We need to "manually" install them, since pip will not install build
+    deps with `--no-build-isolation`.
+    """
+    archive = Archive(sdist_file)
+    pyproject = _read_pyproject(archive)
+
+    info = toml.loads(pyproject)
+    deps = info.get("build-system", {}).get("requires", [])
+    deps += EXTRA_BUILD_DEPS.get(package, [])
+    # Remove setuptools from requirements (and deduplicate)
+    requirements = {Requirement(d).name: d for d in deps}
+    return [v for k, v in requirements.items() if k not in IN_TEST_VENV]
+
+
+def _read_pyproject(archive):
+    for member in archive:
+        if os.path.basename(archive.get_name(member)) == "pyproject.toml":
+            return archive.get_content(member)
+    return ""
+
+
+class Archive:
+    """Compatibility layer for ZipFile/Info and TarFile/Info"""
+    def __init__(self, filename):
+        self._filename = filename
+        if filename.endswith("tar.gz"):
+            self._obj = tarfile.open(filename, "r:gz")
+        elif filename.endswith("zip"):
+            self._obj = ZipFile(filename)
+        else:
+            raise ValueError(f"{filename} doesn't seem to be a zip or tar.gz")
+
+    def __iter__(self):
+        if hasattr(self._obj, "infolist"):
+            return iter(self._obj.infolist())
+        return iter(self._obj)
+
+    def get_name(self, zip_or_tar_info):
+        if hasattr(zip_or_tar_info, "filename"):
+            return zip_or_tar_info.filename
+        return zip_or_tar_info.name
+
+    def get_content(self, zip_or_tar_info):
+        if hasattr(self._obj, "extractfile"):
+            content = self._obj.extractfile(zip_or_tar_info)
+            if content is None:
+                msg = f"Invalid {zip_or_tar_info.name} in {self._filename}"
+                raise ValueError(msg)
+            return str(content.read(), "utf-8")
+        return str(self._obj.read(zip_or_tar_info), "utf-8")

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,16 @@ passenv =
 	SETUPTOOLS_USE_DISTUTILS
 	windir  # required for test_pkg_resources
 
+[testenv:integration]
+deps = {[testenv]deps}
+extras = {[testenv]extras}
+passenv =
+	{[testenv]passenv}
+	DOWNLOAD_PATH
+commands =
+	pytest --integration {posargs:-vv --durations=10 --no-cov setuptools/tests/integration}
+	# use verbose mode by default to facilitate debugging from CI logs
+
 [testenv:docs]
 extras =
 	docs

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,8 @@ extras = testing-integration
 passenv =
 	{[testenv]passenv}
 	DOWNLOAD_PATH
+setenv =
+    PROJECT_ROOT = {toxinidir}
 commands =
 	pytest --integration {posargs:-vv --durations=10 setuptools/tests/integration}
 	# use verbose mode by default to facilitate debugging from CI logs

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ passenv =
 	{[testenv]passenv}
 	DOWNLOAD_PATH
 commands =
-	pytest --integration {posargs:-vv --durations=10 --no-cov setuptools/tests/integration}
+	pytest --integration {posargs:-vv --durations=10 -p no:cov -p no:flake8 setuptools/tests/integration}
 	# use verbose mode by default to facilitate debugging from CI logs
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -22,12 +22,12 @@ passenv =
 
 [testenv:integration]
 deps = {[testenv]deps}
-extras = {[testenv]extras}
+extras = testing-integration
 passenv =
 	{[testenv]passenv}
 	DOWNLOAD_PATH
 commands =
-	pytest --integration {posargs:-vv --durations=10 -p no:cov -p no:flake8 setuptools/tests/integration}
+	pytest --integration {posargs:-vv --durations=10 setuptools/tests/integration}
 	# use verbose mode by default to facilitate debugging from CI logs
 
 [testenv:docs]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Motivation

As shown in https://github.com/pypa/setuptools/issues/2849, sometimes it is tricky to identify when a change introduces backward compatibility problems, specially considering that a lot o packages still rely on `distutils`.

Integration tests able to identify when such rare errors scenarios happen are very useful.

## Summary of changes

This PR introduces one specific type of integration tests: installing sdists using `pip`

Although very specific, this class of tests works very well for setuptools, since it exercises the API exposed by users that want to not only include binary extensions, but also customise their compilation process.

The configurations for pytest, tox and Github Actions were changed in such a way that integration tests will only run before a release (not on regular merge or push).

The selection of Python packages being used for the test was only kept small, to minimise the "cost" of the test (in terms of time and resources). I tried to choose between popular packages that would cover most of the parts of setuptools API, however there is always room for improvement, and the list can be changed to better suit the needs of the project/community.

Closes #2862

### Evidence that the proposed changes work

Testing the tests is something always difficult. In order to provide evidence that the proposed test and tox/pytest/CI configuration changes work, I have created the following repository:

- [abravalheri/experiment-setuptools-integration-tests](https://github.com/abravalheri/experiment-setuptools-integration-tests)

This repository was created by taking the important parts from setuptools/this PR and organising them in a way that Github Actions would run as expected, as show in the [CI logs](https://github.com/abravalheri/experiment-setuptools-integration-tests/actions/runs/1435396291). More information is available on the README.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
