### PR TITLE
Speedup startup of Python by importing less

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -1,17 +1,14 @@
+# don't import any costly modules
 import sys
 import os
-import re
-import importlib
-import warnings
-import contextlib
 
 
 is_pypy = '__pypy__' in sys.builtin_module_names
 
 
-warnings.filterwarnings('ignore',
-                        r'.+ distutils\b.+ deprecated',
-                        DeprecationWarning)
+# warnings.filterwarnings('ignore',
+#                        r'.+ distutils\b.+ deprecated',
+#                        DeprecationWarning)
 
 
 def warn_distutils_present():
@@ -21,6 +18,7 @@ def warn_distutils_present():
         # PyPy for 3.6 unconditionally imports distutils, so bypass the warning
         # https://foss.heptapod.net/pypy/pypy/-/blob/be829135bc0d758997b3566062999ee8b23872b4/lib-python/3/site.py#L250
         return
+    import warnings
     warnings.warn(
         "Distutils was imported before Setuptools, but importing Setuptools "
         "also replaces the `distutils` module in `sys.modules`. This may lead "
@@ -33,8 +31,12 @@ def warn_distutils_present():
 def clear_distutils():
     if 'distutils' not in sys.modules:
         return
+    import warnings
     warnings.warn("Setuptools is replacing distutils.")
-    mods = [name for name in sys.modules if re.match(r'distutils\b', name)]
+    mods = [
+        name for name in sys.modules
+        if name == "distutils" or name.startswith("distutils.")
+    ]
     for name in mods:
         del sys.modules[name]
 
@@ -48,6 +50,7 @@ def enabled():
 
 
 def ensure_local_distutils():
+    import importlib
     clear_distutils()
 
     # With the DistutilsMetaFinder in place,
@@ -73,17 +76,6 @@ def do_override():
         ensure_local_distutils()
 
 
-class suppress(contextlib.suppress, contextlib.ContextDecorator):
-    """
-    A version of contextlib.suppress with decorator support.
-
-    >>> @suppress(KeyError)
-    ... def key_error():
-    ...     {}['']
-    >>> key_error()
-    """
-
-
 class DistutilsMetaFinder:
     def find_spec(self, fullname, path, target=None):
         if path is not None:
@@ -94,6 +86,7 @@ class DistutilsMetaFinder:
         return method()
 
     def spec_for_distutils(self):
+        import importlib
         import importlib.abc
         import importlib.util
 
@@ -144,13 +137,15 @@ class DistutilsMetaFinder:
         )
 
     @classmethod
-    @suppress(AttributeError)
     def is_get_pip(cls):
         """
         Detect if get-pip is being invoked. Ref #2993.
         """
-        import __main__
-        return os.path.basename(__main__.__file__) == 'get-pip.py'
+        try:
+            import __main__
+            return os.path.basename(__main__.__file__) == 'get-pip.py'
+        except AttributeError:
+            pass
 
     @staticmethod
     def frame_file_is_setup(frame):
@@ -168,12 +163,11 @@ def add_shim():
     DISTUTILS_FINDER in sys.meta_path or insert_shim()
 
 
-@contextlib.contextmanager
-def shim():
-    insert_shim()
-    try:
-        yield
-    finally:
+class shim:
+    def __enter__(self):
+        insert_shim()
+
+    def __exit__(self, exc, value, tb):
         remove_shim()
 
 

--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -5,10 +5,10 @@ import os
 
 is_pypy = '__pypy__' in sys.builtin_module_names
 
-
-# warnings.filterwarnings('ignore',
-#                        r'.+ distutils\b.+ deprecated',
-#                        DeprecationWarning)
+import warnings
+warnings.filterwarnings('ignore',
+                       r'.+ distutils\b.+ deprecated',
+                       DeprecationWarning)
 
 
 def warn_distutils_present():

--- a/changelog.d/3006.change.rst
+++ b/changelog.d/3006.change.rst
@@ -1,0 +1,2 @@
+Fixed startup performance issue of Python interpreter due to imports of
+costly modules in ``_distutils_hack`` -- by :user:`tiran`

--- a/pytest.ini
+++ b/pytest.ini
@@ -38,8 +38,7 @@ filterwarnings=
 	# SETUPTOOLS_USE_DISTUTILS=stdlib but for
 	# https://github.com/pytest-dev/pytest/discussions/9296
 	ignore:The distutils.sysconfig module is deprecated, use sysconfig instead
-
-    ignore:The distutils package is deprecated.*
+	ignore:The distutils package is deprecated.*
 
 	# Workaround for pypa/setuptools#2868
 	# ideally would apply to PyPy only but for

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,8 @@ filterwarnings=
 	# https://github.com/pytest-dev/pytest/discussions/9296
 	ignore:The distutils.sysconfig module is deprecated, use sysconfig instead
 
+    ignore:The distutils package is deprecated.*
+
 	# Workaround for pypa/setuptools#2868
 	# ideally would apply to PyPy only but for
 	# https://github.com/pytest-dev/pytest/discussions/9296


### PR DESCRIPTION
``_distutils_hack`` is imported by a ``.pth`` file at every start of a
Python interpreter. The import of costly modules like ``re`` and
``contextlib`` almost doubles the initial startup time of an
interpreter.

- replace ``contextlib`` with simple context manager and try/except
- replace ``re`` with simple string match
- move import of ``importlib`` into function body
- remove ``warnings.filterwarnings()``, which imports ``re``, too.

Fixes: #3006
Signed-off-by: Christian Heimes <christian@python.org>

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
