### PR TITLE
[follow-up `discovery`, `pyproject.toml`] Prevent existing C-extension only packages from failing

### DIFF
--- a/changelog.d/2887.change.1.rst
+++ b/changelog.d/2887.change.1.rst
@@ -10,8 +10,8 @@ the project root).
 The automatic discovery will also respect layouts that are explicitly
 configured using the ``package_dir`` option.
 
-For backward-compatibility, this behavior will be observed **only if both**
-``py_modules`` **and** ``packages`` **are not set**.
+For backward-compatibility, this behavior will be observed **only if none of
+the following is set**: ``packages``, ``py_modules``, ``ext_modules``.
 
 If setuptools detects modules or packages that are not supposed to be in the
 distribution, please manually set ``py_modules`` and ``packages`` in your

--- a/changelog.d/2887.change.1.rst
+++ b/changelog.d/2887.change.1.rst
@@ -4,14 +4,16 @@
 Setuptools will try to find these values assuming that the package uses either
 the *src-layout* (a ``src`` directory containing all the packages or modules),
 the *flat-layout* (package directories directly under the project root),
-or the *single-module* approach (isolated Python files, directly under
+or the *single-module* approach (an isolated Python file, directly under
 the project root).
 
 The automatic discovery will also respect layouts that are explicitly
 configured using the ``package_dir`` option.
 
-For backward-compatibility, this behavior will be observed **only if none of
-the following is set**: ``packages``, ``py_modules``, ``ext_modules``.
+For backward-compatibility, this behavior will be observed **only if both**
+``py_modules`` **and** ``packages`` **are not set**.
+(**Note**: specifying ``ext_modules`` might also prevent auto-discover from
+taking place)
 
 If setuptools detects modules or packages that are not supposed to be in the
 distribution, please manually set ``py_modules`` and ``packages`` in your

--- a/changelog.d/2894.breaking.rst
+++ b/changelog.d/2894.breaking.rst
@@ -2,10 +2,9 @@ If you purposefully want to create an *"empty distribution"*, please be aware
 that some Python files (or general folders) might be automatically detected and
 included.
 
-Projects that currently don't specify ``packages``, ``py_modules`` and
-``ext_modules`` in their configuration and have extra Python files and folders
-(not meant for distribution), might see these files being included in the wheel
-archive.
+Projects that currently don't specify both ``packages`` and ``py_modules`` in their
+configuration and have extra Python files and folders (not meant for distribution),
+might see these files being included in the wheel archive.
 
 You can check details about the automatic discovery behaviour (and
 how to configure a different one) in :doc:`/userguide/package_discovery`.

--- a/changelog.d/2894.breaking.rst
+++ b/changelog.d/2894.breaking.rst
@@ -2,9 +2,10 @@ If you purposefully want to create an *"empty distribution"*, please be aware
 that some Python files (or general folders) might be automatically detected and
 included.
 
-Projects that currently don't specify both ``packages`` and ``py_modules`` in their
-configuration and have extra Python files and folders (not meant for distribution),
-might see these files being included in the wheel archive.
+Projects that currently don't specify ``packages``, ``py_modules`` and
+``ext_modules`` in their configuration and have extra Python files and folders
+(not meant for distribution), might see these files being included in the wheel
+archive.
 
 You can check details about the automatic discovery behaviour (and
 how to configure a different one) in :doc:`/userguide/package_discovery`.

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -137,8 +137,8 @@ layouts and try to guess the correct values for the :ref:`packages <declarative
 config>` and :doc:`py_modules </references/keywords>` configuration.
 
 .. important::
-   Automatic discovery will **only** be enabled if you don't provide any
-   configuration for both ``packages`` and ``py_modules``.
+   Automatic discovery will **only** be enabled if you **don't** provide any
+   configuration for ``packages``, ``py_modules`` and ``ext_modules``.
    If at least one of them is explicitly set, automatic discovery will not take place.
 
 .. _src-layout:

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -138,8 +138,12 @@ config>` and :doc:`py_modules </references/keywords>` configuration.
 
 .. important::
    Automatic discovery will **only** be enabled if you **don't** provide any
-   configuration for ``packages``, ``py_modules`` and ``ext_modules``.
+   configuration for ``packages`` and ``py_modules``.
    If at least one of them is explicitly set, automatic discovery will not take place.
+
+   **Note**: specifying ``ext_modules`` might also prevent auto-discover from
+   taking place, unless your opt into :doc:`pyproject_config` (which will
+   disable the backward compatible behaviour).
 
 .. _src-layout:
 

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -184,6 +184,8 @@ class _EnsurePackagesDiscovered(_expand.EnsurePackagesDiscovered):
         package_dir.update(dist.package_dir or {})
         dist.package_dir = package_dir  # needs to be the same object
 
+        dist.set_defaults._ignore_ext_modules()  # pyproject.toml-specific behaviour
+
         # Set `py_modules` and `packages` in dist to short-circuit auto-discovery,
         # but avoid overwriting empty lists purposefully set by users.
         if dist.py_modules is None:

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -270,10 +270,23 @@ class ConfigDiscovery:
         self.dist = distribution
         self._called = False
         self._disabled = False
+        self._skip_ext_modules = False
 
     def _disable(self):
         """Internal API to disable automatic discovery"""
         self._disabled = True
+
+    def _ignore_ext_modules(self):
+        """Internal API to disregard ext_modules.
+
+        Normally auto-discovery would not be triggered if ``ext_modules`` are set
+        (this is done for backward compatibility with existing packages relying on
+        ``setup.py`` or ``setup.cfg``). However, ``setuptools`` can call this function
+        to ignore given ``ext_modules`` and proceed with the auto-discovery if
+        ``packages`` and ``py_modules`` are not given (e.g. when using pyproject.toml
+        metadata).
+        """
+        self._skip_ext_modules = True
 
     @property
     def _root_dir(self) -> _Path:
@@ -286,7 +299,7 @@ class ConfigDiscovery:
             return {}
         return self.dist.package_dir
 
-    def __call__(self, force=False, name=True):
+    def __call__(self, force=False, name=True, ignore_ext_modules=False):
         """Automatically discover missing configuration fields
         and modifies the given ``distribution`` object in-place.
 
@@ -301,22 +314,24 @@ class ConfigDiscovery:
             # Avoid overhead of multiple calls
             return
 
-        self._analyse_package_layout()
+        self._analyse_package_layout(ignore_ext_modules)
         if name:
             self.analyse_name()  # depends on ``packages`` and ``py_modules``
 
         self._called = True
 
-    def _explicitly_specified(self) -> bool:
+    def _explicitly_specified(self, ignore_ext_modules: bool) -> bool:
         """``True`` if the user has specified some form of package/module listing"""
+        ignore_ext_modules = ignore_ext_modules or self._skip_ext_modules
+        ext_modules = not (self.dist.ext_modules is None or ignore_ext_modules)
         return (
             self.dist.packages is not None
             or self.dist.py_modules is not None
-            or self.dist.ext_modules is not None
+            or ext_modules
         )
 
-    def _analyse_package_layout(self) -> bool:
-        if self._explicitly_specified():
+    def _analyse_package_layout(self, ignore_ext_modules: bool) -> bool:
+        if self._explicitly_specified(ignore_ext_modules):
             # For backward compatibility, just try to find modules/packages
             # when nothing is given
             return True

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -307,8 +307,16 @@ class ConfigDiscovery:
 
         self._called = True
 
+    def _explicitly_specified(self) -> bool:
+        """``True`` if the user has specified some form of package/module listing"""
+        return (
+            self.dist.packages is not None
+            or self.dist.py_modules is not None
+            or self.dist.ext_modules is not None
+        )
+
     def _analyse_package_layout(self) -> bool:
-        if self.dist.packages is not None or self.dist.py_modules is not None:
+        if self._explicitly_specified():
             # For backward compatibility, just try to find modules/packages
             # when nothing is given
             return True


### PR DESCRIPTION
[This CI build](https://github.com/pypa/setuptools/runs/5636559907?check_suite_focus=true) shows that some existing C-extension only packages might fail now that the safe-guards against flat-layouts with multi-top level modules/packages are in place.

## Summary of changes

This PR attempts to improve backward compatibility by disabling auto-discovery when `ext_modules` is set.

This backward compatibility behaviour will be disabled, however when `pyproject.toml` metadata is used (a.k.a. PEP 621-style config).

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
