### PR TITLE
Add setuptools.command.build

### DIFF
--- a/changelog.d/3256.change.rst
+++ b/changelog.d/3256.change.rst
@@ -1,0 +1,1 @@
+Added setuptools.command.build command to match distutils.command.build -- by :user:`isuruf`

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,6 +105,7 @@ distutils.commands =
 	alias = setuptools.command.alias:alias
 	bdist_egg = setuptools.command.bdist_egg:bdist_egg
 	bdist_rpm = setuptools.command.bdist_rpm:bdist_rpm
+	build = setuptools.command.build:build
 	build_clib = setuptools.command.build_clib:build_clib
 	build_ext = setuptools.command.build_ext:build_ext
 	build_py = setuptools.command.build_py:build_py

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -19,6 +19,6 @@ class build(_build):
             new subcommands. Using `distutils` directly is considered deprecated,
             please use `setuptools.command.build`.
             """
-            warnings.warns(msg, SetuptoolsDeprecationWarning)
+            warnings.warn(msg, SetuptoolsDeprecationWarning)
             self.sub_commands = _build.sub_commands
         super().run()

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -1,5 +1,24 @@
 from distutils.command.build import build as _build
+import warnings
+
+from setuptools import SetuptoolsDeprecationWarning
+
+
+_ORIGINAL_SUBCOMMANDS = {"build_py", "build_clib", "build_ext", "build_scripts"}
 
 
 class build(_build):
-    pass
+    # copy to avoid sharing the object with parent class
+    sub_commands = _build.sub_commands[:]
+
+    def run(self):
+        subcommands = {cmd[0] for cmd in _build.sub_commands}
+        if subcommands - _ORIGINAL_SUBCOMMANDS:
+            msg = """
+            It seems that you are using `distutils.command.build.build` to add
+            new subcommands. Using `distutils` directly is considered deprecated,
+            please use `setuptools.command.build`.
+            """
+            warnings.warns(msg, SetuptoolsDeprecationWarning)
+            self.sub_commands = _build.sub_commands
+        super().run()

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -1,0 +1,4 @@
+from distutils.command.build import build as _build
+
+class build(_build):
+    pass

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -1,4 +1,5 @@
 from distutils.command.build import build as _build
 
+
 class build(_build):
     pass

--- a/setuptools/tests/test_build.py
+++ b/setuptools/tests/test_build.py
@@ -1,5 +1,6 @@
 from setuptools.dist import Distribution
 from setuptools.command.build import build
+from distutils.command.build import build as distutils_build
 
 
 def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
@@ -13,4 +14,11 @@ def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
         packages=[''],
         package_data={'': ['path/*']},
     ))
-    assert isinstance(dist.get_command_obj("build"), build)
+
+    build_obj = dist.get_command_obj("build")
+    assert isinstance(build_obj, build)
+
+    build_obj.sub_commands.append(("custom_build_subcommand", None))
+
+    distutils_subcommands = [cmd[0] for cmd in distutils_build.sub_commands]
+    assert "custom_build_subcommand" not in distutils_subcommands

--- a/setuptools/tests/test_build.py
+++ b/setuptools/tests/test_build.py
@@ -1,0 +1,16 @@
+from setuptools.dist import Distribution
+from setuptools.command.build import build
+
+
+def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
+    """
+    Check that the setuptools Distribution uses the
+    setuptools specific build object.
+    """
+    dist = Distribution(dict(
+        script_name='setup.py',
+        script_args=['build'],
+        packages=[''],
+        package_data={'': ['path/*']},
+    ))
+    assert isinstance(dist.get_command_obj("build"), build)

--- a/setuptools/tests/test_build.py
+++ b/setuptools/tests/test_build.py
@@ -1,6 +1,9 @@
+from setuptools import Command, SetuptoolsDeprecationWarning
 from setuptools.dist import Distribution
 from setuptools.command.build import build
 from distutils.command.build import build as distutils_build
+
+import pytest
 
 
 def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
@@ -8,17 +11,22 @@ def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
     Check that the setuptools Distribution uses the
     setuptools specific build object.
     """
+    class Subcommand(Command):
+        def run(self):
+            raise NotImplementedError("just to check if the command runs")
+
     dist = Distribution(dict(
         script_name='setup.py',
         script_args=['build'],
         packages=[''],
         package_data={'': ['path/*']},
+        cmdclass={'subcommand': Subcommand},
     ))
 
-    build_obj = dist.get_command_obj("build")
-    assert isinstance(build_obj, build)
+    distutils_build.sub_commands.append(('subcommand', None))
 
-    build_obj.sub_commands.append(("custom_build_subcommand", None))
-
-    distutils_subcommands = [cmd[0] for cmd in distutils_build.sub_commands]
-    assert "custom_build_subcommand" not in distutils_subcommands
+    warning_msg = "please use .setuptools.command.build."
+    with pytest.raises(SetuptoolsDeprecationWarning, match=warning_msg):
+        # For backward compatibility, the subcommand should run anyway:
+        with pytest.raises(NotImplementedError, match="the command runs"):
+            build(dist).run()

--- a/setuptools/tests/test_build.py
+++ b/setuptools/tests/test_build.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from setuptools import Command, SetuptoolsDeprecationWarning
 from setuptools.dist import Distribution
 from setuptools.command.build import build
@@ -11,22 +12,52 @@ def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
     Check that the setuptools Distribution uses the
     setuptools specific build object.
     """
-    class Subcommand(Command):
-        def run(self):
-            raise NotImplementedError("just to check if the command runs")
 
     dist = Distribution(dict(
         script_name='setup.py',
         script_args=['build'],
-        packages=[''],
+        packages=[],
         package_data={'': ['path/*']},
+    ))
+    assert isinstance(dist.get_command_obj("build"), build)
+
+
+@contextmanager
+def _restore_sub_commands():
+    orig = distutils_build.sub_commands[:]
+    try:
+        yield
+    finally:
+        distutils_build.sub_commands = orig
+
+
+class Subcommand(Command):
+    """Dummy command to be used in tests"""
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        raise NotImplementedError("just to check if the command runs")
+
+
+@_restore_sub_commands()
+def test_subcommand_in_distutils(tmpdir_cwd):
+    """
+    Ensure that sub commands registered in ``distutils`` run,
+    after instructing the users to migrate to ``setuptools``.
+    """
+    dist = Distribution(dict(
+        packages=[],
         cmdclass={'subcommand': Subcommand},
     ))
-
     distutils_build.sub_commands.append(('subcommand', None))
 
     warning_msg = "please use .setuptools.command.build."
-    with pytest.raises(SetuptoolsDeprecationWarning, match=warning_msg):
+    with pytest.warns(SetuptoolsDeprecationWarning, match=warning_msg):
         # For backward compatibility, the subcommand should run anyway:
         with pytest.raises(NotImplementedError, match="the command runs"):
-            build(dist).run()
+            dist.run_command("build")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

In order to override distutils.command.build on downstream projects
it is good to have a setuptools specific command which allows
downstream projects to avoid importing distutils.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
