### PR TITLE
Remove workaround for test/CI dependency on Sphinx

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,12 +61,12 @@ testing =
 	pip>=19.1 # For proper file:// URLs support.
 	jaraco.envs>=2.2
 	pytest-xdist
-	sphinx
+	sphinx>=4.3.2
 	jaraco.path>=3.2.0
 
 docs =
 	# upstream
-	sphinx
+	sphinx >= 4.3.2
 	jaraco.packaging >= 8.2
 	rst.linker >= 1.9
 	jaraco.tidelift >= 1.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ testing =
 
 docs =
 	# upstream
-	sphinx >= 4.3.2
+	sphinx
 	jaraco.packaging >= 8.2
 	rst.linker >= 1.9
 	jaraco.tidelift >= 1.4

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,6 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 
 [testenv]
 deps =
-	# workaround for sphinx-doc/sphinx#9562
-	# TODO: remove after Sphinx>4.1.2 is available.
-	sphinx@git+https://github.com/sphinx-doc/sphinx; python_version>="3.10"
 	# TODO: remove after man-group/pytest-plugins#188 is solved
 	pytest-virtualenv @ git+https://github.com/jaraco/pytest-plugins@distutils-deprecated#subdirectory=pytest-virtualenv
 commands =


### PR DESCRIPTION
It seems that Sphinx now supports Python 3.10, which means that we can
remove the dependency workaround.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Updated docs/tests dependency on Sphinx to >=4.3.2

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests  (I assume the existing tests should be enough to catch any incompatibility error)
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
