### PR TITLE
[CI] Add temporary workaround for `pytest==7.0.0` deprecations

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -45,3 +45,7 @@ filterwarnings=
 	# https://github.com/pytest-dev/pytest/discussions/9296
 	ignore:Distutils was imported before setuptools
 	ignore:Setuptools is replacing distutils
+
+	# Workaround for pypa/setuptools#3079
+	ignore:.*not using a cooperative constructor.*:pytest.PytestDeprecationWarning
+	ignore:.*argument to .* is deprecated.*:pytest.PytestRemovedIn8Warning


### PR DESCRIPTION
## Summary of changes

Temporarily filter out specific deprecation warnings from `pytest==7.0.0`

Closes #3079

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
