### PR TITLE
Attempt to re-enable Windows tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,8 +24,7 @@ jobs:
         platform:
         - ubuntu-latest
         - macos-latest
-        # disable tests on Windows due to pypa/distutils#118
-        # - windows-latest
+        - windows-latest
         include:
         - platform: ubuntu-latest
           python: "3.10"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         platform:
         - ubuntu-latest
         - macos-latest
-        - windows-latest
+        - windows-2019
         include:
         - platform: ubuntu-latest
           python: "3.10"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,11 +29,6 @@ jobs:
         - platform: ubuntu-latest
           python: "3.10"
           distutils: stdlib
-        exclude:
-        # The combination of PyPy+Windows+pytest-xdist+ProcessPoolExecutor is flaky/problematic
-        - platform: windows-2019
-          python: pypy-3.7
-          distutils: local
     runs-on: ${{ matrix.platform }}
     env:
       SETUPTOOLS_USE_DISTUTILS: ${{ matrix.distutils }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,11 @@ jobs:
         - platform: ubuntu-latest
           python: "3.10"
           distutils: stdlib
+        exclude:
+        # The combination of PyPy+Windows+pytest-xdist+ProcessPoolExecutor is flaky/problematic
+        - platform: windows-2019
+          python: pypy-3.7
+          distutils: local
     runs-on: ${{ matrix.platform }}
     env:
       SETUPTOOLS_USE_DISTUTILS: ${{ matrix.distutils }}

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -18,6 +18,13 @@ TIMEOUT = int(os.getenv("TIMEOUT_BACKEND_TEST", "180"))  # in seconds
 IS_PYPY = '__pypy__' in sys.builtin_module_names
 
 
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" and IS_PYPY,
+    reason="The combination of PyPy + Windows + pytest-xdist + ProcessPoolExecutor "
+    "is flaky and problematic"
+)
+
+
 class BuildBackendBase:
     def __init__(self, cwd='.', env={}, backend_name='setuptools.build_meta'):
         self.cwd = cwd

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ passenv =
 	windir  # required for test_pkg_resources
 	# honor git config in pytest-perf
 	HOME
+	PROGRAMFILES
+	PROGRAMFILES(x86)
 
 [testenv:integration]
 deps = {[testenv]deps}
@@ -27,6 +29,8 @@ extras = testing-integration
 passenv =
 	{[testenv]passenv}
 	DOWNLOAD_PATH
+	PROGRAMFILES
+	PROGRAMFILES(x86)
 setenv =
     PROJECT_ROOT = {toxinidir}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -20,8 +20,6 @@ passenv =
 	windir  # required for test_pkg_resources
 	# honor git config in pytest-perf
 	HOME
-	PROGRAMFILES
-	PROGRAMFILES(x86)
 
 [testenv:integration]
 deps = {[testenv]deps}
@@ -29,8 +27,6 @@ extras = testing-integration
 passenv =
 	{[testenv]passenv}
 	DOWNLOAD_PATH
-	PROGRAMFILES
-	PROGRAMFILES(x86)
 setenv =
     PROJECT_ROOT = {toxinidir}
 commands =


### PR DESCRIPTION
~According to a comment in pypa/distutils#118 this problem might be
solved by allowing tox to pass some environment variables.~ This approach does not work.

We can instead re-enable the tests for Windows, using 2019 (maybe that is better than skipping them completely?)

## Summary of changes

- ~Change `tox.ini` to pass `PROGRAMFILES(x86)` to tests
  see https://github.com/pypa/distutils/issues/118#issuecomment-1052703319~

- Use `windows-2019` instead of `windows-latest` in the workflow description

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
