### PR TITLE
[CI] Remove the need for the `tmp_src` fixture

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
         run: tox -e integration
 
   release:
-    needs: [test, integration-test]
+    needs: [test, test_cygwin, integration-test]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ docs/build
 include
 lib
 distribute.egg-info
-foo.egg-info
 setuptools.egg-info
 .coverage
 .eggs

--- a/changelog.d/2968.misc.1.rst
+++ b/changelog.d/2968.misc.1.rst
@@ -1,0 +1,9 @@
+Removed ``tmp_src`` test fixture. Previously this fixture was copying all the
+files and folders under the project root, including the ``.git`` directory,
+which is error prone and increases testing time.
+
+Since ``tmp_src`` was used to populate virtual environments (installing the
+version of ``setuptools`` under test via the source tree), it was replaced by
+the new ``setuptools_sdist`` and ``setuptools_wheel`` fixtures (that are build
+only once per session testing and can be shared between all the workers for
+read-only usage).

--- a/changelog.d/2968.misc.2.rst
+++ b/changelog.d/2968.misc.2.rst
@@ -1,0 +1,4 @@
+Introduced new test fixtures ``venv``, ``venv_without_setuptools``,
+``bare_venv`` that rely on the ``jaraco.envs`` package.
+These new test fixtures were also used to remove the (currently problematic)
+dependency on the ``pytest_virtualenv`` plugin.

--- a/changelog.d/2968.misc.3.rst
+++ b/changelog.d/2968.misc.3.rst
@@ -1,0 +1,4 @@
+Improved isolation for some tests that where inadvertently using the project
+root for builds, and therefore creating directories (e.g. ``build``, ``dist``,
+``*.egg-info``) that could interfere with the outcome of other tests
+-- by :user:`abravalheri`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,9 +69,13 @@ testing-integration =
 	pytest
 	pytest-xdist
 	pytest-enabler
-	virtualenv
+	virtualenv>=13.0.0
 	tomli
 	wheel
+	jaraco.path>=3.2.0
+	jaraco.envs>=2.2
+	build[virtualenv]
+	filelock>=3.4.0
 
 
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,8 @@ testing =
 	pytest-xdist
 	sphinx>=4.3.2
 	jaraco.path>=3.2.0
+	build[virtualenv]
+	filelock>=3.4.0
 
 testing-integration =
 	pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ testing =
 	mock
 	flake8-2020
 	virtualenv>=13.0.0
-	pytest-virtualenv>=1.2.7  # TODO: Update once man-group/pytest-plugins#188 is solved
 	wheel
 	paver
 	pip>=19.1 # For proper file:// URLs support.

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -1,8 +1,23 @@
 import os
 import sys
+import subprocess
 import unicodedata
-
 from subprocess import Popen as _Popen, PIPE as _PIPE
+
+import jaraco.envs
+
+
+class VirtualEnv(jaraco.envs.VirtualEnv):
+    name = '.env'
+    # Some version of PyPy will import distutils on startup, implicitly
+    # importing setuptools, and thus leading to BackendInvalid errors
+    # when upgrading Setuptools. Bypass this behavior by avoiding the
+    # early availability and need to upgrade.
+    create_opts = ['--no-setuptools']
+
+    def run(self, cmd, *args, **kwargs):
+        cmd = [self.exe(cmd[0])] + cmd[1:]
+        return subprocess.check_output(cmd, *args, cwd=self.root, **kwargs)
 
 
 def _which_dirs(cmd):

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -17,7 +17,8 @@ class VirtualEnv(jaraco.envs.VirtualEnv):
 
     def run(self, cmd, *args, **kwargs):
         cmd = [self.exe(cmd[0])] + cmd[1:]
-        return subprocess.check_output(cmd, *args, cwd=self.root, **kwargs)
+        kwargs = {"cwd": self.root, **kwargs}  # Allow overriding
+        return subprocess.check_output(cmd, *args, **kwargs)
 
 
 def _which_dirs(cmd):

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -4,8 +4,9 @@ import shutil
 import subprocess
 
 import pytest
+import path
 
-from . import contexts
+from . import contexts, environment
 
 
 @pytest.fixture
@@ -104,3 +105,32 @@ def setuptools_wheel(tmp_path_factory, request):
             "--outdir", str(tmp) , str(request.config.rootdir)
         ])
         return next(tmp.glob("*.whl"))
