### PR TITLE
Towards no-config packaging: Automatic discovery of `packages`, `py_modules` and `name`

### DIFF
--- a/changelog.d/2887.change.1.rst
+++ b/changelog.d/2887.change.1.rst
@@ -7,13 +7,14 @@ the *flat-layout* (package directories directly under the project root),
 or the *single-module* approach (isolated Python files, directly under
 the project root).
 
-The automatic discovery will also respect layouts that are explicit configured
-using the ``package_dir`` option.
+The automatic discovery will also respect layouts that are explicitly
+configured using the ``package_dir`` option.
 
 For backward-compatibility, this behavior will be observed **only if both**
-``py_modules`` **and** ``packages`` **are not explicitly set**.
+``py_modules`` **and** ``packages`` **are not set**.
 
 If setuptools detects modules or packages that are not supposed to be in the
-distribution, please explicitly set ``py_modules`` and ``packages``.
+distribution, please manually set ``py_modules`` and ``packages`` in your
+``setup.cfg`` or ``setup.py`` file.
 If you are using a *flat-layout*, you can also consider switching to
 *src-layout*.

--- a/changelog.d/2887.change.1.rst
+++ b/changelog.d/2887.change.1.rst
@@ -10,8 +10,8 @@ the project root).
 The automatic discovery will also respect layouts that are explicit configured
 using the ``package_dir`` option.
 
-For backward-compatibility, this behavior will be observed **only if both
-``py_modules`` and ``packages`` are not explicitly set**.
+For backward-compatibility, this behavior will be observed **only if both**
+``py_modules`` **and** ``packages`` **are not explicitly set**.
 
 If setuptools detects modules or packages that are not supposed to be in the
 distribution, please explicitly set ``py_modules`` and ``packages``.

--- a/changelog.d/2887.change.1.rst
+++ b/changelog.d/2887.change.1.rst
@@ -1,0 +1,19 @@
+Added automatic discovery for ``py_modules`` and ``packages``
+-- by :user:`abravalheri`.
+
+Setuptools will try to find these values assuming that the package uses either
+the *src-layout* (a ``src`` directory containing all the packages or modules),
+the *flat-layout* (package directories directly under the project root),
+or the *single-module* approach (isolated Python files, directly under
+the project root).
+
+The automatic discovery will also respect layouts that are explicit configured
+using the ``package_dir`` option.
+
+For backward-compatibility, this behavior will be observed **only if both
+``py_modules`` and ``packages`` are not explicitly set**.
+
+If setuptools detects modules or packages that are not supposed to be in the
+distribution, please explicitly set ``py_modules`` and ``packages``.
+If you are using a *flat-layout*, you can also consider switching to
+*src-layout*.

--- a/changelog.d/2887.change.2.rst
+++ b/changelog.d/2887.change.2.rst
@@ -2,7 +2,7 @@ Added automatic configuration for the ``name`` metadata
 -- by :user:`abravalheri`.
 
 Setuptools will adopt the name of the top-level package (or module in the case
-of single-module distributions), **only when ``name`` is not explicitly
+of single-module distributions), **only when** ``name`` **is not explicitly
 provided**.
 
 Please note that it is not possible to automatically derive a single name when

--- a/changelog.d/2887.change.2.rst
+++ b/changelog.d/2887.change.2.rst
@@ -1,0 +1,9 @@
+Added automatic configuration for the ``name`` metadata
+-- by :user:`abravalheri`.
+
+Setuptools will adopt the name of the top-level package (or module in the case
+of single-module distributions), **only when ``name`` is not explicitly
+provided**.
+
+Please note that it is not possible to automatically derive a single name when
+the distribution consists of multiple top-level packages or modules.

--- a/changelog.d/2894.breaking.rst
+++ b/changelog.d/2894.breaking.rst
@@ -1,0 +1,4 @@
+If you purposefully want to create an *"empty distribution"*, please be aware
+that some Python files (or general folders) might be automatically detected and
+included. You can check details about the automatic discovery behaviour (and
+how to configure a different one) in :doc:`/userguide/package_discovery`.

--- a/changelog.d/2894.breaking.rst
+++ b/changelog.d/2894.breaking.rst
@@ -1,4 +1,10 @@
 If you purposefully want to create an *"empty distribution"*, please be aware
 that some Python files (or general folders) might be automatically detected and
