### PR TITLE
Prevent test files from being included in setuptools own wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ exclude =
 	docs*
 	tests*
 	*.tests
+	*.tests.*
 	tools*
 
 [options.extras_require]

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -7,6 +7,7 @@ import distutils.cmd
 from distutils.errors import DistutilsOptionError
 from distutils.errors import DistutilsSetupError
 from distutils.core import Extension
+from zipfile import ZipFile
 
 import pytest
 
@@ -294,3 +295,11 @@ def test_findall_missing_symlink(tmpdir, can_symlink):
         os.symlink('foo', 'bar')
         found = list(setuptools.findall())
         assert found == []
+
+
+def test_its_own_wheel_does_not_contain_tests(setuptools_wheel):
+    with ZipFile(setuptools_wheel) as zipfile:
+        contents = [f.replace(os.sep, '/') for f in zipfile.namelist()]
+
+    for member in contents:
+        assert '/tests/' not in member


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Add a new exclude pattern to `setup.cfg [options.packages.find]`.
This new exclude pattern should prevent any files contained in the tests directories to be added to the wheel.

Closes #3017

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
