### PR TITLE
Consolidate lingering news fragments named 'docs' 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,18 @@ Changes
 * #3057: Don't include optional ``Home-page`` in metadata if no ``url`` is specified. -- by :user:`cdce8p`
 * #3062: Merge with pypa/distutils@b53a824ec3 including improved support for lib directories on non-x64 Windows builds.
 
+Documentation changes
+^^^^^^^^^^^^^^^^^^^^^
+* #2897: Added documentation about wrapping ``setuptools.build_meta`` in a in-tree
+  custom backend. This is a :pep:`517`-compliant way of dynamically specifying
+  build dependencies (e.g. when platform, OS and other markers are not enough).
+  -- by :user:`abravalheri`
+* #3034: Replaced occurrences of the defunct distutils-sig mailing list with pointers
+  to GitHub Discussions.
+  -- by :user:`ashemedai`
+* #3056: The documentation has stopped suggesting to add ``wheel`` to
+  :pep:`517` requirements -- by :user:`webknjaz`
+
 Misc
 ^^^^
 * #3054: Used Py3 syntax ``super().__init__()`` -- by :user:`imba-tjd`

--- a/changelog.d/2897.docs.rst
+++ b/changelog.d/2897.docs.rst
@@ -1,4 +1,0 @@
-Added documentation about wrapping ``setuptools.build_meta`` in a in-tree
-custom backend. This is a :pep:`517`-compliant way of dynamically specifying
-build dependencies (e.g. when platform, OS and other markers are not enough)
--- by :user:`abravalheri`.

--- a/changelog.d/3034.docs.rst
+++ b/changelog.d/3034.docs.rst
@@ -1,4 +1,0 @@
-Replaced occurrences of the defunct distutils-sig mailing list with pointers
-to GitHub Discussions.
--- by :user:`ashemedai`
-

--- a/changelog.d/3056.docs.rst
+++ b/changelog.d/3056.docs.rst
@@ -1,2 +1,0 @@
-The documentation has stopped suggesting to add ``wheel`` to
-:pep:`517` requirements -- by :user:`webknjaz`

--- a/tools/finalize.py
+++ b/tools/finalize.py
@@ -79,11 +79,18 @@ def check_changes():
     """
     allowed = 'deprecation', 'breaking', 'change', 'doc', 'misc'
     except_ = 'README.rst', '.gitignore'
-    assert all(
-        any(key in file.name for key in allowed)
+    news_fragments = (
+        file
         for file in pathlib.Path('changelog.d').iterdir()
         if file.name not in except_
     )
+    unrecognized = [
+        str(file)
+        for file in news_fragments
+        if not any(f".{key}" in file.suffixes for key in allowed)
+    ]
+    if unrecognized:
+        raise ValueError(f"Some news fragments have invalid names: {unrecognized}")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary of changes

This change address partially #3076.
The following tasks are handled:
- Locating the releases pertinent to those entries.
- Rendering those entries into the appropriate release.

Instead of writing a check that fails if any files are left in the `chagelog.d` directory after `tox -e finalize`, I reworked the existing `check_changes` function.

Previously, this function would check if the file name has one of the allowed substrings. While this check is useful it is not fail-proof. For example, a file named `9999.docs.rst` has the valid `doc` substring so it would pass the check, but it would still be an invalid name.


### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
