### PR TITLE
Stop mentioning `wheel` in the context of PEP 517

### DIFF
--- a/changelog.d/3056.docs.rst
+++ b/changelog.d/3056.docs.rst
@@ -1,0 +1,2 @@
+The documentation has stopped suggesting to add ``wheel`` to
+:pep:`517` requirements -- by :user:`webknjaz`

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -53,12 +53,13 @@ being used to package your scripts and install from source). To use it with
 setuptools, the content would be::
 
     [build-system]
-    requires = ["setuptools", "wheel"]
+    requires = ["setuptools"]
     build-backend = "setuptools.build_meta"
 
 The ``setuptools`` package implements the ``build_sdist``
 command and the ``wheel`` package implements the ``build_wheel``
-command; both are required to be compliant with PEP 517.
+command; the latter is a dependency of the former
+exposed via :pep:`517` hooks.
 
 Use ``setuptools``' :ref:`declarative config <declarative config>` to
 specify the package information::

--- a/docs/userguide/dependency_management.rst
+++ b/docs/userguide/dependency_management.rst
@@ -28,7 +28,7 @@ other two types of dependency keyword, this one is specified in your
 .. code-block:: ini
 
     [build-system]
-    requires = ["setuptools", "wheel"]
+    requires = ["setuptools"]
     #...
 
 .. note::

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -32,7 +32,7 @@ package your project:
 .. code-block:: toml
 
     [build-system]
-    requires = ["setuptools", "wheel"]
+    requires = ["setuptools"]
     build-backend = "setuptools.build_meta"
 
 Then, you will need a ``setup.cfg`` or ``setup.py`` to specify your package


### PR DESCRIPTION
## Summary of changes

This dependency is exposed automatically by setuptools and the users do not need to declare it explicitly — it will be installed by PEP 517 front-ends automatically when building wheels.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
