### PR TITLE
WIP direct module load shims

### DIFF
--- a/_distutils_hack/override.py
+++ b/_distutils_hack/override.py
@@ -1,1 +1,0 @@
-__import__('_distutils_hack').do_override()

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -5,7 +5,8 @@ import functools
 import os
 import re
 
-import _distutils_hack.override  # noqa: F401
+from ._distutils_shim import do_override  # noqa: F401
+do_override()
 
 import distutils.core
 from distutils.errors import DistutilsOptionError


### PR DESCRIPTION
## Summary of changes
* .pth uses direct shim module load from sibling setuptools dir instead of import
* import shims attempt to remove themselves/others when it's clear they're not needed (eg, setuptools path mismatch from .pth)
* removes _distutils_hack top-level package

Closes #2957

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
