### PR TITLE
[`pyproject.toml`: part 1] Update `build_meta` to use dist objects instead of simply running `setup.py`

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 60.8.1
+current_version = 60.8.2
 commit = True
 tag = True
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+v60.8.2
+-------
+
+
+Misc
+^^^^
+* #3091: Make ``concurrent.futures`` import lazy in vendored ``more_itertools``
+  package to a  avoid importing threading as a side effect (which caused
+  `gevent/gevent#1865 <https://github.com/gevent/gevent/issues/1865>`__).
+  -- by :user:`maciejp-ro`
+
+
 v60.8.1
 -------
 

--- a/bootstrap.egg-info/entry_points.txt
+++ b/bootstrap.egg-info/entry_points.txt
@@ -2,6 +2,11 @@
 egg_info = setuptools.command.egg_info:egg_info
 build_py = setuptools.command.build_py:build_py
 sdist = setuptools.command.sdist:sdist
+dist_info = setuptools.command.dist_info:dist_info
+develop = setuptools.command.develop:develop
+install_scripts = setuptools.command.install_scripts:install_scripts
+bdist_egg = setuptools.command.bdist_egg:bdist_egg
+install_egg_info = setuptools.command.install_egg_info:install_egg_info
 
 [distutils.setup_keywords]
 include_package_data = setuptools.dist:assert_bool

--- a/changelog.d/3064.breaking.rst
+++ b/changelog.d/3064.breaking.rst
@@ -1,0 +1,2 @@
+Removed public class ``SetupRequirementsError`` from the
+:doc:`setuptools.build_meta <build_meta>` module.

--- a/changelog.d/3064.change.rst
+++ b/changelog.d/3064.change.rst
@@ -1,0 +1,3 @@
+Changed the means of interaction between :doc:`setuptools.build_meta <build_meta>`
+and ``setuptools.setup``. Instead of simply executing the script, the backend
+now relies on ``distutils.core.run_setup`` to obtain a distribution object.

--- a/changelog.d/3091.misc.rst
+++ b/changelog.d/3091.misc.rst
@@ -1,4 +1,0 @@
-Make ``concurrent.futures`` import lazy in vendored ``more_itertools``
-package to a  avoid importing threading as a side effect (which caused
-`gevent/gevent#1865 <https://github.com/gevent/gevent/issues/1865>`__).
--- by :user:`maciejp-ro`

--- a/changelog.d/3091.misc.rst
+++ b/changelog.d/3091.misc.rst
@@ -1,0 +1,4 @@
+Make ``concurrent.futures`` import lazy in vendored ``more_itertools``
+package to a  avoid importing threading as a side effect (which caused
+`gevent/gevent#1865 <https://github.com/gevent/gevent/issues/1865>`__).
+-- by :user:`maciejp-ro`

