### PR TITLE
Honor sysconfig vars in easy_install

### DIFF
--- a/changelog.d/3026.misc.rst
+++ b/changelog.d/3026.misc.rst
@@ -1,0 +1,1 @@
+Honor sysconfig variables in easy_install.

--- a/setuptools/_distutils/command/install.py
+++ b/setuptools/_distutils/command/install.py
@@ -397,20 +397,20 @@ class install(Command):
             abiflags = ''
         local_vars = {
             'dist_name': self.distribution.get_name(),
-                            'dist_version': self.distribution.get_version(),
-                            'dist_fullname': self.distribution.get_fullname(),
-                            'py_version': py_version,
-                            'py_version_short': '%d.%d' % sys.version_info[:2],
-                            'py_version_nodot': '%d%d' % sys.version_info[:2],
-                            'sys_prefix': prefix,
-                            'prefix': prefix,
-                            'sys_exec_prefix': exec_prefix,
-                            'exec_prefix': exec_prefix,
-                            'abiflags': abiflags,
-                            'platlibdir': getattr(sys, 'platlibdir', 'lib'),
-                            'implementation_lower': _get_implementation().lower(),
-                            'implementation': _get_implementation(),
-                           }
+            'dist_version': self.distribution.get_version(),
+            'dist_fullname': self.distribution.get_fullname(),
+            'py_version': py_version,
+            'py_version_short': '%d.%d' % sys.version_info[:2],
+            'py_version_nodot': '%d%d' % sys.version_info[:2],
+            'sys_prefix': prefix,
+            'prefix': prefix,
+            'sys_exec_prefix': exec_prefix,
+            'exec_prefix': exec_prefix,
+            'abiflags': abiflags,
+            'platlibdir': getattr(sys, 'platlibdir', 'lib'),
+            'implementation_lower': _get_implementation().lower(),
+            'implementation': _get_implementation(),
+        }
 
         if HAS_USER_SITE:
             local_vars['userbase'] = self.install_userbase

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -39,9 +39,10 @@ import subprocess
 import shlex
 import io
 import configparser
+import sysconfig
 
 
-from sysconfig import get_config_vars, get_path
+from sysconfig import get_path
 
 from setuptools import SetuptoolsDeprecationWarning
 
@@ -236,23 +237,22 @@ class easy_install(Command):
         self.version and self._render_version()
 
         py_version = sys.version.split()[0]
-        prefix, exec_prefix = get_config_vars('prefix', 'exec_prefix')
 
-        self.config_vars = {
+        self.config_vars = dict(sysconfig.get_config_vars())
+
+        self.config_vars.update({
             'dist_name': self.distribution.get_name(),
             'dist_version': self.distribution.get_version(),
             'dist_fullname': self.distribution.get_fullname(),
             'py_version': py_version,
             'py_version_short': f'{sys.version_info.major}.{sys.version_info.minor}',
             'py_version_nodot': f'{sys.version_info.major}{sys.version_info.minor}',
-            'sys_prefix': prefix,
-            'prefix': prefix,
-            'sys_exec_prefix': exec_prefix,
-            'exec_prefix': exec_prefix,
+            'sys_prefix': self.config_vars['prefix'],
+            'sys_exec_prefix': self.config_vars['exec_prefix'],
             # Only python 3.2+ has abiflags
             'abiflags': getattr(sys, 'abiflags', ''),
             'platlibdir': getattr(sys, 'platlibdir', 'lib'),
-        }
+        })
         with contextlib.suppress(AttributeError):
             # only for distutils outside stdlib
             self.config_vars.update({


### PR DESCRIPTION
- Trim excess indentation.
- Honor sysconfig variables in easy_install. Fixes #3026.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #3026

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
