### PR TITLE
[CI] XFAIL on OSError in `test_build_meta` for PyPy

### DIFF
--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -46,7 +46,7 @@ class BuildBackend(BuildBackendBase):
                 self.pool.shutdown(wait=False)  # doesn't stop already running processes
                 self._kill(pid)
                 pytest.xfail(f"Backend did not respond before timeout ({TIMEOUT} s)")
-            except (futures.process.BrokenProcessPool, MemoryError):
+            except (futures.process.BrokenProcessPool, MemoryError, OSError):
                 if IS_PYPY:
                     pytest.xfail("PyPy frequently fails tests with ProcessPoolExector")
                 raise


### PR DESCRIPTION
Everyday the combination Windows + PyPy on the CI surprises me with new and exciting ways of unexpectedly failing 😅

This time I found that an `OSError` or `PermissionError` might happen when running the process pool for the backend tests:

- https://github.com/pypa/setuptools/runs/5260647654?check_suite_focus=true#step:5:73
- https://github.com/pypa/setuptools/runs/5264625500?check_suite_focus=true#step:5:150

## Summary of changes

- Added `OSError` to the list of exceptions that will cause an `XFAIL` on PyPy.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
