### PR TITLE
Sync with pypa/distutils@9867e2e42

### DIFF
--- a/changelog.d/2960.misc.rst
+++ b/changelog.d/2960.misc.rst
@@ -1,0 +1,1 @@
+Install schemes fall back to default scheme for headers.


### PR DESCRIPTION
- Fix AttributeError when sysconfig does not supply platsubdir
- When headers are missing in a preferred scheme, use the default scheme as a fallback to resolve headers. Workaround for and fixes #88.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
