### PR TITLE
Instead of detecting 'get-pip' during the import of pip, detect 'import setuptools'

### DIFF
--- a/changelog.d/2993.misc.rst
+++ b/changelog.d/2993.misc.rst
@@ -1,0 +1,1 @@
+In _distutils_hack, for get-pip, simulate existence of setuptools.


### PR DESCRIPTION
Ref #3022. Fixes #2993.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
