### PR TITLE
Trigger deprecation warning when find_packages() finds reserved name

### DIFF
--- a/changelog.d/3243.deprecation.rst
+++ b/changelog.d/3243.deprecation.rst
@@ -1,0 +1,3 @@
+Added a deprecation warning when `setuptools.find_packages()` includes
+a package in the reserved top-level package name list (e.g. ``tests``)
+-- by :user:`mgorny`.

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -44,11 +44,14 @@ from glob import glob
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Callable, Dict, Iterator, Iterable, List, Optional, Tuple, Union
+import warnings
 
 import _distutils_hack.override  # noqa: F401
 
 from distutils import log
 from distutils.util import convert_path
+
+import setuptools
 
 _Path = Union[str, os.PathLike]
 _Filter = Callable[[str], bool]
@@ -148,6 +151,13 @@ class PackageFinder(_Finder):
 
                 # Should this package be included?
                 if include(package) and not exclude(package):
+                    top_package = package.split(".")[0]
+                    if top_package in FlatLayoutPackageFinder._EXCLUDE:
+                        warnings.warn(
+                            f"{top_package!r} is a reserved package name. "
+                            "Please add it to find_package(exclude=...)",
+                            setuptools.SetuptoolsDeprecationWarning,
+                        )
                     yield package
 
                 # Keep searching subdirectories, as there may be more packages

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -7,6 +7,7 @@ import platform
 
 import pytest
 
+import setuptools
 from setuptools import find_packages
 from setuptools import find_namespace_packages
 from setuptools.discovery import FlatLayoutPackageFinder
@@ -157,13 +158,17 @@ class TestFindPackages:
         self._assert_packages(packages, ['pkg', 'pkg.nspkg', 'pkg.subpkg'])
 
     def test_pep420_ns_package_no_includes(self):
-        packages = find_namespace_packages(
-            self.dist_dir, exclude=['pkg.subpkg.assets'])
+        with pytest.warns(setuptools.SetuptoolsDeprecationWarning,
+                          match="'docs' is a reserved package name"):
+            packages = find_namespace_packages(
+                self.dist_dir, exclude=['pkg.subpkg.assets'])
         self._assert_packages(
             packages, ['docs', 'pkg', 'pkg.nspkg', 'pkg.subpkg'])
 
     def test_pep420_ns_package_no_includes_or_excludes(self):
-        packages = find_namespace_packages(self.dist_dir)
+        with pytest.warns(setuptools.SetuptoolsDeprecationWarning,
+                          match="'docs' is a reserved package name"):
+            packages = find_namespace_packages(self.dist_dir)
         expected = [
             'docs', 'pkg', 'pkg.nspkg', 'pkg.subpkg', 'pkg.subpkg.assets']
         self._assert_packages(packages, expected)


### PR DESCRIPTION
## Summary of changes

Trigger SetuptoolsDeprecationWarning whenever find_packages() finds
a top-level package whose name is found in reserved package name list,
e.g. "tests".  Installing these packages is probably always wrong,
yet it is still a frequent mistake in packages using setuptools.  This
warning should increase the chance of the mistake being caught before
releasing.

Closes #3243

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request