### PR TITLE
Don't include `Home-page` with UNKNOWN value

### DIFF
--- a/changelog.d/3057.change.rst
+++ b/changelog.d/3057.change.rst
@@ -1,0 +1,1 @@
+Don't include optional ``Home-page`` in metadata if no ``url`` is specified. -- by :user:`cdce8p`

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -113,12 +113,8 @@ def read_pkg_file(self, file):
     self.author_email = _read_field_from_msg(msg, 'author-email')
     self.maintainer_email = None
     self.url = _read_field_from_msg(msg, 'home-page')
+    self.download_url = _read_field_from_msg(msg, 'download-url')
     self.license = _read_field_unescaped_from_msg(msg, 'license')
-
-    if 'download-url' in msg:
-        self.download_url = _read_field_from_msg(msg, 'download-url')
-    else:
-        self.download_url = None
 
     self.long_description = _read_field_unescaped_from_msg(msg, 'description')
     if (
@@ -171,9 +167,10 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     write_field('Name', self.get_name())
     write_field('Version', self.get_version())
     write_field('Summary', single_line(self.get_description()))
-    write_field('Home-page', self.get_url())
 
     optional_fields = (
+        ('Home-page', 'url'),
+        ('Download-URL', 'download_url'),
         ('Author', 'author'),
         ('Author-email', 'author_email'),
         ('Maintainer', 'maintainer'),
@@ -187,8 +184,6 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
 
     license = rfc822_escape(self.get_license())
     write_field('License', license)
-    if self.download_url:
-        write_field('Download-URL', self.download_url)
     for project_url in self.project_urls.items():
         write_field('Project-URL', '%s, %s' % project_url)
 


### PR DESCRIPTION
## Summary of changes
Similar to `Download-URL`, `Home-page` is handled as an optional field by PyPI. No need to include it in the package metadata if it's unknown. This will better support packages which choose to specify all urls inside `project_urls`.

[pypa/warehouse - forklift/legacy.py](https://github.com/pypa/warehouse/blob/213fdf9dd849580ced0759b1dc16edac368ca955/warehouse/forklift/legacy.py#L520-L528)

Reading a missing field is also not an issue. `msg[field]` will return `None` in these cases.

https://github.com/pypa/setuptools/blob/d3124ac33e1407ced092deb2e8854471773786d4/setuptools/dist.py#L71-L76

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
