### PR TITLE
[follow-up `discovery`, `pyproject.toml`] Improve integration between auto-discovery and `pyproject.toml` metadata

### DIFF
--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -137,9 +137,9 @@ def expand_configuration(
     root_dir = root_dir or os.getcwd()
     project_cfg = config.get("project", {})
     setuptools_cfg = config.get("tool", {}).get("setuptools", {})
-    silent = ignore_option_errors
+    ignore = ignore_option_errors
 
-    _expand_packages(setuptools_cfg, root_dir, silent)
+    _expand_packages(setuptools_cfg, root_dir, ignore)
     _canonic_package_data(setuptools_cfg)
     _canonic_package_data(setuptools_cfg, "exclude-package-data")
 
@@ -148,13 +148,13 @@ def expand_configuration(
 
     with _EnsurePackagesDiscovered(dist, setuptools_cfg) as ensure_discovered:
         package_dir = ensure_discovered.package_dir
-        process = partial(_process_field, ignore_option_errors=silent)
+        process = partial(_process_field, ignore_option_errors=ignore)
         cmdclass = partial(_expand.cmdclass, package_dir=package_dir, root_dir=root_dir)
         data_files = partial(_expand.canonic_data_files, root_dir=root_dir)
 
         process(setuptools_cfg, "data-files", data_files)
         process(setuptools_cfg, "cmdclass", cmdclass)
-        _expand_all_dynamic(project_cfg, setuptools_cfg, package_dir, root_dir, silent)
+        _expand_all_dynamic(project_cfg, setuptools_cfg, package_dir, root_dir, ignore)
 
     return config
 
@@ -208,7 +208,7 @@ def _expand_all_dynamic(
     root_dir: _Path,
     ignore_option_errors: bool,
 ):
-    silent = ignore_option_errors
+    ignore = ignore_option_errors
     dynamic_cfg = setuptools_cfg.get("dynamic", {})
     pkg_dir = package_dir
     special = (
@@ -224,23 +224,23 @@ def _expand_all_dynamic(
     regular_dynamic = (x for x in dynamic if x not in special)
 
     for field in regular_dynamic:
-        value = _expand_dynamic(dynamic_cfg, field, pkg_dir, root_dir, silent)
+        value = _expand_dynamic(dynamic_cfg, field, pkg_dir, root_dir, ignore)
         project_cfg[field] = value
 
     if "version" in dynamic and "version" in dynamic_cfg:
-        version = _expand_dynamic(dynamic_cfg, "version", pkg_dir, root_dir, silent)
+        version = _expand_dynamic(dynamic_cfg, "version", pkg_dir, root_dir, ignore)
         project_cfg["version"] = _expand.version(version)
 
     if "readme" in dynamic:
-        project_cfg["readme"] = _expand_readme(dynamic_cfg, root_dir, silent)
+        project_cfg["readme"] = _expand_readme(dynamic_cfg, root_dir, ignore)
 
     if "entry-points" in dynamic:
         field = "entry-points"
-        value = _expand_dynamic(dynamic_cfg, field, pkg_dir, root_dir, silent)
+        value = _expand_dynamic(dynamic_cfg, field, pkg_dir, root_dir, ignore)
         project_cfg.update(_expand_entry_points(value, dynamic))
 
     if "classifiers" in dynamic:
-        value = _expand_dynamic(dynamic_cfg, "classifiers", pkg_dir, root_dir, silent)
+        value = _expand_dynamic(dynamic_cfg, "classifiers", pkg_dir, root_dir, ignore)
         project_cfg["classifiers"] = value.splitlines()
 
 
@@ -267,9 +267,9 @@ def _expand_dynamic(
 def _expand_readme(
     dynamic_cfg: dict, root_dir: _Path, ignore_option_errors: bool
 ) -> Dict[str, str]:
-    silent = ignore_option_errors
+    ignore = ignore_option_errors
     return {
-        "text": _expand_dynamic(dynamic_cfg, "readme", {}, root_dir, silent),
+        "text": _expand_dynamic(dynamic_cfg, "readme", {}, root_dir, ignore),
         "content-type": dynamic_cfg["readme"].get("content-type", "text/x-rst"),
     }
 

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -368,7 +368,7 @@ class ConfigHandler(Generic[Target]):
         attr_desc = value.replace(attr_directive, '')
 
         # Make sure package_dir is populated correctly, so `attr:` directives can work
-        package_dir.update(self.ensure_discovered())
+        package_dir.update(self.ensure_discovered.package_dir)
         return expand.read_attr(attr_desc, package_dir, root_dir)
 
     @classmethod
@@ -596,7 +596,7 @@ class ConfigOptionsHandler(ConfigHandler["Distribution"]):
         }
 
     def _parse_cmdclass(self, value):
-        package_dir = self.ensure_discovered()
+        package_dir = self.ensure_discovered.package_dir
         return expand.cmdclass(self._parse_dict(value), package_dir, self.root_dir)
 
     def _parse_packages(self, value):

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -833,7 +833,7 @@ class Distribution(_Distribution):
             self, self.command_options, ignore_option_errors=ignore_option_errors
         )
         for filename in tomlfiles:
-            pyprojecttoml.apply_configuration(self, filename)
+            pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
 
         self._finalize_requires()
         self._finalize_license_files()

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -264,7 +264,7 @@ class TestNoConfig:
     def test_discover_name(self, tmp_path, example):
         _populate_project_dir(tmp_path, self.EXAMPLES[example], {})
         dist = _get_dist(tmp_path, {})
-        dist.get_name() == example
+        assert dist.get_name() == example
 
     def test_build_with_discovered_name(self, tmp_path):
         files = ["src/ns/nested/pkg/__init__.py"]

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -303,6 +303,18 @@ def test_discovered_package_dir_with_attr_directive_in_config(tmp_path, folder, 
     assert dist_file.is_file()
 
 
+def test_discovered_package_dir_with_attr_in_pyproject_config(tmp_path):
+    _populate_project_dir(tmp_path, ["src/pkg/__init__.py"], {})
+    (tmp_path / "src/pkg/__init__.py").write_text("version = 42")
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = 'pkg'\ndynamic = ['version']\n"
+        "[tool.setuptools.dynamic]\nversion = {attr = 'pkg.version'}\n"
+    )
+    dist = _get_dist(tmp_path, {})
+    assert dist.get_version() == "42"
+    assert dist.package_dir == {"": "src"}
+
+
 def _populate_project_dir(root, files, options):
     # NOTE: Currently pypa/build will refuse to build the project if no
     # `pyproject.toml` or `setup.py` is found. So it is impossible to do


### PR DESCRIPTION
This is an incremental change on top of the existing integration between auto-discovery and `pyproject.toml` metadata configuration

## Summary of changes

- Fix missing assertion in text
- Rename variable alias (`silent` does not really capture the meaning of the what is happening)
- Use a lazy proxy for `package_dir` to avoid eagerly running auto-discovery

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