+
+
+@pytest.fixture
+def venv(tmp_path, setuptools_wheel):
+    """Virtual env with the version of setuptools under test installed"""
+    env = environment.VirtualEnv()
+    env.root = path.Path(tmp_path / 'venv')
+    env.req = str(setuptools_wheel)
+    return env.create()
+
+
+@pytest.fixture
+def venv_without_setuptools(tmp_path):
+    """Virtual env without any version of setuptools installed"""
+    env = environment.VirtualEnv()
+    env.root = path.Path(tmp_path / 'venv_without_setuptools')
+    env.create_opts = ['--no-setuptools']
+    env.ensure_env()
+    return env
+
+
+@pytest.fixture
+def bare_venv(tmp_path):
+    """Virtual env without any common packages installed"""
+    env = environment.VirtualEnv()
+    env.root = path.Path(tmp_path / 'bare_venv')
+    env.create_opts = ['--no-setuptools', '--no-pip', '--no-wheel', '--no-seed']
+    env.ensure_env()
+    return env

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -72,3 +72,35 @@ def sample_project(tmp_path):
     except Exception:
         pytest.skip("Unable to clone sampleproject")
     return tmp_path / 'sampleproject'
+
+
+# sdist and wheel artifacts should be stable across a round of tests
+# so we can build them once per session and use the files as "readonly"
+
+
+@pytest.fixture(scope="session")
+def setuptools_sdist(tmp_path_factory, request):
+    with contexts.session_locked_tmp_dir(tmp_path_factory, "sdist_build") as tmp:
+        dist = next(tmp.glob("*.tar.gz"), None)
+        if dist:
+            return dist
+
+        subprocess.check_call([
+            sys.executable, "-m", "build", "--sdist",
+            "--outdir", str(tmp), str(request.config.rootdir)
+        ])
+        return next(tmp.glob("*.tar.gz"))
+
+
+@pytest.fixture(scope="session")
+def setuptools_wheel(tmp_path_factory, request):
+    with contexts.session_locked_tmp_dir(tmp_path_factory, "wheel_build") as tmp:
+        dist = next(tmp.glob("*.whl"), None)
+        if dist:
+            return dist
+
+        subprocess.check_call([
+            sys.executable, "-m", "build", "--wheel",
+            "--outdir", str(tmp) , str(request.config.rootdir)
+        ])
+        return next(tmp.glob("*.whl"))

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -1,6 +1,5 @@
 import contextlib
 import sys
-import shutil
 import subprocess
 
 import pytest
@@ -27,22 +26,6 @@ def user_override(monkeypatch):
 def tmpdir_cwd(tmpdir):
     with tmpdir.as_cwd() as orig:
         yield orig
-
-
-@pytest.fixture
-def tmp_src(request, tmp_path):
-    """Make a copy of the source dir under `$tmp/src`.
-
-    This fixture is useful whenever it's necessary to run `setup.py`
-    or `pip install` against the source directory when there's no
-    control over the number of simultaneous invocations. Such
-    concurrent runs create and delete directories with the same names
-    under the target directory and so they influence each other's runs
-    when they are not being executed sequentially.
-    """
-    tmp_src_path = tmp_path / 'src'
-    shutil.copytree(request.config.rootdir, tmp_src_path)
-    return tmp_src_path
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/setuptools/tests/test_bdist_deprecations.py
+++ b/setuptools/tests/test_bdist_deprecations.py
@@ -11,7 +11,7 @@ from setuptools import SetuptoolsDeprecationWarning
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='non-Windows only')
 @mock.patch('distutils.command.bdist_rpm.bdist_rpm')
