### PR TITLE
distutils shim should ignore setuptools on another path

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -85,20 +85,18 @@ class DistutilsMetaFinder:
     def spec_for_distutils(self):
         import importlib.abc
         import importlib.util
-        from pathlib import Path
 
-        st_mod = importlib.import_module('setuptools')
-
-        # prevent this import redirection shim from interacting with a possibly
-        # incompatible setuptools in another location on sys.path
-        # see pypa/setuptools#2957
-        if not Path(__file__).parents[1].samefile(Path(st_mod.__file__).parents[1]):
+        try:
+            mod = importlib.import_module('setuptools._distutils')
+        except Exception:
+            # an older Setuptools without a local distutils is taking
+            # precedence, so fall back to stdlib. Ref #2957.
             return None
 
         class DistutilsLoader(importlib.abc.Loader):
 
             def create_module(self, spec):
-                return importlib.import_module('setuptools._distutils')
+                return mod
 
             def exec_module(self, module):
                 pass

--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -58,9 +58,7 @@ def ensure_local_distutils():
 
     # check that submodules load as expected
     core = importlib.import_module('distutils.core')
-    # FIXME: this assertion blows up if the MetaFinder below has no-opped on a
-    #  setuptools from another path
-    # assert '_distutils' in core.__file__, core.__file__
+    assert '_distutils' in core.__file__, core.__file__
 
 
 def do_override():

--- a/changelog.d/2962.misc.rst
+++ b/changelog.d/2962.misc.rst
@@ -1,0 +1,1 @@
+Avoid attempting to use local distutils when the presiding version of Setuptools on the path doesn't have one.


### PR DESCRIPTION
## Summary of changes
Prevents `_distutils_hack` finder shim from interacting with a possibly incompatible setuptools higher on sys.path

Closes #2957


### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
