### PR TITLE
[`pyproject.toml`] Temporarily warn about improper backfilling without `dynamic`

### DIFF
--- a/changelog.d/3218.change.rst
+++ b/changelog.d/3218.change.rst
@@ -1,0 +1,8 @@
+Prevented builds from erroring (**temporarily**) if the project specifies
+metadata via ``pyproject.toml``, but uses other files (e.g. ``setup.py``) to
+complement it, without setting ``dynamic`` properly.
+
+.. important::
+   This is a **transitional** behaviour.
+   Future releases of ``setuptools`` may simply ignore externally set metadata
+   not backed by ``dynamic`` or even halt the build with an error.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -351,7 +351,6 @@ class _WouldIgnoreField(UserWarning):
     To prevent this warning, you can list {field!r} under `dynamic` or alternatively
     remove the `[project]` table from your file and rely entirely on other means of
     configuration.
-
     \n\n!!
     """
 

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -332,13 +332,16 @@ _PREVIOUSLY_DEFINED = {
 
 
 class _WouldIgnoreField(UserWarning):
-    """Inform users that ``pyproject.toml`` would overwrite previously defined metadata.
+    """Inform users that ``pyproject.toml`` would overwrite previously defined metadata:
     !!\n\n
     ##############################################
     # field would be ignored by `pyproject.toml` #
     ##############################################
 
-    `{field} = {value!r}` seems to be defined outside of `pyproject.toml`.
+    The following seems to be defined outside of `pyproject.toml`:
+
+    `{field} = {value!r}`
+
     According to the spec (see the link bellow), however, setuptools CANNOT
     consider this value unless {field!r} is listed as `dynamic`.
 

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -250,3 +250,34 @@ TOOL_TABLE_RENAMES = {"script_files": "scripts"}
 
 SETUPTOOLS_PATCHES = {"long_description_content_type", "project_urls",
                       "provides_extras", "license_file", "license_files"}
+
+
+class _WouldIgnoreField(UserWarning):
+    """Inform users that ``pyproject.toml`` would overwrite previously defined metadata.
+    !!\n\n
+    ##############################################
+    # field would be ignored by `pyproject.toml` #
+    ##############################################
+
+    `{field} = {value!r}` seems to be defined outside of `pyproject.toml`.
+    According to the spec (see the link bellow), however, setuptools CANNOT
+    consider this value unless {field!r} is listed as `dynamic`.
+
+    https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+
+    For the time being, `setuptools` will still consider the given value (as a
+    **transitional** measure), but please note that future releases of setuptools will
+    follow strictly the standard.
+
+    To prevent this warning, you can list {field!r} under `dynamic` or alternatively
+    remove the `[project]` table from your file and rely entirely on other means of
+    configuration.
+
+    \n\n!!
+    """
+
+    @classmethod
+    def message(cls, field, value):
+        from inspect import cleandoc
+        msg = "\n".join(cls.__doc__.splitlines()[1:])
+        return cleandoc(msg.format(field=field, value=value))

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -7,9 +7,10 @@ need to be processed before being applied.
 """
 import logging
 import os
+import warnings
 from collections.abc import Mapping
 from email.headerregistry import Address
