### PR TITLE
[`pyproject.toml`: part 4] Integrate `pyproject.toml` configuration into existing classes

### DIFF
--- a/changelog.d/3068.change.rst
+++ b/changelog.d/3068.change.rst
@@ -1,0 +1,13 @@
+Added **experimental** support for ``pyproject.toml`` configuration
+(as introduced by :pep:`621`). Configuration parameters not covered by
+standards are handled in the ``[tool.setuptools]`` sub-table.
+
+In the future, existing ``setup.cfg`` configuration
+may be automatically converted into the ``pyproject.toml`` equivalent before taking effect
+(as proposed in :issue:`1688`). Meanwhile users can use automated tools like
+:pypi:`ini2toml` to help in the transition.
+
+Please note that the legacy backend is not guaranteed to work with
+``pyproject.toml`` configuration.
+
+-- by :user:`abravalheri`

--- a/changelog.d/3068.deprecation.rst
+++ b/changelog.d/3068.deprecation.rst
@@ -1,0 +1,8 @@
+Deprecated ``setuptools.config.read_configuration``,
+``setuptools.config.parse_configuration`` and other functions or classes
+from ``setuptools.config``.
+
+Users that still need to parse and process configuration from ``setup.cfg`` can
+import a direct replacement from ``setuptools.config.setupcfg``, however this
+module is transitional and might be removed in the future
+(the ``setup.cfg`` configuration format itself is likely to be deprecated in the future).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -93,10 +93,16 @@ intersphinx_mapping.update({
 
 # Add support for linking usernames
 github_url = 'https://github.com'
+github_repo_org = 'pypa'
+github_repo_name = 'setuptools'
+github_repo_slug = f'{github_repo_org}/{github_repo_name}'
+github_repo_url = f'{github_url}/{github_repo_slug}'
 github_sponsors_url = f'{github_url}/sponsors'
 extlinks = {
+    'issue': (f'{github_repo_url}/issues/%s', 'issue #%s'),  # noqa: WPS323
+    'pr': (f'{github_repo_url}/pull/%s', 'PR #%s'),  # noqa: WPS323
     'user': (f'{github_sponsors_url}/%s', '@'),  # noqa: WPS323
-    'pypi': ('https://pypi.org/project/%s', '%s'),
+    'pypi': ('https://pypi.org/project/%s', '%s'),  # noqa: WPS323
 }
 extensions += ['sphinx.ext.extlinks']
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -58,3 +58,5 @@ filterwarnings=
 	# https://github.com/pytest-dev/pytest/discussions/9296
 	ignore:Distutils was imported before setuptools
 	ignore:Setuptools is replacing distutils
+
+	ignore:Support for project metadata in .pyproject.toml. is still experimental

--- a/setuptools/config/__init__.py
+++ b/setuptools/config/__init__.py
@@ -1,11 +1,35 @@
-# For backward compatibility, the following classes/functions are exposed
-# from `config.setupcfg`
-from setuptools.config.setupcfg import (
-    parse_configuration,
-    read_configuration,
-)
+"""For backward compatibility, expose main functions from
+``setuptools.config.setupcfg``
+"""
+import warnings
+from functools import wraps
+from textwrap import dedent
+from typing import Callable, TypeVar, cast
 
-__all__ = (
-    'parse_configuration',
-    'read_configuration'
-)
+from .._deprecation_warning import SetuptoolsDeprecationWarning
+from . import setupcfg
+
+Fn = TypeVar("Fn", bound=Callable)
+
+__all__ = ('parse_configuration', 'read_configuration')
+
+
+def _deprecation_notice(fn: Fn) -> Fn:
+    @wraps(fn)
+    def _wrapper(*args, **kwargs):
+        msg = f"""\
+        As setuptools moves its configuration towards `pyproject.toml`,
+        `{__name__}.{fn.__name__}` became deprecated.
+
+        For the time being, you can use the `{setupcfg.__name__}` module
+        to access a backward compatible API, but this module is provisional
+        and might be removed in the future.
+        """
+        warnings.warn(dedent(msg), SetuptoolsDeprecationWarning)
+        return fn(*args, **kwargs)
+
+    return cast(Fn, _wrapper)
+
+
+read_configuration = _deprecation_notice(setupcfg.read_configuration)
+parse_configuration = _deprecation_notice(setupcfg.parse_configuration)

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -1,6 +1,7 @@
 """Load setuptools configuration from ``pyproject.toml`` files"""
 import json
 import os
+import warnings
 from contextlib import contextmanager
 from distutils import log
 from functools import partial
@@ -77,6 +78,13 @@ def read_configuration(filepath, expand=True, ignore_option_errors=False):
     tool_table = asdict.get("tool", {}).get("setuptools", {})
     if not asdict or not(project_table or tool_table):
         return {}  # User is not using pyproject to configure setuptools
+
+    # TODO: Remove once the future stabilizes
+    msg = (
+        "Support for project metadata in `pyproject.toml` is still experimental "
+        "and may be removed (or change) in future releases."
+    )
+    warnings.warn(msg, _ExperimentalProjectMetadata)
 
     # There is an overall sense in the community that making include_package_data=True
     # the default would be an improvement.
@@ -218,3 +226,7 @@ def _ignore_errors(ignore_option_errors):
         yield
     except Exception as ex:
         log.debug(f"Ignored error: {ex.__class__.__name__} - {ex}")
+
+
+class _ExperimentalProjectMetadata(UserWarning):
+    """Explicitly inform users that `pyproject.toml` configuration is experimental"""

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -33,7 +33,7 @@ def validate(config: dict, filepath: _Path):
     except Exception as ex:
         if ex.__class__.__name__ != "ValidationError":
             # Workaround for the fact that `extern` can duplicate imports
-            ex_cls = ex.__class__.__name
+            ex_cls = ex.__class__.__name__
             error = ValueError(f"invalid pyproject.toml config: {ex_cls} - {ex}")
             raise error from None
 

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -4,7 +4,7 @@ import warnings
 import logging
 from contextlib import contextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Union, cast
+from typing import TYPE_CHECKING, Union
 
 from setuptools.errors import FileError, OptionError
 

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -1,5 +1,4 @@
 """Load setuptools configuration from ``pyproject.toml`` files"""
-import json
 import os
 import warnings
 from contextlib import contextmanager
@@ -27,21 +26,8 @@ def load_file(filepath: _Path) -> dict:
 
 def validate(config: dict, filepath: _Path):
     from setuptools.extern import _validate_pyproject
-    from setuptools.extern._validate_pyproject import fastjsonschema_exceptions
 
-    try:
-        return _validate_pyproject.validate(config)
-    except fastjsonschema_exceptions.JsonSchemaValueException as ex:
-        msg = [f"Schema: {ex}"]
-        if ex.value:
-            msg.append(f"Given value:\n{json.dumps(ex.value, indent=2)}")
-        if ex.rule:
-            msg.append(f"Offending rule: {json.dumps(ex.rule, indent=2)}")
-        if ex.definition:
-            msg.append(f"Definition:\n{json.dumps(ex.definition, indent=2)}")
-
-        log.error("\n\n".join(msg) + "\n")
-        raise
+    return _validate_pyproject.validate(config)
 
 
 def apply_configuration(dist: "Distribution", filepath: _Path) -> "Distribution":

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -310,6 +310,7 @@ class TestBuildMetaBackend:
                 foo = "foo.cli:main"
 
                 [tool.setuptools]
+                zip-safe = false
                 package-dir = {"" = "src"}
                 packages = {find = {where = ["src"]}}
 
@@ -377,6 +378,7 @@ class TestBuildMetaBackend:
             'foo-0.1/src/foo.egg-info/entry_points.txt',
             'foo-0.1/src/foo.egg-info/requires.txt',
             'foo-0.1/src/foo.egg-info/top_level.txt',
+            'foo-0.1/src/foo.egg-info/not-zip-safe',
         }
         assert wheel_contents == {
             "foo/__init__.py",

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -1,0 +1,109 @@
+import subprocess
+from textwrap import dedent
+
+import pytest
+import jaraco.envs
+import path
+
+
+@pytest.fixture
+def venv(tmp_path, setuptools_wheel):
+    env = jaraco.envs.VirtualEnv()
+    vars(env).update(
+        root=path.Path(tmp_path),  # workaround for error on windows
+        name=".venv",
+        create_opts=["--no-setuptools"],
+        req=str(setuptools_wheel),
+    )
+    return env.create()
+
+
+SETUP_SCRIPT_STUB = "__import__('setuptools').setup()"
+
+EXAMPLE = {
+    'pyproject.toml': dedent("""\
+        [build-system]
+        requires = ["setuptools", "wheel"]
+        build-backend = "setuptools.build_meta"
+
+        [project]
+        name = "mypkg"
+        version = "3.14159"
+        description = "This is a Python package"
+        dynamic = ["license", "readme"]
+        classifiers = [
+            "Development Status :: 5 - Production/Stable",
+            "Intended Audience :: Developers"
+        ]
+        urls = {Homepage = "http://github.com"}
+        dependencies = ['importlib-metadata; python_version<"3.8"']
+
+        [tool.setuptools]
+        package-dir = {"" = "src"}
+        packages = {find = {where = ["src"]}}
+
+        [tool.setuptools.dynamic]
+        license = "MIT"
+        license_files = ["LICENSE*"]
+        readme = {file = "README.rst"}
+
+        [tool.distutils.egg_info]
+        tag-build = ".post0"
+        """),
+    "MANIFEST.in": dedent("""\
+        global-include *.py *.txt
+        global-exclude *.py[cod]
+        """).strip(),
+    "README.rst": "This is a ``README``",
+    "LICENSE.txt": "---- placeholder MIT license ----",
+    "src": {
+        "mypkg": {
+            "__init__.py": dedent("""\
+                import sys
+
+                if sys.version_info[:2] >= (3, 8):
+                    from importlib.metadata import PackageNotFoundError, version
+                else:
+                    from importlib_metadata import PackageNotFoundError, version
+
+                try:
+                    __version__ = version(__name__)
+                except PackageNotFoundError:
+                    __version__ = "unknown"
+                """),
+            "__main__.py": dedent("""\
+                from importlib.resources import read_text
+                from . import __version__, __name__ as parent
+                from .mod import x
+
+                data = read_text(parent, "data.txt")
+                print(__version__, data, x)
+                """),
+            "mod.py": "x = ''",
+            "data.txt": "Hello World",
+        }
+    }
+}
+
+
+@pytest.mark.parametrize("setup_script", [SETUP_SCRIPT_STUB, None])
+def test_editable_with_pyproject(tmp_path, venv, setup_script):
+    if setup_script is None:
+        pytest.skip("Editable install currently only supported with `setup.py` stub")
+
+    project = tmp_path / "mypkg"
+    files = {**EXAMPLE, "setup.py": setup_script}
+    project.mkdir()
+    jaraco.path.build(files, prefix=project)
+
+    cmd = [venv.exe(), "-m", "pip", "install",
+           "--no-build-isolation",  # required to force current version of setuptools
+           "-e", str(project)]
+    print(str(subprocess.check_output(cmd), "utf-8"))
+
+    cmd = [venv.exe(), "-m", "mypkg"]
+    assert subprocess.check_output(cmd).strip() == b"3.14159.post0 Hello World"
+
+    (project / "src/mypkg/data.txt").write_text("foobar")
+    (project / "src/mypkg/mod.py").write_text("x = 42")
+    assert subprocess.check_output(cmd).strip() == b"3.14159.post0 foobar 42"

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -18,8 +18,6 @@ def venv(tmp_path, setuptools_wheel):
     return env.create()
 
 
-SETUP_SCRIPT_STUB = "__import__('setuptools').setup()"
-
 EXAMPLE = {
     'pyproject.toml': dedent("""\
         [build-system]
@@ -86,11 +84,17 @@ EXAMPLE = {
 }
 
 
-@pytest.mark.parametrize("setup_script", [SETUP_SCRIPT_STUB, None])
-def test_editable_with_pyproject(tmp_path, venv, setup_script):
-    if setup_script is None:
-        pytest.skip("Editable install currently only supported with `setup.py` stub")
+SETUP_SCRIPT_STUB = "__import__('setuptools').setup()"
+MISSING_SETUP_SCRIPT = pytest.param(
+    None,
+    marks=pytest.mark.xfail(
+        reason="Editable install is currently only supported with `setup.py`"
+    )
+)
 
+
+@pytest.mark.parametrize("setup_script", [SETUP_SCRIPT_STUB, MISSING_SETUP_SCRIPT])
+def test_editable_with_pyproject(tmp_path, venv, setup_script):
     project = tmp_path / "mypkg"
     files = {**EXAMPLE, "setup.py": setup_script}
     project.mkdir()


### PR DESCRIPTION
> *This is part of #2970, split into several stacked PRs as requested in https://github.com/pypa/setuptools/pull/2970#pullrequestreview-868151658*
> *Follows #3067*

This change builds on top of the recently added ability to parse and apply configurations from TOML files to distribution objects by tapping into the existing mechanism for handling configuration and making these TOML files to be read by default.

A series of deprecation warnings and tests is also added.

## Summary of changes

- Add `pyproject.toml` to `dist.parse_config_files` - b12b9d76a6fe5ff18646a3df19bbd193322ea7c4
- Add `PendingDeprecationWarning` for `setup.cfg` - 5baed645b8b67727a1cb8a4c74d3442381969d58
- Add backend test with `pyproject.toml`-based configs - b9ddb598ae1b6ec3d894b3dec2595a044a414203
- Test editable installs with `pyproject.toml` metadata - e991760fb9f3037ebe0e31610d78615c4acd8c49
- Replace skip in editable install test with `xfail` - 9179116437830a43aded0ffe3350f0381bbb071c

Some individual commits have a more detailed explanation for the change, please refer to the commit text if more information/context is needed

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
