### PR TITLE
Fix error with `test_easy_install`

### DIFF
--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1185,6 +1185,8 @@ def test_editable_user_and_build_isolation(setup_context, monkeypatch, tmp_path)
     # 2. We are going to force `site` to update site.USER_BASE and site.USER_SITE
     #    To point inside our new home
     monkeypatch.setenv('HOME', str(tmp_path / '.home'))
+    monkeypatch.setenv('USERPROFILE', str(tmp_path / '.home'))
+    monkeypatch.setenv('APPDATA', str(tmp_path / '.home'))
     monkeypatch.setattr('site.USER_BASE', None)
     monkeypatch.setattr('site.USER_SITE', None)
     user_site = Path(site.getusersitepackages())

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1194,7 +1194,9 @@ def test_editable_user_and_build_isolation(setup_context, monkeypatch, tmp_path)
     sys_prefix.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr('sys.prefix', str(sys_prefix))
 
-    setup_script = "__import__('setuptools').setup(name='aproj', version=42)\n"
+    setup_script = (
+        "__import__('setuptools').setup(name='aproj', version=42, packages=[])\n"
+    )
     (tmp_path / "setup.py").write_text(setup_script, encoding="utf-8")
 
     # == Sanity check ==

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1184,15 +1184,18 @@ def test_editable_user_and_build_isolation(setup_context, monkeypatch, tmp_path)
     # it will `makedirs("/home/user/.pyenv/versions/3.9.10 /home/user/.pyenv/versions/3.9.10/lib /home/user/.pyenv/versions/3.9.10/lib/python3.9 /home/user/.pyenv/versions/3.9.10/lib/python3.9/lib-dynload")``  # noqa: E501
     # 2. We are going to force `site` to update site.USER_BASE and site.USER_SITE
     #    To point inside our new home
-    monkeypatch.setenv('HOME', str(tmp_path / 'home'))
+    monkeypatch.setenv('HOME', str(tmp_path / '.home'))
     monkeypatch.setattr('site.USER_BASE', None)
     monkeypatch.setattr('site.USER_SITE', None)
     user_site = Path(site.getusersitepackages())
     user_site.mkdir(parents=True, exist_ok=True)
 
-    sys_prefix = (tmp_path / 'sys_prefix')
+    sys_prefix = (tmp_path / '.sys_prefix')
     sys_prefix.mkdir(parents=True, exist_ok=True)
     monkeypatch.setattr('sys.prefix', str(sys_prefix))
+
+    setup_script = "__import__('setuptools').setup(name='aproj', version=42)\n"
+    (tmp_path / "setup.py").write_text(setup_script, encoding="utf-8")
 
     # == Sanity check ==
     assert list(sys_prefix.glob("*")) == []
@@ -1208,4 +1211,4 @@ def test_editable_user_and_build_isolation(setup_context, monkeypatch, tmp_path)
     installed = {f.name for f in user_site.glob("*")}
     # sometimes easy-install.pth is created and sometimes not
     installed = installed - {"easy-install.pth"}
-    assert installed == {'UNKNOWN.egg-link'}
+    assert installed == {'aproj.egg-link'}


### PR DESCRIPTION
## Summary of changes

Due to an outdated merge base `test_easy_install` ended up introducing some incompatibility with v61.*

The changes implemented in this PR attempt to fix the incompatibilities.

### Pull Request Checklist
- [x] Changes have tests

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
