### PR TITLE
[follow-up `pyproject.toml`] Adopt namespaces by default when discovering packages.

### DIFF
--- a/changelog.d/3125.change.rst
+++ b/changelog.d/3125.change.rst
@@ -1,0 +1,10 @@
+Implicit namespaces (as introduced in :pep:`420`) are now considered by default
+during :doc:`package discovery </userguide/package_discovery>`, when
+``setuptools`` configuration and project metadata are added to the
+``pyproject.toml`` file.
+
+To disable this behaviour, use ``namespaces = False`` when explicitly setting
+the ``[tool.setuptools.packages.find]`` section in ``pyproject.toml``.
+
+This change is backwards compatible and does not affect the behaviour of
+configuration done in ``setup.cfg`` or ``setup.py``.

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -249,7 +249,7 @@ def cmdclass(
 
 
 def find_packages(
-    *, namespaces=False, root_dir: Optional[_Path] = None, **kwargs
+    *, namespaces=True, root_dir: Optional[_Path] = None, **kwargs
 ) -> List[str]:
     """Works similarly to :func:`setuptools.find_packages`, but with all
     arguments given as keyword arguments. Moreover, ``where`` can be given

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -580,15 +580,12 @@ class ConfigOptionsHandler(ConfigHandler["Distribution"]):
         if trimmed_value not in find_directives:
             return self._parse_list(value)
 
-        findns = trimmed_value == find_directives[1]
-
         # Read function arguments from a dedicated section.
         find_kwargs = self.parse_section_packages__find(
             self.sections.get('packages.find', {})
         )
 
-        if findns:
-            find_kwargs["namespaces"] = True
+        find_kwargs["namespaces"] = (trimmed_value == find_directives[1])
 
         return expand.find_packages(**find_kwargs)
 

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -88,9 +88,10 @@ def test_resolve_class():
 @pytest.mark.parametrize(
     'args, pkgs',
     [
-        ({"where": ["."]}, {"pkg", "other"}),
-        ({"where": [".", "dir1"]}, {"pkg", "other", "dir2"}),
+        ({"where": ["."], "namespaces": False}, {"pkg", "other"}),
+        ({"where": [".", "dir1"], "namespaces": False}, {"pkg", "other", "dir2"}),
         ({"namespaces": True}, {"pkg", "other", "dir1", "dir1.dir2"}),
+        ({}, {"pkg", "other", "dir1", "dir1.dir2"}),  # default value for `namespaces`
     ]
 )
 def test_find_packages(tmp_path, monkeypatch, args, pkgs):

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -43,7 +43,6 @@ platforms = ["any"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-namespaces = true
 
 [tool.setuptools.cmdclass]
 sdist = "pkg.mod.CustomSdist"
@@ -74,7 +73,7 @@ def test_read_configuration(tmp_path):
 
     files = [
         "src/pkg/__init__.py",
-        "src/other/nested/__init__.py",
+        "src/other/nested/__init__.py",  # ensure namespaces are discovered by default
         "files/file.txt"
     ]
     for file in files:


### PR DESCRIPTION
## Motivation

As described in https://github.com/pypa/setuptools/pull/2970#discussion_r778432831 the adoption of configuration via `pyprojec.toml` is a perfect opportunity to consider namespaces by default (PEP 420) when automatically finding projects.

## Summary of changes

In projects using `setup.cfg` or `setup.py` nothing will be changed for backward compatibility, but for projects including metadata in `pyproject.toml` (as initially proposed in PEP 621), namespaces will be considered by default.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
