### PR TITLE
Avoid overwriting `dist.include_package_data` given by `setup.py`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,15 @@ Breaking Changes
 
   You can check details about the automatic discovery (and how to configure a
   different behaviour) in :doc:`/userguide/package_discovery`.
+* #3067: If the file ``pyproject.toml`` exists and it includes project
+  metadata/config (via ``[project]`` table or ``[tool.setuptools]``),
+  a series of new behaviors that are not backward compatible may take place:
+
+  - The default value of ``include_package_data`` will be considered to be ``True``.
+  - Setuptools will attempt to validate the ``pyproject.toml`` file according
+    to PEP 621 specification.
+  - The values specified in ``pyproject.toml`` will take precedence over those
+    specified in ``setup.cfg`` or ``setup.py``.
 
 Changes
 ^^^^^^^
@@ -63,6 +72,8 @@ Changes
 * #3066: Added vendored dependencies for :pypi:`tomli`, :pypi:`validate-pyproject`.
 
   These dependencies are used to read ``pyproject.toml`` files and validate them.
+* #3067: **[EXPERIMENTAL]** When using ``pyproject.toml`` metadata,
+  the default value of ``include_package_data`` is changed to ``True``.
 * #3068: **[EXPERIMENTAL]** Add support for ``pyproject.toml`` configuration
   (as introduced by :pep:`621`). Configuration parameters not covered by
   standards are handled in the ``[tool.setuptools]`` sub-table.

--- a/changelog.d/3203.change.rst
+++ b/changelog.d/3203.change.rst
@@ -1,0 +1,3 @@
+Prevented ``pyproject.toml`` parsing from overwriting
+``dist.include_package_data`` explicitly set in ``setup.py`` with default
+value.

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -103,7 +103,10 @@ def read_configuration(
     # the default would be an improvement.
     # `ini2toml` backfills include_package_data=False when nothing is explicitly given,
     # therefore setting a default here is backwards compatible.
-    setuptools_table.setdefault("include-package-data", True)
+    if dist and getattr(dist, "include_package_data") is not None:
+        setuptools_table.setdefault("include-package-data", dist.include_package_data)
+    else:
+        setuptools_table.setdefault("include-package-data", True)
     # Persist changes:
     asdict["tool"] = tool_table
     tool_table["setuptools"] = setuptools_table


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Consider that `dist.include_package_data` can be given via `setup.py` when parsing `pyproject.toml`
- Add missing notes about changes to previous release

Closes #3203 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
