### PR TITLE
Fix problems with missing `setupcfg_examples.txt`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -15,3 +15,4 @@ include launcher.c
 include msvc-build-launcher.cmd
 include pytest.ini
 include tox.ini
+include setuptools/tests/config/setupcfg_examples.txt

--- a/changelog.d/3233.misc.1.rst
+++ b/changelog.d/3233.misc.1.rst
@@ -1,0 +1,1 @@
+Included missing test file ``setupcfg_examples.txt`` in ``sdist``.

--- a/changelog.d/3233.misc.2.rst
+++ b/changelog.d/3233.misc.2.rst
@@ -1,0 +1,3 @@
+Added script that allows developers to download ``setupcfg_examples.txt`` prior to
+running tests. By caching these files it should be possible to run the test suite
+offline.

--- a/setuptools/tests/config/downloads/.gitignore
+++ b/setuptools/tests/config/downloads/.gitignore
@@ -1,2 +1,4 @@
 *
 !.gitignore
+!__init__.py
+!preload.py

--- a/setuptools/tests/config/downloads/__init__.py
+++ b/setuptools/tests/config/downloads/__init__.py
@@ -1,4 +1,3 @@
-import io
 import re
 from pathlib import Path
 from urllib.request import urlopen

--- a/setuptools/tests/config/downloads/__init__.py
+++ b/setuptools/tests/config/downloads/__init__.py
@@ -9,6 +9,11 @@ NAME_REMOVE = ("http://", "https://", "github.com/", "/raw/")
 DOWNLOAD_DIR = Path(__file__).parent
 
 
+# ----------------------------------------------------------------------
+# Please update ./preload.py accordingly when modifying this file
+# ----------------------------------------------------------------------
+
+
 def output_file(url: str, download_dir: Path = DOWNLOAD_DIR):
     file_name = url.strip()
     for part in NAME_REMOVE:

--- a/setuptools/tests/config/downloads/__init__.py
+++ b/setuptools/tests/config/downloads/__init__.py
@@ -1,0 +1,47 @@
+import io
+import re
+from pathlib import Path
+from urllib.request import urlopen
+
+__all__ = ["DOWNLOAD_DIR", "retrieve_file", "output_file", "urls_from_file"]
+
+
+NAME_REMOVE = ("http://", "https://", "github.com/", "/raw/")
+DOWNLOAD_DIR = Path(__file__).parent
+
+
+def output_file(url: str, download_dir: Path = DOWNLOAD_DIR):
+    file_name = url.strip()
+    for part in NAME_REMOVE:
+        file_name = file_name.replace(part, '').strip().strip('/:').strip()
+    return Path(download_dir, re.sub(r"[^\-_\.\w\d]+", "_", file_name))
+
+
+def retrieve_file(url: str, download_dir: Path = DOWNLOAD_DIR):
+    path = output_file(url, download_dir)
+    if path.exists():
+        print(f"Skipping {url} (already exists: {path})")
+    else:
+        download_dir.mkdir(exist_ok=True, parents=True)
+        print(f"Downloading {url} to {path}")
+        download(url, path)
+    return path
+
+
+def urls_from_file(list_file: Path):
+    """``list_file`` should be a text file where each line corresponds to a URL to
+    download.
+    """
+    print(f"file: {list_file}")
+    content = list_file.read_text(encoding="utf-8")
+    return [url for url in content.splitlines() if not url.startswith("#")]
+
+
+def download(url: str, dest: Path):
+    with urlopen(url) as f:
+        data = f.read()
+
+    with open(dest, "wb") as f:
+        f.write(data)
+
+    assert Path(dest).exists()

--- a/setuptools/tests/config/downloads/preload.py
+++ b/setuptools/tests/config/downloads/preload.py
@@ -1,0 +1,18 @@
+"""This file can be used to preload files needed for testing.
+
+For example you can use::
+
+    cd setuptools/tests/config
+    python -m downloads.preload setupcfg_examples.txt
+
+to make sure the `setup.cfg` examples are downloaded before starting the tests.
+"""
+import sys
+from pathlib import Path
+
+from . import retrieve_file, urls_from_file
+
+
+if __name__ == "__main__":
+    urls = urls_from_file(Path(sys.argv[1]))
+    list(map(retrieve_file, urls))

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -5,7 +5,6 @@ import io
 import re
 import tarfile
 from pathlib import Path
-from urllib.request import urlopen
 from unittest.mock import Mock
 from zipfile import ZipFile
 

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -1,5 +1,7 @@
 """Make sure that applying the configuration from pyproject.toml is equivalent to
 applying a similar configuration from setup.cfg
+
+To run these tests offline, please have a look on ``./downloads/preload.py``
 """
 import io
 import re


### PR DESCRIPTION
## Summary of changes

- Adds `setupcfg_examples.txt` to sdist via `MANIFEST.in`
- Ensure `setupcfg_examples.txt` is included in `sdist` but not included in `wheel`
- Add script to pre-load examples from `setupcfg_examples.txt` in case developers want to run the tests offline.

Closes #3233

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
