### PR TITLE
[CI] Disable xdist in PyPy

### DIFF
--- a/changelog.d/3121.misc.rst
+++ b/changelog.d/3121.misc.rst
@@ -1,0 +1,1 @@
+``pytest-xdist`` is no longer used when running tests on PyPy.

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,9 @@ testing =
 	wheel
 	pip>=19.1 # For proper file:// URLs support.
 	jaraco.envs>=2.2
-	pytest-xdist
+	pytest-xdist; \
+		# PyPy constantly has problems with xdist
+		python_implementation != "PyPy"
 	jaraco.path>=3.2.0
 	build[virtualenv]
 	filelock>=3.4.0
@@ -70,7 +72,9 @@ testing =
 
 testing-integration =
 	pytest
-	pytest-xdist
+	pytest-xdist; \
+		# PyPy constantly has problems with xdist
+		python_implementation != "PyPy"
 	pytest-enabler
 	virtualenv>=13.0.0
 	tomli


### PR DESCRIPTION
Currently the test suite is problematic on PyPy.
As advised by @blink1073 in https://github.com/pypa/setuptools/pull/3112#issuecomment-1042185326 disabling `xdist` may help.

I put this experiment together to see how disabling `xdist` would affect the total testing time.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Define `pytest-xdist` as a conditional dependency on `setup.cfg`, that is not installed in PyPy

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
