### PR TITLE
Reduce GitHub Actions timeout from 6h to 75min

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     env:
       SETUPTOOLS_USE_DISTUTILS: ${{ matrix.distutils }}
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -50,6 +51,7 @@ jobs:
 
   test_cygwin:
     runs-on: windows-latest
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v2
       - name: Install Cygwin with Python
@@ -82,6 +84,7 @@ jobs:
     #    "integration")
     # With that in mind, the integration tests can run for a single setup
     runs-on: ubuntu-latest
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v2
       - name: Install OS-level dependencies
@@ -103,7 +106,7 @@ jobs:
     needs: [test, test_cygwin, integration-test]
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
-
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python


### PR DESCRIPTION
## Motivation

From times to times, tests (specially on PyPy) seem to get stuck and be cancelled by GitHub after the default timeout (6h).

Before these tests are cancelled, however they count as an active job and limit the amount of concurrent jobs/workflows PyPA's organization may have running.


<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes


Currently, the slowest job running for the `main` workflow seem to be the test for PyPy+Windows, which take around 55 min. Therefore, chances are that, if any test is taking much more than 1h to run, it got stuck.

We can be pragmatic and reduce the timeout for the `main` workflow and free the resources quickly.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
