### PR TITLE
[CI] Fix codecov config

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,4 +2,5 @@ comment: false
 coverage:
   status:
     project:
-      threshold: 0.5%
+      default:
+        threshold: 0.5%


### PR DESCRIPTION
## Motivation
The previous `.codecov.yml` file had an invalid configuration:

```bash
$ curl --data-binary @.codecov.yml https://codecov.io/validate
Error at ['coverage', 'status', 'project', 'threshold']:
must be of ['dict', 'boolean'] type
```

## Summary of changes

According to the [documentation](https://docs.codecov.com/docs/commit-status#section-project-status), `coverage.status.project` does not seem to accept configuration parameters directly. Instead it requires a mapping between project names (or `"default"` when all the projects are targeted) and the configuration parameters.

This change fixes that by introducing a new nesting level with the `default` key between `project` and `default`. This passes the validation:

```bash
% curl --data-binary @.codecov.yml https://codecov.io/validate
Valid!

{
  "comment": false,
  "coverage": {
    "status": {
      "project": {
        "default": {
          "threshold": 0.5
        }
      }
    }
  }
}
```

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->


Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
