### PR TITLE
Enable logging through Python logging module

### DIFF
--- a/changelog.d/2974.change.rst
+++ b/changelog.d/2974.change.rst
@@ -1,0 +1,1 @@
+Setuptools now relies on the Python logging infrastructure to log messages. Instead of using ``distutils.log.*``, use ``logging.getLogger(name).*``.

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -18,6 +18,7 @@ from setuptools.extension import Extension
 from setuptools.dist import Distribution
 from setuptools.depends import Require
 from . import monkey
+from . import logging
 
 
 __all__ = [
@@ -149,6 +150,7 @@ def _install_setup_requires(attrs):
 
 def setup(**attrs):
     # Make sure we have any requirements needed to interpret 'attrs'.
+    logging.configure()
     _install_setup_requires(attrs)
     return distutils.core.setup(**attrs)
 

--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -1,5 +1,7 @@
 import sys
 import logging
+import distutils.log
+from . import monkey
 
 
 def _not_warning(record):
@@ -20,3 +22,9 @@ def configure():
     handlers = err_handler, out_handler
     logging.basicConfig(
         format="{message}", style='{', handlers=handlers, level=logging.DEBUG)
+    monkey.patch_func(set_threshold, distutils.log, 'set_threshold')
+
+
+def set_threshold(level):
+    logging.root.setLevel(level*10)
+    return set_threshold.unpatched(level)

--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -1,0 +1,22 @@
+import sys
+import logging
+
+
+def _not_warning(record):
+    return record.levelno < logging.WARNING
+
+
+def configure():
+    """
+    Configure logging to emit warning and above to stderr
+    and everything else to stdout. This behavior is provided
+    for compatibilty with distutils.log but may change in
+    the future.
+    """
+    err_handler = logging.StreamHandler()
+    err_handler.setLevel(logging.WARNING)
+    out_handler = logging.StreamHandler(sys.stdout)
+    out_handler.addFilter(_not_warning)
+    handlers = err_handler, out_handler
+    logging.basicConfig(
+        format="{message}", style='{', handlers=handlers, level=logging.DEBUG)


### PR DESCRIPTION
- Add setuptools.log to supersede distutils.log. Ref #2973.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #2973. Closes #2023.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
