### PR TITLE
Disable coverage on PyPy

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,4 +3,8 @@ coverage:
   status:
     project:
       default:
+        informational: true  # Treat coverage info as informational only
         threshold: 0.5%
+    patch:
+      default:
+        informational: true  # Treat coverage info as informational only

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,5 @@ coverage:
     patch:
       default:
         informational: true  # Treat coverage info as informational only
+github_checks:
+  annotations: false  # Codecov may pollute the "files" diff view

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,9 +39,12 @@ jobs:
         run: |
           python -m pip install tox
       - name: Run tests
-        run: tox -- --cov-report xml
+        run: tox
+      - name: Create coverage report
+        if: hashFiles('.coverage') != ''  # Rudimentary `file.exists()`
+        run: pipx run coverage xml --ignore-errors
       - name: Publish coverage
-        if: false  # disabled for #2727
+        if: hashFiles('coverage.xml') != ''  # Rudimentary `file.exists()`
         uses: codecov/codecov-action@v1
         with:
           flags: >-  # Mark which lines are covered by which envs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install tox
+      - name: Disable coverage on PyPy
+        # Coverage seems to slow things down on PyPy (ubuntu is still OK-ish)
+        if: contains(matrix.python, 'pypy') && matrix.platform != 'ubuntu-latest'
+        shell: bash
+        run: echo 'PYTEST_ADDOPTS=-p no:cov' >> $GITHUB_ENV
       - name: Run tests
         run: tox -- --cov-report xml
       - name: Publish coverage

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,6 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install tox
-      - name: Disable coverage on PyPy
-        # Coverage seems to slow things down on PyPy (ubuntu is still OK-ish)
-        if: contains(matrix.python, 'pypy') && matrix.platform != 'ubuntu-latest'
-        shell: bash
-        run: echo 'PYTEST_ADDOPTS=-p no:cov' >> $GITHUB_ENV
       - name: Run tests
         run: tox -- --cov-report xml
       - name: Publish coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,9 @@ testing =
 	pytest-black >= 0.3.7; \
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"
-	pytest-cov
+	pytest-cov; \
+		# coverage seems to make PyPy extremely slow
+		python_implementation != "PyPy"
 	pytest-mypy >= 0.9.1; \
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"


### PR DESCRIPTION
Currently, CI jobs running on PyPy are (painfully) slow.
This seems to be a well know side effect of enabling coverage.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The change proposed here is to disable coverage on PyPy for both Windows and MacOS (which seem to be very slow).

Coverage for PyPy on Ubuntu is preserved because, while being slower than CPython, it is still OK-ish.
Hopefully tests running on PyPy/Ubuntu will include most of PyPy's specific corner cases.


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
