### PR TITLE
[Docs] Fix incorrectly displayed links in CHANGELOG

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -543,7 +543,7 @@ Changes
 
 Documentation changes
 ^^^^^^^^^^^^^^^^^^^^^
-* #2792: Document how the legacy and non-legacy versions are compared, and reference to the `PEP 440 <https://www.python.org/dev/peps/pep-0440/>`_ scheme.
+* #2792: Document how the legacy and non-legacy versions are compared, and reference to the PEP 440 scheme.
 
 
 v58.1.0
@@ -4758,8 +4758,7 @@ how it parses version numbers.
   Jython.
 * Work around Jython #1980 and Jython #1981.
 * Distribute #334: Provide workaround for packages that reference ``sys.__stdout__``
-  such as numpy does. This change should address
-  `virtualenv #359 <https://github.com/pypa/virtualenv/issues/359>`_ as long
+  such as numpy does. This change should address pypa/virtualenv#359 as long
   as the system encoding is UTF-8 or the IO encoding is specified in the
   environment, i.e.::
 
@@ -4785,7 +4784,7 @@ how it parses version numbers.
 
 * BB Pull Request #14: Honor file permissions in zip files.
 * Distribute #327: Merged pull request #24 to fix a dependency problem with pip.
-* Merged pull request #23 to fix https://github.com/pypa/virtualenv/issues/301.
+* Merged pull request #23 to fix pypa/virtualenv#301.
 * If Sphinx is installed, the ``upload_docs`` command now runs ``build_sphinx``
   to produce uploadable documentation.
 * Distribute #326: ``upload_docs`` provided mangled auth credentials under Python 3.

--- a/changelog.d/3124.misc.rst
+++ b/changelog.d/3124.misc.rst
@@ -1,0 +1,2 @@
+Improved configuration for :pypi:`rst-linker` (extension used to build the
+changelog).

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,12 +62,12 @@ link_files = {
                 url='{GH}/jaraco/setuptools_svn/issues/{setuptools_svn}',
             ),
             dict(
-                pattern=r'pypa/distutils#(?P<distutils>\d+)',
-                url='{GH}/pypa/distutils/issues/{distutils}',
+                pattern=r'pypa/(?P<issue_repo>[\-\.\w]+)#(?P<issue_number>\d+)',
+                url='{GH}/pypa/{issue_repo}/issues/{issue_number}',
             ),
             dict(
-                pattern=r'pypa/distutils@(?P<distutils_commit>[\da-f]+)',
-                url='{GH}/pypa/distutils/commit/{distutils_commit}',
+                pattern=r'pypa/(?P<commit_repo>[\-\.\w]+)@(?P<commit_number>[\da-f]+)',
+                url='{GH}/pypa/{commit_repo}/commit/{commit_number}',
             ),
             dict(
                 pattern=r'^(?m)((?P<scm_version>v?\d+(\.\d+){1,2}))\n[-=]+\n',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ link_files = {
         ),
         replace=[
             dict(
-                pattern=r'(Issue )?#(?P<issue>\d+)',
+                pattern=r'(?<!\w)(Issue )?#(?P<issue>\d+)',
                 url='{package_url}/issues/{issue}',
             ),
             dict(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,7 +54,7 @@ link_files = {
                 url='{GH}/pypa/packaging/blob/{packaging_ver}/CHANGELOG.rst',
             ),
             dict(
-                pattern=r'PEP[- ](?P<pep_number>\d+)',
+                pattern=r'(?<![`/\w])PEP[- ](?P<pep_number>\d+)',
                 url='https://www.python.org/dev/peps/pep-{pep_number:0>4}/',
             ),
             dict(


### PR DESCRIPTION
## Motivation

Currently, there are a series of links being incorrectly displayed in the CHANGELOG, for example:

![image](https://user-images.githubusercontent.com/320755/154801678-62ec0998-7023-4b64-822e-0054c3fae8ab.png)

![image](https://user-images.githubusercontent.com/320755/154801701-73f81355-7879-4365-a68f-c3f58177fd02.png)

![image](https://user-images.githubusercontent.com/320755/154801719-ccd591ad-1f88-4bda-9a21-df11ff48465a.png)

![image](https://user-images.githubusercontent.com/320755/154801743-4a4d8a63-0b8e-4023-8109-9f7cf4462de4.png)


## Summary of changes

- Improve regex in `docs/conf.py` to avoid accidentally matching `#<issue-number>` or PEP mentions.
- Extend matching of `pypa/<repo>#<issue>` and `pypa/<repo>@<commit>` to any PyPA repository (currently only distutils is supported).
- Manually convert some entries to make use of the improvements above.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
