### PR TITLE
set origin= for distutils.__spec__

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -118,7 +118,9 @@ class DistutilsMetaFinder:
             def exec_module(self, module):
                 pass
 
-        return importlib.util.spec_from_loader('distutils', DistutilsLoader())
+        return importlib.util.spec_from_loader(
+            'distutils', DistutilsLoader(), origin=mod.__file__
+        )
 
     def spec_for_pip(self):
         """

--- a/changelog.d/2990.change.rst
+++ b/changelog.d/2990.change.rst
@@ -1,0 +1,1 @@
+Set the ``.origin`` attribute of the ``distutils`` module to the module's ``__file__``.

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -86,3 +86,10 @@ def test_pip_import(venv):
     """
     cmd = ['python', '-c', 'import pip']
     popen_text(venv.run)(cmd)
+
+
+def test_distutils_has_origin():
+    """
+    Distutils module spec should have an origin. #2990.
+    """
+    assert __import__('distutils').__spec__.origin


### PR DESCRIPTION
set origin so spec finding reports the correct location -- https://docs.python.org/3/library/importlib.html#importlib.machinery.ModuleSpec

## Summary of changes

Closes https://github.com/asottile/reorder_python_imports/issues/210

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
