### PR TITLE
[Docs] Improve documentation about migration from distutils

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,6 +200,7 @@ favicons = [
 
 intersphinx_mapping['pip'] = 'https://pip.pypa.io/en/latest', None
 intersphinx_mapping['PyPUG'] = ('https://packaging.python.org/en/latest/', None)
+intersphinx_mapping['packaging'] = ('https://packaging.pypa.io/en/latest/', None)
 intersphinx_mapping['importlib-resources'] = (
     'https://importlib-resources.readthedocs.io/en/latest', None
 )

--- a/docs/deprecated/distutils-legacy.rst
+++ b/docs/deprecated/distutils-legacy.rst
@@ -3,11 +3,10 @@ Porting from Distutils
 
 Setuptools and the PyPA have a `stated goal <https://github.com/pypa/packaging-problems/issues/127>`_ to make Setuptools the reference API for distutils.
 
-Since the 49.1.2 release, Setuptools includes a local, vendored copy of distutils (from late copies of CPython) that is disabled by default. To enable the use of this copy of distutils when invoking setuptools, set the enviroment variable:
+Since the 49.1.2 release, Setuptools includes a local, vendored copy of distutils (from late copies of CPython) that is enabled by default. To disable the use of this copy of distutils when invoking setuptools, set the enviroment variable:
 
-    SETUPTOOLS_USE_DISTUTILS=local
+    SETUPTOOLS_USE_DISTUTILS=stdlib
 
-This behavior is planned to become the default.
 
 Prefer Setuptools
 -----------------
@@ -20,11 +19,14 @@ As Distutils is deprecated, any usage of functions or objects from distutils is 
 
 ``distutils.command.{build_clib,build_ext,build_py,sdist}`` → ``setuptools.command.*``
 
-``distutils.log`` → (no replacement yet)
+``distutils.log`` → :mod:`logging` (standard library)
 
 ``distutils.version.*`` → ``packaging.version.*``
 
 ``distutils.errors.*`` → ``setuptools.errors.*`` [#errors]_
+
+
+Migration is also provided by :pep:`632#migration-advice`.
 
 If a project relies on uses of ``distutils`` that do not have a suitable replacement above, please search the `Setuptools issue tracker <https://github.com/pypa/setuptools/issues/>`_ and file a request, describing the use-case so that Setuptools' maintainers can investigate. Please provide enough detail to help the maintainers understand how distutils is used, what value it provides, and why that behavior should be supported.
 

--- a/docs/deprecated/distutils-legacy.rst
+++ b/docs/deprecated/distutils-legacy.rst
@@ -3,7 +3,7 @@ Porting from Distutils
 
 Setuptools and the PyPA have a `stated goal <https://github.com/pypa/packaging-problems/issues/127>`_ to make Setuptools the reference API for distutils.
 
-Since the 49.1.2 release, Setuptools includes a local, vendored copy of distutils (from late copies of CPython) that is enabled by default. To disable the use of this copy of distutils when invoking setuptools, set the enviroment variable:
+Since the 60.0.0 release, Setuptools includes a local, vendored copy of distutils (from late copies of CPython) that is enabled by default. To disable the use of this copy of distutils when invoking setuptools, set the enviroment variable:
 
     SETUPTOOLS_USE_DISTUTILS=stdlib
 

--- a/docs/deprecated/distutils-legacy.rst
+++ b/docs/deprecated/distutils-legacy.rst
@@ -21,12 +21,12 @@ As Distutils is deprecated, any usage of functions or objects from distutils is 
 
 ``distutils.log`` → :mod:`logging` (standard library)
 
-``distutils.version.*`` → ``packaging.version.*``
+``distutils.version.*`` → :doc:`packaging.version.* <packaging:version>`
 
 ``distutils.errors.*`` → ``setuptools.errors.*`` [#errors]_
 
 
-Migration is also provided by :pep:`PEP 632 <632#migration-advice>`.
+Migration advice is also provided by :pep:`PEP 632 <632#migration-advice>`.
 
 If a project relies on uses of ``distutils`` that do not have a suitable replacement above, please search the `Setuptools issue tracker <https://github.com/pypa/setuptools/issues/>`_ and file a request, describing the use-case so that Setuptools' maintainers can investigate. Please provide enough detail to help the maintainers understand how distutils is used, what value it provides, and why that behavior should be supported.
 

--- a/docs/deprecated/distutils-legacy.rst
+++ b/docs/deprecated/distutils-legacy.rst
@@ -26,7 +26,7 @@ As Distutils is deprecated, any usage of functions or objects from distutils is 
 ``distutils.errors.*`` → ``setuptools.errors.*`` [#errors]_
 
 
-Migration is also provided by :pep:`632#migration-advice`.
+Migration is also provided by :pep:`PEP 632 <632#migration-advice>`.
 
 If a project relies on uses of ``distutils`` that do not have a suitable replacement above, please search the `Setuptools issue tracker <https://github.com/pypa/setuptools/issues/>`_ and file a request, describing the use-case so that Setuptools' maintainers can investigate. Please provide enough detail to help the maintainers understand how distutils is used, what value it provides, and why that behavior should be supported.
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- State that the local copy of distutils is active by default
- Recommend `logging` instead of `distutils.log`
- Link PEP 632 migration advice.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