-from functools import partial
+from functools import partial, reduce
 from itertools import chain
 from types import MappingProxyType
 from typing import (TYPE_CHECKING, Any, Callable, Dict, List, Optional, Set, Tuple,
@@ -35,23 +36,9 @@ def apply(dist: "Distribution", config: dict, filename: _Path) -> "Distribution"
         return dist  # short-circuit unrelated pyproject.toml file
 
     root_dir = os.path.dirname(filename) or "."
-    tool_table = config.get("tool", {}).get("setuptools", {})
-    project_table = config.get("project", {}).copy()
-    _unify_entry_points(project_table)
-    for field, value in project_table.items():
-        norm_key = json_compatible_key(field)
-        corresp = PYPROJECT_CORRESPONDENCE.get(norm_key, norm_key)
-        if callable(corresp):
-            corresp(dist, value, root_dir)
-        else:
-            _set_config(dist, corresp, value)
 
-    for field, value in tool_table.items():
-        norm_key = json_compatible_key(field)
-        norm_key = TOOL_TABLE_RENAMES.get(norm_key, norm_key)
-        _set_config(dist, norm_key, value)
-
-    _copy_command_options(config, dist, filename)
+    _apply_project_table(dist, config, root_dir)
+    _apply_tool_table(dist, config, filename)
 
     current_directory = os.getcwd()
     os.chdir(root_dir)
@@ -62,6 +49,48 @@ def apply(dist: "Distribution", config: dict, filename: _Path) -> "Distribution"
         os.chdir(current_directory)
 
     return dist
+
+
+def _apply_project_table(dist: "Distribution", config: dict, root_dir: _Path):
+    project_table = config.get("project", {}).copy()
+    if not project_table:
+        return  # short-circuit
+
+    _handle_missing_dynamic(dist, project_table)
+    _unify_entry_points(project_table)
+
+    for field, value in project_table.items():
+        norm_key = json_compatible_key(field)
+        corresp = PYPROJECT_CORRESPONDENCE.get(norm_key, norm_key)
+        if callable(corresp):
+            corresp(dist, value, root_dir)
+        else:
+            _set_config(dist, corresp, value)
+
+
+def _apply_tool_table(dist: "Distribution", config: dict, filename: _Path):
+    tool_table = config.get("tool", {}).get("setuptools", {})
+    if not tool_table:
+        return  # short-circuit
+
+    for field, value in tool_table.items():
+        norm_key = json_compatible_key(field)
+        norm_key = TOOL_TABLE_RENAMES.get(norm_key, norm_key)
+        _set_config(dist, norm_key, value)
+
+    _copy_command_options(config, dist, filename)
+
+
+def _handle_missing_dynamic(dist: "Distribution", project_table: dict):
+    """Be temporarily forgiving with ``dynamic`` fields not listed in ``dynamic``"""
+    # TODO: Set fields back to `None` once the feature stabilizes
+    dynamic = set(project_table.get("dynamic", []))
+    for field, getter in _PREVIOUSLY_DEFINED.items():
+        if not (field in project_table or field in dynamic):
+            value = getter(dist)
+            if value:
+                msg = _WouldIgnoreField.message(field, value)
+                warnings.warn(msg, _WouldIgnoreField)
 
 
 def json_compatible_key(key: str) -> str:
@@ -235,6 +264,39 @@ def _normalise_cmd_options(desc: List[Tuple[str, Optional[str], str]]) -> Set[st
     return {_normalise_cmd_option_key(fancy_option[0]) for fancy_option in desc}
 
 
+def _attrgetter(attr):
+    """
+    Similar to ``operator.attrgetter`` but returns None if ``attr`` is not found
+    >>> from types import SimpleNamespace
+    >>> obj = SimpleNamespace(a=42, b=SimpleNamespace(c=13))
+    >>> _attrgetter("a")(obj)
+    42
+    >>> _attrgetter("b.c")(obj)
+    13
+    >>> _attrgetter("d")(obj) is None
+    True
+    """
+    return partial(reduce, lambda acc, x: getattr(acc, x, None), attr.split("."))
+
+
+def _some_attrgetter(*items):
+    """
+    Return the first "truth-y" attribute or None
+    >>> from types import SimpleNamespace
+    >>> obj = SimpleNamespace(a=42, b=SimpleNamespace(c=13))
+    >>> _some_attrgetter("d", "a", "b.c")(obj)
+    42
+    >>> _some_attrgetter("d", "e", "b.c", "a")(obj)
+    13
+    >>> _some_attrgetter("d", "e", "f")(obj) is None
+    True
+    """
+    def _acessor(obj):
+        values = (_attrgetter(i)(obj) for i in items)
+        return next((i for i in values if i), None)
+    return _acessor
+
+
 PYPROJECT_CORRESPONDENCE: Dict[str, _Correspondence] = {
     "readme": _long_description,
     "license": _license,
@@ -250,6 +312,23 @@ TOOL_TABLE_RENAMES = {"script_files": "scripts"}
 
 SETUPTOOLS_PATCHES = {"long_description_content_type", "project_urls",
                       "provides_extras", "license_file", "license_files"}
+
+_PREVIOUSLY_DEFINED = {
+    "name": _attrgetter("metadata.name"),
+    "version": _attrgetter("metadata.version"),
+    "description": _attrgetter("metadata.description"),
+    "readme": _attrgetter("metadata.long_description"),
+    "requires-python": _some_attrgetter("python_requires", "metadata.python_requires"),
+    "license": _attrgetter("metadata.license"),
+    "authors": _some_attrgetter("metadata.author", "metadata.author_email"),
+    "maintainers": _some_attrgetter("metadata.maintainer", "metadata.maintainer_email"),
+    "keywords": _attrgetter("metadata.keywords"),
+    "classifiers": _attrgetter("metadata.classifiers"),
+    "urls": _attrgetter("metadata.project_urls"),
+    "entry-points": _attrgetter("entry_points"),
+    "dependencies": _some_attrgetter("_orig_install_requires", "install_requires"),
+    "optional-dependencies": _some_attrgetter("_orig_extras_require", "extras_require"),
+}
 
 
 class _WouldIgnoreField(UserWarning):

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -334,9 +334,9 @@ _PREVIOUSLY_DEFINED = {
 class _WouldIgnoreField(UserWarning):
     """Inform users that ``pyproject.toml`` would overwrite previously defined metadata:
     !!\n\n
-    ##############################################
-    # field would be ignored by `pyproject.toml` #
-    ##############################################
+    ##########################################################################
+    # configuration would be ignored/result in error due to `pyproject.toml` #
+    ##########################################################################
 
     The following seems to be defined outside of `pyproject.toml`:
 

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -285,9 +285,9 @@ class _ConfigExpander:
         previous = _PREVIOUSLY_DEFINED[field](dist)
         if not previous and not self.ignore_option_errors:
             msg = (
-                f"No configuration found for dynamic {field!r}. "
-                "Some fields need to be specified via `tool.setuptools.dynamic` "
-                "others must be specified via the equivalent attribute in `setup.py`."
+                f"No configuration found for dynamic {field!r}.\n"
+                "Some dynamic fields need to be specified via `tool.setuptools.dynamic`"
+                "\nothers must be specified via the equivalent attribute in `setup.py`."
             )
             raise OptionError(msg)
 
@@ -400,7 +400,7 @@ class _ExperimentalProjectMetadata(UserWarning):
 
 
 class _InvalidFile(UserWarning):
-    """Inform users that the given `pyproject.toml` is experimental.
+    """Inform users that the given `pyproject.toml` is experimental:
     !!\n\n
     ############################
     # Invalid `pyproject.toml` #

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -265,6 +265,7 @@ class _ConfigExpander:
             "gui-scripts",
             "classifiers",
         )
+        # `_obtain` functions are assumed to raise appropriate exceptions/warnings.
         obtained_dynamic = {
             field: self._obtain(dist, field, package_dir)
             for field in self.dynamic
@@ -276,7 +277,8 @@ class _ConfigExpander:
             readme=self._obtain_readme(dist),
             classifiers=self._obtain_classifiers(dist),
         )
-        # Preserve previous value if obtained value is None
+        # `None` indicates there is nothing in `tool.setuptools.dynamic` but the value
+        # might have already been set by setup.py/extensions, so avoid overwriting.
         self.project_cfg.update({k: v for k, v in obtained_dynamic.items() if v})
 
     def _ensure_previously_set(self, dist: "Distribution", field: str):
@@ -298,6 +300,9 @@ class _ConfigExpander:
                     return _expand.read_files(directive["file"], root_dir)
                 if "attr" in directive:
                     return _expand.read_attr(directive["attr"], package_dir, root_dir)
+                msg = f"invalid `tool.setuptools.dynamic.{field}`: {directive!r}"
+                raise ValueError(msg)
+            return None
         self._ensure_previously_set(dist, field)
         return None
 

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -228,7 +228,7 @@ class TestPresetField:
         """
         pyproject = self.pyproject(tmp_path, [])
         dist = makedist(tmp_path, **{attr: value})
-        msg = f"{field}.*seems to be defined outside of .pyproject.toml."
+        msg = re.compile(f"defined outside of `pyproject.toml`:.*{field}", re.S)
         with pytest.warns(_WouldIgnoreField, match=msg):
             dist = pyprojecttoml.apply_configuration(dist, pyproject)
 

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -14,6 +14,7 @@ import setuptools  # noqa ensure monkey patch to metadata
 from setuptools.dist import Distribution
 from setuptools.config import setupcfg, pyprojecttoml
 from setuptools.config import expand
+from setuptools.config._apply_pyprojecttoml import _WouldIgnoreField
 
 
 EXAMPLES = (Path(__file__).parent / "setupcfg_examples.txt").read_text()
@@ -21,8 +22,8 @@ EXAMPLE_URLS = [x for x in EXAMPLES.splitlines() if not x.startswith("#")]
 DOWNLOAD_DIR = Path(__file__).parent / "downloads"
 
 
-def makedist(path):
-    return Distribution({"src_root": path})
+def makedist(path, **attrs):
+    return Distribution({"src_root": path, **attrs})
 
 
 @pytest.mark.parametrize("url", EXAMPLE_URLS)
@@ -203,6 +204,51 @@ def test_license_and_license_files(tmp_path):
     dist = pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
     assert set(dist.metadata.license_files) == {"_FILE.rst", "_FILE.txt"}
     assert dist.metadata.license == "LicenseRef-Proprietary\n"
+
+
+class TestPresetField:
+    def pyproject(self, tmp_path, dynamic):
+        content = f"[project]\nname = 'proj'\ndynamic = {dynamic!r}\n"
+        if "version" not in dynamic:
+            content += "version = '42'\n"
+        file = tmp_path / "pyproject.toml"
+        file.write_text(content, encoding="utf-8")
+        return file
+
+    @pytest.mark.parametrize(
+        "attr, field, value",
+        [
+            ("install_requires", "dependencies", ["six"]),
+            ("classifiers", "classifiers", ["Private :: Classifier"]),
+        ]
+    )
+    def test_not_listed_in_dynamic(self, tmp_path, attr, field, value):
+        """For the time being we just warn if the user pre-set values (e.g. via
+        ``setup.py``) but do not include them in ``dynamic``.
+        """
+        pyproject = self.pyproject(tmp_path, [])
+        dist = makedist(tmp_path, **{attr: value})
+        msg = f"{field}.*seems to be defined outside of .pyproject.toml."
+        with pytest.warns(_WouldIgnoreField, match=msg):
+            dist = pyprojecttoml.apply_configuration(dist, pyproject)
+
+        # TODO: Once support for pyproject.toml config stabilizes attr should be None
+        dist_value = getattr(dist, attr, None) or getattr(dist.metadata, attr, object())
+        assert dist_value == value
+
+    @pytest.mark.parametrize(
+        "attr, field, value",
+        [
+            ("install_requires", "dependencies", ["six"]),
+            ("classifiers", "classifiers", ["Private :: Classifier"]),
+        ]
+    )
+    def test_listed_in_dynamic(self, tmp_path, attr, field, value):
+        pyproject = self.pyproject(tmp_path, [field])
+        dist = makedist(tmp_path, **{attr: value})
+        dist = pyprojecttoml.apply_configuration(dist, pyproject)
+        dist_value = getattr(dist, attr, None) or getattr(dist.metadata, attr, object())
+        assert dist_value == value
 
 
 # --- Auxiliary Functions ---

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -236,7 +236,7 @@ class TestClassifiers:
 
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text(cleandoc(config))
-        with pytest.raises(OptionError, match="No configuration found"):
+        with pytest.raises(OptionError, match="No configuration .* .classifiers."):
             read_configuration(pyproject)
 
     def test_dynamic_without_file(self, tmp_path):
@@ -254,7 +254,7 @@ class TestClassifiers:
         pyproject.write_text(cleandoc(config))
         with pytest.warns(UserWarning, match="File .*classifiers.txt. cannot be found"):
             expanded = read_configuration(pyproject)
-        assert not expanded["project"]["classifiers"]
+        assert "classifiers" not in expanded["project"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary of changes

- Added a warning if the project has a valid `pyproject.toml` with a `[project]` table, but at the same time it is trying to set other configs via other files (e.g. `setup.py`), without setting `dynamic` properly
- In future releases (when support for `pyproject.toml` metadata stabilises), instead of warning, setuptools should fail.

Closes #3195

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
