### PR TITLE
Suppress distutils replacement when building or testing CPython.

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -89,6 +89,9 @@ class DistutilsMetaFinder:
         return method()
 
     def spec_for_distutils(self):
+        if self.is_cpython():
+            return
+
         import importlib
         import importlib.abc
         import importlib.util
@@ -117,6 +120,14 @@ class DistutilsMetaFinder:
         return importlib.util.spec_from_loader(
             'distutils', DistutilsLoader(), origin=mod.__file__
         )
+
+    @staticmethod
+    def is_cpython():
+        """
+        Suppress supplying distutils for CPython (build and tests).
+        Ref #2965 and #3007.
+        """
+        return os.path.isfile('pybuilddir.txt')
 
     def spec_for_pip(self):
         """

--- a/changelog.d/3031.misc.rst
+++ b/changelog.d/3031.misc.rst
@@ -1,0 +1,1 @@
+Suppress distutils replacement when building or testing CPython.


### PR DESCRIPTION
Fixes #2965. Fixes #3007.
