### PR TITLE
Remove `numpy` sdists from integration tests

### DIFF
--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -41,7 +41,6 @@ LATEST, = list(Enum("v", "LATEST"))
 # that `build-essential`, `gfortran` and `libopenblas-dev` are installed,
 # due to their relevance to the numerical/scientific programming ecosystem)
 EXAMPLES = [
-    ("numpy", LATEST),  # custom distutils-based commands
     ("pandas", LATEST),  # cython + custom build_ext
     ("sphinx", LATEST),  # custom setup.py
     ("pip", LATEST),  # just in case...
@@ -174,7 +173,7 @@ def retrieve_pypi_sdist_metadata(package, version):
         if dist["filename"].endswith(".tar.gz"):
             return dist
 
-    # Not all packages are publishing tar.gz, e.g. numpy==1.21.4
+    # Not all packages are publishing tar.gz
     return dist
 
 


### PR DESCRIPTION
## Summary of changes

Numpy now uses a version cap for setuptools in their `pyproject.toml`, which defies a bit the value of including it in the integration tests.

As revealed in a conversation with `numpy` maintainer, it seems that they don't plan to remove this cap (maybe only update it from time to time, if strictly necessary). Moreover they are also studying other build backends.

So I think that now the best thing to do would be stop trying to build numpy sdists with the current version of setuptools, otherwise we risk to break this test.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->
<!-- Summary goes here -->

<!-- Closes issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
