### PR TITLE
[follow-up `auto-discovery`] Prevent auto-discovery from being too aggressive

### DIFF
--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -109,10 +109,10 @@ Setuptools will automatically scan your project directory looking for these
 layouts and try to guess the correct values for the :ref:`packages <declarative
 config>` and :doc:`py_modules </references/keywords>` configuration.
 
-To avoid confusion, file and folder names that are used by popular tools (or
-that correspond to well-known conventions, such as distributing documentation
-alongside the project code) are automatically filtered out in the case of
-*flat-layouts*:
+In the case of *flat-layouts*, only packages or modules that match your
+project's name metadata will be considered (at first). If no match is found,
+then ``setuptools`` will proceed and evaluate other files and directories,
+except the following:
 
 .. autoattribute:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
 
@@ -176,8 +176,8 @@ Custom discovery
 ================
 
 If the automatic discovery does not work for you
-(e.g., you want to *include* in the distribution top-level packages with
-reserved names such as ``tasks``, ``example`` or ``docs``, or you want to
+(e.g., you want to distribute multiple packages together, your package or
+module name does not match the name you want to display on PyPI, or you want to
 *exclude* nested packages that would be otherwise included), you can use
 the provided tools for package discovery:
 

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -67,6 +67,23 @@ class TestDiscoverPackagesAndPyModules:
         for file in files:
             assert any(f.endswith(file) for f in manifest)
 
+    def test_flat_layout_with_name(self, tmp_path):
+        files = ["venv/bin/simulate_venv", "util.py", "utils/__init__.py"]
+        files += self.FILES["flat"]
+        (tmp_path / "setup.cfg").write_text("[metadata]\nname = pkg")
+        _populate_project_dir(tmp_path, files, {})
+        dist, _ = _run_sdist_programatically(tmp_path, {})
+        assert dist.packages == ["pkg"]
+        assert dist.py_modules == []
+
+    def test_flat_layout_without_name(self, tmp_path):
+        files = ["venv/bin/simulate_venv", "util.py", "utils/__init__.py"]
+        files += self.FILES["flat"]
+        _populate_project_dir(tmp_path, files, {})
+        dist, _ = _run_sdist_programatically(tmp_path, {})
+        assert dist.packages == ["pkg", "utils"]
+        assert dist.py_modules == ["util"]
+
     @pytest.mark.parametrize("circumstance", OPTIONS.keys())
     def test_project(self, tmp_path, circumstance):
         files, options = self._get_info(circumstance)


### PR DESCRIPTION
As discussed in https://discuss.python.org/t/help-testing-experimental-features-in-setuptools/13821/41 automatically scanning all the directories might be very error-prone.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- If available, the name metadata can be used to filter packages.

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