-included. You can check details about the automatic discovery behaviour (and
+included.
+
+Projects that currently don't specify both ``packages`` and ``py_modules`` in their
+configuration and have extra Python files and folders (not meant for distribution),
+might see these files being included in the wheel archive.
+
+You can check details about the automatic discovery behaviour (and
 how to configure a different one) in :doc:`/userguide/package_discovery`.

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -107,7 +107,7 @@ config>` and :doc:`py_modules </references/keywords>` configuration.
 
 To avoid confusion, file and folder names that are used by popular tools (or
 that correspond to well-known conventions, such as distributing documentation
-alongside the project code) are automatically filtered in the case of
+alongside the project code) are automatically filtered out in the case of
 *flat-layouts*:
 
 .. autoattribute:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -115,7 +115,50 @@ alongside the project code) are automatically filtered in the case of
 .. autoattribute:: setuptools.discovery.FlatLayoutModuleFinder.DEFAULT_EXCLUDE
 
 Also note that you can customise your project layout by explicitly setting
-:doc:`package_dir <userguide/declarative_config>`.
+``package_dir``:
+
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [options]
+        # ...
+        package_dir =
+            = lib
+            # similar to "src-layout" but using the "lib" folder
+            # pkg.mod corresponds to lib/pkg/mod.py
+        # OR
+        package_dir =
+            pkg1 = lib1
+            # pkg1.mod corresponds to lib1/mod.py
+            # pkg1.subpkg.mod corresponds to lib1/subpkg/mod.py
+            pkg2 = lib2
+            # pkg2.mod corresponds to lib2/mod.py
+            pkg2.subpkg = lib3
+            # pkg2.subpkg.mod corresponds to lib3/mod.py
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        setup(
+            # ...
+            package_dir = {"": "pkg"}
+            # similar to "src-layout" but using the "pkg" folder
+            # mylib.mod corresponds to pkg/mylib/mod.py
+        )
+
+        # OR
+
+        setup(
+            # ...
+            package_dir = {
+                "pkg1": "lib1",  # pkg1.mod corresponds to lib1/mod.py
+                                 # pkg1.subpkg.mod corresponds to lib1/subpkg/mod.py
+                "pkg2": "lib2",   # pkg2.mod corresponds to lib2/mod.py
+                "pkg2.subpkg": "lib3"  # pkg2.subpkg.mod corresponds to lib3/mod.py
+                # ...
+        )
 
 .. important:: Automatic discovery will **only** be enabled if you don't
    provide any configuration for both ``packages`` and ``py_modules``.

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -143,9 +143,9 @@ Also note that you can customise your project layout by explicitly setting
 
         setup(
             # ...
-            package_dir = {"": "pkg"}
-            # similar to "src-layout" but using the "pkg" folder
-            # mylib.mod corresponds to pkg/mylib/mod.py
+            package_dir = {"": "lib"}
+            # similar to "src-layout" but using the "lib" folder
+            # pkg.mod corresponds to lib/pkg/mod.py
         )
 
         # OR

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -65,11 +65,11 @@ src-layout:
                 └── mymodule.py
 
     This layout is very handy when you wish to use automatic discovery,
-    since you don't have to worry about other Python files or folder in your
-    project root being distributed by mistake. In some circumstances it can
+    since you don't have to worry about other Python files or folders in your
+    project root being distributed by mistake. In some circumstances it can be
     also less error-prone for testing or when using :pep:`420`-style packages.
     On the other hand you cannot rely on the implicit ``PYTHONPATH=.`` to fire
-    up the Python REPL and play with the your package (you will need an
+    up the Python REPL and play with your package (you will need an
     `editable install`_ to be able to do that).
 
 flat-layout (also known as "adhoc"):
@@ -92,8 +92,8 @@ There is also a handy variation of the *flat-layout* for utilities/libraries
 that can be implemented with a single Python file:
 
 single-module approach (or "few top-level modules"):
-    Modules are placed directly under the project root, instead of inside
-    a package folder::
+    Standalone modules are placed directly under the project root, instead of
+    inside a package folder::
 
         project_root_directory
         ├── pyproject.toml
@@ -102,8 +102,8 @@ single-module approach (or "few top-level modules"):
         └── single_file_lib.py
 
 Setuptools will automatically scan your project directory looking for these
-layouts and try to guess the correct values for the :doc:`packages
-<userguide/declarative_config>` and :doc:`py_modules <keywords>` configuration.
+layouts and try to guess the correct values for the :ref:`packages <declarative
+config>` and :doc:`py_modules </references/keywords>` configuration.
 
 To avoid confusion, file and folder names that are used by popular tools (or
 that correspond to well-known conventions, such as distributing documentation

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -52,7 +52,18 @@ its own set of advantages and disadvantages [#layout1]_ [#layout2]_.
 src-layout:
     The project should contain a ``src`` directory under the project root and
     all modules and packages meant for distribution are placed inside this
-    directory.
+    directory::
+
+        project_root_directory
+        ├── pyproject.toml
+        ├── setup.cfg  # or setup.py
+        ├── ...
+        └── src/
+            └── mypkg/
+                ├── __init__.py
+                ├── ...
+                └── mymodule.py
+
     This layout is very handy when you wish to use automatic discovery,
     since you don't have to worry about other Python files or folder in your
     project root being distributed by mistake. In some circumstances it can
@@ -62,7 +73,17 @@ src-layout:
     `editable install`_ to be able to do that).
 
 flat-layout (also known as "adhoc"):
-    The package folder(s) are placed directly under the project root.
+    The package folder(s) are placed directly under the project root::
+
+        project_root_directory
+        ├── pyproject.toml
+        ├── setup.cfg  # or setup.py
+        ├── ...
+        └── mypkg/
+            ├── __init__.py
+            ├── ...
+            └── mymodule.py
+
     This layout is very practical for using the REPL, but in some situations
     it can be can be more error-prone (e.g. during tests or if you have a bunch
     of folders or Python files hanging around your project root)
@@ -72,7 +93,13 @@ be implemented with a single Python file:
 
 single-module approach (or "few top-level modules"):
     This Python files are placed directly under the project root,
-    instead of inside a package folder.
+    instead of inside a package folder::
+
+        project_root_directory
+        ├── pyproject.toml
+        ├── setup.cfg  # or setup.py
+        ├── ...
+        └── single_file_lib.py
 
 Setuptools will automatically scan your project directory looking for these
 layouts and try to guess the correct values for the :doc:`packages
@@ -83,10 +110,8 @@ that correspond to well-known conventions, such as distributing documentation
 alongside the project code) are automatically filtered out of the
 *flat-layout*:
 
-- reserved package names:
-    .. autodata:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
+.. autodata:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
 
-- reserved top-level module names:
 .. autodata:: setuptools.discovery.FlatLayoutModuleFinder.DEFAULT_EXCLUDE
 
 Also note that you can customise your project layout by explicitly setting

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -110,9 +110,9 @@ that correspond to well-known conventions, such as distributing documentation
 alongside the project code) are automatically filtered in the case of
 *flat-layouts*:
 
-.. autodata:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
+.. autoattribute:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
 
-.. autodata:: setuptools.discovery.FlatLayoutModuleFinder.DEFAULT_EXCLUDE
+.. autoattribute:: setuptools.discovery.FlatLayoutModuleFinder.DEFAULT_EXCLUDE
 
 Also note that you can customise your project layout by explicitly setting
 :doc:`package_dir <userguide/declarative_config>`.
@@ -121,12 +121,6 @@ Also note that you can customise your project layout by explicitly setting
    provide any configuration for both ``packages`` and ``py_modules``.
    If at least one of them is explicitly set, automatic discovery will not take
    place.
