### PR TITLE
Add setup.py code for console_scripts

### DIFF
--- a/changelog.d/3144.doc.rst
+++ b/changelog.d/3144.doc.rst
@@ -1,0 +1,1 @@
+Added documentation on using console_scripts from setup.py, which was previously only shown in setup.cfg  -- by :user:`xhlulu`

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -54,11 +54,32 @@ above example, to create a command ``hello-world`` that invokes
 ``timmins.hello_world``, add a console script entry point to
 ``setup.cfg``:
 
-.. code-block:: ini
+.. tab:: setup.cfg
 
-    [options.entry_points]
-    console_scripts =
-        hello-world = timmins:hello_world
+	.. code-block:: ini
+
+		[options.entry_points]
+		console_scripts =
+			hello-world = timmins:hello_world
+
+.. tab:: setup.py
+
+    .. code-block:: python
+	
+        from setuptools import setup
+
+        setup(
+            name='timmins',
+            version='0.0.1',
+            packages=['timmins'],
+			# ...
+            entry_points={
+				'console_scripts': [
+					'hello-world=timmins:hello_world',
+				]
+			}
+        )
+
 
 After installing the package, a user may invoke that function by simply calling
 ``hello-world`` on the command line.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

This adds documentation on using `console_scripts` from `setup.py`, which was previously only shown in setup.cfg

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
