### PR TITLE
[CI] Attempt to capture yet another common PyPy error

### DIFF
--- a/changelog.d/3120.misc.rst
+++ b/changelog.d/3120.misc.rst
@@ -1,0 +1,4 @@
+Added workaround for intermittent failures of backend tests on PyPy.
+These tests now are marked with `XFAIL
+<https://docs.pytest.org/en/stable/how-to/skipping.html>`_, instead of erroring
+out directly.


### PR DESCRIPTION
In previous PRs, I have tried to improve the situation with tests being flaky on PyPy (specially via timeouts).

Still, there seems to be problems with `ProcessPoolExecutor`:
- https://github.com/pypa/setuptools/runs/5241255918?check_suite_focus=true#step:5:321
- https://github.com/pypa/setuptools/runs/5250475520?check_suite_focus=true#step:5:38

This might be related to the fact that `pytest-xdist` can struggle to run tests that use threads/processes themselves and that can be worse in PyPy. One alternative could be disabling `xdist` for PyPy (but I don't know how much longer the tests would take)

## Summary of changes

- Intercept `futures.process.BrokenProcessPool`/`MemoryError` on PyPy and `xfail`

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
