### PR TITLE
[follow-up auto-discovery] Simplify `package_dir`

### DIFF
--- a/changelog.d/3249.misc.rst
+++ b/changelog.d/3249.misc.rst
@@ -1,0 +1,1 @@
+Simplified ``package_dir`` obtained via auto-discovery.

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -312,8 +312,12 @@ def find_packages(
     where = kwargs.pop('where', ['.'])
     packages: List[str] = []
     fill_package_dir = {} if fill_package_dir is None else fill_package_dir
+    find = list(unique_everseen(always_iterable(where)))
 
-    for path in unique_everseen(always_iterable(where)):
+    if len(find) == 1 and all(not _same_path(find[0], x) for x in (".", root_dir)):
+        fill_package_dir.setdefault("", find[0])
+
+    for path in find:
         package_path = _nest_path(root_dir, path)
         pkgs = PackageFinder.find(package_path, **kwargs)
         packages.extend(pkgs)
@@ -326,8 +330,27 @@ def find_packages(
     return packages
 
 
+def _same_path(p1: _Path, p2: _Path) -> bool:
+    """Differs from os.path.samefile because it does not require paths to exist.
+    Purely string based (no comparison between i-nodes).
+    >>> _same_path("a/b", "./a/b")
+    True
+    >>> _same_path("a/b", "a/./b")
+    True
+    >>> _same_path("a/b", "././a/b")
+    True
+    >>> _same_path("a/b", "./a/b/c/..")
+    True
+    >>> _same_path("a/b", "../a/b/c")
+    False
+    >>> _same_path("a", "a/b")
+    False
+    """
+    return os.path.normpath(p1) == os.path.normpath(p2)
+
+
 def _nest_path(parent: _Path, path: _Path) -> str:
-    path = parent if path == "." else os.path.join(parent, path)
+    path = parent if path in {".", ""} else os.path.join(parent, path)
     return os.path.normpath(path)
 
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -312,12 +312,12 @@ def find_packages(
     where = kwargs.pop('where', ['.'])
     packages: List[str] = []
     fill_package_dir = {} if fill_package_dir is None else fill_package_dir
-    find = list(unique_everseen(always_iterable(where)))
+    search = list(unique_everseen(always_iterable(where)))
 
-    if len(find) == 1 and all(not _same_path(find[0], x) for x in (".", root_dir)):
-        fill_package_dir.setdefault("", find[0])
+    if len(search) == 1 and all(not _same_path(search[0], x) for x in (".", root_dir)):
+        fill_package_dir.setdefault("", search[0])
 
-    for path in find:
+    for path in search:
         package_path = _nest_path(root_dir, path)
         pkgs = PackageFinder.find(package_path, **kwargs)
         packages.extend(pkgs)


### PR DESCRIPTION
## Summary of changes
- If the directory follows a `src-layout`-ish, try harder to make `package_dir` in the form `{"": "src"}`.

This might be later important for PEP 660 (e.g. when composing `pth` files or symlinking the top-level packages).

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
