### PR TITLE
docs/2674: packaging resources in quickstart guide

### DIFF
--- a/changelog.d/2674.doc.rst
+++ b/changelog.d/2674.doc.rst
@@ -1,0 +1,1 @@
+Added link to additional resources on packaging in Quickstart guide

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -227,4 +227,4 @@ Resources on Python packaging
 =============================
 Packaging in Python can be hard and is constantly evolving.
 `Python Packaging User Guide <https://packaging.python.org>`_ has tutorials and
-up-to-date references.
+up-to-date references that can help you when it is time to distribute your work.

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -225,5 +225,6 @@ parsed by ``setuptool`` to ease the pain of transition.
 
 Resources on Python packaging
 =============================
-Packaging in Python is hard. Here we provide a list of links for those that
-want to learn more.
+Packaging in Python can be hard and is constantly evolving.
+`Python Packaging User Guide <https://packaging.python.org>`_ has tutorials and
+up-to-date references.


### PR DESCRIPTION
## Summary of changes

Quickstart guide has a section for additional resources on packaging in Python, but did not provide any links. Based on the discussion at #2674, this PR adds a link to Python Packaging User Guide.

Closes #2674 