### PR TITLE
fix `pkg_resources` import failures w/ py3-only loaders

### DIFF
--- a/changelog.d/2918.misc.rst
+++ b/changelog.d/2918.misc.rst
@@ -1,0 +1,1 @@
+Correct support for Python 3 native loaders.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2205,12 +2205,14 @@ def _handle_ns(packageName, path_item):
 
     # use find_spec (PEP 451) and fall-back to find_module (PEP 302)
     try:
-        loader = importer.find_spec(packageName).loader
+        spec = importer.find_spec(packageName)
     except AttributeError:
         # capture warnings due to #1111
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             loader = importer.find_module(packageName)
+    else:
+        loader = spec.loader if spec else None
 
     if loader is None:
         return None


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
https://github.com/pypa/setuptools/pull/1563 introduced a subtle bug in the fallback code for `pkg_resources` enumeration. The original code that only used `find_module` later accounts for a `None` loader return value (ie, the requested module couldn't be found), but the new code blindly dots into the return from `find_spec` (which can also be `None`) to grab its `loader`. When this occurs, it inadvertently trips the `AttributeError` that was supposed to be there for py2 loaders that don't implement `find_spec`, causing `find_module` to be called even on a py3-native loader. Loaders that still implement the deprecated 2.x methods will (correctly) return `None`, triggering the old fallback path, all is well. However, new loaders that don't implement `find_module` will blow up the `pkg_resources` enumeration with another `AttributeError`.

The inadvertent trip of the py2 fallback happens *a lot* even with just the built-in loaders (eg, instrument the fallback exception handler with a `print` or something, then install `straight.plugin` in a fresh venv and `import pkg_resources`)- it works by accident until the builtin loaders start dropping `find_module` (as is planned for Python 3.11+), at which point it gets ugly fast.

This PR minimizes the try block's surface area to only the necessary loader method call, and defensively checks for a non-empty response from `find_spec` before trying to grab its `loader` (otherwise setting the loader to `None` to restore the previous early exit behavior for modules that can't be loaded.

This one's pretty tricky to add tests for without wiring up a bespoke py3 loader. Happy to add a changelog entry if the fix otherwise looks good...

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
