### PR TITLE
Add default values for the `packages` and `py_modules` options

### DIFF
--- a/changelog.d/2887.change.rst
+++ b/changelog.d/2887.change.rst
@@ -1,0 +1,8 @@
+Added default values for the ``py_modules`` and ``packages`` options.
+Setuptools will try to find the best values assuming that the package uses
+either the *src-layout* (a ``src`` directory containing all the packages),
+the *flat-layout* (a single directory with the same name as the distribution
+as the top-level package), or the *single-module* approach (a single Python
+file with the same name as the distribution).
+This behavior will be observed **only if both of options are not explicitly
+set**.

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,8 @@ testing =
 	sphinx
 	jaraco.path>=3.2.0
 
+	build
+
 docs =
 	# upstream
 	sphinx

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -555,8 +555,7 @@ class Distribution(_Distribution):
             for candidate in (package_name, namespace):
                 pkg_dir = os.path.join(root_dir, candidate)
                 if os.path.isdir(pkg_dir):
-                    _pkgs = _find_packages_within(candidate, pkg_dir)
-                    return _pkgs
+                    return _find_packages_within(candidate, pkg_dir)
 
         # ---- "src" layout: single folder with package name ----
         self.package_dir = self.package_dir or {}

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -455,14 +455,14 @@ def test_dist_default_packages(
     dist.set_option_defaults()
     assert not dist.py_modules
     assert not dist.py_modules
-    assert dist.packages == packages
+    assert set(dist.packages) == set(packages)
     # When `py_modules` is given, don't do anything
-    dist = Distribution({**attrs, "py_modules": ["explicity_py_module"]})
+    dist = Distribution({**attrs, "py_modules": ["explicit_py_module"]})
     dist.set_option_defaults()
     assert not dist.packages
-    assert not dist.py_modules == ["explicit_py_module"]
+    assert set(dist.py_modules) == {"explicit_py_module"}
     # When `packages` is given, don't do anything
-    dist = Distribution({**attrs, "packages": ["explicity_package"]})
+    dist = Distribution({**attrs, "packages": ["explicit_package"]})
     dist.set_option_defaults()
     assert not dist.py_modules
-    assert dist.packages == ["explicity_package"]
+    assert set(dist.packages) == {"explicit_package"}

--- a/setuptools/tests/test_option_defaults.py
+++ b/setuptools/tests/test_option_defaults.py
@@ -1,0 +1,167 @@
+import os
+import subprocess
+import sys
+import tarfile
+from configparser import ConfigParser
+from pathlib import Path
+from subprocess import CalledProcessError
+from zipfile import ZipFile
+
+import pytest
+
+from setuptools.command.sdist import sdist
+from setuptools.dist import Distribution
+
+from .contexts import quiet
+
+
+class TestDefaultPackagesAndPyModules:
+    """Make sure default values for ``packages`` and ``py_modules`` work
+    similarly to explicit configuration for the simple scenarios.
+    """
+
+    METADATA = {
+        "name": "example",
+        "version": "0.0.1",
+        "author": "Example Author"
+    }
+    OPTIONS = {
+        # Different options according to the circumstance being tested
+        "explicit-src": {
+            "package_dir": {"": "src"},
+            "packages": ["example"]
+        },
+        "explicit-flat": {
+            "packages": ["example"]
+        },
+        "explicit-single_module": {
+            "py_modules": ["example"]
+        },
+        "explicit-namespace": {
+            "packages": ["ns", "ns.example"]
+        },
+        "automatic-src": {},
+        "automatic-flat": {},
+        "automatic-single_module": {},
+        "automatic-namespace": {}
+    }
+    FILES = {
+        "src": ["src/example/__init__.py", "src/example/main.py"],
+        "flat": ["example/__init__.py", "example/main.py"],
+        "single_module": ["example.py"],
+        "namespace": ["ns/example/__init__.py"]
+    }
+
+    def _get_info(self, circumstance):
+        _, _, layout = circumstance.partition("-")
+        files = self.FILES[layout]
+        options = self.OPTIONS[circumstance]
+        metadata = self.METADATA
+        if layout == "namespace":
+            metadata = {**metadata, "name": "ns.example"}
+        return files, metadata, options
+
+    @pytest.mark.parametrize("circumstance", OPTIONS.keys())
+    def test_sdist_filelist(self, tmp_path, circumstance):
+        files, metadata, options = self._get_info(circumstance)
+        _populate_project_dir(tmp_path, files, metadata, options)
+
+        here = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            dist = Distribution({**metadata, **options, "src_root": tmp_path})
+            dist.script_name = 'setup.py'
+            dist.set_option_defaults()
+            cmd = sdist(dist)
+            cmd.ensure_finalized()
+            assert cmd.distribution.packages or cmd.distribution.py_modules
+
+            with quiet():
+                cmd.run()
+        finally:
+            os.chdir(here)
+
+        manifest = cmd.filelist.files
+        for file in files:
+            assert any(f.endswith(file) for f in manifest)
+
+    @pytest.mark.parametrize("circumstance", OPTIONS.keys())
+    def test_project(self, tmp_path, circumstance):
+        files, metadata, options = self._get_info(circumstance)
+        _populate_project_dir(tmp_path, files, metadata, options)
+
+        _run_build(tmp_path)
+
+        sdist_files = _get_sdist_members(next(tmp_path.glob("dist/*.tar.gz")))
+        print("~~~~~ sdist_members ~~~~~")
+        print('\n'.join(sdist_files))
+        assert sdist_files >= set(files)
+
+        wheel_files = _get_wheel_members(next(tmp_path.glob("dist/*.whl")))
+        print("~~~~~ wheel_members ~~~~~")
+        print('\n'.join(wheel_files))
+        assert wheel_files >= {f.replace("src/", "") for f in files}
+
+
+def _populate_project_dir(root, files, metadata, options):
+    (root / "setup.py").write_text("import setuptools\nsetuptools.setup()")
+    (root / "README.md").write_text("# Example Package")
+    (root / "LICENSE").write_text("Copyright (c) 2018")
+    _write_setupcfg(root, metadata, options)
+
+    for file in files:
+        path = root / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('"hello world"')
+
+
+def _write_setupcfg(root, metadata, options):
+    setupcfg = ConfigParser()
+    setupcfg.add_section("metadata")
+    setupcfg["metadata"].update(metadata)
+    setupcfg.add_section("options")
+    for key, value in options.items():
+        if isinstance(value, list):
+            setupcfg["options"][key] = ", ".join(value)
+        elif isinstance(value, dict):
+            str_value = "\n".join(f"\t{k} = {v}" for k, v in value.items())
+            setupcfg["options"][key] = "\n" + str_value
+        else:
+            setupcfg["options"][key] = str(value)
+    with open(root / "setup.cfg", "w") as f:
+        setupcfg.write(f)
+    assert setupcfg["metadata"]["name"]
+    print("~~~~~ setup.cfg ~~~~~")
+    print((root / "setup.cfg").read_text())
+
+
+def _get_sdist_members(sdist_path):
+    with tarfile.open(sdist_path, "r:gz") as tar:
+        files = [Path(f) for f in tar.getnames()]
+    relative_files = ("/".join(f.parts[1:]) for f in files)
+    # remove root folder
+    return {f for f in relative_files if f}
+
+
+def _get_wheel_members(wheel_path):
+    with ZipFile(wheel_path) as zipfile:
+        return set(zipfile.namelist())
+
+
+def _run_build(path):
+    cmd = [sys.executable, "-m", "build", "--no-isolation", str(path)]
+    r = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        env={**os.environ, 'DISTUTILS_DEBUG': '1'}
+    )
+    out = r.stdout + "\n" + r.stderr
+    print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    print("Command", repr(cmd), "returncode", r.returncode)
+    print(out)
+
+    if r.returncode != 0:
+        raise CalledProcessError(r.returncode, cmd, r.stdout, r.stderr)
+    return out