-
-
-.. [#layout1] https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
-.. [#layout2] https://blog.ionelmc.ro/2017/09/25/rehashing-the-src-layout/
-
-.. _editable install: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
 
 
 Using setuptools functions
@@ -346,3 +340,9 @@ file contains the following:
     __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 The project layout remains the same and ``setup.cfg`` remains the same.
+
+
+.. [#layout1] https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
+.. [#layout2] https://blog.ionelmc.ro/2017/09/25/rehashing-the-src-layout/
+
+.. _editable install: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -39,7 +39,7 @@ included manually in the following manner:
         )
 
 This can get tiresome really quickly. To speed things up, you can rely on
-setuptools automatic discovery, or use the provided functions, as explained in
+setuptools automatic discovery, or use the provided tools, as explained in
 the following sections.
 
 
@@ -88,12 +88,12 @@ flat-layout (also known as "adhoc"):
     it can be can be more error-prone (e.g. during tests or if you have a bunch
     of folders or Python files hanging around your project root)
 
-There is also a variation of the *flat-layout* for utilities/libraries that can
-be implemented with a single Python file:
+There is also a handy variation of the *flat-layout* for utilities/libraries
+that can be implemented with a single Python file:
 
 single-module approach (or "few top-level modules"):
-    This Python files are placed directly under the project root,
-    instead of inside a package folder::
+    Modules are placed directly under the project root, instead of inside
+    a package folder::
 
         project_root_directory
         ├── pyproject.toml
@@ -103,7 +103,7 @@ single-module approach (or "few top-level modules"):
 
 Setuptools will automatically scan your project directory looking for these
 layouts and try to guess the correct values for the :doc:`packages
-<userguide/declarative_config>` and :doc:`py_modules <keywords>`.
+<userguide/declarative_config>` and :doc:`py_modules <keywords>` configuration.
 
 To avoid confusion, file and folder names that are used by popular tools (or
 that correspond to well-known conventions, such as distributing documentation
@@ -123,14 +123,14 @@ Also note that you can customise your project layout by explicitly setting
    place.
 
 
-Using setuptools functions
-==========================
+Custom discovery
+================
 
 If the automatic discovery does not work for you
 (e.g., you want to *include* in the distribution top-level packages with
 reserved names such as ``tasks``, ``example`` or ``docs``, or you want to
-*exclude* nested packages that would be otherwise included), you can set up
-setuptools to use special functions for the package discovery:
+*exclude* nested packages that would be otherwise included), you can use
+the provided tools for package discovery:
 
 .. tab:: setup.cfg
 

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -38,8 +38,80 @@ included manually in the following manner:
             packages=['mypkg1', 'mypkg2']
         )
 
-This can get tiresome really quickly. To speed things up, we introduce two
-functions provided by setuptools:
+This can get tiresome really quickly. To speed things up, you can rely on
+setuptools automatic discovery, or use the provided functions, as explained in
+the following sections.
+
+
+Automatic discovery
+===================
+
+By default setuptools will consider 2 popular project layouts, each one with
+its own set of advantages and disadvantages [#layout1]_ [#layout2]_.
+
+src-layout:
+    The project should contain a ``src`` directory under the project root and
+    all modules and packages meant for distribution are placed inside this
+    directory.
+    This layout is very handy when you wish to use automatic discovery,
+    since you don't have to worry about other Python files or folder in your
+    project root being distributed by mistake. In some circumstances it can
+    also less error-prone for testing or when using :pep:`420`-style packages.
+    On the other hand you cannot rely on the implicit ``PYTHONPATH=.`` to fire
+    up the Python REPL and play with the your package (you will need an
+    `editable install`_ to be able to do that).
+
+flat-layout (also known as "adhoc"):
+    The package folder(s) are placed directly under the project root.
+    This layout is very practical for using the REPL, but in some situations
+    it can be can be more error-prone (e.g. during tests or if you have a bunch
+    of folders or Python files hanging around your project root)
+
+There is also a variation of the *flat-layout* for utilities/libraries that can
+be implemented with a single Python file:
+
+single-module approach (or "few top-level modules"):
+    This Python files are placed directly under the project root,
+    instead of inside a package folder.
+
+Setuptools will automatically scan your project directory looking for these
+layouts and try to guess the correct values for the :doc:`packages
+<userguide/declarative_config>` and :doc:`py_modules <keywords>`.
+
+To avoid confusion, file and folder names that are used by popular tools (or
+that correspond to well-known conventions, such as distributing documentation
+alongside the project code) are automatically filtered out of the
+*flat-layout*:
+
+- reserved package names:
+    .. autodata:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
+
+- reserved top-level module names:
+.. autodata:: setuptools.discovery.FlatLayoutModuleFinder.DEFAULT_EXCLUDE
+
+Also note that you can customise your project layout by explicitly setting
+:doc:`package_dir <userguide/declarative_config>`.
+
+.. important:: Automatic discovery will **only** be enabled if you don't
+   provide any configuration for both ``packages`` and ``py_modules``.
+   If at least one of them is explicitly set, automatic discovery will not take
+   place.
+
+
+.. [#layout1] https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
+.. [#layout2] https://blog.ionelmc.ro/2017/09/25/rehashing-the-src-layout/
+
+.. _editable install: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs
+
+
+Using setuptools functions
+==========================
+
+If the automatic discovery does not work for you
+(e.g., you want to *include* in the distribution top-level packages with
+reserved names such as ``tasks``, ``example`` or ``docs``, or you want to
+*exclude* nested packages that would be otherwise included), you can set up
+setuptools to use special functions for the package discovery:
 
 .. tab:: setup.cfg
 
@@ -61,7 +133,7 @@ functions provided by setuptools:
 
 
 Using ``find:`` or ``find_packages``
-====================================
+------------------------------------
 Let's start with the first tool. ``find:`` (``find_packages``) takes a source
 directory and two lists of package name patterns to exclude and include, and
 then return a list of ``str`` representing the packages it could find. To use
@@ -113,7 +185,7 @@ in ``src`` that starts with the name ``pkg`` and not ``additional``:
 .. _Namespace Packages:
 
 Using ``find_namespace:`` or ``find_namespace_packages``
-========================================================
+--------------------------------------------------------
 ``setuptools``  provides the ``find_namespace:`` (``find_namespace_packages``)
 which behaves similarly to ``find:`` but works with namespace package. Before
 diving in, it is important to have a good understanding of what namespace

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -107,8 +107,8 @@ layouts and try to guess the correct values for the :doc:`packages
 
 To avoid confusion, file and folder names that are used by popular tools (or
 that correspond to well-known conventions, such as distributing documentation
-alongside the project code) are automatically filtered out of the
-*flat-layout*:
+alongside the project code) are automatically filtered in the case of
+*flat-layouts*:
 
 .. autodata:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -80,9 +80,6 @@ testing-integration =
 	build[virtualenv]
 	filelock>=3.4.0
 
-
-	build
-
 docs =
 	# upstream
 	sphinx

--- a/setup.cfg
+++ b/setup.cfg
@@ -81,6 +81,8 @@ testing-integration =
 	filelock>=3.4.0
 
 
+	build
+
 docs =
 	# upstream
 	sphinx

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -1,6 +1,5 @@
 """Extensions to the 'distutils' for large or complex distributions"""
 
-from fnmatch import fnmatchcase
 import functools
 import os
 import re
@@ -9,7 +8,6 @@ import _distutils_hack.override  # noqa: F401
 
 import distutils.core
 from distutils.errors import DistutilsOptionError
-from distutils.util import convert_path
 
 from ._deprecation_warning import SetuptoolsDeprecationWarning
 
@@ -17,6 +15,7 @@ import setuptools.version
 from setuptools.extension import Extension
 from setuptools.dist import Distribution
 from setuptools.depends import Require
+from setuptools.discovery import PackageFinder, PEP420PackageFinder
 from . import monkey
 from . import logging
 
@@ -35,85 +34,6 @@ __all__ = [
 __version__ = setuptools.version.__version__
 
 bootstrap_install_from = None
-
-
-class PackageFinder:
-    """
-    Generate a list of all Python packages found within a directory
-    """
-
-    @classmethod
-    def find(cls, where='.', exclude=(), include=('*',)):
-        """Return a list all Python packages found within directory 'where'
-
-        'where' is the root directory which will be searched for packages.  It
-        should be supplied as a "cross-platform" (i.e. URL-style) path; it will
-        be converted to the appropriate local path syntax.
-
-        'exclude' is a sequence of package names to exclude; '*' can be used
-        as a wildcard in the names, such that 'foo.*' will exclude all
-        subpackages of 'foo' (but not 'foo' itself).
-
-        'include' is a sequence of package names to include.  If it's
-        specified, only the named packages will be included.  If it's not
-        specified, all found packages will be included.  'include' can contain
-        shell style wildcard patterns just like 'exclude'.
-        """
-
-        return list(
-            cls._find_packages_iter(
-                convert_path(where),
-                cls._build_filter('ez_setup', '*__pycache__', *exclude),
-                cls._build_filter(*include),
-            )
-        )
-
-    @classmethod
-    def _find_packages_iter(cls, where, exclude, include):
-        """
-        All the packages found in 'where' that pass the 'include' filter, but
-        not the 'exclude' filter.
-        """
-        for root, dirs, files in os.walk(where, followlinks=True):
-            # Copy dirs to iterate over it, then empty dirs.
-            all_dirs = dirs[:]
-            dirs[:] = []
-
-            for dir in all_dirs:
-                full_path = os.path.join(root, dir)
-                rel_path = os.path.relpath(full_path, where)
-                package = rel_path.replace(os.path.sep, '.')
-
-                # Skip directory trees that are not valid packages
-                if '.' in dir or not cls._looks_like_package(full_path):
-                    continue
-
-                # Should this package be included?
-                if include(package) and not exclude(package):
-                    yield package
-
-                # Keep searching subdirectories, as there may be more packages
-                # down there, even if the parent was excluded.
-                dirs.append(dir)
-
-    @staticmethod
-    def _looks_like_package(path):
-        """Does a directory look like a package?"""
-        return os.path.isfile(os.path.join(path, '__init__.py'))
-
-    @staticmethod
-    def _build_filter(*patterns):
-        """
-        Given a list of patterns, return a callable that will be true only if
-        the input matches at least one of the patterns.
-        """
-        return lambda name: any(fnmatchcase(name, pat=pat) for pat in patterns)
-
-
-class PEP420PackageFinder(PackageFinder):
-    @staticmethod
-    def _looks_like_package(path):
-        return True
 
 
 find_packages = PackageFinder.find

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -176,6 +176,7 @@ class ModuleFinder(_Finder):
 
 class FlatLayoutPackageFinder(PEP420PackageFinder):
     _EXCLUDE = (
+        "bin",
         "doc",
         "docs",
         "test",

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -186,6 +186,8 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
         "examples",
         "scripts",
         "tools",
+        "build",
+        "dist",
         # ---- Task runners / Build tools ----
         "tasks",  # invoke
         "fabfile",  # fabric

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -179,10 +179,13 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
         "bin",
         "doc",
         "docs",
+        "documentation",
         "test",
         "tests",
         "example",
         "examples",
+        "scripts",
+        "tools",
         # ---- Task runners / Build tools ----
         "tasks",  # invoke
         "fabfile",  # fabric
@@ -205,6 +208,7 @@ class FlatLayoutModuleFinder(ModuleFinder):
         "tests",
         "example",
         "examples",
+        "build",
         # ---- Task runners ----
         "noxfile",
         "pavement",

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -265,7 +265,7 @@ class ConfigDiscovery:
         self._called = True
 
     def _analyse_package_layout(self):
-        if self.dist.packages or self.dist.py_modules:
+        if self.dist.packages is not None or self.dist.py_modules is not None:
             # For backward compatibility, just try to find modules/packages
             # when nothing is given
             return None

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -191,6 +191,7 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
     )
 
     DEFAULT_EXCLUDE = tuple(chain_iter((p, f"{p}.*") for p in _EXCLUDE))
+    """Reserved package names"""
 
     _looks_like_package = staticmethod(_valid_name)
 
@@ -216,6 +217,7 @@ class FlatLayoutModuleFinder(ModuleFinder):
         # ---- Hidden files/Private modules ----
         "[._]*",
     )
+    """Reserved top-level module names"""
 
 
 def _find_packages_within(root_pkg, pkg_dir):

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -1,0 +1,89 @@
+"""Automatic discovery for Python modules and packages for inclusion in the
+distribution.
+"""
+
+import os
+from fnmatch import fnmatchcase
+
+import _distutils_hack.override  # noqa: F401
+
+from distutils.util import convert_path
+
+
+class PackageFinder:
+    """
+    Generate a list of all Python packages found within a directory
+    """
+
+    @classmethod
+    def find(cls, where='.', exclude=(), include=('*',)):
+        """Return a list all Python packages found within directory 'where'
+
+        'where' is the root directory which will be searched for packages.  It
+        should be supplied as a "cross-platform" (i.e. URL-style) path; it will
+        be converted to the appropriate local path syntax.
+
+        'exclude' is a sequence of package names to exclude; '*' can be used
+        as a wildcard in the names, such that 'foo.*' will exclude all
+        subpackages of 'foo' (but not 'foo' itself).
+
+        'include' is a sequence of package names to include.  If it's
+        specified, only the named packages will be included.  If it's not
+        specified, all found packages will be included.  'include' can contain
+        shell style wildcard patterns just like 'exclude'.
+        """
+
+        return list(
+            cls._find_packages_iter(
+                convert_path(where),
+                cls._build_filter('ez_setup', '*__pycache__', *exclude),
+                cls._build_filter(*include),
+            )
+        )
+
+    @classmethod
+    def _find_packages_iter(cls, where, exclude, include):
+        """
+        All the packages found in 'where' that pass the 'include' filter, but
+        not the 'exclude' filter.
+        """
+        for root, dirs, files in os.walk(where, followlinks=True):
+            # Copy dirs to iterate over it, then empty dirs.
+            all_dirs = dirs[:]
+            dirs[:] = []
+
+            for dir in all_dirs:
+                full_path = os.path.join(root, dir)
+                rel_path = os.path.relpath(full_path, where)
+                package = rel_path.replace(os.path.sep, '.')
+
+                # Skip directory trees that are not valid packages
+                if '.' in dir or not cls._looks_like_package(full_path):
+                    continue
+
+                # Should this package be included?
+                if include(package) and not exclude(package):
+                    yield package
+
+                # Keep searching subdirectories, as there may be more packages
+                # down there, even if the parent was excluded.
+                dirs.append(dir)
+
+    @staticmethod
+    def _looks_like_package(path):
+        """Does a directory look like a package?"""
+        return os.path.isfile(os.path.join(path, '__init__.py'))
+
+    @staticmethod
+    def _build_filter(*patterns):
+        """
+        Given a list of patterns, return a callable that will be true only if
+        the input matches at least one of the patterns.
+        """
+        return lambda name: any(fnmatchcase(name, pat=pat) for pat in patterns)
+
+
+class PEP420PackageFinder(PackageFinder):
+    @staticmethod
+    def _looks_like_package(path):
+        return True

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -231,7 +231,7 @@ class ConfigDiscovery:
     def __init__(self, distribution):
         self.dist = distribution
         self._called = False
-        self._root_dir = distribution.src_root or os.getcwd()
+        self._root_dir = None  # delay so `src_root` can be set in dist
 
     def __call__(self, force=False):
         """Automatically discover missing configuration fields
@@ -247,6 +247,8 @@ class ConfigDiscovery:
         if force is False and self._called:
             # Avoid overhead of multiple calls
             return
+
+        self._root_dir = self.dist.src_root or os.curdir
 
         self._analyse_package_layout()
         self._analyse_name()  # depends on ``packages`` and ``py_modules``

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -47,6 +47,8 @@ import _distutils_hack.override  # noqa: F401
 from distutils import log
 from distutils.util import convert_path
 
+chain_iter = itertools.chain.from_iterable
+
 
 def _valid_name(path):
     # Ignore invalid names that cannot be imported directly
@@ -173,7 +175,7 @@ class ModuleFinder(_Finder):
 
 
 class FlatLayoutPackageFinder(PEP420PackageFinder):
-    DEFAULT_EXCLUDE = (
+    _EXCLUDE = (
         "doc",
         "docs",
         "test",
@@ -187,6 +189,8 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
         # ---- Hidden directories/Private packages ----
         "[._]*",
     )
+
+    DEFAULT_EXCLUDE = tuple(chain_iter((p, f"{p}.*") for p in _EXCLUDE))
 
     _looks_like_package = staticmethod(_valid_name)
 
@@ -276,7 +280,7 @@ class ConfigDiscovery:
         if not package_dir:
             return False
 
-        pkgs = itertools.chain.from_iterable(
+        pkgs = chain_iter(
             _find_packages_within(pkg, os.path.join(root_dir, parent_dir))
             for pkg, parent_dir in package_dir.items()
         )

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -188,6 +188,7 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
         "tools",
         "build",
         "dist",
+        "venv",
         # ---- Task runners / Build tools ----
         "tasks",  # invoke
         "fabfile",  # fabric

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -39,6 +39,8 @@ import setuptools.command
 from setuptools import windows_support
 from setuptools.monkey import get_unpatched
 from setuptools.config import parse_configuration
+from setuptools.discovery import ConfigDiscovery
+
 import pkg_resources
 from setuptools.extern.packaging import version, requirements
 from . import _reqs
@@ -463,6 +465,8 @@ class Distribution(_Distribution):
                 if k not in self._DISTUTILS_UNSUPPORTED_METADATA
             },
         )
+
+        self.set_defaults = ConfigDiscovery(self)
 
         self._set_metadata_defaults(attrs)
 
@@ -1185,6 +1189,13 @@ class Distribution(_Distribution):
             sys.stdout = io.TextIOWrapper(
                 sys.stdout.detach(), encoding, errors, newline, line_buffering
             )
+
+    def run_command(self, command):
+        self.set_defaults()
+        # Postpone defaults until all explicit configuration is considered
+        # (setup() args, config files, command line and plugins)
+
+        super().run_command(command)
 
 
 class DistDeprecationWarning(SetuptoolsDeprecationWarning):

--- a/setuptools/tests/integration/helpers.py
+++ b/setuptools/tests/integration/helpers.py
@@ -8,6 +8,7 @@ import os
 import subprocess
 import tarfile
 from zipfile import ZipFile
+from pathlib import Path
 
 
 def run(cmd, env=None):
@@ -59,3 +60,16 @@ class Archive:
                 raise ValueError(msg)
             return str(content.read(), "utf-8")
         return str(self._obj.read(zip_or_tar_info), "utf-8")
+
+
+def get_sdist_members(sdist_path):
+    with tarfile.open(sdist_path, "r:gz") as tar:
+        files = [Path(f) for f in tar.getnames()]
+    # remove root folder
+    relative_files = ("/".join(f.parts[1:]) for f in files)
+    return {f for f in relative_files if f}
+
+
+def get_wheel_members(wheel_path):
+    with ZipFile(wheel_path) as zipfile:
+        return set(zipfile.namelist())

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -59,7 +59,8 @@ class TestDiscoverPackagesAndPyModules:
         _populate_project_dir(tmp_path, files, options)
 
         here = os.getcwd()
-        dist = Distribution({**options, "src_root": tmp_path})
+        root = "/".join(os.path.split(tmp_path))  # POSIX-style
+        dist = Distribution({**options, "src_root": root})
         dist.script_name = 'setup.py'
         dist.set_defaults()
         cmd = sdist(dist)

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -78,6 +78,16 @@ class TestDiscoverPackagesAndPyModules:
         files, options = self._get_info(circumstance)
         _populate_project_dir(tmp_path, files, options)
 
+        # Simulate a pre-existing `build` directory
+        (tmp_path / "build").mkdir()
+        (tmp_path / "build/lib").mkdir()
+        (tmp_path / "build/bdist.linux-x86_64").mkdir()
+        (tmp_path / "build/bdist.linux-x86_64/file.py").touch()
+        (tmp_path / "build/lib/__init__.py").touch()
+        (tmp_path / "build/lib/file.py").touch()
+        (tmp_path / "dist").mkdir()
+        (tmp_path / "dist/file.py").touch()
+
         _run_build(tmp_path)
 
         sdist_files = get_sdist_members(next(tmp_path.glob("dist/*.tar.gz")))
@@ -89,6 +99,11 @@ class TestDiscoverPackagesAndPyModules:
         print("~~~~~ wheel_members ~~~~~")
         print('\n'.join(wheel_files))
         assert wheel_files >= {f.replace("src/", "") for f in files}
+
+        # Make sure build files are not included by mistake
+        for file in wheel_files:
+            assert "build" not in files
+            assert "dist" not in files
 
 
 class TestNoConfig:

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -1,0 +1,177 @@
+import os
+import subprocess
+import sys
+import tarfile
+from configparser import ConfigParser
+from pathlib import Path
+from subprocess import CalledProcessError
+from zipfile import ZipFile
+
+import pytest
+
+from setuptools.command.sdist import sdist
+from setuptools.dist import Distribution
+
+from .contexts import quiet
+from .test_find_packages import ensure_files
+
+
+class TestDiscoverPackagesAndPyModules:
+    """Make sure discovered values for ``packages`` and ``py_modules`` work
+    similarly to explicit configuration for the simple scenarios.
+    """
+    OPTIONS = {
+        # Different options according to the circumstance being tested
+        "explicit-src": {
+            "package_dir": {"": "src"},
+            "packages": ["pkg"]
+        },
+        "explicit-flat": {
+            "packages": ["pkg"]
+        },
+        "explicit-single_module": {
+            "py_modules": ["pkg"]
+        },
+        "explicit-namespace": {
+            "packages": ["ns", "ns.pkg"]
+        },
+        "automatic-src": {},
+        "automatic-flat": {},
+        "automatic-single_module": {},
+        "automatic-namespace": {}
+    }
+    FILES = {
+        "src": ["src/pkg/__init__.py", "src/pkg/main.py"],
+        "flat": ["pkg/__init__.py", "pkg/main.py"],
+        "single_module": ["pkg.py"],
+        "namespace": ["ns/pkg/__init__.py"]
+    }
+
+    def _get_info(self, circumstance):
+        _, _, layout = circumstance.partition("-")
+        files = self.FILES[layout]
+        options = self.OPTIONS[circumstance]
+        return files, options
+
+    @pytest.mark.parametrize("circumstance", OPTIONS.keys())
+    def test_sdist_filelist(self, tmp_path, circumstance):
+        files, options = self._get_info(circumstance)
+        _populate_project_dir(tmp_path, files, options)
+
+        here = os.getcwd()
+        dist = Distribution({**options, "src_root": tmp_path})
+        dist.script_name = 'setup.py'
+        dist.set_defaults()
+        cmd = sdist(dist)
+        cmd.ensure_finalized()
+        assert cmd.distribution.packages or cmd.distribution.py_modules
+
+        with quiet():
+            try:
+                os.chdir(tmp_path)
+                cmd.run()
+            finally:
+                os.chdir(here)
+
+        manifest = [f.replace(os.sep, "/") for f in cmd.filelist.files]
+        for file in files:
+            assert any(f.endswith(file) for f in manifest)
+
+    @pytest.mark.parametrize("circumstance", OPTIONS.keys())
+    def test_project(self, tmp_path, circumstance):
+        files, options = self._get_info(circumstance)
+        _populate_project_dir(tmp_path, files, options)
+
+        _run_build(tmp_path)
+
+        sdist_files = _get_sdist_members(next(tmp_path.glob("dist/*.tar.gz")))
+        print("~~~~~ sdist_members ~~~~~")
+        print('\n'.join(sdist_files))
+        assert sdist_files >= set(files)
+
+        wheel_files = _get_wheel_members(next(tmp_path.glob("dist/*.whl")))
+        print("~~~~~ wheel_members ~~~~~")
+        print('\n'.join(wheel_files))
+        assert wheel_files >= {f.replace("src/", "") for f in files}
+
+
+class TestNoConfig:
+    DEFAULT_VERSION = "0.0.0"  # Default version given by setuptools
+
+    EXAMPLES = {
+        "pkg1": ["src/pkg1.py"],
+        "pkg2": ["src/pkg2/__init__.py"],
+        "ns.nested.pkg3": ["src/ns/nested/pkg3/__init__.py"]
+    }
+
+    @pytest.mark.parametrize("example", EXAMPLES.keys())
+    def test_discover_name(self, tmp_path, example):
+        _populate_project_dir(tmp_path, self.EXAMPLES[example], {})
+        _run_build(tmp_path, "--sdist")
+        # Expected distribution file
+        dist_file = tmp_path / f"dist/{example}-{self.DEFAULT_VERSION}.tar.gz"
+        assert dist_file.is_file()
+
+
+def _populate_project_dir(root, files, options):
+    # NOTE: Currently pypa/build will refuse to build the project if no
+    # `pyproject.toml` or `setup.py` is found. So it is impossible to do
+    # completely "config-less" projects.
+    (root / "setup.py").write_text("import setuptools\nsetuptools.setup()")
+    (root / "README.md").write_text("# Example Package")
+    (root / "LICENSE").write_text("Copyright (c) 2018")
+    _write_setupcfg(root, options)
+    ensure_files(root, files)
+
+
+def _write_setupcfg(root, options):
+    if not options:
+        print("~~~~~ **NO** setup.cfg ~~~~~")
+        return
+    setupcfg = ConfigParser()
+    setupcfg.add_section("options")
+    for key, value in options.items():
+        if isinstance(value, list):
+            setupcfg["options"][key] = ", ".join(value)
+        elif isinstance(value, dict):
+            str_value = "\n".join(f"\t{k} = {v}" for k, v in value.items())
+            setupcfg["options"][key] = "\n" + str_value
+        else:
+            setupcfg["options"][key] = str(value)
+    with open(root / "setup.cfg", "w") as f:
+        setupcfg.write(f)
+    print("~~~~~ setup.cfg ~~~~~")
+    print((root / "setup.cfg").read_text())
+
+
+def _get_sdist_members(sdist_path):
+    with tarfile.open(sdist_path, "r:gz") as tar:
+        files = [Path(f) for f in tar.getnames()]
+    relative_files = ("/".join(f.parts[1:]) for f in files)
+    # remove root folder
+    return {f for f in relative_files if f}
+
+
+def _get_wheel_members(wheel_path):
+    with ZipFile(wheel_path) as zipfile:
+        return set(zipfile.namelist())
+
+
+def _run_build(path, *flags):
+    cmd = [sys.executable, "-m", "build", "--no-isolation", *flags, str(path)]
+    r = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+        env={**os.environ, 'DISTUTILS_DEBUG': '1'}
+    )
+    out = r.stdout + "\n" + r.stderr
+    print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    print("Command", repr(cmd), "returncode", r.returncode)
+    print(out)
+    map(print, path.glob("*"))
+
+    if r.returncode != 0:
+        raise CalledProcessError(r.returncode, cmd, r.stdout, r.stderr)
+    return out

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -8,7 +8,6 @@ from setuptools.command.sdist import sdist
 from setuptools.dist import Distribution
 
 from .contexts import quiet
-from .test_find_packages import ensure_files
 from .integration.helpers import get_sdist_members, get_wheel_members, run
 
 
@@ -118,7 +117,10 @@ def _populate_project_dir(root, files, options):
     (root / "README.md").write_text("# Example Package")
     (root / "LICENSE").write_text("Copyright (c) 2018")
     _write_setupcfg(root, options)
-    ensure_files(root, files)
+    paths = (root / f for f in files)
+    for path in paths:
+        path.parent.mkdir(exist_ok=True, parents=True)
+        path.touch()
 
 
 def _write_setupcfg(root, options):

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -23,6 +23,9 @@ class TestDiscoverPackagesAndPyModules:
             "package_dir": {"": "src"},
             "packages": ["pkg"]
         },
+        "variation-lib": {
+            "package_dir": {"": "lib"},  # variation of the source-layout
+        },
         "explicit-flat": {
             "packages": ["pkg"]
         },
@@ -39,6 +42,7 @@ class TestDiscoverPackagesAndPyModules:
     }
     FILES = {
         "src": ["src/pkg/__init__.py", "src/pkg/main.py"],
+        "lib": ["lib/pkg/__init__.py", "lib/pkg/main.py"],
         "flat": ["pkg/__init__.py", "pkg/main.py"],
         "single_module": ["pkg.py"],
         "namespace": ["ns/pkg/__init__.py"]
@@ -100,7 +104,8 @@ class TestDiscoverPackagesAndPyModules:
         wheel_files = get_wheel_members(next(tmp_path.glob("dist/*.whl")))
         print("~~~~~ wheel_members ~~~~~")
         print('\n'.join(wheel_files))
-        assert wheel_files >= {f.replace("src/", "") for f in files}
+        orig_files = {f.replace("src/", "").replace("lib/", "") for f in files}
+        assert wheel_files >= orig_files
 
         # Make sure build files are not included by mistake
         for file in wheel_files:

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -18,6 +18,7 @@ from setuptools import Distribution
 
 from .textwrap import DALS
 from .test_easy_install import make_nspkg_sdist
+from .test_find_packages import ensure_files
 
 import pytest
 
@@ -69,16 +70,19 @@ def test_dist__get_unpatched_deprecated():
     pytest.warns(DistDeprecationWarning, _get_unpatched, [""])
 
 
+EXAMPLE_BASE_INFO = dict(
+    name="package",
+    version="0.0.1",
+    author="Foo Bar",
+    author_email="foo@bar.net",
+    long_description="Long\ndescription",
+    description="Short description",
+    keywords=["one", "two"],
+)
+
+
 def __read_test_cases():
-    base = dict(
-        name="package",
-        version="0.0.1",
-        author="Foo Bar",
-        author_email="foo@bar.net",
-        long_description="Long\ndescription",
-        description="Short description",
-        keywords=["one", "two"],
-    )
+    base = EXAMPLE_BASE_INFO
 
     params = functools.partial(dict, base)
 
@@ -379,3 +383,127 @@ def test_rfc822_unescape(content, result):
 def test_metadata_name():
     with pytest.raises(DistutilsSetupError, match='missing.*name'):
         Distribution()._validate_metadata()
+
+
+@pytest.mark.parametrize(
+    "dist_name, py_module",
+    [
+        ("my.pkg", "my_pkg"),
+        ("my-pkg", "my_pkg"),
+        ("my_pkg", "my_pkg"),
+        ("pkg", "pkg"),
+    ]
+)
+def test_dist_default_py_modules(tmp_path, dist_name, py_module):
+    (tmp_path / f"{py_module}.py").touch()
+
+    (tmp_path / "setup.py").touch()
+    (tmp_path / "noxfile.py").touch()
+    # ^-- make sure common tool files are ignored
+
+    attrs = {
+        **EXAMPLE_BASE_INFO,
+        "name": dist_name,
+        "src_root": str(tmp_path)
+    }
+    # Find `py_modules` corresponding to dist_name if not given
+    dist = Distribution(attrs)
+    dist.set_defaults()
+    assert dist.py_modules == [py_module]
+    # When `py_modules` is given, don't do anything
+    dist = Distribution({**attrs, "py_modules": ["explicity_py_module"]})
+    dist.set_defaults()
+    assert dist.py_modules == ["explicity_py_module"]
+    # When `packages` is given, don't do anything
+    dist = Distribution({**attrs, "packages": ["explicity_package"]})
+    dist.set_defaults()
+    assert not dist.py_modules
+
+
+@pytest.mark.parametrize(
+    "dist_name, package_dir, package_files, packages",
+    [
+        ("my.pkg", None, ["my_pkg/__init__.py", "my_pkg/mod.py"], ["my_pkg"]),
+        ("my-pkg", None, ["my_pkg/__init__.py", "my_pkg/mod.py"], ["my_pkg"]),
+        ("my_pkg", None, ["my_pkg/__init__.py", "my_pkg/mod.py"], ["my_pkg"]),
+        ("my.pkg", None, ["my/pkg/__init__.py"], ["my", "my.pkg"]),
+        (
+            "my_pkg",
+            None,
+            ["src/my_pkg/__init__.py", "src/my_pkg2/__init__.py"],
+            ["my_pkg", "my_pkg2"]
+        ),
+        (
+            "my_pkg",
+            {"pkg": "lib", "pkg2": "lib2"},
+            ["lib/__init__.py", "lib/nested/__init__.pyt", "lib2/__init__.py"],
+            ["pkg", "pkg.nested", "pkg2"]
+        ),
+    ]
+)
+def test_dist_default_packages(
+    tmp_path, dist_name, package_dir, package_files, packages
+):
+    ensure_files(tmp_path, package_files)
+
+    (tmp_path / "setup.py").touch()
+    (tmp_path / "noxfile.py").touch()
+    # ^-- should not be included by default
+
+    attrs = {
+        **EXAMPLE_BASE_INFO,
+        "name": dist_name,
+        "src_root": str(tmp_path),
+        "package_dir": package_dir
+    }
+    # Find `packages` either corresponding to dist_name or inside src
+    dist = Distribution(attrs)
+    dist.set_defaults()
+    assert not dist.py_modules
+    assert not dist.py_modules
+    assert set(dist.packages) == set(packages)
+    # When `py_modules` is given, don't do anything
+    dist = Distribution({**attrs, "py_modules": ["explicit_py_module"]})
+    dist.set_defaults()
+    assert not dist.packages
+    assert set(dist.py_modules) == {"explicit_py_module"}
+    # When `packages` is given, don't do anything
+    dist = Distribution({**attrs, "packages": ["explicit_package"]})
+    dist.set_defaults()
+    assert not dist.py_modules
+    assert set(dist.packages) == {"explicit_package"}
+
+
+@pytest.mark.parametrize(
+    "dist_name, package_dir, package_files",
+    [
+        ("my.pkg.nested", None, ["my/pkg/nested/__init__.py"]),
+        ("my.pkg", None, ["my/pkg/__init__.py", "my/pkg/file.py"]),
+        ("my_pkg", None, ["my_pkg.py"]),
+        ("my_pkg", None, ["my_pkg/__init__.py", "my_pkg/nested/__init__.py"]),
+        ("my_pkg", None, ["src/my_pkg/__init__.py", "src/my_pkg/nested/__init__.py"]),
+        (
+            "my_pkg",
+            {"my_pkg": "lib", "my_pkg.lib2": "lib2"},
+            ["lib/__init__.py", "lib/nested/__init__.pyt", "lib2/__init__.py"],
+        ),
+        # Should not try to guess a name from multiple py_modules/packages
+        ("UNKNOWN", None, ["mod1.py", "mod2.py"]),
+        ("UNKNOWN", None, ["pkg1/__ini__.py", "pkg2/__init__.py"]),
+        ("UNKNOWN", None, ["src/pkg1/__ini__.py", "src/pkg2/__init__.py"]),
+    ]
+)
+def test_dist_default_name(tmp_path, dist_name, package_dir, package_files):
+    """Make sure dist.name is discovered from packages/py_modules"""
+    ensure_files(tmp_path, package_files)
+    attrs = {
+        **EXAMPLE_BASE_INFO,
+        "src_root": str(tmp_path),
+        "package_dir": package_dir
+    }
+    del attrs["name"]
+
+    dist = Distribution(attrs)
+    dist.set_defaults()
+    assert dist.py_modules or dist.packages
+    assert dist.get_name() == dist_name

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -2,6 +2,7 @@ import io
 import collections
 import re
 import functools
+import os
 import urllib.request
 import urllib.parse
 from distutils.errors import DistutilsSetupError
@@ -498,7 +499,7 @@ def test_dist_default_name(tmp_path, dist_name, package_dir, package_files):
     ensure_files(tmp_path, package_files)
     attrs = {
         **EXAMPLE_BASE_INFO,
-        "src_root": str(tmp_path),
+        "src_root": "/".join(os.path.split(tmp_path)),  # POSIX-style
         "package_dir": package_dir
     }
     del attrs["name"]

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -219,7 +219,9 @@ class TestFlatLayoutPackageFinder:
             [
                 "pkg/__init__.py",
                 "tasks/__init__.py",
+                "tasks/subpackage/__init__.py",
                 "fabfile/__init__.py",
+                "fabfile/subpackage/__init__.py",
                 # Sub-packages should always be fine
                 "pkg/tasks/__init__.py",
                 "pkg/fabfile/__init__.py",

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -9,6 +9,7 @@ import pytest
 
 from setuptools import find_packages
 from setuptools import find_namespace_packages
+from setuptools.discovery import FlatLayoutPackageFinder
 
 
 # modeled after CPython's test.support.can_symlink
@@ -178,3 +179,63 @@ class TestFindPackages:
         shutil.rmtree(os.path.join(self.dist_dir, 'pkg/subpkg/assets'))
         packages = find_namespace_packages(self.dist_dir)
         self._assert_packages(packages, ['pkg', 'pkg.nspkg', 'pkg.subpkg'])
+
+
+class TestFlatLayoutPackageFinder:
+    EXAMPLES = {
+        "hidden-folders": (
+            [".pkg/__init__.py", "pkg/__init__.py", "pkg/nested/file.txt"],
+            ["pkg", "pkg.nested"]
+        ),
+        "private-packages": (
+            ["_pkg/__init__.py", "pkg/_private/__init__.py"],
+            ["pkg", "pkg._private"]
+        ),
+        "invalid-name": (
+            ["invalid-pkg/__init__.py", "other.pkg/__init__.py", "yet,another/file.py"],
+            []
+        ),
+        "docs": (
+            ["pkg/__init__.py", "docs/conf.py", "docs/readme.rst"],
+            ["pkg"]
+        ),
+        "tests": (
+            ["pkg/__init__.py", "tests/test_pkg.py", "tests/__init__.py"],
+            ["pkg"]
+        ),
+        "examples": (
+            [
+                "pkg/__init__.py",
+                "examples/__init__.py",
+                "examples/file.py"
+                "example/other_file.py",
+                # Sub-packages should always be fine
+                "pkg/example/__init__.py",
+                "pkg/examples/__init__.py",
+            ],
+            ["pkg", "pkg.examples", "pkg.example"]
+        ),
+        "tool-specific": (
+            [
+                "pkg/__init__.py",
+                "tasks/__init__.py",
+                "fabfile/__init__.py",
+                # Sub-packages should always be fine
+                "pkg/tasks/__init__.py",
+                "pkg/fabfile/__init__.py",
+            ],
+            ["pkg", "pkg.tasks", "pkg.fabfile"]
+        )
+    }
+
+    @pytest.mark.parametrize("example", EXAMPLES.keys())
+    def test_unwanted_directories_not_included(self, tmp_path, example):
+        package_files, packages = self.EXAMPLES[example]
+
+        for file in package_files:
+            path = tmp_path / file
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.touch()
+
+        found_packages = FlatLayoutPackageFinder.find(tmp_path)
+        assert set(found_packages) == set(packages)

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -1,4 +1,4 @@
-"""Tests for setuptools.find_packages()."""
+"""Tests for automatic package discovery"""
 import os
 import sys
 import shutil
@@ -230,12 +230,14 @@ class TestFlatLayoutPackageFinder:
 
     @pytest.mark.parametrize("example", EXAMPLES.keys())
     def test_unwanted_directories_not_included(self, tmp_path, example):
-        package_files, packages = self.EXAMPLES[example]
+        files, expected_packages = self.EXAMPLES[example]
+        ensure_files(tmp_path, files)
+        found_packages = FlatLayoutPackageFinder.find(str(tmp_path))
+        assert set(found_packages) == set(expected_packages)
 
-        for file in package_files:
-            path = tmp_path / file
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.touch()
 
-        found_packages = FlatLayoutPackageFinder.find(tmp_path)
-        assert set(found_packages) == set(packages)
+def ensure_files(root_path, files):
+    for file in files:
+        path = root_path / file
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()

--- a/setuptools/tests/test_find_py_modules.py
+++ b/setuptools/tests/test_find_py_modules.py
@@ -1,15 +1,11 @@
 """Tests for automatic discovery of modules"""
 import os
-import sys
-import shutil
-import tempfile
-import platform
 
 import pytest
 
-from setuptools.discovery import ModuleFinder, FlatLayoutModuleFinder
+from setuptools.discovery import FlatLayoutModuleFinder, ModuleFinder
 
-from .test_find_packages import has_symlink, ensure_files
+from .test_find_packages import ensure_files, has_symlink
 
 
 class TestModuleFinder:

--- a/setuptools/tests/test_find_py_modules.py
+++ b/setuptools/tests/test_find_py_modules.py
@@ -1,0 +1,85 @@
+"""Tests for automatic discovery of modules"""
+import os
+import sys
+import shutil
+import tempfile
+import platform
+
+import pytest
+
+from setuptools.discovery import ModuleFinder, FlatLayoutModuleFinder
+
+from .test_find_packages import has_symlink, ensure_files
+
+
+class TestModuleFinder:
+    def find(self, path, *args, **kwargs):
+        return set(ModuleFinder.find(str(path), *args, **kwargs))
+
+    EXAMPLES = {
+        # circumstance: (files, kwargs, expected_modules)
+        "simple_folder": (
+            ["file.py", "other.py"],
+            {},  # kwargs
+            ["file", "other"],
+        ),
+        "exclude": (
+            ["file.py", "other.py"],
+            {"exclude": ["f*"]},
+            ["other"],
+        ),
+        "include": (
+            ["file.py", "fole.py", "other.py"],
+            {"include": ["f*"], "exclude": ["fo*"]},
+            ["file"],
+        ),
+        "invalid-name": (
+            ["my-file.py", "other.file.py"],
+            {},
+            []
+        )
+    }
+
+    @pytest.mark.parametrize("example", EXAMPLES.keys())
+    def test_finder(self, tmp_path, example):
+        files, kwargs, expected_modules = self.EXAMPLES[example]
+        ensure_files(tmp_path, files)
+        assert self.find(tmp_path, **kwargs) == set(expected_modules)
+
+    @pytest.mark.skipif(not has_symlink(), reason='Symlink support required')
+    def test_symlinked_packages_are_included(self, tmp_path):
+        src = "_myfiles/file.py"
+        ensure_files(tmp_path, [src])
+        os.symlink(tmp_path / src, tmp_path / "link.py")
+        assert self.find(tmp_path) == {"link"}
+
+
+class TestFlatLayoutModuleFinder:
+    def find(self, path, *args, **kwargs):
+        return set(FlatLayoutModuleFinder.find(str(path)))
+
+    EXAMPLES = {
+        # circumstance: (files, expected_modules)
+        "hidden-files": (
+            [".module.py"],
+            []
+        ),
+        "private-modules": (
+            ["_module.py"],
+            []
+        ),
+        "common-names": (
+            ["setup.py", "conftest.py", "test.py", "tests.py", "example.py", "mod.py"],
+            ["mod"]
+        ),
+        "tool-specific": (
+            ["tasks.py", "fabfile.py", "noxfile.py", "dodo.py", "manage.py", "mod.py"],
+            ["mod"]
+        )
+    }
+
+    @pytest.mark.parametrize("example", EXAMPLES.keys())
+    def test_unwanted_files_not_included(self, tmp_path, example):
+        files, expected_modules = self.EXAMPLES[example]
+        ensure_files(tmp_path, files)
+        assert self.find(tmp_path) == set(expected_modules)


### PR DESCRIPTION
As discussed in #2887 and #2888, it would be nice to have some configurations automatically derived.
This is definitely possible for `packages` and `py_modules`, and (based on these two) also for `name` (as suggested by @jaraco).

This implementation supersedes #2888 (closes #2888).

<!-- First time contributors: Take a moment to review https://setuptools.readthedocs.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- A new class `setuptools.discovery.ConfigDiscovery` implementing the automatic discovery logic
- Moved `PackageFinder` and `PEP420PackageFinder` to the `setuptools.discovery` module due to the implementation affinity.
- New `FlatLayoutPackageFinder` and `FlatLayoutModuleFinder` classes implementing a more careful discovery (more exclude patterns) since they are meant to be used directly with the project directory.
- `ConfigDiscovery` changes the `Distribution` object just before running commands.
  Unfortunately, it is not possible to call `ConfigDiscovery` in `finalize_options`, since options coming from configuration files (such as `setup.cfg`) can be still missing (parsed in a later stage).

Please notice all these class/module names can be changed upon suggestion. I just adopted them for the lack of better ones 😝.

Closes #2887

## Differences from #2888

In #2888, I assumed that `name` have to be statically defined (this assumption follows the ideas in PEP 621). Therefore it is possible to implement a more restricted discovery, only finding modules/packages that match the distribution name when the *flat-layout* is employed.

The implementation in this PR is "eager" (can find more files), since it does not rely on the given metadata.

Moreover this PR goes in the opposite direction and derives ``name`` for ``packages`` and ``py_modules`` as per the [#2887 suggestion](https://github.com/pypa/setuptools/issues/2887#issuecomment-970708430).

## How the user can "exclude" modules/packages not meant for distribution?

One of the main motivations of this PR is to simplify package configuration. Currently there is already a lot of options for configuring setuptools behaviour (``py_modules``, ``packages`` and ``package_dir``). Something I do not wish to do is to complicate even more the understanding of the current existing options by introducing new ones or overloading the existing ones.

Instead if the users want to change which files/folder are discovered they can manually specify them via the existing fields in ``setup.cfg``, or switch to the *src-layout* (which is supposed to solve most of these problems) when possible. In other words, they have to configure setuptools as it was done before the changes in this PR (so the worst case scenario: automatic discovery doesn't change anything).

## How about backward compatibility?

The same approach used in #2888 was adopted here: automatic values for `packages` and `py_modules` will only be discovered if the user don't provide both (which would result, I believe, in an empty distribution prior to this PR -- in the majority of the cases, this would mean that some configuration was missing/wrong).

Empty distributions are still possible (e.g. for those that wish to create "metapackages"), as long as they don't create Python module/packages in the project directory (files/folder associated with common tools are automatically excluded, e.g. `docs`, `fabfile.py`, `tasks.py` -- as well as "private"/"hidden" ones, i.e. files/folders starting with an `_` or `.) -- which sound as a reasonable requirement for empty distributions.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.readthedocs.io/en/latest/development/developer-guide.html#making-a-pull-request
