### PR TITLE
[follow-up `pyproject.toml`] Add initial docs about `pyproject.toml` configs

### DIFF
--- a/changelog.d/3172.doc.rst
+++ b/changelog.d/3172.doc.rst
@@ -1,0 +1,2 @@
+Added initial documentation about configuring ``setuptools`` via ``pyproject.toml``
+(using standard project metadata).

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -72,6 +72,8 @@ specify the package information::
     [options]
     packages = find:
 
+.. _building:
+
 Now generate the distribution. To build the package, use
 `PyPA build <https://pypa-build.readthedocs.io/en/latest/>`_::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ extlinks = {
     'pr': (f'{github_repo_url}/pull/%s', 'PR #%s'),  # noqa: WPS323
     'user': (f'{github_sponsors_url}/%s', '@'),  # noqa: WPS323
     'pypi': ('https://pypi.org/project/%s', '%s'),  # noqa: WPS323
+    'wiki': ('https://wikipedia.org/wiki/%s', '%s'),  # noqa: WPS323
 }
 extensions += ['sphinx.ext.extlinks']
 

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -1,8 +1,8 @@
 .. _declarative config:
 
------------------------------------------
-Configuring setup() using setup.cfg files
------------------------------------------
+------------------------------------------------
+Configuring setuptools using ``setup.cfg`` files
+------------------------------------------------
 
 .. note:: New in 30.3.0 (8 Dec 2016).
 
@@ -24,27 +24,22 @@ boilerplate code in some cases.
 
     [metadata]
     name = my_package
-    version = attr: src.VERSION
+    version = attr: my_package.VERSION
     description = My package description
     long_description = file: README.rst, CHANGELOG.rst, LICENSE.rst
     keywords = one, two
     license = BSD 3-Clause License
     classifiers =
         Framework :: Django
-        License :: OSI Approved :: BSD License
         Programming Language :: Python :: 3
-        Programming Language :: Python :: 3.5
 
     [options]
     zip_safe = False
     include_package_data = True
     packages = find:
-    scripts =
-        bin/first.py
-        bin/second.py
     install_requires =
         requests
-        importlib; python_version == "2.6"
+        importlib-metadata; python_version<"3.8"
 
     [options.package_data]
     * = *.txt, *.rst
@@ -52,7 +47,7 @@ boilerplate code in some cases.
 
     [options.entry_points]
     console_scripts =
-        executable-name = package.module:function
+        executable-name = my_package.module:function
 
     [options.extras_require]
     pdf = ReportLab>=1.2; RXP
@@ -60,8 +55,10 @@ boilerplate code in some cases.
 
     [options.packages.find]
     exclude =
-        src.subpackage1
-        src.subpackage2
+        examples*
+        tools*
+        docs*
+        my_package.tests*
 
 Metadata and options are set in the config sections of the same name.
 

--- a/docs/userguide/dependency_management.rst
+++ b/docs/userguide/dependency_management.rst
@@ -293,49 +293,9 @@ dependencies for it to work:
         PDF = ["ReportLab>=1.2", "RXP"]
 
 The name ``PDF`` is an arbitrary identifier of such a list of dependencies, to
-which other components can refer and have them installed. There are two common
-use cases.
+which other components can refer and have them installed.
 
-First is the console_scripts entry point:
-
-.. tab:: setup.cfg
-
-    .. code-block:: ini
-
-        [metadata]
-        name = Project A
-        #...
-
-        [options]
-        #...
-        entry_points=
-            [console_scripts]
-            rst2pdf = project_a.tools.pdfgen [PDF]
-            rst2html = project_a.tools.htmlgen
-
-.. tab:: setup.py
-
-    .. code-block:: python
-
-        setup(
-            name="Project-A",
-            ...,
-            entry_points={
-                "console_scripts": [
-                    "rst2pdf = project_a.tools.pdfgen [PDF]",
-                    "rst2html = project_a.tools.htmlgen",
-                ],
-            },
-        )
-
-This syntax indicates that the entry point (in this case a console script)
-is only valid when the PDF extra is installed. It is up to the installer
-to determine how to handle the situation where PDF was not indicated
-(e.g. omit the console script, provide a warning when attempting to load
-the entry point, assume the extras are present and let the implementation
-fail later).
-
-The second use case is that other package can use this "extra" for their
+A use case for this approach is that other package can use this "extra" for their
 own dependencies. For example, if "Project-B" needs "project A" with PDF support
 installed, it might declare the dependency like this:
 
@@ -383,10 +343,55 @@ ReportLab in order to provide PDF support, Project B's setup information does
 not need to change, but the right packages will still be installed if needed.
 
 .. note::
-    Best practice: if a project ends up not needing any other packages to
+    Best practice: if a project ends up no longer needing any other packages to
     support a feature, it should keep an empty requirements list for that feature
     in its ``extras_require`` argument, so that packages depending on that feature
     don't break (due to an invalid feature name).
+
+Historically ``setuptools`` also used to support extra dependencies in console
+scripts, for example:
+
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [metadata]
+        name = Project A
+        #...
+
+        [options]
+        #...
+        entry_points=
+            [console_scripts]
+            rst2pdf = project_a.tools.pdfgen [PDF]
+            rst2html = project_a.tools.htmlgen
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        setup(
+            name="Project-A",
+            ...,
+            entry_points={
+                "console_scripts": [
+                    "rst2pdf = project_a.tools.pdfgen [PDF]",
+                    "rst2html = project_a.tools.htmlgen",
+                ],
+            },
+        )
+
+This syntax indicates that the entry point (in this case a console script)
+is only valid when the PDF extra is installed. It is up to the installer
+to determine how to handle the situation where PDF was not indicated
+(e.g. omit the console script, provide a warning when attempting to load
+the entry point, assume the extras are present and let the implementation
+fail later).
+
+.. warning::
+   ``pip`` and other tools might not support this use case for extra
+   dependencies, therefore this practice is considered **deprecated**.
+   See :doc:`PyPUG:specifications/entry-points`.
 
 
 Python requirement
@@ -432,7 +437,7 @@ This can be configured as shown in the example bellow.
 
 .. [#experimental]
    While the ``[build-system]`` table should always be specified in the
-   ``pyproject.toml`` file, adding package metadata and build configuration
+   ``pyproject.toml`` file, support for adding package metadata and build configuration
    options via the ``[project]`` and ``[tool.setuptools]`` tables is still
    experimental and might change (or be completely removed) in future releases.
    See :doc:`/userguide/pyproject_config`.

--- a/docs/userguide/dependency_management.rst
+++ b/docs/userguide/dependency_management.rst
@@ -69,6 +69,18 @@ finesse to it, let's start with a simple example.
             ],
         )
 
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+    .. code-block:: toml
+
+        [project]
+        # ...
+        dependencies = [
+            "docutils",
+            "BazSpam == 1.1",
+        ]
+        # ...
+
 
 When your project is installed (e.g. using pip), all of the dependencies not
 already installed will be located (via PyPI), downloaded, built (if necessary),
@@ -104,6 +116,17 @@ the Python version is older than 3.4. To accomplish this
             ],
         )
 
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+    .. code-block:: toml
+
+        [project]
+        # ...
+        dependencies = [
+            "enum34; python_version<'3.4'",
+        ]
+        # ...
+
 Similarly, if you also wish to declare ``pywin32`` with a minimal version of 1.0
 and only install it if the user is using a Windows operating system:
 
@@ -128,6 +151,18 @@ and only install it if the user is using a Windows operating system:
                 "pywin32 >= 1.0;platform_system=='Windows'",
             ],
         )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+    .. code-block:: toml
