### PR TITLE
Tweak concurrency group for CI so `tag` is not cancelled by `push`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,10 @@ name: tests
 on: [push, pull_request, workflow_dispatch]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/changelog.d/3093.misc.rst
+++ b/changelog.d/3093.misc.rst
@@ -1,0 +1,1 @@
+Repaired automated release process.


### PR DESCRIPTION
This is an attempt to prevent the `release` job from being cancelled.
The problem was described in https://github.com/pypa/setuptools/pull/3097#issuecomment-1040377788 and https://github.com/pypa/setuptools/issues/3093#issuecomment-1041517254.

## Summary of changes

Add `github.ref_type` to the `concurrency.group`

According to the [docs](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) `github.ref_type` can be either `tag` or `branch`, so my hope is that it should differentiate between a push to main and a new tag, but I don't know how to test that...

The drawback of this change is that the CI workflow will run twice for the commit being tagged (but I think that is not problematic, giving that tags are only created sporadically and the number of duplication will be very small)

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
