### PR TITLE
Ensure log level is set correctly (and `setuptools.logging.set_threshold` is called)

### DIFF
--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -25,9 +25,9 @@ def configure():
     monkey.patch_func(set_threshold, distutils.log, 'set_threshold')
 
     # For some reason `distutils.log` module is getting cached in `distutils.dist`
-    # and then loaded again when we have the opportunity to patch it.
-    # This implies: id(distutils.log) != id(distutils.dist.log).
-    # We need to make sure the same module object is used everywhere:
+    # and then loaded again when patched,
+    # implying: id(distutils.log) != id(distutils.dist.log).
+    # Make sure the same module object is used everywhere:
     distutils.dist.log = distutils.log
 
 

--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -24,6 +24,12 @@ def configure():
         format="{message}", style='{', handlers=handlers, level=logging.DEBUG)
     monkey.patch_func(set_threshold, distutils.log, 'set_threshold')
 
+    # For some reason `distutils.log` module is getting cached in `distutils.dist`
+    # and then loaded again when we have the opportunity to patch it.
+    # This implies: id(distutils.log) != id(distutils.dist.log).
+    # We need to make sure the same module object is used everywhere:
+    distutils.dist.log = distutils.log
+
 
 def set_threshold(level):
     logging.root.setLevel(level*10)

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -16,16 +16,21 @@ setup(
 @pytest.mark.parametrize(
     "flag, expected_level", [("--dry-run", "INFO"), ("--verbose", "DEBUG")]
 )
-def test_verbosity_level(tmp_path, flag, expected_level):
+def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     """Make sure the correct verbosity level is set (issue #3038)"""
     import setuptools  # noqa: Import setuptools to monkeypatch distutils
     import distutils  # <- load distutils after all the patches take place
+
+    logger = logging.Logger(__name__)
+    monkeypatch.setattr(logging, "root", logger)
+    unset_log_level = logger.getEffectiveLevel()
+    assert logging.getLevelName(unset_log_level) == "NOTSET"
 
     setup_script = tmp_path / "setup.py"
     setup_script.write_text(setup_py)
     dist = distutils.core.run_setup(setup_script, stop_after="init")
     dist.script_args = [flag, "sdist"]
     dist.parse_command_line()  # <- where the log level is set
-    log_level = logging.root.getEffectiveLevel()  # <- setuptools uses the root logger
+    log_level = logger.getEffectiveLevel()
     log_level_name = logging.getLevelName(log_level)
     assert log_level_name == expected_level

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -1,0 +1,31 @@
+import logging
+
+import pytest
+
+
+setup_py = """\
+from setuptools import setup
+
+setup(
+    name="test_logging",
+    version="0.0"
+)
+"""
+
+
+@pytest.mark.parametrize(
+    "flag, expected_level", [("--dry-run", "INFO"), ("--verbose", "DEBUG")]
+)
+def test_verbosity_level(tmp_path, flag, expected_level):
+    """Make sure the correct verbosity level is set (issue #3038)"""
+    import setuptools  # noqa: Import setuptools to monkeypatch distutils
+    import distutils  # <- load distutils after all the patches take place
+
+    setup_script = tmp_path / "setup.py"
+    setup_script.write_text(setup_py)
+    dist = distutils.core.run_setup(setup_script, stop_after="init")
+    dist.script_args = [flag, "sdist"]
+    dist.parse_command_line()  # <- where the log level is set
+    log_level = logging.root.getEffectiveLevel()  # <- setuptools uses the root logger
+    log_level_name = logging.getLevelName(log_level)
+    assert log_level_name == expected_level


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Motivation

For some reason `distutils.log` module is getting cached in `distutils.dist` and then loaded again when we have the opportunity to patch it.

This implies: `id(distutils.log) != id(distutils.dist.log)`, and therefore the function `setuptools.logging.set_threshold` never gets called (instead the old version `setuptools._distutils.log.set_threshold` is used).

## Summary of changes

- Add a test case to ensure the correct verbosity level is set for logging
- Replace the cached `distutils.dist.log` with the "correct" patched module object.

Closes #3038

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
