### PR TITLE
Merge distutils at 5229dad46b

### DIFF
--- a/changelog.d/3258.change.rst
+++ b/changelog.d/3258.change.rst
@@ -1,0 +1,1 @@
+Merge pypa/distutils@5229dad46b.

--- a/setuptools/_distutils/command/build.py
+++ b/setuptools/_distutils/command/build.py
@@ -81,7 +81,8 @@ class build(Command):
                             "--plat-name only supported on Windows (try "
                             "using './configure --help' on your platform)")
 
-        plat_specifier = ".%s-%d.%d" % (self.plat_name, *sys.version_info[:2])
+        plat_specifier = ".%s-%s" % (self.plat_name,
+                                     sys.implementation.cache_tag)
 
         # Make it so Python 2.x and Python 2.x with --with-pydebug don't
         # share the same build directories. Doing so confuses the build

--- a/setuptools/_distutils/py39compat.py
+++ b/setuptools/_distutils/py39compat.py
@@ -1,0 +1,21 @@
+import sys
+import platform
+
+
+def add_ext_suffix_39(vars):
+    """
+    Ensure vars contains 'EXT_SUFFIX'. pypa/distutils#130
+    """
+    import _imp
+    ext_suffix = _imp.extension_suffixes()[0]
+    vars.update(
+        EXT_SUFFIX=ext_suffix,
+        # sysconfig sets SO to match EXT_SUFFIX, so maintain
+        # that expectation.
+        # https://github.com/python/cpython/blob/785cc6770588de087d09e89a69110af2542be208/Lib/sysconfig.py#L671-L673
+        SO=ext_suffix,
+    )
+
+
+needs_ext_suffix = sys.version_info < (3, 10) and platform.system() == 'Windows'
+add_ext_suffix = add_ext_suffix_39 if needs_ext_suffix else lambda vars: None

--- a/setuptools/_distutils/tests/test_build.py
+++ b/setuptools/_distutils/tests/test_build.py
@@ -24,10 +24,10 @@ class BuildTestCase(support.TempdirManager,
         wanted = os.path.join(cmd.build_base, 'lib')
         self.assertEqual(cmd.build_purelib, wanted)
 
-        # build_platlib is 'build/lib.platform-x.x[-pydebug]'
+        # build_platlib is 'build/lib.platform-cache_tag[-pydebug]'
         # examples:
-        #   build/lib.macosx-10.3-i386-2.7
-        plat_spec = '.%s-%d.%d' % (cmd.plat_name, *sys.version_info[:2])
+        #   build/lib.macosx-10.3-i386-cpython39
+        plat_spec = '.%s-%s' % (cmd.plat_name, sys.implementation.cache_tag)
         if hasattr(sys, 'gettotalrefcount'):
             self.assertTrue(cmd.build_platlib.endswith('-pydebug'))
             plat_spec += '-pydebug'

--- a/setuptools/_distutils/tests/test_install.py
+++ b/setuptools/_distutils/tests/test_install.py
@@ -56,14 +56,15 @@ class InstallTestCase(support.TempdirManager,
             expected = os.path.normpath(expected)
             self.assertEqual(got, expected)
 
-        libdir = os.path.join(destination, "lib", "python")
+        impl_name = sys.implementation.name.replace("cpython", "python")
+        libdir = os.path.join(destination, "lib", impl_name)
         check_path(cmd.install_lib, libdir)
         _platlibdir = getattr(sys, "platlibdir", "lib")
-        platlibdir = os.path.join(destination, _platlibdir, "python")
+        platlibdir = os.path.join(destination, _platlibdir, impl_name)
         check_path(cmd.install_platlib, platlibdir)
         check_path(cmd.install_purelib, libdir)
         check_path(cmd.install_headers,
-                   os.path.join(destination, "include", "python", "foopkg"))
+                   os.path.join(destination, "include", impl_name, "foopkg"))
         check_path(cmd.install_scripts, os.path.join(destination, "bin"))
         check_path(cmd.install_data, destination)
 

--- a/setuptools/_distutils/tests/test_sysconfig.py
+++ b/setuptools/_distutils/tests/test_sysconfig.py
@@ -40,6 +40,8 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
 
     @unittest.skipIf(sys.platform == 'win32',
                      'Makefile only exists on Unix like systems')
+    @unittest.skipIf(sys.implementation.name != 'cpython',
+                     'Makefile only exists in CPython')
     def test_get_makefile_filename(self):
         makefile = sysconfig.get_makefile_filename()
         self.assertTrue(os.path.isfile(makefile), makefile)
@@ -298,6 +300,14 @@ class SysconfigTestCase(support.EnvironGuard, unittest.TestCase):
         with open(config_h, encoding="utf-8") as f:
             result = sysconfig.parse_config_h(f)
         self.assertTrue(isinstance(result, dict))
+
+    @unittest.skipUnless(sys.platform == 'win32',
+                     'Testing windows pyd suffix')
+    @unittest.skipUnless(sys.implementation.name == 'cpython',
+                     'Need cpython for this test')
+    def test_win_ext_suffix(self):
+        self.assertTrue(sysconfig.get_config_var("EXT_SUFFIX").endswith(".pyd"))
+        self.assertNotEqual(sysconfig.get_config_var("EXT_SUFFIX"), ".pyd")
 
 def test_suite():
     suite = unittest.TestSuite()

--- a/setuptools/_distutils/version.py
+++ b/setuptools/_distutils/version.py
@@ -50,14 +50,14 @@ class Version:
     """
 
     def __init__ (self, vstring=None):
+        if vstring:
+            self.parse(vstring)
         warnings.warn(
             "distutils Version classes are deprecated. "
             "Use packaging.version instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        if vstring:
-            self.parse(vstring)
 
     def __repr__ (self):
         return "%s ('%s')" % (self.__class__.__name__, str(self))


### PR DESCRIPTION
- Fix EXT_SUFFIX for windows py<3.8
- Fix SO too
- Move EXT_SUFFIX support to _py39compat, to be removed after support for Python 3.9 is dropped. Fall back to default behavior on Python 3.10. Remove functionality for SO, which has been long deprecated and is untested.
- 👹 Feed the hobgoblins (delint).
- Just modify the vars in place.
- Restore expectation that SO matches EXT_SUFFIX with rationale.
- Get the version logic correct.
- Move compatibility concerns out of the function to do the adding.
- Emit warning after parsing. Fixes pypa/distutils#122.
- Disable installation of Setuptools in tox instead of GHA. Ref pypa/distutils#99.
- Use cache_tag in default build_platlib dir
- Skip test_get_makefile_filename on non-CPython
- Update test_home_installation_scheme for pypy install paths
- Refactor as simple replace. If a full string substitution proves to be necessary, let's create a mapping.