+
+        [project]
+        # ...
+        dependencies = [
+            "enum34; python_version<'3.4'",
+            "pywin32 >= 1.0; platform_system=='Windows'",
+        ]
+        # ...
 
 The environmental markers that may be used for testing platform types are
 detailed in `PEP 508 <https://www.python.org/dev/peps/pep-0508/>`_.
@@ -249,6 +284,14 @@ dependencies for it to work:
             },
         )
 
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+    .. code-block:: toml
+
+        # ...
+        [project.optional-dependencies]
+        PDF = ["ReportLab>=1.2", "RXP"]
+
 The name ``PDF`` is an arbitrary identifier of such a list of dependencies, to
 which other components can refer and have them installed. There are two common
 use cases.
@@ -319,6 +362,17 @@ installed, it might declare the dependency like this:
             ...,
         )
 
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+    .. code-block:: toml
+
+        [project]
+        name = "Project-B"
+        # ...
+        dependencies = [
+            "Project-A[PDF]"
+        ]
+
 This will cause ReportLab to be installed along with project A, if project B is
 installed -- even if project A was already installed.  In this way, a project
 can encapsulate groups of optional "downstream dependencies" under a feature
@@ -338,9 +392,7 @@ not need to change, but the right packages will still be installed if needed.
 Python requirement
 ==================
 In some cases, you might need to specify the minimum required python version.
-This is handled with the ``python_requires`` keyword supplied to ``setup.cfg``
-or ``setup.py``.
-
+This can be configured as shown in the example bellow.
 
 .. tab:: setup.cfg
 
@@ -363,3 +415,24 @@ or ``setup.py``.
             python_requires=">=3.6",
             ...,
         )
