### PR TITLE
[CI] Allow pre-built distribution to be used in tests with virtualenvs

### DIFF
--- a/changelog.d/3147.misc.rst
+++ b/changelog.d/3147.misc.rst
@@ -1,4 +1,4 @@
-Added options to provide a pre-build ``setuptools`` wheel or sdist for being
+Added options to provide a pre-built ``setuptools`` wheel or sdist for being
 used during tests with virtual environments.
 Paths for these pre-built distribution files can now be set via the environment
 variables: ``PRE_BUILT_SETUPTOOLS_SDIST`` and ``PRE_BUILT_SETUPTOOLS_WHEEL``.

--- a/changelog.d/3147.misc.rst
+++ b/changelog.d/3147.misc.rst
@@ -1,0 +1,4 @@
+Added options to provide a pre-build ``setuptools`` wheel or sdist for being
+used during tests with virtual environments.
+Paths for these pre-built distribution files can now be set via the environment
+variables: ``PRE_BUILT_SETUPTOOLS_SDIST`` and ``PRE_BUILT_SETUPTOOLS_WHEEL``.

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -1,6 +1,8 @@
+import os
 import contextlib
 import sys
 import subprocess
+from pathlib import Path
 
 import pytest
 import path
@@ -64,6 +66,9 @@ def sample_project(tmp_path):
 
 @pytest.fixture(scope="session")
 def setuptools_sdist(tmp_path_factory, request):
+    if os.getenv("PRE_BUILT_SETUPTOOLS_SDIST"):
+        return Path(os.getenv("PRE_BUILT_SETUPTOOLS_SDIST")).resolve()
+
     with contexts.session_locked_tmp_dir(
             request, tmp_path_factory, "sdist_build") as tmp:
         dist = next(tmp.glob("*.tar.gz"), None)
@@ -79,6 +84,9 @@ def setuptools_sdist(tmp_path_factory, request):
 
 @pytest.fixture(scope="session")
 def setuptools_wheel(tmp_path_factory, request):
+    if os.getenv("PRE_BUILT_SETUPTOOLS_WHEEL"):
+        return Path(os.getenv("PRE_BUILT_SETUPTOOLS_WHEEL")).resolve()
+
     with contexts.session_locked_tmp_dir(
             request, tmp_path_factory, "wheel_build") as tmp:
         dist = next(tmp.glob("*.whl"), None)

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,8 @@ usedevelop = True
 extras = testing
 passenv =
 	SETUPTOOLS_USE_DISTUTILS
+	PRE_BUILT_SETUPTOOLS_WHEEL
+	PRE_BUILT_SETUPTOOLS_SDIST
 	TIMEOUT_BACKEND_TEST  # timeout (in seconds) for test_build_meta
 	windir  # required for test_pkg_resources
 	# honor git config in pytest-perf


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Check for ``PRE_BUILT_SETUPTOOLS_SDIST`` and ``PRE_BUILT_SETUPTOOLS_WHEEL`` environment variables before re-packaging the project in the `setuptools_wheel` and `setuptools_sdist` fixtures.

Closes #3147

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