--- a/pkg_resources/_vendor/more_itertools/more.py
+++ b/pkg_resources/_vendor/more_itertools/more.py
@@ -2,7 +2,6 @@ import warnings
 
 from collections import Counter, defaultdict, deque, abc
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial, reduce, wraps
 from heapq import merge, heapify, heapreplace, heappop
 from itertools import (
@@ -3656,7 +3655,7 @@ class callback_iter:
         self._aborted = False
         self._future = None
         self._wait_seconds = wait_seconds
-        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._executor = __import__("concurrent.futures").futures.ThreadPoolExecutor(max_workers=1)
         self._iterator = self._reader()
 
     def __enter__(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = setuptools
-version = 60.8.1
+version = 60.8.2
 author = Python Packaging Authority
 author_email = distutils-sig@python.org
 description = Easily download, build, install, upgrade, and uninstall Python packages

--- a/setuptools/_vendor/more_itertools/more.py
+++ b/setuptools/_vendor/more_itertools/more.py
@@ -2,7 +2,6 @@ import warnings
 
 from collections import Counter, defaultdict, deque, abc
 from collections.abc import Sequence
-from concurrent.futures import ThreadPoolExecutor
 from functools import partial, reduce, wraps
 from heapq import merge, heapify, heapreplace, heappop
 from itertools import (
@@ -3454,7 +3453,7 @@ class callback_iter:
         self._aborted = False
         self._future = None
         self._wait_seconds = wait_seconds
-        self._executor = ThreadPoolExecutor(max_workers=1)
+        self._executor = __import__("concurrent.futures").futures.ThreadPoolExecutor(max_workers=1)
         self._iterator = self._reader()
 
     def __enter__(self):

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -39,6 +39,7 @@ from uuid import uuid4
 import setuptools
 import distutils
 from ._reqs import parse_strings
+from setuptools.extern.packaging.requirements import Requirement
 
 __all__ = ['get_requires_for_build_sdist',
            'get_requires_for_build_wheel',
@@ -161,9 +162,10 @@ class _BuildMetaBackend(object):
 
     def _get_build_requires(self, config_settings, requirements):
         dist = self._get_dist()
-        parsed = chain(parse_strings(requirements),
-                       parse_strings(dist.setup_requires))
-        deduplicated = {r.key: str(r) for r in parsed}
+        req_strings = chain(parse_strings(requirements),
+                            parse_strings(dist.setup_requires))
+        parsed = (Requirement(r) for r in req_strings)
+        deduplicated = {r.name: str(r) for r in parsed}
         return list(deduplicated.values())
 
     def run_command(self, *args):

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -99,6 +99,10 @@ def _file_with_extension(directory, extension):
     return file
 
 
+def _exists_and_is_not_empty(file):
+    return os.path.exists(file) and os.stat(file).st_size > 0
+
+
 @contextlib.contextmanager
 def suppress_known_deprecation():
     with warnings.catch_warnings():
@@ -151,7 +155,7 @@ class _BuildMetaBackend(object):
     def _get_dist(self):
         """Retrieve a distribution object already configured."""
 
-        if os.path.exists(SETUP_SCRIPT) and os.stat(SETUP_SCRIPT).st_size > 0:
+        if _exists_and_is_not_empty(SETUP_SCRIPT):
             with no_install_setup_requires(), _patch_distutils_core():
                 dist = distutils.core.run_setup(SETUP_SCRIPT, stop_after="init")
                 dist.script_name = SETUP_SCRIPT
@@ -275,7 +279,7 @@ class _BuildMetaLegacyBackend(_BuildMetaBackend):
         # '' into sys.path. (pypa/setuptools#1642)
         sys_path = list(sys.path)           # Save the original path
 
-        if not os.path.exists(SETUP_SCRIPT) or os.stat(SETUP_SCRIPT).st_size == 0:
+        if not _exists_and_is_not_empty(SETUP_SCRIPT):
             msg = f"__legacy__ backend conflicts with empty/missing {SETUP_SCRIPT!r}"
             warnings.warn(msg, setuptools.SetuptoolsDeprecationWarning)
             return super().run_command(*args)

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -113,7 +113,7 @@ def suppress_known_deprecation():
 
 @contextlib.contextmanager
 def _patch_distutils_core():
-    """Make sure distutils.core uses the latest enhancements"""
+    """Make sure distutils.core uses the latest enhancements."""
     orig_exec = exec
     if hasattr(distutils.core, "run_commands"):
         yield  # do nothing, already using the improved version of distutils
@@ -131,7 +131,7 @@ def _patch_distutils_core():
         try:
             dist.run_commands()
         except Exception as ex:
-            raise SystemExit("error:" + str(ex))
+            raise SystemExit(f"error: {ex!s}") from ex
 
     distutils.core.exec = _exec
     distutils.core.run_commands = _run_commands

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -51,13 +51,17 @@ __all__ = ['get_requires_for_build_sdist',
 SETUP_SCRIPT = "setup.py"
 CONFIG_FILE = "pyproject.toml"
 LEGACY_CONFIG_FILE = "setup.cfg"
-SAFE_SCRIPT_NAME = "%%setuptools.build_meta%%"
-# ^-- distutils.sdist:sdist._add_defaults_standards will try to add `script_name`
-#     to the list of files to include in the distribution.
-#     If the SETUP_SCRIPT does not exist, the best is to use some made-up name
-#     that is unlikely to exist as a file.
-#     If we use `sys.argv[0]` setuptools might try to add things like
-#     `.tox/python/bin/pytest` to the tar.gz (and this will result in an error)
+
+
+def _safe_script_name():
+    """``distutils.sdist:sdist._add_defaults_standards`` will try to add ``script_name``
+    to the list of files to include in the distribution.
+    If the ``SETUP_SCRIPT`` does not exist, the best is to use some made-up name
+    that is unlikely to exist as a file.
+    If we use `sys.argv[0]` setuptools might try to add things like
+    `.tox/python/bin/pytest` to the tar.gz (and this will result in an error)
+    """
+    return f"%%setuptools.build_meta%%{uuid4()!s}"
 
 
 @contextlib.contextmanager
@@ -154,7 +158,7 @@ class _BuildMetaBackend(object):
                 # ^-- preserve _add_defaults_standards behaviour
         else:
             dist = setuptools.dist.Distribution()
-            dist.script_name = SAFE_SCRIPT_NAME
+            dist.script_name = _safe_script_name()
 
         dist.parse_config_files()
         dist.finalize_options()

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -282,9 +282,10 @@ class _BuildMetaLegacyBackend(_BuildMetaBackend):
         sys_path = list(sys.path)           # Save the original path
 
         if not os.path.exists(SETUP_SCRIPT):
-            msg = f"__legacy__ backend conflicts with empty/missing {SETUP_SCRIPT!r}"
-            warnings.warn(msg, setuptools.SetuptoolsDeprecationWarning)
-            return super().run_command(*args)
+            raise ValueError(
+                f"__legacy__ backend should not be used without {SETUP_SCRIPT!r}."
+                "Try using `setuptools.build_meta` instead."
+            )
 
         _ensure_setup_script_is_not_empty(SETUP_SCRIPT)
         script_dir = os.path.dirname(os.path.abspath(SETUP_SCRIPT))

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -314,13 +314,15 @@ def check_requirements(dist, attr, value):
 
 def check_specifier(dist, attr, value):
     """Verify that value is a valid version specifier"""
+    if value.__class__.__name__ == "SpecifierSet":
+        # ^-- avoid isinstance because 'packaging.specifiers' module might have been
+        #     evaluated twice (generating 2 different class objects)
+        return value
     try:
         packaging.specifiers.SpecifierSet(value)
     except (packaging.specifiers.InvalidSpecifier, AttributeError) as error:
-        tmpl = (
-            "{attr!r} must be a string " "containing valid version specifiers; {error}"
-        )
-        raise DistutilsSetupError(tmpl.format(attr=attr, error=error)) from error
+        msg = f"{attr!r} must be a string containing valid version specifiers; {error}"
+        raise DistutilsSetupError(msg) from error
 
 
 def check_entry_points(dist, attr, value):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -456,14 +456,8 @@ class TestBuildMetaBackend:
         files = {'setup.py': ''}
         path.build(files)
 
-        # TODO: Clarify why is it necessary that the error is raised?
-        # Or is it just a side effect that was found to happen,
-        # but it is not necessary for setuptools to work properly?
-        # >>> with pytest.raises(
-        # >>>         ValueError,
-        # >>>         match=re.escape('No distribution was found.')):
-
-        getattr(build_backend, build_hook)("temp")
+        with pytest.raises(ValueError, match="Empty 'setup.py' detected"):
+            getattr(build_backend, build_hook)("temp")
 
 
 class TestBuildMetaLegacyBackend(TestBuildMetaBackend):

--- a/tools/vendored.py
+++ b/tools/vendored.py
@@ -64,6 +64,21 @@ def rewrite_importlib_resources(pkg_files, new_root):
         file.write_text(text)
 
 
+def rewrite_more_itertools(pkg_files: Path):
+    """
+    Defer import of concurrent.futures. Workaround for #3090.
+    """
+    more_file = pkg_files.joinpath('more.py')
+    text = more_file.read_text()
+    text = re.sub(r'^.*concurrent.futures.*?\n', '', text, flags=re.MULTILINE)
+    text = re.sub(
+        'ThreadPoolExecutor',
+        '__import__("concurrent.futures").futures.ThreadPoolExecutor',
+        text,
+    )
+    more_file.write_text(text)
+
+
 def clean(vendor):
     """
     Remove all files out of the vendor directory except the meta
@@ -96,6 +111,7 @@ def update_pkg_resources():
     rewrite_jaraco_text(vendor / 'jaraco/text', 'pkg_resources.extern')
     rewrite_jaraco(vendor / 'jaraco', 'pkg_resources.extern')
     rewrite_importlib_resources(vendor / 'importlib_resources', 'pkg_resources.extern')
+    rewrite_more_itertools(vendor / "more_itertools")
 
 
 def update_setuptools():
@@ -105,6 +121,7 @@ def update_setuptools():
     rewrite_jaraco_text(vendor / 'jaraco/text', 'setuptools.extern')
     rewrite_jaraco(vendor / 'jaraco', 'setuptools.extern')
     rewrite_importlib_resources(vendor / 'importlib_resources', 'setuptools.extern')
+    rewrite_more_itertools(vendor / "more_itertools")
 
 
 __name__ == '__main__' and update_vendored()


### PR DESCRIPTION
> *This is the first part of #2970, split into several stacked PRs as requested in https://github.com/pypa/setuptools/pull/2970#pullrequestreview-868151658*

We can rely on `distutils.core.run_setup` to get access to the distribution object while also postponing the execution of the build commands.

This allows directly manipulation of the distribution object (which is for example useful to add configurations from different files such as `pyproject.toml`) as well as introspecting it for metadata (such as `setup_requires`).

## Summary of changes

- Use `distutils.core.run_setup` to obtain a dist object in `build_meta` - 8773aa266ee09ac408b2b295488d638ebfcca321
- Use the distribution object to run commands in `build_meta` - 3d7e7df6acfa397fecb759922523e16536ae2fcb
- Replace `_get_build_requires` by using the dist object - ec5b43b900908beadb82619b91e64ea2e648ec3e
- Add some entry-points to the bootstrap - 6bbc7547cc5932f0a470d8d6fc176f3fc96c675d
- Make sure changes in `build_meta` are compatible with tests - 2f991555571b0e7300962e3f183b3f2413c8590c
- Make `script_name` on `build_meta` less error prone - 90f216c9cbc910ed48d0748dd9064b7036e86bb0

Please see the commit message of each individual commit for more information about the changes.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
