### PR TITLE
Make sure auto-discovery does not break `include_package_data`

### DIFF
--- a/changelog.d/3202.change.rst
+++ b/changelog.d/3202.change.rst
@@ -1,0 +1,2 @@
+Changed behaviour of auto-discovery to not explicitly expand ``package_dir``
+for flat-layouts and to not use relative paths starting with ``./``.

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -41,6 +41,7 @@ import itertools
 import os
 from fnmatch import fnmatchcase
 from glob import glob
+from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Callable, Dict, Iterator, Iterable, List, Optional, Tuple, Union
 
@@ -577,3 +578,9 @@ def find_package_path(name: str, package_dir: Dict[str, str], root_dir: _Path) -
 
     parent = package_dir.get("") or ""
     return os.path.join(root_dir, *parent.split("/"), *parts)
+
+
+def construct_package_dir(packages: List[str], package_path: _Path) -> Dict[str, str]:
+    parent_pkgs = remove_nested_packages(packages)
+    prefix = Path(package_path).parts
+    return {pkg: "/".join([*prefix, *pkg.split(".")]) for pkg in parent_pkgs}

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -476,13 +476,11 @@ class TestWithPackageData:
         self._simulate_package_with_data_files(tmp_path, src_root)
 
         expected = {
-            os.path.normpath(f"{src_root}/proj/file1.txt"),
-            os.path.normpath(f"{src_root}/proj/nested/file2.txt"),
+            os.path.normpath(f"{src_root}/proj/file1.txt").replace(os.sep, "/"),
+            os.path.normpath(f"{src_root}/proj/nested/file2.txt").replace(os.sep, "/"),
         }
 
         _run_build(tmp_path)
-        from pprint import pprint
-        pprint(files)
 
         sdist_files = get_sdist_members(next(tmp_path.glob("dist/*.tar.gz")))
         print("~~~~~ sdist_members ~~~~~")


### PR DESCRIPTION
This is an attempt to fix #3196

## Summary of changes

- Avoid auto-discovery to add entries to ``package_dir`` in flat-layouts
- Avoid using paths starting with `./` in ``package_dir``

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
