### PR TITLE
Fix `bellow` typo in docs

### DIFF
--- a/docs/userguide/dependency_management.rst
+++ b/docs/userguide/dependency_management.rst
@@ -397,7 +397,7 @@ fail later).
 Python requirement
 ==================
 In some cases, you might need to specify the minimum required python version.
-This can be configured as shown in the example bellow.
+This can be configured as shown in the example below.
 
 .. tab:: setup.cfg
 

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -29,7 +29,7 @@ a standard way of specifying *project metadata*.
 ``Setuptools`` has adopted this standard and will use the information contained
 in this file as an input in the build process.
 
-The example bellow illustrates how to write a ``pyproject.toml`` file that can
+The example below illustrates how to write a ``pyproject.toml`` file that can
 be used with ``setuptools``. It contains two TOML tables (identified by the
 ``[table-header]`` syntax): ``build-system`` and ``project``.
 The ``build-system`` table is used to tell the build frontend (e.g.
@@ -91,8 +91,8 @@ Key                       Value Type (TOML)           Notes
 ``zip-safe``              boolean                     If not specified, ``setuptools`` will try to guess
                                                       a reasonable default for the package
 ``eager-resources``       array
-``py-modules``            array                       See tip bellow
-``packages``              array or ``find`` directive See tip bellow
+``py-modules``            array                       See tip below
+``packages``              array or ``find`` directive See tip below
 ``package-dir``           table/inline-table          Used when explicitly listing ``packages``
 ``namespace-packages``    array                       Not necessary if you use :pep:`420`
 ``package-data``          table/inline-table          See :doc:`/userguide/datafiles`

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -236,7 +236,7 @@ Dependency management
 =====================
 Packages built with ``setuptools`` can specify dependencies to be automatically
 installed when the package itself is installed.
-The example bellow show how to configure this kind of dependencies:
+The example below show how to configure this kind of dependencies:
 
 .. tab:: setup.cfg
 

--- a/setuptools/_vendor/_validate_pyproject/NOTICE
+++ b/setuptools/_vendor/_validate_pyproject/NOTICE
@@ -31,7 +31,7 @@ by the same projects:
 - `__init__.py`
 - `fastjsonschema_validations.py`
 
-The relevant copyright notes and licenses are included bellow.
+The relevant copyright notes and licenses are included below.
 
 
 ***

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -53,7 +53,7 @@ EXAMPLES = [
     ("brotli", LATEST),  # not in the list but used by urllib3
 
     # When adding packages to this list, make sure they expose a `__version__`
-    # attribute, or modify the tests bellow
+    # attribute, or modify the tests below
 ]
 
 


### PR DESCRIPTION
## Summary of changes

Spotted a tiny typo on the new `pyproject.toml` documentation. Grepping through the repository, the same typo was also present in other documents.

### Pull Request Checklist
- [ ] ~Changes have tests~ Not applicable
- [ ] ~News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_~ Not applicable