### PR TITLE
fix: get-pip __main__ missing __file__ attribute sometimes

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -138,7 +138,7 @@ class DistutilsMetaFinder:
         Detect if get-pip is being invoked. Ref #2993.
         """
         import __main__
-        return os.path.basename(__main__.__file__) == 'get-pip.py'
+        return os.path.basename(getattr(__main__, '__file__', '')) == 'get-pip.py'
 
     @staticmethod
     def frame_file_is_setup(frame):

--- a/changelog.d/3005.change.rst
+++ b/changelog.d/3005.change.rst
@@ -1,0 +1,1 @@
+Added protection for `get-pip` in cases where `__main__` does not have a `__file__` attribute.


### PR DESCRIPTION
## Summary of changes

Closes #3002. This resolves the crash by adding protection around the `__file__` attribute request from `__main__` which sometimes doesn't have it depending on how `setuptools` is invoked.

It seems `__main__` may or may not have a `__file__` attribute, for example:

```
$ python
Python 3.8.6 (default, Oct 28 2020, 19:59:21) 
[Clang 10.0.1 (clang-1001.0.46.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import __main__
>>> __main__.__file__
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module '__main__' has no attribute '__file__'
```

while this works fine

```
$ cat get-pip.py
import __main__
print(__main__.__file__)
$ python get-pip.py
get-pip.py
```

It seems this might come down to the difference of invoking through `python -m` vs the regular file invocation (executables) mentioned in the issue as well.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
