### PR TITLE
Add support for extended install schemes in easy_install.

### DIFF
--- a/changelog.d/2944.misc.rst
+++ b/changelog.d/2944.misc.rst
@@ -1,0 +1,1 @@
+Add support for extended install schemes in easy_install.

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -252,9 +252,13 @@ class easy_install(Command):
             # Only python 3.2+ has abiflags
             'abiflags': getattr(sys, 'abiflags', ''),
             'platlibdir': getattr(sys, 'platlibdir', 'lib'),
-            'implementation_lower': install._get_implementation().lower(),
-            'implementation': install._get_implementation(),
         }
+        with contextlib.suppress(AttributeError):
+            # only for distutils outside stdlib
+            self.config_vars.update({
+                'implementation_lower': install._get_implementation().lower(),
+                'implementation': install._get_implementation(),
+            })
 
         if site.ENABLE_USER_SITE:
             self.config_vars['userbase'] = self.install_userbase
@@ -714,7 +718,11 @@ class easy_install(Command):
                     return dist
 
     def select_scheme(self, name):
-        install._select_scheme(self, name)
+        try:
+            install._select_scheme(self, name)
+        except AttributeError:
+            # stdlib distutils
+            install.install.select_scheme(self, name)
 
     # FIXME: 'easy_install.process_distribution' is too complex (12)
     def process_distribution(  # noqa: C901

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -17,10 +17,10 @@ from distutils.errors import (
     DistutilsArgError, DistutilsOptionError,
     DistutilsError, DistutilsPlatformError,
 )
-from distutils.command.install import INSTALL_SCHEMES, SCHEME_KEYS
 from distutils import log, dir_util
 from distutils.command.build_scripts import first_line_re
 from distutils.spawn import find_executable
+from distutils.command import install
 import sys
 import os
 import zipimport
@@ -251,6 +251,9 @@ class easy_install(Command):
             'exec_prefix': exec_prefix,
             # Only python 3.2+ has abiflags
             'abiflags': getattr(sys, 'abiflags', ''),
+            'platlibdir': getattr(sys, 'platlibdir', 'lib'),
+            'implementation_lower': install._get_implementation().lower(),
+            'implementation': install._get_implementation(),
         }
 
         if site.ENABLE_USER_SITE:
@@ -711,13 +714,7 @@ class easy_install(Command):
                     return dist
 
     def select_scheme(self, name):
-        """Sets the install directories by applying the install schemes."""
-        # it's the caller's problem if they supply a bad name!
-        scheme = INSTALL_SCHEMES[name]
-        for key in SCHEME_KEYS:
-            attrname = 'install_' + key
-            if getattr(self, attrname) is None:
-                setattr(self, attrname, scheme[key])
+        install._select_scheme(self, name)
 
     # FIXME: 'easy_install.process_distribution' is too complex (12)
     def process_distribution(  # noqa: C901


### PR DESCRIPTION
- Extract _select_scheme function to be re-used by Setuptools.
- In easy_install, re-use scheme selection from distutils if available.
- Add fallback support for distutils in stdlib.

Fixes #2938
