### PR TITLE
Add timeout to `test_build_meta`

### DIFF
--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -38,6 +38,7 @@ class BuildBackend(BuildBackendBase):
             try:
                 return task.result(TIMEOUT)
             except futures.TimeoutError:
+                self.pool.shutdown(wait=False)
                 pytest.xfail(f"Backend did not respond before timeout ({TIMEOUT} s)")
 
         return method

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -50,8 +50,8 @@ class BuildBackend(BuildBackendBase):
     def _kill(self, pid):
         if pid is None:
             return
-        with contextlib.suppress(ProcessLookupError):
-            os.kill(pid, signal.SIGKILL)
+        with contextlib.suppress(ProcessLookupError, OSError):
+            os.kill(pid, signal.SIGTERM if os.name == "nt" else signal.SIGKILL)
 
 
 class BuildBackendCaller(BuildBackendBase):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -11,7 +11,7 @@ from jaraco import path
 from .textwrap import DALS
 
 
-TIMEOUT = os.getenv("TIMEOUT_BACKEND_TEST", 3 * 60)
+TIMEOUT = int(os.getenv("TIMEOUT_BACKEND_TEST", "180"))  # in seconds
 
 
 class BuildBackendBase:

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ usedevelop = True
 extras = testing
 passenv =
 	SETUPTOOLS_USE_DISTUTILS
+	TIMEOUT_BACKEND_TEST  # timeout for test_build_meta
 	windir  # required for test_pkg_resources
 	# honor git config in pytest-perf
 	HOME

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ usedevelop = True
 extras = testing
 passenv =
 	SETUPTOOLS_USE_DISTUTILS
-	TIMEOUT_BACKEND_TEST  # timeout for test_build_meta
+	TIMEOUT_BACKEND_TEST  # timeout (in seconds) for test_build_meta
 	windir  # required for test_pkg_resources
 	# honor git config in pytest-perf
 	HOME


### PR DESCRIPTION
As discussed in #3087, `test_build_meta` seems to be flaky specially for the combination of Windows + PyPy.

This is a proposed workaround for such scenarios.

## Summary of changes

- Added a timeout for the process pool executor
- Added a env var to control the timeout (useful for contributors with slower machines or network)

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
