### PR TITLE
[follow-up `pyproject.toml`] Fix auto-discovery when `attr:` directive is used in configuration

### DIFF
--- a/changelog.d/2887.change.1.rst
+++ b/changelog.d/2887.change.1.rst
@@ -1,4 +1,4 @@
-Added automatic discovery for ``py_modules`` and ``packages``
+**[EXPERIMENTAL]** Added automatic discovery for ``py_modules`` and ``packages``
 -- by :user:`abravalheri`.
 
 Setuptools will try to find these values assuming that the package uses either

--- a/changelog.d/2887.change.2.rst
+++ b/changelog.d/2887.change.2.rst
@@ -1,4 +1,4 @@
-Added automatic configuration for the ``name`` metadata
+**[EXPERIMENTAL]** Added automatic configuration for the ``name`` metadata
 -- by :user:`abravalheri`.
 
 Setuptools will adopt the name of the top-level package (or module in the case

--- a/changelog.d/3068.change.rst
+++ b/changelog.d/3068.change.rst
@@ -1,4 +1,4 @@
-Added **experimental** support for ``pyproject.toml`` configuration
+**[EXPERIMENTAL]** Add support for ``pyproject.toml`` configuration
 (as introduced by :pep:`621`). Configuration parameters not covered by
 standards are handled in the ``[tool.setuptools]`` sub-table.
 

--- a/changelog.d/3152.change.rst
+++ b/changelog.d/3152.change.rst
@@ -1,0 +1,4 @@
+**[EXPERIMENTAL]** Added support for ``attr:`` and ``cmdclass`` configurations
+in ``setup.cfg`` and ``pyproject.toml`` when ``package_dir`` is implicitly
+found via auto-discovery.
+

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -46,7 +46,7 @@ the following sections.
 Automatic discovery
 ===================
 
-.. warning:: Automatic discovery is an **experimental** future and might change
+.. warning:: Automatic discovery is an **experimental** feature and might change
    (or be completely removed) in the future.
    See :ref:`custom-discovery` for a stable way of configuring ``setuptools``.
 
@@ -170,7 +170,7 @@ Also note that you can customise your project layout by explicitly setting
    place.
 
 
-.. custom-discovery::
+.. _custom-discovery:
 
 Custom discovery
 ================

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -46,6 +46,10 @@ the following sections.
 Automatic discovery
 ===================
 
+.. warning:: Automatic discovery is an **experimental** future and might change
+   (or be completely removed) in the future.
+   See :ref:`custom-discovery` for a stable way of configuring ``setuptools``.
+
 By default setuptools will consider 2 popular project layouts, each one with
 its own set of advantages and disadvantages [#layout1]_ [#layout2]_.
 
@@ -165,6 +169,8 @@ Also note that you can customise your project layout by explicitly setting
    If at least one of them is explicitly set, automatic discovery will not take
    place.
 
+
+.. custom-discovery::
 
 Custom discovery
 ================

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ testing =
 	filelock>=3.4.0
 	pip_run>=8.8
 	ini2toml[lite]>=0.9
+	tomli-w>=1.0.0
 
 testing-integration =
 	pytest

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -249,7 +249,11 @@ def cmdclass(
 
 
 def find_packages(
-    *, namespaces=True, root_dir: Optional[_Path] = None, **kwargs
+    *,
+    namespaces=True,
+    fill_package_dir: Optional[Dict[str, str]] = None,
+    root_dir: Optional[_Path] = None,
+    **kwargs
 ) -> List[str]:
     """Works similarly to :func:`setuptools.find_packages`, but with all
     arguments given as keyword arguments. Moreover, ``where`` can be given
@@ -259,6 +263,13 @@ def find_packages(
     behave like :func:`setuptools.find_namespace_packages`` (i.e. include
     implicit namespaces as per :pep:`420`).
 
+    The ``where`` argument will be considered relative to ``root_dir`` (or the current
+    working directory when ``root_dir`` is not given).
+
+    If the ``fill_package_dir`` argument is passed, this function will consider it as a
+    similar data structure to the ``package_dir`` configuration parameter add fill-in
+    any missing package location.
+
     :rtype: list
     """
 
@@ -267,12 +278,39 @@ def find_packages(
     else:
         from setuptools.discovery import PackageFinder  # type: ignore
 
-    root_dir = root_dir or "."
+    root_dir = root_dir or os.curdir
     where = kwargs.pop('where', ['.'])
     if isinstance(where, str):
         where = [where]
-    target = [_nest_path(root_dir, path) for path in where]
-    return list(chain_iter(PackageFinder.find(x, **kwargs) for x in target))
+
+    packages = []
+    fill_package_dir = {} if fill_package_dir is None else fill_package_dir
+    for path in where:
+        pkgs = PackageFinder.find(_nest_path(root_dir, path), **kwargs)
+        packages.extend(pkgs)
+        if fill_package_dir.get("") != path:
+            parent_pkgs = _parent_packages(pkgs)
+            parent = {pkg: "/".join([path, *pkg.split(".")]) for pkg in parent_pkgs}
+            fill_package_dir.update(parent)
+
+    return packages
+
+
+def _parent_packages(packages: List[str]) -> List[str]:
+    """Remove children packages from the list
+    >>> _parent_packages(["a", "a.b1", "a.b2", "a.b1.c1"])
+    ['a']
+    >>> _parent_packages(["a", "b", "c.d", "c.d.e.f", "g.h", "a.a1"])
+    ['a', 'b', 'c.d', 'g.h']
+    """
+    pkgs = sorted(packages, key=len)
+    top_level = pkgs[:]
+    size = len(pkgs)
+    for i, name in enumerate(reversed(pkgs)):
+        if any(name.startswith(f"{other}.") for other in top_level):
+            top_level.pop(size - i - 1)
+
+    return top_level
 
 
 def _nest_path(parent: _Path, path: _Path) -> str:

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -263,9 +263,9 @@ def find_packages(
     """
 
     if namespaces:
-        from setuptools import PEP420PackageFinder as PackageFinder
+        from setuptools.discovery import PEP420PackageFinder as PackageFinder
     else:
-        from setuptools import PackageFinder  # type: ignore
+        from setuptools.discovery import PackageFinder  # type: ignore
 
     root_dir = root_dir or "."
     where = kwargs.pop('where', ['.'])

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -121,7 +121,6 @@ def expand_configuration(
     setuptools_cfg = config.get("tool", {}).get("setuptools", {})
     package_dir = setuptools_cfg.get("package-dir")
 
-    _expand_all_dynamic(project_cfg, setuptools_cfg, root_dir, ignore_option_errors)
     _expand_packages(setuptools_cfg, root_dir, ignore_option_errors)
     _canonic_package_data(setuptools_cfg)
     _canonic_package_data(setuptools_cfg, "exclude-package-data")
@@ -129,8 +128,10 @@ def expand_configuration(
     process = partial(_process_field, ignore_option_errors=ignore_option_errors)
     cmdclass = partial(_expand.cmdclass, package_dir=package_dir, root_dir=root_dir)
     data_files = partial(_expand.canonic_data_files, root_dir=root_dir)
+
     process(setuptools_cfg, "data-files", data_files)
     process(setuptools_cfg, "cmdclass", cmdclass)
+    _expand_all_dynamic(project_cfg, setuptools_cfg, root_dir, ignore_option_errors)
 
     return config
 

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -47,6 +47,9 @@ import _distutils_hack.override  # noqa: F401
 from distutils import log
 from distutils.util import convert_path
 
+from typing import Dict, List, Optional, Union
+_Path = Union[str, os.PathLike]
+
 chain_iter = itertools.chain.from_iterable
 
 
@@ -363,37 +366,51 @@ class ConfigDiscovery:
             return None
 
         packages = sorted(self.dist.packages, key=len)
-        common_ancestors = []
-        for i, name in enumerate(packages):
-            if not all(n.startswith(name) for n in packages[i+1:]):
-                # Since packages are sorted by length, this condition is able
-                # to find a list of all common ancestors.
-                # When there is divergence (e.g. multiple root packages)
-                # the list will be empty
-                break
-            common_ancestors.append(name)
+        package_dir = self.dist.package_dir or {}
 
-        for name in common_ancestors:
-            init = os.path.join(self._find_package_path(name), "__init__.py")
-            if os.path.isfile(init):
-                log.debug(f"Common parent package detected, name: {name}")
-                return name
+        parent_pkg = find_parent_package(packages, package_dir, self._root_dir)
+        if parent_pkg:
+            log.debug(f"Common parent package detected, name: {parent_pkg}")
+            return parent_pkg
 
         log.warn("No parent package detected, impossible to derive `name`")
         return None
 
-    def _find_package_path(self, name):
-        """Given a package name, return the path where it should be found on
-        disk, considering the ``package_dir`` option.
-        """
-        package_dir = self.dist.package_dir or {}
-        parts = name.split(".")
-        for i in range(len(parts), 0, -1):
-            # Look backwards, the most specific package_dir first
-            partial_name = ".".join(parts[:i])
-            if partial_name in package_dir:
-                parent = package_dir[partial_name]
-                return os.path.join(self._root_dir, parent, *parts[i:])
 
-        parent = (package_dir.get("") or "").split("/")
-        return os.path.join(self._root_dir, *parent, *parts)
+def find_parent_package(
+    packages: List[str], package_dir: Dict[str, str], root_dir: _Path
+) -> Optional[str]:
+    packages = sorted(packages, key=len)
+    common_ancestors = []
+    for i, name in enumerate(packages):
+        if not all(n.startswith(name) for n in packages[i+1:]):
+            # Since packages are sorted by length, this condition is able
+            # to find a list of all common ancestors.
+            # When there is divergence (e.g. multiple root packages)
+            # the list will be empty
+            break
+        common_ancestors.append(name)
+
+    for name in common_ancestors:
+        pkg_path = _find_package_path(name, package_dir, root_dir)
+        init = os.path.join(pkg_path, "__init__.py")
+        if os.path.isfile(init):
+            return name
+
+    return None
+
+
+def _find_package_path(name: str, package_dir: Dict[str, str], root_dir: _Path) -> str:
+    """Given a package name, return the path where it should be found on
+    disk, considering the ``package_dir`` option.
+    """
+    parts = name.split(".")
+    for i in range(len(parts), 0, -1):
+        # Look backwards, the most specific package_dir first
+        partial_name = ".".join(parts[:i])
+        if partial_name in package_dir:
+            parent = package_dir[partial_name]
+            return os.path.join(root_dir, parent, *parts[i:])
+
+    parent = package_dir.get("") or ""
+    return os.path.join(root_dir, *parent.split("/"), *parts)

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -392,7 +392,7 @@ def find_parent_package(
         common_ancestors.append(name)
 
     for name in common_ancestors:
-        pkg_path = _find_package_path(name, package_dir, root_dir)
+        pkg_path = find_package_path(name, package_dir, root_dir)
         init = os.path.join(pkg_path, "__init__.py")
         if os.path.isfile(init):
             return name
@@ -400,7 +400,7 @@ def find_parent_package(
     return None
 
 
-def _find_package_path(name: str, package_dir: Dict[str, str], root_dir: _Path) -> str:
+def find_package_path(name: str, package_dir: Dict[str, str], root_dir: _Path) -> str:
     """Given a package name, return the path where it should be found on
     disk, considering the ``package_dir`` option.
     """

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -242,7 +242,7 @@ class ConfigDiscovery:
         self._called = False
         self._root_dir = None  # delay so `src_root` can be set in dist
 
-    def __call__(self, force=False):
+    def __call__(self, force=False, name=True):
         """Automatically discover missing configuration fields
         and modifies the given ``distribution`` object in-place.
 
@@ -260,7 +260,8 @@ class ConfigDiscovery:
         self._root_dir = self.dist.src_root or os.curdir
 
         self._analyse_package_layout()
-        self._analyse_name()  # depends on ``packages`` and ``py_modules``
+        if name:
+            self.analyse_name()  # depends on ``packages`` and ``py_modules``
 
         self._called = True
 
@@ -328,7 +329,7 @@ class ConfigDiscovery:
         log.debug(f"`flat-layout` detected -- analysing {self._root_dir}")
         return True
 
-    def _analyse_name(self):
+    def analyse_name(self):
         """The packages/modules are the essential contribution of the author.
         Therefore the name of the distribution can be derived from them.
         """

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -818,11 +818,13 @@ class Distribution(_Distribution):
         and loads configuration.
         """
         tomlfiles = []
+        standard_project_metadata = Path(self.src_root or os.curdir, "pyproject.toml")
         if filenames is not None:
-            tomlfiles, other = partition(lambda f: Path(f).suffix == ".toml", filenames)
-            filenames = other
-        elif os.path.exists("pyproject.toml"):
-            tomlfiles = ["pyproject.toml"]
+            parts = partition(lambda f: Path(f).suffix == ".toml", filenames)
+            filenames = list(parts[0])  # 1st element => predicate is False
+            tomlfiles = list(parts[1])  # 2nd element => predicate is True
+        elif standard_project_metadata.exists():
+            tomlfiles = [standard_project_metadata]
 
         self._parse_config_files(filenames=filenames)
 

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -178,7 +178,7 @@ class TestNoConfig:
         ("lib", {"packages": "find:", "packages.find": {"where": "lib"}}),
     ]
 )
-def test_discovered_packagedir_with_attr_directive_in_config(tmp_path, folder, opts):
+def test_discovered_package_dir_with_attr_directive_in_config(tmp_path, folder, opts):
     _populate_project_dir(tmp_path, [f"{folder}/pkg/__init__.py", "setup.cfg"], opts)
     (tmp_path / folder / "pkg/__init__.py").write_text("version = 42")
     (tmp_path / "setup.cfg").write_text(


### PR DESCRIPTION
## Motivation

In https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/2, a user pointed out that the auto-discovery of packages was not playing well with `attr:`.
The aim of this PR is to fix that, and make the discovery work when users want to use directives and dynamic configs (e.g. `attr:` and `cmdclass`) with `setup.cfg` or `pyproject.toml`.

## Summary of changes

- Run auto-discovery before using `package_dir` when parsing either `setup.cfg` or `pyproject.toml`.
- When parsing `setup.cfg` we have to be a bit more careful because the `parse_config_files` function can include files other than `setup.cfg`, so the best is to postpone the execution until the moment it is really necessary (the auto-discovery just run once, so we don't want to run it with incomplete arguments...)

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
