### PR TITLE
Correct behavior under LegacyVersion when deprecation warnings are enabled.

### DIFF
--- a/changelog.d/2885.misc.rst
+++ b/changelog.d/2885.misc.rst
@@ -1,0 +1,1 @@
+Fixed errors when encountering LegacyVersions.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2015,7 +2015,7 @@ def _by_version_descending(names):
 
     >>> names = 'bar', 'foo', 'Python-2.7.10.egg', 'Python-2.7.2.egg'
     >>> _by_version_descending(names)
-    ['Python-2.7.10.egg', 'Python-2.7.2.egg', 'foo', 'bar']
+    ['Python-2.7.10.egg', 'Python-2.7.2.egg', 'bar', 'foo']
     >>> names = 'Setuptools-1.2.3b1.egg', 'Setuptools-1.2.3.egg'
     >>> _by_version_descending(names)
     ['Setuptools-1.2.3.egg', 'Setuptools-1.2.3b1.egg']
@@ -2023,13 +2023,22 @@ def _by_version_descending(names):
     >>> _by_version_descending(names)
     ['Setuptools-1.2.3.post1.egg', 'Setuptools-1.2.3b1.egg']
     """
+    def try_parse(name):
+        """
+        Attempt to parse as a version or return a null version.
+        """
+        try:
+            return packaging.version.Version(name)
+        except Exception:
+            return packaging.version.Version('0')
+
     def _by_version(name):
         """
         Parse each component of the filename
         """
         name, ext = os.path.splitext(name)
         parts = itertools.chain(name.split('-'), [ext])
-        return [packaging.version.parse(part) for part in parts]
+        return [try_parse(part) for part in parts]
 
     return sorted(names, key=_by_version, reverse=True)
 

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -703,7 +703,7 @@ class TestParsing:
         )
 
     def test_local_version(self):
-        req, = parse_requirements('foo==1.0.org1')
+        req, = parse_requirements('foo==1.0+org1')
 
     def test_spaces_between_multiple_versions(self):
         req, = parse_requirements('foo>=1.0, <3')

--- a/pytest.ini
+++ b/pytest.ini
@@ -34,7 +34,6 @@ filterwarnings=
 
 	# https://github.com/pypa/setuptools/issues/2497
 	ignore:.* is an invalid version and will not be supported::pkg_resources
-	ignore:Creating a LegacyVersion has been deprecated
 
 	# https://github.com/pypa/setuptools/pull/2865#issuecomment-965700112
 	# ideally would apply to Python 3.10+ when

--- a/setuptools/config.py
+++ b/setuptools/config.py
@@ -13,7 +13,7 @@ from glob import iglob
 import contextlib
 
 from distutils.errors import DistutilsOptionError, DistutilsFileError
-from setuptools.extern.packaging.version import LegacyVersion, parse
+from setuptools.extern.packaging.version import Version, InvalidVersion
 from setuptools.extern.packaging.specifiers import SpecifierSet
 
 
@@ -585,7 +585,9 @@ class ConfigMetadataHandler(ConfigHandler):
             version = version.strip()
             # Be strict about versions loaded from file because it's easy to
             # accidentally include newlines and other unintended content
-            if isinstance(parse(version), LegacyVersion):
+            try:
+                Version(version)
+            except InvalidVersion:
                 tmpl = (
                     'Version loaded from {value} does not '
                     'comply with PEP 440: {version}'

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -21,7 +21,7 @@ import setuptools
 from pkg_resources import (
     CHECKOUT_DIST, Distribution, BINARY_DIST, normalize_path, SOURCE_DIST,
     Environment, find_distributions, safe_name, safe_version,
-    to_filename, Requirement, DEVELOP_DIST, EGG_DIST,
+    to_filename, Requirement, DEVELOP_DIST, EGG_DIST, parse_version,
 )
 from distutils import log
 from distutils.errors import DistutilsError
@@ -293,6 +293,14 @@ class PackageIndex(Environment):
         self.allows = re.compile('|'.join(map(translate, hosts))).match
         self.to_scan = []
         self.opener = urllib.request.urlopen
+
+    def add(self, dist):
+        # ignore invalid versions
+        try:
+            parse_version(dist.version)
+        except Exception:
+            return
+        return super().add(dist)
 
     # FIXME: 'PackageIndex.process_url' is too complex (14)
     def process_url(self, url, retrieve=False):  # noqa: C901


### PR DESCRIPTION
- Remove suppression of deprecation warning for LegacyVersion. Ref #2885.
- Fix sorting of filenames not to rely on LegacyVersion. Fixes #2885.
- Replace invalid local version with a valid form.
- Update config.ConfigMetadataHandler._parse_version not to rely on LegacyVersion.
- Suppress invalid versions when parsing in package_index. They will still be allowed for now as long as DeprecationWarnings aren't treated as errors.

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
