### PR TITLE
Skip non-string values from sysconfig.get_config_vars()

### DIFF
--- a/changelog.d/3070.misc.rst
+++ b/changelog.d/3070.misc.rst
@@ -1,0 +1,1 @@
+Avoid AttributeError in easy_install.create_home_path when sysconfig.get_config_vars values are not strings.

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1334,9 +1334,7 @@ class easy_install(Command):
         if not self.user:
             return
         home = convert_path(os.path.expanduser("~"))
-        for path in self.config_vars.values():
-            if not isinstance(path, str):
-                continue
+        for path in only_strs(self.config_vars.values()):
             if path.startswith(home) and not os.path.isdir(path):
                 self.debug_print("os.makedirs('%s', 0o700)" % path)
                 os.makedirs(path, 0o700)
@@ -2304,6 +2302,13 @@ def current_umask():
     tmp = os.umask(0o022)
     os.umask(tmp)
     return tmp
+
+
+def only_strs(values):
+    """
+    Exclude non-str values. Ref #3063.
+    """
+    return filter(lambda val: isinstance(val, str), values)
 
 
 class EasyInstallDeprecationWarning(SetuptoolsDeprecationWarning):

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1334,7 +1334,9 @@ class easy_install(Command):
         if not self.user:
             return
         home = convert_path(os.path.expanduser("~"))
-        for name, path in self.config_vars.items():
+        for path in self.config_vars.values():
+            if not isinstance(path, str):
+                continue
             if path.startswith(home) and not os.path.isdir(path):
                 self.debug_print("os.makedirs('%s', 0o700)" % path)
                 os.makedirs(path, 0o700)


### PR DESCRIPTION
## Summary of changes

`sysconfig.get_config_vars()` can return values which are not strings (including integers), but the current code assumes all values are strings. This results in an `AttributeError`. Adding a check for non-string values and skipping them avoids the error.


Closes #3063

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
