### PR TITLE
Fix typo in quickstart section

### DIFF
--- a/changelog.d/3217.doc.rst
+++ b/changelog.d/3217.doc.rst
@@ -1,0 +1,1 @@
+Fixed typo in pyproject.toml -- by :user:`pablo-cardenas`.

--- a/changelog.d/3217.doc.rst
+++ b/changelog.d/3217.doc.rst
@@ -1,1 +1,1 @@
-Fixed typo in pyproject.toml -- by :user:`pablo-cardenas`.
+Fixed typo in ``pyproject.toml`` example in Quickstart -- by :user:`pablo-cardenas`.

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -222,7 +222,7 @@ The following configuration examples show how to accomplish this:
     .. code-block:: toml
 
        [project.scripts]
-       cli-name = mypkg.mymodule:some_func
+       cli-name = "mypkg.mymodule:some_func"
 
 When this project is installed, a ``cli-name`` executable will be created.
 ``cli-name`` will invoke the function ``some_func`` in the


### PR DESCRIPTION

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fixed typo in pyproject.toml

```
cli-name = mypkg.mymodule:some_func    =>    cli-name = "mypkg.mymodule:some_func"
```

Closes #3216

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
