### PR TITLE
Only import ctypes when necessary

### DIFF
--- a/changelog.d/3178.change.rst
+++ b/changelog.d/3178.change.rst
@@ -1,0 +1,2 @@
+Postponed importing ``ctypes`` when hidding files on Windows.
+This helps to prevent errors in systems that might not have `libffi` installed.

--- a/changelog.d/3178.change.rst
+++ b/changelog.d/3178.change.rst
@@ -1,2 +1,2 @@
-Postponed importing ``ctypes`` when hidding files on Windows.
+Postponed importing ``ctypes`` when hiding files on Windows.
 This helps to prevent errors in systems that might not have `libffi` installed.

--- a/setuptools/windows_support.py
+++ b/setuptools/windows_support.py
@@ -1,5 +1,4 @@
 import platform
-import ctypes
 
 
 def windows_only(func):
@@ -17,6 +16,7 @@ def hide_file(path):
 
     `path` must be text.
     """
+    import ctypes
     __import__('ctypes.wintypes')
     SetFileAttributes = ctypes.windll.kernel32.SetFileAttributesW
     SetFileAttributes.argtypes = ctypes.wintypes.LPWSTR, ctypes.wintypes.DWORD


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->
In appdirs.py, ctypes is only imported within a function, rather than always for appdirs.py.
https://github.com/pypa/setuptools/blob/02f3821b9af91feadae2326b78a814ac2fbbe520/pkg_resources/_vendor/appdirs.py#L506-L507
This is also done in both copies of _manylinux.py.
https://github.com/pypa/setuptools/blob/02f3821b9af91feadae2326b78a814ac2fbbe520/setuptools/_vendor/packaging/_manylinux.py#L154-L159
https://github.com/pypa/setuptools/blob/02f3821b9af91feadae2326b78a814ac2fbbe520/pkg_resources/_vendor/packaging/_manylinux.py#L154-L159

## Summary of changes

This PR applies this pattern to windows_support.py as well, only importing ctypes within `hide_file()`.

This will also save non-Windows users from always requiring ctypes (yes, windows_support.py is [imported regardless of platform](https://github.com/pypa/setuptools/blob/02f3821b9af91feadae2326b78a814ac2fbbe520/setuptools/dist.py#L40)).

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request