-def test_bdist_rpm_warning(distutils_cmd):
+def test_bdist_rpm_warning(distutils_cmd, tmpdir_cwd):
     dist = Distribution(
         dict(
             script_name='setup.py',

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -1,37 +1,13 @@
 import os
 import sys
 import functools
-import subprocess
 import platform
 import textwrap
 
 import pytest
-import jaraco.envs
-import path
 
 
 IS_PYPY = '__pypy__' in sys.builtin_module_names
-
-
-class VirtualEnv(jaraco.envs.VirtualEnv):
-    name = '.env'
-    # Some version of PyPy will import distutils on startup, implicitly
-    # importing setuptools, and thus leading to BackendInvalid errors
-    # when upgrading Setuptools. Bypass this behavior by avoiding the
-    # early availability and need to upgrade.
-    create_opts = ['--no-setuptools']
-
-    def run(self, cmd, *args, **kwargs):
-        cmd = [self.exe(cmd[0])] + cmd[1:]
-        return subprocess.check_output(cmd, *args, cwd=self.root, **kwargs)
-
-
-@pytest.fixture
-def venv(tmp_path, tmp_src):
-    env = VirtualEnv()
-    env.root = path.Path(tmp_path / 'venv')
-    env.req = str(tmp_src)
-    return env.create()
 
 
 def popen_text(call):

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -18,6 +18,11 @@ import setuptools.depends as dep
 from setuptools.depends import Require
 
 
+@pytest.fixture(autouse=True)
+def isolated_dir(tmpdir_cwd):
+    yield
+
+
 def makeSetup(**args):
     """Return distribution from 'setup(**args)', without executing commands"""
 

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -1,52 +1,34 @@
-import glob
 import os
 import sys
 import itertools
+import subprocess
 
 import pathlib
 
 import pytest
-from pytest_fixture_config import yield_requires_config
 
-import pytest_virtualenv
-
+from . import contexts
 from .textwrap import DALS
 from .test_easy_install import make_nspkg_sdist
 
 
 @pytest.fixture(autouse=True)
-def pytest_virtualenv_works(virtualenv):
+def pytest_virtualenv_works(venv):
     """
     pytest_virtualenv may not work. if it doesn't, skip these
     tests. See #1284.
     """
-    venv_prefix = virtualenv.run(
-        'python -c "import sys; print(sys.prefix)"',
-        capture=True,
-    ).strip()
+    venv_prefix = venv.run(["python" , "-c", "import sys; print(sys.prefix)"]).strip()
     if venv_prefix == sys.prefix:
         pytest.skip("virtualenv is broken (see pypa/setuptools#1284)")
 
 
-@yield_requires_config(pytest_virtualenv.CONFIG, ['virtualenv_executable'])
-@pytest.fixture(scope='function')
-def bare_virtualenv():
-    """ Bare virtualenv (no pip/setuptools/wheel).
-    """
-    with pytest_virtualenv.VirtualEnv(args=(
-        '--no-wheel',
-        '--no-pip',
-        '--no-setuptools',
-    )) as venv:
-        yield venv
-
-
-def test_clean_env_install(bare_virtualenv, tmp_src):
+def test_clean_env_install(venv_without_setuptools, setuptools_wheel):
     """
     Check setuptools can be installed in a clean environment.
     """
-    cmd = [bare_virtualenv.python, 'setup.py', 'install']
-    bare_virtualenv.run(cmd, cd=tmp_src)
+    cmd = ["python", "-m", "pip", "install", str(setuptools_wheel)]
+    venv_without_setuptools.run(cmd)
 
 
 def _get_pip_versions():
@@ -99,41 +81,31 @@ def _get_pip_versions():
     reason="https://github.com/pypa/setuptools/pull/2865#issuecomment-965834995",
 )
 @pytest.mark.parametrize('pip_version', _get_pip_versions())
-def test_pip_upgrade_from_source(pip_version, tmp_src, virtualenv):
+def test_pip_upgrade_from_source(pip_version, venv_without_setuptools,
+                                 setuptools_wheel, setuptools_sdist):
     """
     Check pip can upgrade setuptools from source.
     """
-    # Install pip/wheel, and remove setuptools (as it
+    # Install pip/wheel, in a venv without setuptools (as it
     # should not be needed for bootstraping from source)
-    if pip_version is None:
-        upgrade_pip = ()
-    else:
-        upgrade_pip = ('python -m pip install -U "{pip_version}" --retries=1',)
-    virtualenv.run(' && '.join((
-        'pip uninstall -y setuptools',
-        'pip install -U wheel',
-    ) + upgrade_pip).format(pip_version=pip_version))
-    dist_dir = virtualenv.workspace
-    # Generate source distribution / wheel.
-    virtualenv.run(' && '.join((
-        'python setup.py -q sdist -d {dist}',
-        'python setup.py -q bdist_wheel -d {dist}',
-    )).format(dist=dist_dir), cd=tmp_src)
-    sdist = glob.glob(os.path.join(dist_dir, '*.zip'))[0]
-    wheel = glob.glob(os.path.join(dist_dir, '*.whl'))[0]
-    # Then update from wheel.
-    virtualenv.run('pip install ' + wheel)
+    venv = venv_without_setuptools
+    venv.run(["pip", "install", "-U", "wheel"])
+    if pip_version is not None:
+        venv.run(["python", "-m", "pip", "install", "-U", pip_version, "--retries=1"])
+    with pytest.raises(subprocess.CalledProcessError):
+        # Meta-test to make sure setuptools is not installed
+        venv.run(["python", "-c", "import setuptools"])
+
+    # Then install from wheel.
+    venv.run(["pip", "install", str(setuptools_wheel)])
     # And finally try to upgrade from source.
-    virtualenv.run('pip install --no-cache-dir --upgrade ' + sdist)
+    venv.run(["pip", "install", "--no-cache-dir", "--upgrade", str(setuptools_sdist)])
 
 
-def _check_test_command_install_requirements(virtualenv, tmpdir, cwd):
+def _check_test_command_install_requirements(venv, tmpdir):
     """
     Check the test command will install all required dependencies.
     """
-    # Install setuptools.
-    virtualenv.run('python setup.py develop', cd=cwd)
-
     def sdist(distname, version):
         dist_path = tmpdir.join('%s-%s.tar.gz' % (distname, version))
         make_nspkg_sdist(str(dist_path), distname, version)
@@ -182,28 +154,24 @@ def _check_test_command_install_requirements(virtualenv, tmpdir, cwd):
 
             open('success', 'w').close()
             '''))
-    # Run test command for test package.
-    # use 'virtualenv.python' as workaround for man-group/pytest-plugins#166
-    cmd = [virtualenv.python, 'setup.py', 'test', '-s', 'test']
-    virtualenv.run(cmd, cd=str(tmpdir))
+
+    cmd = ["python", 'setup.py', 'test', '-s', 'test']
+    venv.run(cmd, cwd=str(tmpdir))
     assert tmpdir.join('success').check()
 
 
-def test_test_command_install_requirements(virtualenv, tmpdir, request):
+def test_test_command_install_requirements(venv, tmpdir, tmpdir_cwd):
     # Ensure pip/wheel packages are installed.
-    virtualenv.run(
-        "python -c \"__import__('pkg_resources').require(['pip', 'wheel'])\"")
-    # uninstall setuptools so that 'setup.py develop' works
-    virtualenv.run("python -m pip uninstall -y setuptools")
+    venv.run(["python", "-c", "__import__('pkg_resources').require(['pip', 'wheel'])"])
     # disable index URL so bits and bobs aren't requested from PyPI
-    virtualenv.env['PIP_NO_INDEX'] = '1'
-    _check_test_command_install_requirements(virtualenv, tmpdir, request.config.rootdir)
+    with contexts.environment(PYTHONPATH=None, PIP_NO_INDEX="1"):
+        _check_test_command_install_requirements(venv, tmpdir)
 
 
-def test_no_missing_dependencies(bare_virtualenv, request):
+def test_no_missing_dependencies(bare_venv, request):
     """
     Quick and dirty test to ensure all external dependencies are vendored.
     """
+    setuptools_dir = request.config.rootdir
     for command in ('upload',):  # sorted(distutils.command.__all__):
-        cmd = [bare_virtualenv.python, 'setup.py', command, '-h']
-        bare_virtualenv.run(cmd, cd=request.config.rootdir)
+        bare_venv.run(['python', 'setup.py', command, '-h'], cwd=setuptools_dir)

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,7 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]
 deps =
-	# TODO: remove after man-group/pytest-plugins#188 is solved
-	pytest-virtualenv @ git+https://github.com/jaraco/pytest-plugins@distutils-deprecated#subdirectory=pytest-virtualenv
+	# Ideally all the dependencies should be set as "extras"
 commands =
 	pytest {posargs}
 usedevelop = True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

This change supersedes #2922.

## Summary of changes

As discussed in #2922, the `tmp_src` fixture copies the `.git` repository, which is error prone and may increase testing time.

I noticed that this fixture was used only in `test_virtualenv` and `test_distutils_adoption`, mainly to populate a virtual environment with the version of setuptools that is currently under test.

This PR proposes building sdist/wheel artifacts from the source tree and using them to populate these virtualenvs, instead of `pip install <setuptools directory>` or `python setup.py install/develop`. It also uses a lockfile approach discussed in the [`pytest-xdist` homepage](https://github.com/pytest-dev/pytest-xdist/blob/f9f8a765bae0d177bbecf4150db9853bf700554f/README.rst#making-session-scoped-fixtures-execute-only-once) to make these artifacts session-scoped fixtures that will run only once and be available to all tests (that can use them in parallel for installation).

As a nice side-effect, I also took the opportunity to:

- Replace the problematic `pytest_virtualenv` plugin with `jaraco.envs` as the later was already being used in other tests (this unification of libraries allowed sharing fixtures).
- Improve isolation for some tests that where inadvertently using the project root as CWD for building dummy distribution objects.

This change might introduce some merge conflicts with other PRs that I have open (e.g. #2863), but I can quickly fix them (the conflicts are mostly due to lines being added/removed to the same region of `setup.cfg` for the changes in test dependencies).

Closes #2921.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
