### PR TITLE
Render `distutils` commit links properly in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,10 @@ link_files = {
                 url='{GH}/pypa/distutils/issues/{distutils}',
             ),
             dict(
+                pattern=r'pypa/distutils@(?P<distutils_commit>[\da-f]+)',
+                url='{GH}/pypa/distutils/commit/{distutils_commit}',
+            ),
+            dict(
                 pattern=r'^(?m)((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n',
                 with_scm='{text}\n{rev[timestamp]:%d %b %Y}\n',
             ),


### PR DESCRIPTION
## Summary of changes

There are seven references to `distutils` commits that Sphinx renders as email addresses. I have added a rule to convert these commits into the proper GitHub URLs. I opted to explicitly encode `distutils` into the pattern because it is the only repository for which the documentation references commits. I felt that trying something more general would be more error prone, and this implementation at least solves the current problem. It might be worth revisiting if this documentation links to commits from other repositories.

Closes #2884