### PR TITLE
Make distutils metapath finder shim insertion idempotent

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -130,7 +130,9 @@ DISTUTILS_FINDER = DistutilsMetaFinder()
 
 
 def add_shim():
-    sys.meta_path.insert(0, DISTUTILS_FINDER)
+    # ensure finder is only added once; it will be removed once setuptools has been imported successfully
+    if DISTUTILS_FINDER not in sys.meta_path:
+      sys.meta_path.insert(0, DISTUTILS_FINDER)
 
 
 def remove_shim():


### PR DESCRIPTION
## Summary of changes

Ensure _DistutilsMetaFinder is only added to `sys.meta_path` once.

closes #2958 

(will add tests/changelog if change is otherwise deemed OK)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
