### PR TITLE
Capture performance of interpreter startup.

### DIFF
--- a/exercises.py
+++ b/exercises.py
@@ -1,0 +1,6 @@
+def measure_startup_perf():
+    # run by pytest_perf
+    import subprocess
+    import sys  # end warmup
+
+    subprocess.check_call([sys.executable, '-c', 'pass'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ testing =
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"
 	pytest-enabler >= 1.0.1
+	pytest-perf
 
 	# local
 	mock

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,8 @@ extras = testing
 passenv =
 	SETUPTOOLS_USE_DISTUTILS
 	windir  # required for test_pkg_resources
+	# honor git config in pytest-perf
+	HOME
 
 [testenv:integration]
 deps = {[testenv]deps}


### PR DESCRIPTION
In order to measure and protect the performance of interpreter startup, add performance tests. Ref #3006.
