### PR TITLE
Tests using virtual environments: pass the copy of existing env to the subprocesses

### DIFF
--- a/changelog.d/3133.misc.rst
+++ b/changelog.d/3133.misc.rst
@@ -1,0 +1,1 @@
+Enhanced isolation of tests using virtual environments - PYTHONPATH is not leaking to spawned subprocesses  -- by :user:`befeleme`

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -22,7 +22,7 @@ class VirtualEnv(jaraco.envs.VirtualEnv):
         # - tox isn't used to run tests and
         # - PYTHONPATH is set to point to a specific setuptools codebase and
         # - no custom env is explicitly set by a test
-        # that PYTHONPATH leaks to the spawned processes.
+        # PYTHONPATH will leak into the spawned processes.
         # In that case tests look for module in the wrong place (on PYTHONPATH).
         # Unless the test sets its own special env, pass a copy of the existing
         # environment with removed PYTHONPATH to the subprocesses.

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -18,6 +18,19 @@ class VirtualEnv(jaraco.envs.VirtualEnv):
     def run(self, cmd, *args, **kwargs):
         cmd = [self.exe(cmd[0])] + cmd[1:]
         kwargs = {"cwd": self.root, **kwargs}  # Allow overriding
+        # In some environments (eg. downstream distro packaging), where:
+        # - tox isn't used to run tests and
+        # - PYTHONPATH is set to point to a specific setuptools codebase and
+        # - no custom env is explicitly set by a test
+        # that PYTHONPATH leaks to the spawned processes.
+        # In that case tests look for module in the wrong place (on PYTHONPATH).
+        # Unless the test sets its own special env, pass a copy of the existing
+        # environment with removed PYTHONPATH to the subprocesses.
+        if "env" not in kwargs:
+            env = dict(os.environ)
+            if "PYTHONPATH" in env:
+                del env["PYTHONPATH"]
+            kwargs["env"] = env
         return subprocess.check_output(cmd, *args, **kwargs)
 
 

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -98,7 +98,18 @@ def venv(tmp_path, setuptools_wheel):
     env = environment.VirtualEnv()
     env.root = path.Path(tmp_path / 'venv')
     env.req = str(setuptools_wheel)
-    return env.create()
+    # In some environments (eg. downstream distro packaging),
+    # where tox isn't used to run tests and PYTHONPATH is set to point to
+    # a specific setuptools codebase, that PYTHONPATH leaks to the spawned
+    # processes.
+    # env.create() should install the just created setuptools
+    # wheel, but it doesn't if it finds another existing matching setuptools
+    # installation present on PYTHONPATH:
+    # `setuptools is already installed with the same version as the provided
+    # wheel. Use --force-reinstall to force an installation of the wheel.`
+    # This prevents leaking PYTHONPATH to the created environment.
+    with contexts.environment(PYTHONPATH=None):
+        return env.create()
 
 
 @pytest.fixture

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -100,7 +100,7 @@ def venv(tmp_path, setuptools_wheel):
     env.req = str(setuptools_wheel)
     # In some environments (eg. downstream distro packaging),
     # where tox isn't used to run tests and PYTHONPATH is set to point to
-    # a specific setuptools codebase, that PYTHONPATH leaks to the spawned
+    # a specific setuptools codebase, PYTHONPATH will leak into the spawned
     # processes.
     # env.create() should install the just created setuptools
     # wheel, but it doesn't if it finds another existing matching setuptools


### PR DESCRIPTION
## Summary of changes

In specifically set environment like the build environment in Fedora, we noticed some of the tests running subprocesses were failing. Typically they didn't see the correct paths, leading to multiple `ModuleNotFoundError: No module named setuptools` and failed meta-tests in [`test_virtualenv`](https://github.com/pypa/setuptools/blob/main/setuptools/tests/test_virtualenv.py#L95) (`DID NOT RAISE...`).
The changes: passing the copy of the environment minus PYTHONPATH for the subprocesses made the test suite pass during our builds.


### Pull Request Checklist
- [ ] Changes have tests (I'd say N/A - those are test fixes)
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
