### PR TITLE
Match normalized requirement names

### DIFF
--- a/changelog.d/3153.change.rst
+++ b/changelog.d/3153.change.rst
@@ -1,0 +1,1 @@
+When resolving requirements use both canonical and normalized names -- by :user:`ldaniluk`

--- a/pkg_resources/tests/test_working_set.py
+++ b/pkg_resources/tests/test_working_set.py
@@ -42,7 +42,7 @@ def parse_distributions(s):
             continue
         fields = spec.split('\n', 1)
         assert 1 <= len(fields) <= 2
-        name, version = fields.pop(0).split('-')
+        name, version = fields.pop(0).rsplit('-', 1)
         if fields:
             requires = textwrap.dedent(fields.pop(0))
             metadata = Metadata(('requires.txt', requires))
@@ -464,6 +464,25 @@ def parametrize_test_working_set_resolve(*test_list):
 
     # resolved [replace conflicting]
     VersionConflict
+    ''',
+
+    '''
+    # id
+    wanted_normalized_name_installed_canonical
+
+    # installed
+    foo.bar-3.6
+
+    # installable
+
+    # wanted
+    foo-bar==3.6
+
+    # resolved
+    foo.bar-3.6
+
+    # resolved [replace conflicting]
+    foo.bar-3.6
     ''',
 )
 def test_working_set_resolve(installed_dists, installable_dists, requirements,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Requirements might be specified using normalized names as described in PEP 503 but working set would not match them to installed packages that are identified by their canonical name. This is the reason of this [issue in liccheck].

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
[issue in liccheck]: https://github.com/dhatim/python-license-check/issues/81
