### PR TITLE
Document that pip works with editable `setup.cfg`

### DIFF
--- a/changelog.d/2871.doc.rst
+++ b/changelog.d/2871.doc.rst
@@ -1,0 +1,4 @@
+Added a note to the docs that it is possible to install
+``setup.py``-less projects in editable mode with :doc:`pip v21.1+
+<pip:index>`, only having ``setup.cfg`` and ``pyproject.toml`` in
+project root -- by :user:`webknjaz`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -171,3 +171,5 @@ towncrier_draft_working_directory = '..'
 towncrier_draft_include_empty = False
 
 extensions += ['jaraco.tidelift']
+
+intersphinx_mapping['pip'] = 'https://pip.pypa.io/en/latest', None

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -186,17 +186,17 @@ For more details, see :doc:`datafiles`
 
 Development mode
 ================
+
+.. tip::
+
+	When there is no ``setup.py`` script present, this is only
+	compatible with :pep:`517` since :ref:`pip v21.1 <pip:v21-1>`.
+
 ``setuptools`` allows you to install a package without copying any files
-to your interpreter directory (e.g. the ``site-packages`` directory). This
-allows you to modify your source code and have the changes take effect without
-you having to rebuild and reinstall. This is currently incompatible with
-PEP 517 and therefore it requires a ``setup.py`` script with the following
-content::
-
-    import setuptools
-    setuptools.setup()
-
-Then::
+to your interpreter directory (e.g. the ``site-packages`` directory).
+This allows you to modify your source code and have the changes take
+effect without you having to rebuild and reinstall.
+Here's how to do it::
 
     pip install --editable .
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -189,8 +189,9 @@ Development mode
 
 .. tip::
 
-	When there is no ``setup.py`` script present, this is only
-	compatible with :pep:`517` since :ref:`pip v21.1 <pip:v21-1>`.
+	Prior to :ref:`pip v21.1 <pip:v21-1>`, a ``setup.py`` script was
+	required to be compatible with development mode. With late
+	versions of pip, any project may be installed in this mode.
 
 ``setuptools`` allows you to install a package without copying any files
 to your interpreter directory (e.g. the ``site-packages`` directory).


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

$sbj. This was implemented in https://github.com/pypa/pip/pull/9547, in March.

Preview of the docs section that got updated: https://setuptools--2871.org.readthedocs.build/en/2871/userguide/quickstart.html#development-mode.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
