### PR TITLE
Restore entry points from string

### DIFF
--- a/changelog.d/3103.misc.rst
+++ b/changelog.d/3103.misc.rst
@@ -1,0 +1,1 @@
+Fixed issue where string-based entry points would be omitted.

--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -53,6 +53,15 @@ def load(eps):
 
 @load.register(str)
 def _(eps):
+    r"""
+    >>> ep, = load('[console_scripts]\nfoo=bar')
+    >>> ep.group
+    'console_scripts'
+    >>> ep.name
+    'foo'
+    >>> ep.value
+    'bar'
+    """
     return validate(metadata.EntryPoints._from_text(eps))
 
 

--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -62,7 +62,7 @@ def _(eps):
     >>> ep.value
     'bar'
     """
-    return validate(metadata.EntryPoints._from_text(eps))
+    return validate(metadata.EntryPoints(metadata.EntryPoints._from_text(eps)))
 
 
 load.register(type(None), lambda x: x)


### PR DESCRIPTION
- Add test for loading entry points from a string. Ref #3103.
- Fix issue where string-based entry points would be omitted. Fixes #3103.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #3103

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
