### PR TITLE
Restore 'add_shim' as the way to invoke the hook

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -136,20 +136,20 @@ class DistutilsMetaFinder:
 DISTUTILS_FINDER = DistutilsMetaFinder()
 
 
-def ensure_shim():
-    DISTUTILS_FINDER in sys.meta_path or add_shim()
+def add_shim():
+    DISTUTILS_FINDER in sys.meta_path or insert_shim()
 
 
 @contextlib.contextmanager
 def shim():
-    add_shim()
+    insert_shim()
     try:
         yield
     finally:
         remove_shim()
 
 
-def add_shim():
+def insert_shim():
     sys.meta_path.insert(0, DISTUTILS_FINDER)
 
 

--- a/changelog.d/2983.misc.rst
+++ b/changelog.d/2983.misc.rst
@@ -1,0 +1,1 @@
+Restore 'add_shim' as the way to invoke the hook. Avoids compatibility issues between different versions of Setuptools with the distutils local implementation.

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ class install_with_pth(install):
         import os
         var = 'SETUPTOOLS_USE_DISTUTILS'
         enabled = os.environ.get(var, 'local') == 'local'
-        enabled and __import__('_distutils_hack').ensure_shim()
+        enabled and __import__('_distutils_hack').add_shim()
         """).lstrip().replace('\n', '; ')
 
     def initialize_options(self):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
