### PR TITLE
Check for file existence before using `samefile`

### DIFF
--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -922,8 +922,9 @@ class easy_install(Command):
             ensure_directory(destination)
 
         dist = self.egg_distribution(egg_path)
-        both_exist = os.path.exists(egg_path) and os.path.exists(destination)
-        if not (both_exist and os.path.samefile(egg_path, destination)):
+        if not (
+            os.path.exists(destination) and os.path.samefile(egg_path, destination)
+        ):
             if os.path.isdir(destination) and not os.path.islink(destination):
                 dir_util.remove_tree(destination, dry_run=self.dry_run)
             elif os.path.exists(destination):

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -922,7 +922,8 @@ class easy_install(Command):
             ensure_directory(destination)
 
         dist = self.egg_distribution(egg_path)
-        if not os.path.samefile(egg_path, destination):
+        both_exist = os.path.exists(egg_path) and os.path.exists(destination)
+        if not (both_exist and os.path.samefile(egg_path, destination)):
             if os.path.isdir(destination) and not os.path.islink(destination):
                 dir_util.remove_tree(destination, dry_run=self.dry_run)
             elif os.path.exists(destination):

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -680,8 +680,7 @@ class PackageIndex(Environment):
             # Make sure the file has been downloaded to the temp dir.
             if os.path.dirname(filename) != tmpdir:
                 dst = os.path.join(tmpdir, basename)
-                both_exist = os.path.exists(filename) and os.path.exists(dst)
-                if not (both_exist and os.path.samefile(filename, dst)):
+                if not (os.path.exists(dst) and os.path.samefile(filename, dst)):
                     shutil.copy2(filename, dst)
                     filename = dst
 

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -680,7 +680,8 @@ class PackageIndex(Environment):
             # Make sure the file has been downloaded to the temp dir.
             if os.path.dirname(filename) != tmpdir:
                 dst = os.path.join(tmpdir, basename)
-                if not os.path.samefile(filename, dst):
+                both_exist = os.path.exists(filename) and os.path.exists(dst)
+                if not (both_exist and os.path.samefile(filename, dst)):
                     shutil.copy2(filename, dst)
                     filename = dst
 


### PR DESCRIPTION
In https://github.com/pypa/setuptools/pull/3137, the custom `samefile` checker was removed in favour of the function provided in the stdlib.

However stdlib's version of the function will fail if both files don't exist.

Therefore replacing it is causing the [tests to fail](https://github.com/pypa/setuptools/runs/5346375426?check_suite_focus=true).

## Summary of changes

- Make sure that file exist before doing the `samefile` comparison.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
