### PR TITLE
[CI] Prevent `tmp_src` test fixture from copying the `.git`/`.tox` and other heavy folders

### DIFF
--- a/changelog.d/2922.misc.rst
+++ b/changelog.d/2922.misc.rst
@@ -1,0 +1,3 @@
+Modified ``tmp_src`` test fixture to prevent copying hidden or unnecessary
+files and folders. As a side effect, the tests are expected to run slightly
+faster -- by :user:`abravalheri`.

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -2,6 +2,7 @@ import contextlib
 import sys
 import shutil
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -40,8 +41,17 @@ def tmp_src(request, tmp_path):
     when they are not being executed sequentially.
     """
     tmp_src_path = tmp_path / 'src'
-    shutil.copytree(request.config.rootdir, tmp_src_path)
-    return tmp_src_path
+    tmp_src_path.mkdir(exist_ok=True, parents=True)
+    for item in Path(request.config.rootdir).glob("*"):
+        name = item.name
+        if str(name).startswith(".") or name in ("dist", "build", "docs"):
+            # Avoid copying unnecessary folders, specially the .git one
+            # that can contain lots of files and is error prone
+            continue
+        copy = shutil.copy2 if item.is_file() else shutil.copytree
+        copy(item, tmp_src_path / item.name)
+
+    yield tmp_src_path
 
 
 @pytest.fixture(autouse=True, scope="session")


### PR DESCRIPTION
The `tmp_src` fixture copies the setuptools directory to prevent errors that appear when running tests concurrently. However it seems that is copying everything including the `.git` directory (and possibly others like `.tox`). These directories can be quite heavy and error prone to copy.

The changes introduced here prevent copying these unnecessary folders/files. As a side effect, the tests should run slightly faster.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- In the `tmp_src` fixture, instead of blindly using `shutil.copytree`, glob the src directory and copy entry-by-entry, if they are not hidden or unnecessary file/folders.

Closes #2921

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
