### PR TITLE
Implement PEP 660 hooks in setuptools/build_meta.py

### DIFF
--- a/changelog.d/2872.change.rst
+++ b/changelog.d/2872.change.rst
@@ -1,0 +1,1 @@
+Implemented PEP 660 editable backend hooks.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -49,7 +49,7 @@ import setuptools.command.egg_info
 import distutils
 
 import pkg_resources
-from pkg_resources import parse_requirements
+from pkg_resources import parse_requirements, safe_name, safe_version
 
 __all__ = ['get_requires_for_build_sdist',
            'get_requires_for_build_wheel',
@@ -313,7 +313,11 @@ class _BuildMetaBackend(object):
         dist = pkg_resources.DistInfoDistribution.from_location(
             location, dist_info, metadata=metadata
         )
-        wheel_name = f'{dist.project_name}-{dist.version}-ed.py3-none-any.whl'
+        # Seems like the distribution name and version attributes aren't always
+        # 100% normalized ...
+        dist_name = safe_name(dist.project_name).replace("-", "_")
+        version = safe_version(dist.version).replace("-", "_")
+        wheel_name = f'{dist_name}-{version}-ed.py3-none-any.whl'
         wheel_path = os.path.join(wheel_directory, wheel_name)
         with zipfile.ZipFile(wheel_path, 'w') as archive:
             archive.writestr(f'{dist.project_name}.pth', location)


### PR DESCRIPTION
## Summary of changes

Implements the hooks required to support PEP 660 -- Editable installs for pyproject.toml based builds (wheel based). Resolves #2816.

> dholth's work which I referenced extensively: https://github.com/dholth/setuptools_pep660

I chose the root .pth editable strategy as it "just works" for implicit namespace packages and also looked easier haha. While most of the code is (hopefully) rather straightforward, it is quite verbose as unforunately setuptools doesn't have much in terms of wheel utilties.

There's also a somewhat sketchy hack used to acquire the distribution location so I can put the right path to ${dist-name}.pth in the wheel. Since the PEP 517 is isolated from the command framework, it's pretty hard querying information from the various setup.py commands ran. The shim added captures the egg_info instance when setup.py dist_info runs so the build_editable hook can query the location (i.e. egg_base).

One limitation of this commit is that the build_editable hook completely ignores the metadata_directory parameter and violates the guarantee the hook shall produce a (editable) wheel with identical metadata. Given that it seems no major backends is [currently following through with this promise](https://discuss.python.org/t/nobody-is-following-the-metadata-directory-promise-in-pep-517/6964) this is hopefully fine for now?

### Pull Request Checklist
- [ ] Changes have tests (nope, still gotta figure this out)
- [ ] Test out more non-standard packaging configurations
- [ ] Test out packages with extensions
- [ ] Create wheel_directory if doesn't exist already when build_editable is called
- [x] News fragment added in `changelog.d/`.

---

FWIW this is my first contribution to setuptools so I'm a little nervous I've messed everything up. Hopefully this isn't too bad :)