### PR TITLE
[`pyproject.toml`: part 5] Add some type hints to the `setuptools.config` subpackage

### DIFF
--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
     from setuptools._importlib import metadata  # noqa
     from setuptools.dist import Distribution  # noqa
 
-EMPTY = MappingProxyType({})  # Immutable dict-like
+EMPTY: Mapping = MappingProxyType({})  # Immutable dict-like
 _Path = Union[os.PathLike, str]
 _DictOrStr = Union[dict, str]
 _CorrespFn = Callable[["Distribution", Any, _Path], None]

--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -14,6 +14,7 @@ from ..textwrap import DALS
 
 class ErrConfigHandler(ConfigHandler):
     """Erroneous handler. Fails to implement required methods."""
+    section_prefix = "**err**"
 
 
 def make_package_dir(name, base_dir, ns=False):


### PR DESCRIPTION
> *This is part of #2970, split into several stacked PRs as requested in https://github.com/pypa/setuptools/pull/2970#pullrequestreview-868151658*
> *Follows #3068*

Type hints can help to increase confidence in the code and prevent unexpected bugs.

To typecheck the subpackage the following command can be used:

    mypy setuptools/config --tb --show-error-codes --show-error-context --pretty

## Summary of changes

Type hints added to the packages:
- `setuptools.config.setupcfg`
- `setuptools.config.pyprojecttoml`
- `setuptools.config.expand`


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
