### PR TITLE
Cache downloaded files used during tests for `setuptools.config`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,20 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python }}
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: setuptools/tests/config/downloads/*.cfg
+          key: ${{
+            hashFiles(
+              'setuptools/tests/config/setupcfg_examples.txt',
+              'setuptools/tests/config/downloads/*.py'
+            )
+          }}
+      - name: Populate download cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        working-directory: setuptools/tests/config
+        run: python -m downloads.preload setupcfg_examples.txt
       - name: Install tox
         run: |
           python -m pip install tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,12 +43,9 @@ jobs:
         id: cache
         with:
           path: setuptools/tests/config/downloads/*.cfg
-          key: ${{
-            hashFiles(
-              'setuptools/tests/config/setupcfg_examples.txt',
-              'setuptools/tests/config/downloads/*.py'
-            )
-          }}
+          key: >-
+            ${{ hashFiles('setuptools/tests/config/setupcfg_examples.txt') }}-
+            ${{ hashFiles('setuptools/tests/config/downloads/*.py') }}
       - name: Populate download cache
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: setuptools/tests/config

--- a/changelog.d/3282.misc.rst
+++ b/changelog.d/3282.misc.rst
@@ -1,0 +1,1 @@
+Added CI cache for ``setup.cfg`` examples used when testing ``setuptools.config``.

--- a/setuptools/tests/config/downloads/__init__.py
+++ b/setuptools/tests/config/downloads/__init__.py
@@ -1,5 +1,7 @@
 import re
+import time
 from pathlib import Path
+from urllib.error import HTTPError
 from urllib.request import urlopen
 
 __all__ = ["DOWNLOAD_DIR", "retrieve_file", "output_file", "urls_from_file"]
@@ -21,14 +23,18 @@ def output_file(url: str, download_dir: Path = DOWNLOAD_DIR):
     return Path(download_dir, re.sub(r"[^\-_\.\w\d]+", "_", file_name))
 
 
-def retrieve_file(url: str, download_dir: Path = DOWNLOAD_DIR):
+def retrieve_file(url: str, download_dir: Path = DOWNLOAD_DIR, wait: float = 5):
     path = output_file(url, download_dir)
     if path.exists():
         print(f"Skipping {url} (already exists: {path})")
     else:
         download_dir.mkdir(exist_ok=True, parents=True)
         print(f"Downloading {url} to {path}")
-        download(url, path)
+        try:
+            download(url, path)
+        except HTTPError:
+            time.sleep(wait)  # wait a few seconds and try again.
+            download(url, path)
     return path
 
 


### PR DESCRIPTION
Recently Github Actions started to fail with `HTTP Error 429: Too Many Requests`.
It would seem that GitHub is adding some throttle mechanism (or making it tighter)

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Adds caching, so when the test runs, it doesn't reach the network
- Back off for a few seconds in case of error when downloading the files (this prevents the script for populating the cache from failing).

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