+
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+    .. code-block:: toml
+
+        [project]
+        name = "Project-B"
+        requires-python = ">=3.6"
+        # ...
+
+----
+
+.. rubric:: Notes
+
+.. [#experimental]
+   While the ``[build-system]`` table should always be specified in the
+   ``pyproject.toml`` file, adding package metadata and build configuration
+   options via the ``[project]`` and ``[tool.setuptools]`` tables is still
+   experimental and might change (or be completely removed) in future releases.
+   See :doc:`/userguide/pyproject_config`.

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -31,6 +31,7 @@ quickstart provides an overview of the new workflow.
     distribution
     extension
     declarative_config
+    pyproject_config
     keywords
     commands
     functionalities_rewrite

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -137,59 +137,66 @@ its own set of advantages and disadvantages [#layout1]_ [#layout2]_.
 
 .. _src-layout:
 
-src-layout:
-    The project should contain a ``src`` directory under the project root and
-    all modules and packages meant for distribution are placed inside this
-    directory::
+src-layout
+----------
+The project should contain a ``src`` directory under the project root and
+all modules and packages meant for distribution are placed inside this
+directory::
 
-        project_root_directory
-        ├── pyproject.toml
-        ├── setup.cfg  # or setup.py
-        ├── ...
-        └── src/
-            └── mypkg/
-                ├── __init__.py
-                ├── ...
-                └── mymodule.py
-
-    This layout is very handy when you wish to use automatic discovery,
-    since you don't have to worry about other Python files or folders in your
-    project root being distributed by mistake. In some circumstances it can be
-    also less error-prone for testing or when using :pep:`420`-style packages.
-    On the other hand you cannot rely on the implicit ``PYTHONPATH=.`` to fire
-    up the Python REPL and play with your package (you will need an
-    `editable install`_ to be able to do that).
-
-.. _flat-layout:
-
-flat-layout (also known as "adhoc"):
-    The package folder(s) are placed directly under the project root::
-
-        project_root_directory
-        ├── pyproject.toml
-        ├── setup.cfg  # or setup.py
-        ├── ...
+    project_root_directory
+    ├── pyproject.toml
+    ├── setup.cfg  # or setup.py
+    ├── ...
+    └── src/
         └── mypkg/
             ├── __init__.py
             ├── ...
             └── mymodule.py
 
-    This layout is very practical for using the REPL, but in some situations
-    it can be can be more error-prone (e.g. during tests or if you have a bunch
-    of folders or Python files hanging around your project root)
+This layout is very handy when you wish to use automatic discovery,
+since you don't have to worry about other Python files or folders in your
+project root being distributed by mistake. In some circumstances it can be
+also less error-prone for testing or when using :pep:`420`-style packages.
+On the other hand you cannot rely on the implicit ``PYTHONPATH=.`` to fire
+up the Python REPL and play with your package (you will need an
+`editable install`_ to be able to do that).
+
+.. _flat-layout:
+
+flat-layout
+-----------
+*(also known as "adhoc")*
+
+The package folder(s) are placed directly under the project root::
+
+    project_root_directory
+    ├── pyproject.toml
+    ├── setup.cfg  # or setup.py
+    ├── ...
+    └── mypkg/
+        ├── __init__.py
+        ├── ...
+        └── mymodule.py
+
+This layout is very practical for using the REPL, but in some situations
+it can be can be more error-prone (e.g. during tests or if you have a bunch
+of folders or Python files hanging around your project root)
 
 There is also a handy variation of the *flat-layout* for utilities/libraries
 that can be implemented with a single Python file:
 
-single-module approach (or "few top-level modules"):
-    Standalone modules are placed directly under the project root, instead of
-    inside a package folder::
+single-module approach
+----------------------
+*(or "few top-level modules")*
 
-        project_root_directory
-        ├── pyproject.toml
-        ├── setup.cfg  # or setup.py
-        ├── ...
-        └── single_file_lib.py
+Standalone modules are placed directly under the project root, instead of
+inside a package folder::
+
+    project_root_directory
+    ├── pyproject.toml
+    ├── setup.cfg  # or setup.py
+    ├── ...
+    └── single_file_lib.py
 
 Setuptools will automatically scan your project directory looking for these
 layouts and try to guess the correct values for the :ref:`packages <declarative

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -88,6 +88,8 @@ setuptools automatic discovery, or use the provided tools, as explained in
 the following sections.
 
 
+.. _auto-discovery:
+
 Automatic discovery
 ===================
 
@@ -97,6 +99,8 @@ Automatic discovery
 
 By default setuptools will consider 2 popular project layouts, each one with
 its own set of advantages and disadvantages [#layout1]_ [#layout2]_.
+
+.. _src-layout:
 
 src-layout:
     The project should contain a ``src`` directory under the project root and
@@ -120,6 +124,8 @@ src-layout:
     On the other hand you cannot rely on the implicit ``PYTHONPATH=.`` to fire
     up the Python REPL and play with your package (you will need an
     `editable install`_ to be able to do that).
+
+.. _flat-layout:
 
 flat-layout (also known as "adhoc"):
     The package folder(s) are placed directly under the project root::

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -16,8 +16,9 @@ Package Discovery and Namespace Package
     place to start.
 
 ``Setuptools`` provide powerful tools to handle package discovery, including
-support for namespace package. Normally, you would specify the package to be
-included manually in the following manner:
+support for namespace package.
+
+Normally, you would specify the package to be included manually in the following manner:
 
 .. tab:: setup.cfg
 
@@ -36,6 +37,50 @@ included manually in the following manner:
         setup(
             # ...
             packages=['mypkg1', 'mypkg2']
+        )
+
+If your packages are not in the root of the repository you also need to
+configure ``package_dir``:
+
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [options]
+        # ...
+        package_dir =
+            = src
+            # directory containing all the packages (e.g.  src/mypkg1, src/mypkg2)
+        # OR
+        package_dir =
+            mypkg1 = lib1
+            # mypkg1.mod corresponds to lib1/mod.py
+            # mypkg1.subpkg.mod corresponds to lib1/subpkg/mod.py
+            mypkg2 = lib2
+            # mypkg2.mod corresponds to lib2/mod.py
+            mypkg2.subpkg = lib3
+            # pkg2.subpkg.mod corresponds to lib3/mod.py
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        setup(
+            # ...
+            package_dir = {"": "src"}
+            # directory containing all the packages (e.g.  src/mypkg1, src/mypkg2)
+        )
+
+        # OR
+
+        setup(
+            # ...
+            package_dir = {
+                "mypkg1": "lib1",  # mypkg1.mod corresponds to lib1/mod.py
+                                 # mypkg1.subpkg.mod corresponds to lib1/subpkg/mod.py
+                "mypkg2": "lib2",   # mypkg2.mod corresponds to lib2/mod.py
+                "mypkg2.subpkg": "lib3"  # mypkg2.subpkg.mod corresponds to lib3/mod.py
+                # ...
         )
 
 This can get tiresome really quickly. To speed things up, you can rely on
@@ -112,57 +157,11 @@ config>` and :doc:`py_modules </references/keywords>` configuration.
 To avoid confusion, file and folder names that are used by popular tools (or
 that correspond to well-known conventions, such as distributing documentation
 alongside the project code) are automatically filtered out in the case of
-*flat-layouts*:
+*flat-layouts* [#layout3]_:
 
 .. autoattribute:: setuptools.discovery.FlatLayoutPackageFinder.DEFAULT_EXCLUDE
 
 .. autoattribute:: setuptools.discovery.FlatLayoutModuleFinder.DEFAULT_EXCLUDE
-
-Also note that you can customise your project layout by explicitly setting
-``package_dir``:
-
-.. tab:: setup.cfg
-
-    .. code-block:: ini
-
-        [options]
-        # ...
-        package_dir =
-            = lib
-            # similar to "src-layout" but using the "lib" folder
-            # pkg.mod corresponds to lib/pkg/mod.py
-        # OR
-        package_dir =
-            pkg1 = lib1
-            # pkg1.mod corresponds to lib1/mod.py
-            # pkg1.subpkg.mod corresponds to lib1/subpkg/mod.py
-            pkg2 = lib2
-            # pkg2.mod corresponds to lib2/mod.py
-            pkg2.subpkg = lib3
-            # pkg2.subpkg.mod corresponds to lib3/mod.py
-
-.. tab:: setup.py
-
-    .. code-block:: python
-
-        setup(
-            # ...
-            package_dir = {"": "lib"}
-            # similar to "src-layout" but using the "lib" folder
-            # pkg.mod corresponds to lib/pkg/mod.py
-        )
-
-        # OR
-
-        setup(
-            # ...
-            package_dir = {
-                "pkg1": "lib1",  # pkg1.mod corresponds to lib1/mod.py
-                                 # pkg1.subpkg.mod corresponds to lib1/subpkg/mod.py
-                "pkg2": "lib2",   # pkg2.mod corresponds to lib2/mod.py
-                "pkg2.subpkg": "lib3"  # pkg2.subpkg.mod corresponds to lib3/mod.py
-                # ...
-        )
 
 .. important:: Automatic discovery will **only** be enabled if you don't
    provide any configuration for both ``packages`` and ``py_modules``.
@@ -252,8 +251,8 @@ in ``src`` that starts with the name ``pkg`` and not ``additional``:
 
 .. _Namespace Packages:
 
-Using ``find_namespace:`` or ``find_namespace_packages``
---------------------------------------------------------
+Using ``find_namespace:`` or ``find_namespace_packages:``
+---------------------------------------------------------
 ``setuptools``  provides the ``find_namespace:`` (``find_namespace_packages``)
 which behaves similarly to ``find:`` but works with namespace package. Before
 diving in, it is important to have a good understanding of what namespace
@@ -393,5 +392,10 @@ The project layout remains the same and ``setup.cfg`` remains the same.
 
 .. [#layout1] https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
 .. [#layout2] https://blog.ionelmc.ro/2017/09/25/rehashing-the-src-layout/
+.. [#layout3]
+   If you are using auto-discovery with *flat-layout* and have multiple folders
+   (other than ``tests`` and ``docs``) or Python files in your project root,
+   always check the created :term:`distribution archive <Distribution Package>`
+   to make sure files are not being distributed accidentally.
 
 .. _editable install: https://pip.pypa.io/en/stable/cli/pip_install/#editable-installs

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -118,7 +118,7 @@ consider alternatives.
    However if your project does not follow these conventional layouts
    (e.g. you want to use a ``flat-layout`` but at the same time have custom
    directories at the root of your project), you might need to use the ``find``
-   directive as shown below:
+   directive [#directives]_ as shown below:
 
    .. code-block:: toml
 
@@ -170,9 +170,9 @@ corresponding entry is required in the ``tool.setuptools.dynamic`` table
    version = {attr = "my_package.VERSION"}
    readme = {file = ["README.rst", "USAGE.rst"]}
 
-In the ``dynamic`` table, the ``attr`` directive will read an attribute from
-the given module [#attr]_, while ``file`` will read the contents of all given
-files and concatenate them in a single string.
+In the ``dynamic`` table, the ``attr`` directive [#directives]_ will read an
+attribute from the given module [#attr]_, while ``file`` will read the contents
+of all given files and concatenate them in a single string.
 
 ================= =================== =========================
 Key               Directive           Notes
@@ -194,6 +194,14 @@ Key               Directive           Notes
    ``tool.setuptool.dynamic.entry-points``, and use the values of the
    ``console_scripts`` and ``gui_scripts`` :doc:`entry-point groups
    <PyPUG:specifications/entry-points>`.
+
+.. [#directives] In the context of this document, *directives* are special TOML
+   values that are interpreted differently by ``setuptools`` (usually triggering an
+   associated function). Most of the times they correspond to a special TOML table
+   (or inline-table) with a single top-level key.
+   For example, you can have the ``{find = {where = ["src"], exclude=["tests*"]}}``
+   directive for ``tool.setuptools.packages``, or ``{attr = "mymodule.attr"}``
+   directive for ``tool.setuptools.dynamic.version``.
 
 .. [#attr] ``attr`` is meant to be used when the module attribute is statically
    specified (e.g. as a string, list or tuple). As a rule of thumb, the

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -1,0 +1,188 @@
+.. _pyproject.toml config:
+
+-----------------------------------------------------
+Configuring setuptools using ``pyproject.toml`` files
+-----------------------------------------------------
+
+.. note:: New in 61.0.0 (**experimental**)
+
+.. warning::
+   Support for declaring :doc:`project metadata
+   <PyPUG:specifications/declaring-project-metadata>` or configuring
+   ``setuptools`` via ``pyproject.toml`` files is still experimental and might
+   change (or be removed) in future releases.
+
+Starting with :pep:`621`, the Python community selected ``pyproject.toml`` as
+a standard way of specifying *project metadata*.
+``Setuptools`` has adopted this standard and will use the information contained
+in this file as an input in the build process.
+
+The example bellow illustrates how to write a ``pyproject.toml`` file that can
+be used with ``setuptools``. It contains two TOML tables (identified by the
+``[table-header]`` syntax): ``build-system`` and ``project``.
+The ``build-system`` table is used to tell the build frontend (e.g.
+:pypi:`build` or :pypi:`pip`) to use ``setuptools`` and any other plugins (e.g.
+``setuptools-scm``) to build the package.
+The ``project`` table contains metadata fields as described by
+:doc:`PyPUG:specifications/declaring-project-metadata` guide.
+
+.. _example-pyproject-config:
+
+.. code-block:: toml
+
+   [build-system]
+   requires = ["setuptools", "setuptools-scm"]
+   build-backend = "setuptools.build_meta"
+
+   [project]
+   name = "my_package"
+   description = "My package description"
+   readme = "README.rst"
+   keywords = ["one", "two"]
+   license = {text = "BSD 3-Clause License"}
+   classifiers = [
+       "Framework :: Django",
+       "Programming Language :: Python :: 3",
+   ]
+   dependencies = [
+       "requests",
+       'importlib-metadata; python_version<"3.8"',
+   ]
+   dynamic = ["version"]
+
+   [project.optional-dependencies]
+   pdf = ["ReportLab>=1.2", "RXP"]
+   rest = ["docutils>=0.3", "pack ==1.1, ==1.3"]
+
+   [project.scripts]
+   my-script = "my_package.module:function"
+
+
+.. _setuptools-table:
+
+Setuptools-specific configuration
+=================================
+
+While the standard ``project`` table in the ``pyproject.toml`` file covers most
+of the metadata used during the packaging process, there are still some
+``setuptools``-specific configurations that can be set by users that require
+customization.
+These configurations are completely optional (and probably can be skipped when
+creating simple packages). They are equivalent to the :doc:`/references/keywords`
+used by the ``setup.py`` file:
+
+========================= =========================== =========================
+Key                       Value Type (TOML)           Notes
+========================= =========================== =========================
+``platforms``             array
+``zip-safe``              boolean
+``eager-resources``       array
+``py-modules``            array                       See tip bellow
+``packages``              array or ``find`` directive See tip bellow
+``package-dir``           table/inline-table          Used when explicitly listing ``packages``
+``namespace-packages``    array                       Not necessary if you use :pep:`420`
+``package-data``          table/inline-table          See :doc:`/userguide/datafiles`
+``include-package-data``  boolean                     ``True`` by default
+``exclude-package-data``  table/inline-table
+``license-files``         array of glob patterns      **Provisional** - likely to change with :pep:`639`
+                                                      (by default: ``['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']``)
+``data-files``            table/inline-table          **Deprecated** - check :doc:`/userguide/datafiles`
+``script-files``          array                       **Deprecated** - equivalent to the ``script`` keyword in ``setup.py``
+                                                      (should be avoided in favour of ``project.scripts``)
+``provides``              array                       **Ignored by pip**
+``obsoletes``             array                       **Ignored by pip**
+========================= =========================== =========================
+
+The `TOML value types`_ ``array`` and ``table/inline-table`` are roughly
+equivalent to the Python's :obj:`dict` and :obj:`list` data types.
+
+.. tip::
+   When both ``py-modules`` and ``packages`` are left unspecified,
+   ``setuptools`` will attempt to perform :ref:`auto-discovery`, which should
+   cover most popular project directory organization techniques, such as the
+   :ref:`src <src-layout>` and :ref:`flat <flat-layout>` layouts.
+
+   However if your project does not follow these conventional layouts
+   (e.g. you want to use a ``flat-layout`` but at the same time have custom
+   directories at the root of your project), you might need to use the ``find``
+   directive as shown bellow:
+
+   .. code-block:: toml
+
+      [tool.setuptools.packages.find]
+      where = ["src"]  # list of folders that contain the packages (["."] by default)
+      include = ["my_package*"]  # package names should match these glob patterns (["*"] by default)
+      exclude = ["my_package.tests*"]  # exclude packages matching these glob patterns (empty by default)
+      namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+
+   Note that the glob patterns in the example above need to be matched
+   by the **entire** package name. This means that if you specify ``exclude = ["tests"]``,
+   modules like ``tests.my_package.test1`` will still be included in the distribution
+   (to remove them, add a wildcard to the end of the pattern: ``"tests*"``).
+
+   Alternatively, you can explicitly list the packages in modules:
+
+   .. code-block:: toml
+
+      [tool.setuptools]
+      packages = ["my_package"]
+
+
+.. _dynamic-pyproject-config:
+
+Dynamic Metadata
+================
+
+Note that in the first example of this page we use ``dynamic`` to identify
+which metadata fields are dynamically calculated during the build by either
+``setuptools`` itself or the selected plugins (e.g. ``setuptools-scm`` is
+capable of deriving the current project version directly from the ``git``
+:wiki:`version control` system).
+
+Currently the following fields can be used dynamically: ``version``,
+``classifiers``, ``description``, ``entry-points``, ``scripts``,
+``gui-scripts`` and ``readme``.
+When these fields are expected to be directly provided by ``setuptools`` a
+corresponding entry is required in the ``tool.setuptools.dynamic`` table
+[#entry-points]_. For example:
+
+.. code-block:: toml
+
+   # ...
+   [project]
+   name = "my_package"
+   dynamic = ["version", "readme"]
+   # ...
+   [tool.setuptools.dynamic]
+   version = {attr = "my_package.VERSION"}
+   readme = {file = ["README.rst", "USAGE.rst"]}
+
+In this example the ``attr`` attribute will read an attribute from the given
+module [#attr]_, while ``file`` will read all the given files and concatenate
+them in a single string.
+
+================= =================== =========================
+Key               Directive           Notes
+================= =================== =========================
+``version``       ``attr``, ``file``
+``readme``        ``file``
+``description``   ``file``            One-line text
+``classifiers``   ``file``            Multi-line text with one classifier per line
+``entry-points``  ``file``            INI format following :doc:`PyPUG:specifications/entry-points`
+                                      (``console_scripts`` and ``gui_scripts`` can be included)
+================= =================== =========================
+
+----
+
+.. [#entry-points] Dynamic ``scripts`` and ``gui-scripts`` are a special case.
+   When resolving these metadata keys, ``setuptools`` will look for
+   ``tool.setuptool.dynamic.entry-points``, and use the values of the
+   ``console_scripts`` and ``gui_scripts`` :doc:`entry-point groups
+   <PyPUG:specifications/entry-points>`.
+
+.. [#attr] ``attr`` is meant to be used when the module attribute is statically
+   specified (e.g. as a string, list or tuple). As a rule of thumb, the
+   attribute should be able to be parsed with :func:`ast.literal_eval`, and
+   should not be modified or re-assigned.
+
+.. _TOML value types: https://toml.io/en/v1.0.0

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -186,6 +186,8 @@ Key               Directive           Notes
 
 ----
 
+.. rubric:: Notes
+
 .. [#entry-points] Dynamic ``scripts`` and ``gui-scripts`` are a special case.
    When resolving these metadata keys, ``setuptools`` will look for
    ``tool.setuptool.dynamic.entry-points``, and use the values of the

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -117,7 +117,7 @@ consider alternatives.
    However if your project does not follow these conventional layouts
    (e.g. you want to use a ``flat-layout`` but at the same time have custom
    directories at the root of your project), you might need to use the ``find``
-   directive as shown bellow:
+   directive as shown below:
 
    .. code-block:: toml
 

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -72,9 +72,10 @@ While the standard ``project`` table in the ``pyproject.toml`` file covers most
 of the metadata used during the packaging process, there are still some
 ``setuptools``-specific configurations that can be set by users that require
 customization.
-These configurations are completely optional (and probably can be skipped when
-creating simple packages) and can be set via the ``tool.setuptools`` table.
-They are equivalent to the :doc:`/references/keywords` used by the ``setup.py`` file:
+These configurations are completely optional and probably can be skipped when
+creating simple packages.
+They are equivalent to the :doc:`/references/keywords` used by the ``setup.py``
+file, and can be set via the ``tool.setuptools`` table:
 
 ========================= =========================== =========================
 Key                       Value Type (TOML)           Notes
@@ -99,9 +100,9 @@ Key                       Value Type (TOML)           Notes
 ``obsoletes``             array                       **Ignored by pip**
 ========================= =========================== =========================
 
-In the table above, the `TOML value types`_ ``array`` and
-``table/inline-table`` are roughly equivalent to the Python's :obj:`dict` and
-:obj:`list` data types.
+.. note::
+   The `TOML value types`_ ``array`` and ``table/inline-table`` are roughly
+   equivalent to the Python's :obj:`dict` and :obj:`list` data types.
 
 Please note that some of these configurations are deprecated or at least
 discouraged, but they are made available to ensure portability.
@@ -112,7 +113,7 @@ consider alternatives.
    When both ``py-modules`` and ``packages`` are left unspecified,
    ``setuptools`` will attempt to perform :ref:`auto-discovery`, which should
    cover most popular project directory organization techniques, such as the
-   :ref:`src <src-layout>` and :ref:`flat <flat-layout>` layouts.
+   :ref:`src-layout` and the :ref:`flat-layout`.
 
    However if your project does not follow these conventional layouts
    (e.g. you want to use a ``flat-layout`` but at the same time have custom
@@ -146,15 +147,15 @@ Dynamic Metadata
 ================
 
 Note that in the first example of this page we use ``dynamic`` to identify
-which metadata fields are dynamically calculated during the build by either
-``setuptools`` itself or the selected plugins (e.g. ``setuptools-scm`` is
-capable of deriving the current project version directly from the ``git``
-:wiki:`version control` system).
+which metadata fields are dynamically computed during the build by either
+``setuptools`` itself or the plugins installed via ``build-system.requires``
+(e.g. ``setuptools-scm`` is capable of deriving the current project version
+directly from the ``git`` :wiki:`version control` system).
 
-Currently the following fields can be used dynamically: ``version``,
+Currently the following fields can be listed as dynamic: ``version``,
 ``classifiers``, ``description``, ``entry-points``, ``scripts``,
 ``gui-scripts`` and ``readme``.
-When these fields are expected to be directly provided by ``setuptools`` a
+When these fields are expected to be provided by ``setuptools`` a
 corresponding entry is required in the ``tool.setuptools.dynamic`` table
 [#entry-points]_. For example:
 
@@ -170,8 +171,8 @@ corresponding entry is required in the ``tool.setuptools.dynamic`` table
    readme = {file = ["README.rst", "USAGE.rst"]}
 
 In the ``dynamic`` table, the ``attr`` directive will read an attribute from
-the given module [#attr]_, while ``file`` will read all the given files and
-concatenate them in a single string.
+the given module [#attr]_, while ``file`` will read the contents of all given
+files and concatenate them in a single string.
 
 ================= =================== =========================
 Key               Directive           Notes

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -12,6 +12,11 @@ Configuring setuptools using ``pyproject.toml`` files
    ``setuptools`` via ``pyproject.toml`` files is still experimental and might
    change (or be removed) in future releases.
 
+.. important::
+   For the time being, you still might require a ``setup.py`` file containing
+   a *arg-less* ``setup()`` function call to support
+   :doc:`editable installs <pip:cli/pip_install>`.
+
 Starting with :pep:`621`, the Python community selected ``pyproject.toml`` as
 a standard way of specifying *project metadata*.
 ``Setuptools`` has adopted this standard and will use the information contained

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -73,14 +73,15 @@ of the metadata used during the packaging process, there are still some
 ``setuptools``-specific configurations that can be set by users that require
 customization.
 These configurations are completely optional (and probably can be skipped when
-creating simple packages). They are equivalent to the :doc:`/references/keywords`
-used by the ``setup.py`` file:
+creating simple packages) and can be set via the ``tool.setuptools`` table.
+They are equivalent to the :doc:`/references/keywords` used by the ``setup.py`` file:
 
 ========================= =========================== =========================
 Key                       Value Type (TOML)           Notes
 ========================= =========================== =========================
 ``platforms``             array
-``zip-safe``              boolean
+``zip-safe``              boolean                     If not specified, ``setuptools`` will try to guess
+                                                      a reasonable default for the package
 ``eager-resources``       array
 ``py-modules``            array                       See tip bellow
 ``packages``              array or ``find`` directive See tip bellow
@@ -98,8 +99,14 @@ Key                       Value Type (TOML)           Notes
 ``obsoletes``             array                       **Ignored by pip**
 ========================= =========================== =========================
 
-The `TOML value types`_ ``array`` and ``table/inline-table`` are roughly
-equivalent to the Python's :obj:`dict` and :obj:`list` data types.
+In the table above, the `TOML value types`_ ``array`` and
+``table/inline-table`` are roughly equivalent to the Python's :obj:`dict` and
+:obj:`list` data types.
+
+Please note that some of these configurations are deprecated or at least
+discouraged, but they are made available to ensure portability.
+New packages should avoid relying on them, and existing packages should
+consider alternatives.
 
 .. tip::
    When both ``py-modules`` and ``packages`` are left unspecified,
@@ -162,9 +169,9 @@ corresponding entry is required in the ``tool.setuptools.dynamic`` table
    version = {attr = "my_package.VERSION"}
    readme = {file = ["README.rst", "USAGE.rst"]}
 
-In this example the ``attr`` attribute will read an attribute from the given
-module [#attr]_, while ``file`` will read all the given files and concatenate
-them in a single string.
+In the ``dynamic`` table, the ``attr`` directive will read an attribute from
+the given module [#attr]_, while ``file`` will read all the given files and
+concatenate them in a single string.
 
 ================= =================== =========================
 Key               Directive           Notes

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -35,9 +35,14 @@ package your project:
     requires = ["setuptools"]
     build-backend = "setuptools.build_meta"
 
-Then, you will need to specify your package information (either via
-``setup.cfg``, ``setup.py`` or ``pyproject.toml``), such as metadata, contents,
-dependencies, etc. Here we demonstrate the minimum
+Then, you will need to specify your package information such as metadata,
+contents, dependencies, etc.
+
+Setuptools currently support configurations from either ``setup.cfg``,
+``setup.py`` or ``pyproject.toml`` [#experimental]_ files, however, configuring new
+projects via ``setup.py`` is discouraged [#setup.py]_.
+
+The following example demonstrates a minimum configuration:
 
 .. tab:: setup.cfg
 
@@ -55,7 +60,7 @@ dependencies, etc. Here we demonstrate the minimum
 
     See :doc:`/userguide/declarative_config` for more information.
 
-.. tab:: setup.py
+.. tab:: setup.py [#setup.py]_
 
     .. code-block:: python
 
@@ -73,9 +78,7 @@ dependencies, etc. Here we demonstrate the minimum
 
     See :doc:`/references/keywords` for more information.
 
-.. tab:: pyproject.toml
-
-    **EXPERIMENTAL** [#experimental]_
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
 
     .. code-block:: toml
 
@@ -117,9 +120,9 @@ Automatic package discovery
 ===========================
 For simple projects, it's usually easy enough to manually add packages to
 the ``packages`` keyword in ``setup.cfg``.  However, for very large projects,
-it can be a big burden to keep the package list updated. ``setuptools``
-therefore provides a convenient way to automatically list all the packages in
-your project directory:
+it can be a big burden to keep the package list updated.
+Therefore, ``setuptoops`` provides a convenient way to automatically list all
+the packages in your project directory:
 
 .. tab:: setup.cfg
 
@@ -135,9 +138,10 @@ your project directory:
         include=mypackage*
         exclude=mypackage.tests*
 
-.. tab:: setup.py
+.. tab:: setup.py [#setup.py]_
 
     .. code-block:: python
+
         from setuptools import find_packages  # or find_namespace_packages
 
         setup(
@@ -150,9 +154,7 @@ your project directory:
             # ...
         )
 
-.. tab:: pyproject.toml
-
-    **EXPERIMENTAL** [#experimental]_
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
 
     .. code-block:: toml
 
@@ -178,7 +180,7 @@ use, go to :ref:`package_discovery`.
 .. tip::
    Starting with version 60.10.0, setuptools' automatic discovery capabilities
    have been improved to detect popular project layouts (such as the
-   :ref:`flat-layout` and :ref:`src-layout`) without requiring any
+   :ref:`flat-layout` and :ref:`src-layout` layouts) without requiring any
    special configuration. Check out our :ref:`reference docs <package_discovery>`
    for more information, but please keep in mind that this functionality is
    still considered **experimental** and might change (or even be removed) in
@@ -202,7 +204,7 @@ The following configuration examples show how to accomplish this:
         console_scripts =
             cli-name = mypkg:some_func
 
-.. tab:: setup.py
+.. tab:: setup.py [#setup.py]_
 
     .. code-block:: python
 
@@ -215,9 +217,7 @@ The following configuration examples show how to accomplish this:
             }
         )
 
-.. tab:: pyproject.toml
-
-    **EXPERIMENTAL** [#experimental]_
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
 
     .. code-block:: toml
 
@@ -246,7 +246,7 @@ The example bellow show how to configure this kind of dependencies:
             docutils
             requests <= 0.4
 
-.. tab:: setup.py
+.. tab:: setup.py [#setup.py]_
 
     .. code-block:: python
 
@@ -256,17 +256,17 @@ The example bellow show how to configure this kind of dependencies:
             # ...
         )
 
-.. tab:: pyproject.toml
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
 
-    **EXPERIMENTAL** [#experimental]_
+    .. code-block:: toml
 
-    [project]
-    # ...
-    dependencies = [
-        "docutils",
-        "requires <= 0.4",
-    ]
-    # ...
+        [project]
+        # ...
+        dependencies = [
+            "docutils",
+            "requires <= 0.4",
+        ]
+        # ...
 
 Each dependency is represented a string that can optionally contain version requirements
 (e.g. one of the operators <, >, <=, >=, == or !=, followed by a version identifier),
@@ -297,7 +297,7 @@ can simply use the ``include_package_data`` keyword:
         [options]
         include_package_data = True
 
-.. tab:: setup.py
+.. tab:: setup.py [#setup.py]_
 
     .. code-block:: python
 
@@ -307,9 +307,7 @@ can simply use the ``include_package_data`` keyword:
             # ...
         )
 
-.. tab:: pyproject.toml
-
-    **EXPERIMENTAL** [#experimental]_
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
 
     .. code-block:: toml
 
@@ -361,7 +359,7 @@ associate with your source code. For more information, see :doc:`development_mod
         setup()
 
     You can still keep all the configuration in :doc:`setup.cfg </userguide/declarative_config>`
-    (or :doc:`pyproject.toml </userguide/pyproject_config`).
+    (or :doc:`pyproject.toml </userguide/pyproject_config>`).
 
 
 Uploading your package to PyPI
@@ -396,8 +394,20 @@ up-to-date references that can help you when it is time to distribute your work.
 
 ----
 
+.. rubric:: Notes
+
+.. [#setup.py]
+   The ``setup.py`` file should be used only when absolutely necessary.
+   Examples are kept in this document to help people interested in maintaining or
+   contributing to existing packages that use ``setup.py``.
+   Note that you can still keep most of configuration declarative in
+   :doc:`setup.cfg <declarative_config>` or :doc:`pyproject.toml
+   <pyproject_config>` and use ``setup.py`` only for the parts not
+   supported in those files (e.g. C extensions).
 
 .. [#experimental]
-   Support for specifying package metadata and build configuration options via
-   ``pyproject.toml`` is experimental and might change (or be completely
-   removed) in the future. See :doc:`/userguide/pyproject_config`.
+   While the ``[build-system]`` table should always be specified in the
+   ``pyproject.toml`` file, adding package metadata and build configuration
+   options via the ``[project]`` and ``[tool.setuptools]`` tables is still
+   experimental and might change (or be completely removed) in future releases.
+   See :doc:`/userguide/pyproject_config`.

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -35,9 +35,9 @@ package your project:
     requires = ["setuptools"]
     build-backend = "setuptools.build_meta"
 
-Then, you will need a ``setup.cfg`` or ``setup.py`` to specify your package
-information, such as metadata, contents, dependencies, etc. Here we demonstrate
-the minimum
+Then, you will need to specify your package information (either via
+``setup.cfg``, ``setup.py`` or ``pyproject.toml``), such as metadata, contents,
+dependencies, etc. Here we demonstrate the minimum
 
 .. tab:: setup.cfg
 
@@ -51,7 +51,9 @@ the minimum
         packages = mypackage
         install_requires =
             requests
-            importlib; python_version == "2.6"
+            importlib-metadata; python_version < "3.8"
+
+    See :doc:`/userguide/declarative_config` for more information.
 
 .. tab:: setup.py
 
@@ -65,9 +67,27 @@ the minimum
             packages=['mypackage'],
             install_requires=[
                 'requests',
-                'importlib; python_version == "2.6"',
+                'importlib-metadata; python_version == "3.8"',
             ],
         )
+
+    See :doc:`/keywords` for more information.
+
+.. tab:: pyproject.toml
+
+    **EXPERIMENTAL** [#experimental]_
+
+    .. code-block:: toml
+
+       [project]
+       name = "mypackage"
+       version = "0.0.1"
+       dependencies = [
+           "requests",
+           'importlib-metadata; python_version<"3.8"',
+       ]
+
+    See :doc:`/userguide/pyproject_config` for more information.
 
 This is what your project would look like::
 
@@ -220,8 +240,9 @@ Transitioning from ``setup.py`` to ``setup.cfg``
 To avoid executing arbitrary scripts and boilerplate code, we are transitioning
 into a full-fledged ``setup.cfg`` to declare your package information instead
 of running ``setup()``. This inevitably brings challenges due to a different
-syntax. Here we provide a quick guide to understanding how ``setup.cfg`` is
-parsed by ``setuptool`` to ease the pain of transition.
+syntax. :doc:`Here </userguide/declarative_config>` we provide a quick guide to
+understanding how ``setup.cfg`` is parsed by ``setuptool`` to ease the pain of
+transition.
 
 .. _packaging-resources:
 
@@ -234,3 +255,12 @@ up-to-date references that can help you when it is time to distribute your work.
 
 .. |MANIFEST.in| replace:: ``MANIFEST.in``
 .. _MANIFEST.in: https://packaging.python.org/en/latest/guides/using-manifest-in/
+
+
+----
+
+
+.. [#experimental]
+   Support for specifying package metadata and build configuration options via
+   ``pyproject.toml`` is experimental and might change (or be completely
+   removed) in the future. See :doc:`/userguide/pyproject_config`.

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -137,7 +137,7 @@ it can find following the ``include``  (defaults to none), then removes
 those that match the ``exclude`` and returns a list of Python packages. Note
 that each entry in the ``[options.packages.find]`` is optional. The above
 setup also allows you to adopt a ``src/`` layout. For more details and advanced
-use, go to :ref:`package_discovery`
+use, go to :ref:`package_discovery`.
 
 
 Entry points and automatic script creation
@@ -182,7 +182,7 @@ additional keywords such as ``setup_requires`` that allows you to install
 dependencies before running the script, and ``extras_require`` that take
 care of those needed by automatically generated scripts. It also provides
 mechanisms to handle dependencies that are not in PyPI. For more advanced use,
-see :doc:`dependency_management`
+see :doc:`dependency_management`.
 
 
 .. _Including Data Files:
@@ -203,7 +203,7 @@ This tells setuptools to install any data files it finds in your packages.
 The data files must be specified via the distutils' |MANIFEST.in|_ file
 or automatically added by a :ref:`Revision Control System plugin
 <Adding Support for Revision Control Systems>`.
-For more details, see :doc:`datafiles`
+For more details, see :doc:`datafiles`.
 
 
 Development mode
@@ -231,8 +231,8 @@ Uploading your package to PyPI
 ==============================
 After generating the distribution files, the next step would be to upload your
 distribution so others can use it. This functionality is provided by
-`twine <https://pypi.org/project/twine/>`_ and we will only demonstrate the
-basic use here.
+:pypi:`twine` and is documented in the :doc:`Python packaging tutorial
+<PyPUG:tutorials/packaging-projects>`.
 
 
 Transitioning from ``setup.py`` to ``setup.cfg``

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -118,26 +118,71 @@ Automatic package discovery
 For simple projects, it's usually easy enough to manually add packages to
 the ``packages`` keyword in ``setup.cfg``.  However, for very large projects,
 it can be a big burden to keep the package list updated. ``setuptools``
-therefore provides two convenient tools to ease the burden: :literal:`find:\ ` and
-:literal:`find_namespace:\ `. To use it in your project:
+therefore provides a convenient way to automatically list all the packages in
+your project directory:
 
-.. code-block:: ini
+.. tab:: setup.cfg
 
-    [options]
-    packages = find:
+    .. code-block:: ini
 
-    [options.packages.find] #optional
-    include=pkg1, pkg2
-    exclude=pk3, pk4
+        [options]
+        packages = find: # OR `find_namespaces:` if you want to use namespaces
+
+        [options.packages.find] (always `find` even if `find_namespaces:` was used before)
+        # This section is optional
+        # Each entry in this section is optional, and if not specified, the default values are:
+        # `where=.`, `include=*` and `exclude=` (empty).
+        include=mypackage*
+        exclude=mypackage.tests*
+
+.. tab:: setup.py
+
+    .. code-block:: python
+        from setuptools import find_packages  # or find_namespace_packages
+
+        setup(
+            # ...
+            packages=find_packages(
+                where='.',
+                include=['mypackage*'],  # ["*"] by default
+                exclude=['mypackage.tests'],  # empty by default
+            ),
+            # ...
+        )
+
+.. tab:: pyproject.toml
+
+    **EXPERIMENTAL** [#experimental]_
+
+    .. code-block:: toml
+
+        # ...
+        [tool.setuptools.packages]
+        find = {}  # Scan the project directory with the default parameters
+
+        # OR
+        [tool.setuptools.packages.find]
+        where = ["src"]  # ["."] by default
+        include = ["mypackage*"]  # ["*"] by default
+        exclude = ["mypackage.tests*"]  # empty by default
+        namespaces = false  # true by default
 
 When you pass the above information, alongside other necessary information,
 ``setuptools`` walks through the directory specified in ``where`` (omitted
 here as the package resides in the current directory) and filters the packages
 it can find following the ``include``  (defaults to none), then removes
-those that match the ``exclude`` and returns a list of Python packages. Note
-that each entry in the ``[options.packages.find]`` is optional. The above
+those that match the ``exclude`` and returns a list of Python packages. The above
 setup also allows you to adopt a ``src/`` layout. For more details and advanced
 use, go to :ref:`package_discovery`.
+
+.. tip::
+   Starting with version 60.10.0, setuptools' automatic discovery capabilities
+   have been improved to detect popular project layouts (such as the
+   :ref:`flat-layout` and :ref:`src-layout`) without requiring any
+   special configuration. Check out our :ref:`reference docs <package_discovery>`
+   for more information, but please keep in mind that this functionality is
+   still considered **experimental** and might change (or even be removed) in
+   future releases.
 
 
 Entry points and automatic script creation

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -290,10 +290,34 @@ are placed in a platform-specific location. Setuptools offers three ways to
 specify data files to be included in your packages. For the simplest use, you
 can simply use the ``include_package_data`` keyword:
 
-.. code-block:: ini
+.. tab:: setup.cfg
 
-    [options]
-    include_package_data = True
+    .. code-block:: ini
+
+        [options]
+        include_package_data = True
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        setup(
+            # ...
+            include_package_data=True,
+            # ...
+        )
+
+.. tab:: pyproject.toml
+
+    **EXPERIMENTAL** [#experimental]_
+
+    .. code-block:: toml
+
+        [tool.setuptools]
+        include-package-data = true
+        # This is already the default behaviour if your are using
+        # pyproject.toml to configure your build.
+        # You can deactivate that with `include-package-data = false`
 
 This tells setuptools to install any data files it finds in your packages.
 The data files must be specified via the distutils' |MANIFEST.in|_ file

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -329,28 +329,6 @@ For more details, see :doc:`datafiles`.
 Development mode
 ================
 
-.. tip::
-
-    For the time being you might need to keep a ``setup.py``
-    file in your repository if you want to use editable installs
-    (depending how the project is configured). A simple script will suffice,
-    for example:
-
-    .. code-block:: python
-
-        from setuptools import setup
-
-        setup()
-
-    You can still keep all the configuration in :doc:`setup.cfg </userguide/declarative_config>`
-    (or :doc:`pyproject.toml </userguide/pyproject_config`).
-
-..
-    TODO: Restore the following note once PEP 660 lands in setuptools.
-    tip: Prior to :ref:`pip v21.1 <pip:v21-1>`, a ``setup.py`` script was
-    required to be compatible with development mode. With late
-    versions of pip, any project may be installed in this mode.
-
 ``setuptools`` allows you to install a package without copying any files
 to your interpreter directory (e.g. the ``site-packages`` directory).
 This allows you to modify your source code and have the changes take
@@ -361,6 +339,29 @@ Here's how to do it::
 
 This creates a link file in your interpreter site package directory which
 associate with your source code. For more information, see :doc:`development_mode`.
+
+..
+    TODO: Restore the following note once PEP 660 lands in setuptools.
+    tip: Prior to :ref:`pip v21.1 <pip:v21-1>`, a ``setup.py`` script was
+    required to be compatible with development mode. With late
+    versions of pip, any project may be installed in this mode.
+
+.. tip::
+    If you are experimenting with :doc:`configuration using
+    <pyproject_config>`, or have version of ``pip`` older than :ref:`v21.1 <pip:v21-1>`,
+    you might need to keep a ``setup.py`` file in file in your repository if
+    you want to use editable installs (for the time being).
+
+    A simple script will suffice, for example:
+
+    .. code-block:: python
+
+        from setuptools import setup
+
+        setup()
+
+    You can still keep all the configuration in :doc:`setup.cfg </userguide/declarative_config>`
+    (or :doc:`pyproject.toml </userguide/pyproject_config`).
 
 
 Uploading your package to PyPI

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -180,7 +180,7 @@ use, go to :ref:`package_discovery`.
 .. tip::
    Starting with version 60.10.0, setuptools' automatic discovery capabilities
    have been improved to detect popular project layouts (such as the
-   :ref:`flat-layout` and :ref:`src-layout` layouts) without requiring any
+   :ref:`flat-layout` and :ref:`src-layout`) without requiring any
    special configuration. Check out our :ref:`reference docs <package_discovery>`
    for more information, but please keep in mind that this functionality is
    still considered **experimental** and might change (or even be removed) in

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -331,7 +331,23 @@ Development mode
 
 .. tip::
 
-    Prior to :ref:`pip v21.1 <pip:v21-1>`, a ``setup.py`` script was
+    For the time being you might need to keep a ``setup.py``
+    file in your repository if you want to use editable installs
+    (depending how the project is configured). A simple script will suffice,
+    for example:
+
+    .. code-block:: python
+
+        from setuptools import setup
+
+        setup()
+
+    You can still keep all the configuration in :doc:`setup.cfg </userguide/declarative_config>`
+    (or :doc:`pyproject.toml </userguide/pyproject_config`).
+
+..
+    TODO: Restore the following note once PEP 660 lands in setuptools.
+    tip: Prior to :ref:`pip v21.1 <pip:v21-1>`, a ``setup.py`` script was
     required to be compatible with development mode. With late
     versions of pip, any project may be installed in this mode.
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -38,7 +38,7 @@ package your project:
 Then, you will need to specify your package information such as metadata,
 contents, dependencies, etc.
 
-Setuptools currently support configurations from either ``setup.cfg``,
+Setuptools currently supports configurations from either ``setup.cfg``,
 ``setup.py`` or ``pyproject.toml`` [#experimental]_ files, however, configuring new
 projects via ``setup.py`` is discouraged [#setup.py]_.
 
@@ -275,7 +275,7 @@ and/or conditional environment markers, e.g. ``os_name = "windows"``
 
 When your project is installed, all of the dependencies not already installed
 will be located (via PyPI), downloaded, built (if necessary), and installed.
-This, of course, is a simplified scenarios. You can also specify groups of
+This, of course, is a simplified scenario. You can also specify groups of
 extra dependencies that are not strictly required by your package to work, but
 that will provide additional functionalities.
 For more advanced use, see :doc:`dependency_management`.
@@ -376,7 +376,7 @@ To avoid executing arbitrary scripts and boilerplate code, we are transitioning
 into a full-fledged ``setup.cfg`` to declare your package information instead
 of running ``setup()``. This inevitably brings challenges due to a different
 syntax. :doc:`Here </userguide/declarative_config>` we provide a quick guide to
-understanding how ``setup.cfg`` is parsed by ``setuptool`` to ease the pain of
+understanding how ``setup.cfg`` is parsed by ``setuptools`` to ease the pain of
 transition.
 
 .. _packaging-resources:

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -71,7 +71,7 @@ dependencies, etc. Here we demonstrate the minimum
             ],
         )
 
-    See :doc:`/keywords` for more information.
+    See :doc:`/references/keywords` for more information.
 
 .. tab:: pyproject.toml
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -407,7 +407,7 @@ up-to-date references that can help you when it is time to distribute your work.
 
 .. [#experimental]
    While the ``[build-system]`` table should always be specified in the
-   ``pyproject.toml`` file, adding package metadata and build configuration
+   ``pyproject.toml`` file, support for adding package metadata and build configuration
    options via the ``[project]`` and ``[tool.setuptools]`` tables is still
    experimental and might change (or be completely removed) in future releases.
    See :doc:`/userguide/pyproject_config`.

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -233,27 +233,52 @@ For detailed usage, go to :doc:`entry_point`.
 
 Dependency management
 =====================
-``setuptools`` supports automatically installing dependencies when a package is
-installed. The simplest way to include requirement specifiers is to use the
-``install_requires`` argument to ``setup.cfg``.  It takes a string or list of
-strings containing requirement specifiers (A version specifier is one of the
-operators <, >, <=, >=, == or !=, followed by a version identifier):
+Packages built with ``setuptools`` can specify dependencies to be automatically
+installed when the package itself is installed.
+The example bellow show how to configure this kind of dependencies:
 
-.. code-block:: ini
+.. tab:: setup.cfg
 
-    [options]
-    install_requires =
-        docutils >= 0.3
-        requests <= 0.4
+    .. code-block:: ini
+
+        [options]
+        install_requires =
+            docutils
+            requests <= 0.4
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        setup(
+            # ...
+            install_requires=["docutils", "requests <= 0.4"],
+            # ...
+        )
+
+.. tab:: pyproject.toml
+
+    **EXPERIMENTAL** [#experimental]_
+
+    [project]
+    # ...
+    dependencies = [
+        "docutils",
+        "requires <= 0.4",
+    ]
+    # ...
+
+Each dependency is represented a string that can optionally contain version requirements
+(e.g. one of the operators <, >, <=, >=, == or !=, followed by a version identifier),
+and/or conditional environment markers, e.g. ``os_name = "windows"``
+(see :doc:`PyPUG:specifications/version-specifiers` for more information).
 
 When your project is installed, all of the dependencies not already installed
 will be located (via PyPI), downloaded, built (if necessary), and installed.
-This, of course, is a simplified scenarios. ``setuptools`` also provides
-additional keywords such as ``setup_requires`` that allows you to install
-dependencies before running the script, and ``extras_require`` that take
-care of those needed by automatically generated scripts. It also provides
-mechanisms to handle dependencies that are not in PyPI. For more advanced use,
-see :doc:`dependency_management`.
+This, of course, is a simplified scenarios. You can also specify groups of
+extra dependencies that are not strictly required by your package to work, but
+that will provide additional functionalities.
+For more advanced use, see :doc:`dependency_management`.
 
 
 .. _Including Data Files:

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -188,21 +188,47 @@ use, go to :ref:`package_discovery`.
 Entry points and automatic script creation
 ===========================================
 Setuptools supports automatic creation of scripts upon installation, that runs
-code within your package if you specify them with the ``entry_points`` keyword.
+code within your package if you specify them as :doc:`entry points
+<PyPUG:specifications/entry-points>`.
 This is what allows you to run commands like ``pip install`` instead of having
-to type ``python -m pip install``. To accomplish this, add the entry_points
-keyword in your ``setup.cfg``:
+to type ``python -m pip install``.
+The following configuration examples show how to accomplish this:
 
-.. code-block:: ini
+.. tab:: setup.cfg
 
-    [options.entry_points]
-    console_scripts =
-        main = mypkg:some_func
+    .. code-block:: ini
 
-When this project is installed, a ``main`` script will be installed and will
-invoke the ``some_func`` in the ``__init__.py`` file when called by the user.
-For detailed usage, including managing the additional or optional dependencies,
-go to :doc:`entry_point`.
+        [options.entry_points]
+        console_scripts =
+            cli-name = mypkg:some_func
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        setup(
+            # ...
+            entry_points={
+                'console_scripts': [
+                    'cli-name = mypkg:some_func',
+                ]
+            }
+        )
+
+.. tab:: pyproject.toml
+
+    **EXPERIMENTAL** [#experimental]_
+
+    .. code-block:: toml
+
+       [project.scripts]
+       cli-name = mypkg:some_func
+
+When this project is installed, a ``cli-name`` executable will be installed and will
+invoke the ``some_func`` in the ``mypkg/__init__.py`` file when called by the user.
+Note that you can also use the ``entry-points`` mechanism to advertise
+components between installed packages and implement plugin systems.
+For detailed usage, go to :doc:`entry_point`.
 
 
 Dependency management


### PR DESCRIPTION
## Summary of changes

- Added some docs about how to use `pyproject.toml` to config setuptools (aka PEP 621)
- Improved docs about auto-discovery
- Improved examples of declarative config for `setup.cfg`
- Improved examples in `quickstart` and `depencency management` for using experimental `pyproject.toml`.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
