### PR TITLE
CI/cygwin: use cygwin/cygwin-install-action instead of choco

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,13 +53,24 @@ jobs:
       SETUPTOOLS_USE_DISTUTILS: ${{ matrix.distutils }}
     steps:
       - uses: actions/checkout@v2
-      - name: Install Cygwin with Python and tox
+      - name: Install Cygwin with Python
+        uses: cygwin/cygwin-install-action@v1
+        with:
+          platform: x86_64
+          packages: >-
+            git,
+            gcc-core,
+            python38,
+            python38-devel,
+            python38-pip
+      - name: Install tox
+        shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -leo pipefail -o igncr {0}
         run: |
-          choco install git gcc-core python38-devel python38-pip --source cygwin
-          C:\\tools\\cygwin\\bin\\bash -l -x -c 'python3.8 -m pip install tox'
+          python3.8 -m pip install tox
       - name: Run tests
+        shell: C:\cygwin\bin\env.exe CYGWIN_NOWINPATH=1 CHERE_INVOKING=1 C:\cygwin\bin\bash.exe -leo pipefail -o igncr {0}
         run: |
-          C:\\tools\\cygwin\\bin\\bash -l -x -c 'cd $(cygpath -u "$GITHUB_WORKSPACE") && tox -- --cov-report xml'
+          tox -- --cov-report xml
 
   integration-test:
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,6 @@ jobs:
             ${{ matrix.python }}
 
   test_cygwin:
-    if: ${{ false }}  # failing #3016
     strategy:
       matrix:
         distutils:


### PR DESCRIPTION
Use the official GH action for installing cygwin instead of
going through choco.

See #3016

-----

The job is still disabled. I can re-enable it if wanted.