### PR TITLE
Tweak the entry point format to match what `console_scripts` requires

### DIFF
--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -84,11 +84,12 @@ above example, to create a command ``hello-world`` that invokes
 After installing the package, a user may invoke that function by simply calling
 ``hello-world`` on the command line.
 
-The syntax for entry points is specified as follows:
+The syntax for entry points provided to `console_scripts` is specified as
+follows:
 
 .. code-block:: ini
 
-    <name> = [<package>.[<subpackage>.]]<module>[:<object>.<object>]
+    <name> = [<package>.[<subpackage>.]]<module>:<object>.<object>
 
 where ``name`` is the name for the script you want to create, the left hand
 side of ``:`` is the module that contains your function and the right hand


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

This is in line with the behaviour of how pip, distlib and other tooling handle scripts. See https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts. See also https://github.com/pypa/pip/issues/8632 for context.

### Pull Request Checklist

- [ ] Changes have tests (not needed)
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
