### PR TITLE
Disable auto-discovery when the 'configuration' attribute is passed

### DIFF
--- a/changelog.d/3211.change.rst
+++ b/changelog.d/3211.change.rst
@@ -1,0 +1,12 @@
+Disabled auto-discovery when distribution class has a ``configuration`` field
+(e.g. when the ``setup.py`` script contains ``setup(..., configuration=...)``).
+This is done to ensure extension-only packages created with
+``numpy.distutils.misc_util.Configuration`` are not broken by the safe guard
+behaviour to avoid accidental multiple top-level packages in a flat-layout.
+
+**Note** - Users that don't set ``packages``, ``py_modules``, or
+``configuration`` are still likely to observe the auto-discovery behavior,
+which may interrupt the build if the project contains multiple directories and/or
+multiple Python files directly under the project root.
+For projects that don't use the ``[project]`` table in their ``pyproject.toml``
+setting ``ext_modules`` will also disable auto-discovery.

--- a/changelog.d/3211.change.rst
+++ b/changelog.d/3211.change.rst
@@ -1,12 +1,15 @@
-Disabled auto-discovery when distribution class has a ``configuration`` field
-(e.g. when the ``setup.py`` script contains ``setup(..., configuration=...)``).
-This is done to ensure extension-only packages created with
-``numpy.distutils.misc_util.Configuration`` are not broken by the safe guard
+Disabled auto-discovery when distribution class has a ``configuration``
+attribute (e.g. when the ``setup.py`` script contains ``setup(...,
+configuration=...)``).  This is done to ensure extension-only packages created
+with ``numpy.distutils.misc_util.Configuration`` are not broken by the safe
+guard
 behaviour to avoid accidental multiple top-level packages in a flat-layout.
 
-**Note** - Users that don't set ``packages``, ``py_modules``, or
-``configuration`` are still likely to observe the auto-discovery behavior,
-which may interrupt the build if the project contains multiple directories and/or
-multiple Python files directly under the project root.
-For projects that don't use the ``[project]`` table in their ``pyproject.toml``
-setting ``ext_modules`` will also disable auto-discovery.
+.. note::
+   Users that don't set ``packages``, ``py_modules``, or ``configuration`` are
+   still likely to observe the auto-discovery behavior, which may halt the
+   build if the project contains multiple directories and/or multiple Python
+   files directly under the project root.
+
+   To disable auto-discovery please explicitly set either ``packages`` or
+   ``py_modules``. Alternatively you can also configure :ref:`custom-discovery`.

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -341,6 +341,8 @@ class ConfigDiscovery:
             self.dist.packages is not None
             or self.dist.py_modules is not None
             or ext_modules
+            or hasattr(self.dist, "configuration") and self.dist.configuration
+            # ^ Some projects use numpy.distutils.misc_util.Configuration
         )
 
     def _analyse_package_layout(self, ignore_ext_modules: bool) -> bool:

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -494,6 +494,20 @@ class TestWithPackageData:
         assert wheel_files >= orig_files
 
 
+def test_compatible_with_numpy_configuration(tmp_path):
+    files = [
+        "dir1/__init__.py",
+        "dir2/__init__.py",
+        "file.py",
+    ]
+    _populate_project_dir(tmp_path, files, {})
+    dist = Distribution({})
+    dist.configuration = object()
+    dist.set_defaults()
+    assert dist.py_modules is None
+    assert dist.packages is None
+
+
 def _populate_project_dir(root, files, options):
     # NOTE: Currently pypa/build will refuse to build the project if no
     # `pyproject.toml` or `setup.py` is found. So it is impossible to do


### PR DESCRIPTION
## Summary of changes

- Disable auto-discovery when package is using `numpy.distutils.misc_util.Configuration`


### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
