### PR TITLE
Fix editable --user installs with build isolation

### DIFF
--- a/changelog.d/3151.breaking.rst
+++ b/changelog.d/3151.breaking.rst
@@ -1,0 +1,1 @@
+Made ``setup.py develop --user`` install to the user site packages directory even if it is disabled in the current interpreter.

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -169,12 +169,8 @@ class easy_install(Command):
         self.install_data = None
         self.install_base = None
         self.install_platbase = None
-        if site.ENABLE_USER_SITE:
-            self.install_userbase = site.USER_BASE
-            self.install_usersite = site.USER_SITE
-        else:
-            self.install_userbase = None
-            self.install_usersite = None
+        self.install_userbase = site.USER_BASE
+        self.install_usersite = site.USER_SITE
         self.no_find_links = None
 
         # Options not specifiable via command line
@@ -253,11 +249,9 @@ class easy_install(Command):
             getattr(sys, 'windir', '').replace('.', ''),
         )
 
-        if site.ENABLE_USER_SITE:
-            self.config_vars['userbase'] = self.install_userbase
-            self.config_vars['usersite'] = self.install_usersite
-
-        elif self.user:
+        self.config_vars['userbase'] = self.install_userbase
+        self.config_vars['usersite'] = self.install_usersite
+        if self.user and not site.ENABLE_USER_SITE:
             log.warn("WARNING: The user site-packages directory is disabled.")
 
         self._fix_install_dir_for_user_site()
@@ -373,7 +367,7 @@ class easy_install(Command):
         """
         Fix the install_dir if "--user" was used.
         """
-        if not self.user or not site.ENABLE_USER_SITE:
+        if not self.user:
             return
 
         self.create_home_path()

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -221,6 +221,42 @@ class easy_install(Command):
         raise SystemExit()
 
     def finalize_options(self):  # noqa: C901  # is too complex (25)  # FIXME
+        print(sysconfig._INSTALL_SCHEMES)
+        print(f'{os.name}_user')
+
+        def global_trace(frame, event, arg):
+            pass
+
+        import sys
+
+        sys.settrace(global_trace)
+
+        XXX = [set()]
+
+        def trace(frame, event, arg):
+            config_vars = getattr(self, 'config_vars', {})
+            o = {
+                ('USER_BASE', site.USER_BASE),
+                ('USER_SITE',  site.USER_SITE),
+                ('install_dir', self.install_dir),
+                ('install_userbase', self.install_userbase),
+                ('install_usersite', self.install_usersite),
+                ('install_purelib', self.install_purelib),
+                ('install_scripts', self.install_scripts),
+                ('userbase', config_vars.get('userbase')),
+                ('usersite', config_vars.get('usersite')),
+            }
+            if XXX[0] - o:
+                print('-', XXX[0] - o)
+            if o - XXX[0]:
+                print('+', o - XXX[0])
+            XXX[0] = o
+            lines, start = inspect.getsourcelines(frame)
+            print(frame.f_lineno, lines[frame.f_lineno - start])
+
+        import inspect
+        inspect.currentframe().f_trace = trace
+
         self.version and self._render_version()
 
         py_version = sys.version.split()[0]
@@ -459,6 +495,7 @@ class easy_install(Command):
         instdir = normalize_path(self.install_dir)
         pth_file = os.path.join(instdir, 'easy-install.pth')
 
+        print('XXX', instdir, os.path.exists(instdir))
         if not os.path.exists(instdir):
             try:
                 os.makedirs(instdir)

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -221,42 +221,6 @@ class easy_install(Command):
         raise SystemExit()
 
     def finalize_options(self):  # noqa: C901  # is too complex (25)  # FIXME
-        print(sysconfig._INSTALL_SCHEMES)
-        print(f'{os.name}_user')
-
-        def global_trace(frame, event, arg):
-            pass
-
-        import sys
-
-        sys.settrace(global_trace)
-
-        XXX = [set()]
-
-        def trace(frame, event, arg):
-            config_vars = getattr(self, 'config_vars', {})
-            o = {
-                ('USER_BASE', site.USER_BASE),
-                ('USER_SITE',  site.USER_SITE),
-                ('install_dir', self.install_dir),
-                ('install_userbase', self.install_userbase),
-                ('install_usersite', self.install_usersite),
-                ('install_purelib', self.install_purelib),
-                ('install_scripts', self.install_scripts),
-                ('userbase', config_vars.get('userbase')),
-                ('usersite', config_vars.get('usersite')),
-            }
-            if XXX[0] - o:
-                print('-', XXX[0] - o)
-            if o - XXX[0]:
-                print('+', o - XXX[0])
-            XXX[0] = o
-            lines, start = inspect.getsourcelines(frame)
-            print(frame.f_lineno, lines[frame.f_lineno - start])
-
-        import inspect
-        inspect.currentframe().f_trace = trace
-
         self.version and self._render_version()
 
         py_version = sys.version.split()[0]
@@ -495,7 +459,6 @@ class easy_install(Command):
         instdir = normalize_path(self.install_dir)
         pth_file = os.path.join(instdir, 'easy-install.pth')
 
-        print('XXX', instdir, os.path.exists(instdir))
         if not os.path.exists(instdir):
             try:
                 os.makedirs(instdir)

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1146,8 +1146,6 @@ def test_editable_user_and_build_isolation(setup_context, monkeypatch, tmpdir):
 
     # == Assert ==
     # Should not install to sys.prefix
-    with pytest.raises(AssertionError):
-        assert sys_prefix.listdir() == []
+    assert sys_prefix.listdir() == []
     # Should install to user site
-    with pytest.raises(AssertionError):
-        assert {f.basename for f in user_site.listdir()} == {'UNKNOWN.egg-link'}
+    assert {f.basename for f in user_site.listdir()} == {'UNKNOWN.egg-link'}

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1148,4 +1148,7 @@ def test_editable_user_and_build_isolation(setup_context, monkeypatch, tmpdir):
     # Should not install to sys.prefix
     assert sys_prefix.listdir() == []
     # Should install to user site
-    assert {f.basename for f in user_site.listdir()} == {'UNKNOWN.egg-link'}
+    installed = {f.basename for f in user_site.listdir()}
+    # sometimes easy-install.pth is created and sometimes not
+    installed = installed - {"easy-install.pth"}
+    assert installed == {'UNKNOWN.egg-link'}


### PR DESCRIPTION
## Summary of changes

Make `setup.py develop --user` install to the user site packages directory even if it is disabled in the current interpreter.

Closes https://github.com/pypa/setuptools/issues/3019

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
