### PR TITLE
Reduce scope of setup_requires deprecation

### DIFF
--- a/changelog.d/2877.change.rst
+++ b/changelog.d/2877.change.rst
@@ -1,0 +1,1 @@
+Back out deprecation of setup_requires and replace instead by a deprecation of setuptools.installer and fetch_build_egg. Now setup_requires is still supported when installed as part of a PEP 517 build, but is deprecated when an unsatisfied requirement is encountered.

--- a/pytest.ini
+++ b/pytest.ini
@@ -26,7 +26,7 @@ filterwarnings=
 	ignore:The Windows bytes API has been deprecated:DeprecationWarning
 
 	# https://github.com/pypa/setuptools/issues/2823
-	ignore:setup_requires is deprecated.
+	ignore:setuptools.installer is deprecated.
 
 	# https://github.com/pypa/setuptools/issues/917
 	ignore:setup.py install is deprecated.

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -4,7 +4,6 @@ from fnmatch import fnmatchcase
 import functools
 import os
 import re
-import warnings
 
 import _distutils_hack.override  # noqa: F401
 
@@ -145,11 +144,6 @@ def _install_setup_requires(attrs):
     # Honor setup.cfg's options.
     dist.parse_config_files(ignore_option_errors=True)
     if dist.setup_requires:
-        warnings.warn(
-            "setup_requires is deprecated. Supply build "
-            "dependencies using PEP 517 pyproject.toml build-requires.",
-            SetuptoolsDeprecationWarning,
-        )
         dist.fetch_build_eggs(dist.setup_requires)
 
 

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -3,11 +3,13 @@ import os
 import subprocess
 import sys
 import tempfile
+import warnings
 from distutils import log
 from distutils.errors import DistutilsError
 
 import pkg_resources
 from setuptools.wheel import Wheel
+from ._deprecation_warning import SetuptoolsDeprecationWarning
 
 
 def _fixup_find_links(find_links):
@@ -22,6 +24,11 @@ def fetch_build_egg(dist, req):  # noqa: C901  # is too complex (16)  # FIXME
     """Fetch an egg needed for building.
 
     Use pip/wheel to fetch/build a wheel."""
+    warnings.warn(
+        "setuptools.installer is deprecated. Requirements should "
+        "be satisfied by a PEP 517 installer.",
+        SetuptoolsDeprecationWarning,
+    )
     # Warn if wheel is not available
     try:
         pkg_resources.get_distribution('wheel')


### PR DESCRIPTION
Only deprecate the installation of these requirements, but still honor setup_requires in PEP 517 installers. Fixes #2877.