--- a/setuptools/tests/test_option_defaults.py
+++ b/setuptools/tests/test_option_defaults.py
@@ -81,7 +81,7 @@ class TestDefaultPackagesAndPyModules:
         finally:
             os.chdir(here)
 
-        manifest = cmd.filelist.files
+        manifest = [f.replace(os.sep, "/") for f in cmd.filelist.files]
         for file in files:
             assert any(f.endswith(file) for f in manifest)
 

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -6,6 +6,7 @@ import tempfile
 import unicodedata
 import contextlib
 import io
+from configparser import ConfigParser
 from unittest import mock
 
 import pytest
@@ -533,3 +534,100 @@ def test_default_revctrl():
     ep = pkg_resources.EntryPoint.parse(ep_def)
     res = ep.resolve()
     assert hasattr(res, '__iter__')
+
+
+class TestDefaultPackagesAndPyModules:
+    """Make sure default values for ``packages`` and ``py_modules`` work
+    similarly to explicit configuration for the simple scenarios.
+    """
+    @pytest.fixture(autouse=True)
+    def _chdir(self, tmp_path):
+        here = os.curdir
+        try:
+            os.chdir(tmp_path)
+            yield
+        finally:
+            os.chdir(here)
+
+    METADATA = {
+        "name": "example",
+        "version": "0.0.1",
+        "author": "Example Author"
+    }
+    OPTIONS = {
+        # Different options according to the circumstance being tested
+        "explicit-src": {
+            "package_dir": {"": "src"},
+            "packages": ["example"]
+        },
+        "explicit-flat": {
+            "packages": ["example"]
+        },
+        "explicit-single_module": {
+            "py_modules": ["example"]
+        },
+        "explicit-namespace": {
+            "packages": ["ns", "ns.example"]
+        },
+        "automatic-src": {},
+        "automatic-flat": {},
+        "automatic-single_module": {},
+        "automatic-namespace": {}
+    }
+    FILES = {
+        "src": ["src/example/__init__.py", "src/example/main.py"],
+        "flat": ["example/__init__.py", "example/main.py"],
+        "single_module": ["example.py"],
+        "namespace": ["ns/example/__init__.py"]
+    }
+
+    @pytest.mark.parametrize("circumstance", OPTIONS.keys())
+    def test_options(self, tmp_path, circumstance):
+        _, _, layout = circumstance.partition("-")
+        files = self.FILES[layout]
+        options = self.OPTIONS[circumstance]
+        metadata = self.METADATA
+        if layout == "namespace":
+            metadata = {**metadata, "name": "ns.example"}
+
+        self._populate_project_dir(tmp_path, files, metadata, options)
+
+        dist = Distribution({**metadata, **options, "src_root": tmp_path})
+        dist.script_name = 'setup.py'
+        dist.set_option_defaults()
+        cmd = sdist(dist)
+        cmd.ensure_finalized()
+        assert cmd.distribution.packages or cmd.distribution.py_modules
+
+        with quiet():
+            cmd.run()
+
+        manifest = cmd.filelist.files
+        for file in files:
+            assert any(f.endswith(file) for f in manifest)
+
+    def _populate_project_dir(self, root, files, metadata, options):
+        (root / "README.md").write_text("# Example Package")
+        (root / "LICENSE").write_text("Copyright (c) 2018")
+        self._write_setupcfg(root, metadata, options)
+
+        for file in files:
+            path = root / file
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+
+    def _write_setupcfg(self, root, metadata, options):
+        setupcfg = ConfigParser()
+        setupcfg.add_section("metadata")
+        setupcfg["metadata"].update(metadata)
+        setupcfg.add_section("options")
+        for key, value in options.items():
+            if isinstance(value, list):
+                setupcfg["options"][key] = ", ".join(value)
+            elif isinstance(value, dict):
+                str_value = "\n".join("\t{k} = {v}" for k, v in value.items())
+                setupcfg["options"][key] = "\n" + str_value
+            else:
+                setupcfg["options"][key] = str(value)
+        with open(root / "setup.cfg", "w") as f:
+            setupcfg.write(f)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Motivation

The need for explicitly specifying `packages` and `py_modules` (together with `package_dir`) is often [criticized as a pitfall of setuptools](https://blog.ionelmc.ro/2015/02/24/the-problem-with-packaging-in-python/).

This is also a common cause of confusion (sometimes even frustration) between new users.

Since the majority of the packages in the ecosystem use the "src-layout", "flat-layout" or a "single-module" package, these options can be safely guessed by inspecting the directory structure and comparing with the available metadata (the `name` of the distribution).

## Summary of changes

This PR adds a few methods to the `dist` class, with the purpose of comparing the existing files and directories to the distribution name and the package layout conventions in order to decide which are the best values that could be set to `py_modules` and `packages`.

Please note that this change is meant to be backward compatible, and no attempt to fill-in values for the options will be done if one of them is set.

Empty distributions are still possible, as long as the package author don't create files and directories that coincide with the 3 layouts previously mentioned.
I believe this is a fair assumption, since the chances of an author that purposefully wants to publish an empty package (e.g. metapackage) including a `src` folder or a script/folder with the same name as the distribution are negligible.

Closes #2887

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
