### PR TITLE
Fix 2880, 2881 - Avoid depdencies with URLs in setup.cfg

### DIFF
--- a/changelog.d/2880.misc.rst
+++ b/changelog.d/2880.misc.rst
@@ -1,0 +1,3 @@
+Removed URL requirement for ``pytest-virtualenv`` in ``setup.cfg``.
+PyPI rejects packages with dependencies external to itself.
+Instead the test dependency was overwritten via ``tox.ini``

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ testing =
 	mock
 	flake8-2020
 	virtualenv>=13.0.0
-	pytest-virtualenv @ git+https://github.com/jaraco/pytest-plugins@distutils-deprecated#subdirectory=pytest-virtualenv
+	pytest-virtualenv>=1.2.7  # TODO: Update once man-group/pytest-plugins#188 is solved
 	wheel
 	paver
 	pip>=19.1 # For proper file:// URLs support.

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,8 @@ deps =
 	# workaround for sphinx-doc/sphinx#9562
 	# TODO: remove after Sphinx>4.1.2 is available.
 	sphinx@git+https://github.com/sphinx-doc/sphinx; python_version>="3.10"
+	# TODO: remove after man-group/pytest-plugins#188 is solved
+	pytest-virtualenv @ git+https://github.com/jaraco/pytest-plugins@distutils-deprecated#subdirectory=pytest-virtualenv
 commands =
 	pytest {posargs}
 usedevelop = True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Motivation

It seems that #2865 might have accidentally introduced a kind of dependency that is not accepted by PyPi:

```diff
[options.extras_require]
testing =
        ...
-	pytest-virtualenv>=1.2.7
+	pytest-virtualenv @ git+https://github.com/jaraco/pytest-plugins@distutils-deprecated#subdirectory=pytest-virtualenv
```
in `setup.cfg`.
PyPI forbids uploading packages with dependencies outside of PyPI (via URLs specs).

## Summary of changes

- Leave the previous pytest-virtualenv version in setup.cfg
- Overwrite the version using `deps` in tox.ini

Closes #2880 
Closes #2881

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
