### PR TITLE
Updated declarative_config.rst to fix user guide typo

### DIFF
--- a/changelog.d/3285.doc.rst
+++ b/changelog.d/3285.doc.rst
@@ -1,0 +1,1 @@
+Fixed a typo in docs/userguide/declarative_config.rst -- by user :user:`harrysalmon`

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -109,8 +109,7 @@ the subdirectory like this:
     # the rest of the file as described above.
 
     [options]
-    package_dir=
-        =src
+    package_dir=src
     packages=find:
 
     [options.packages.find]


### PR DESCRIPTION
## Summary of changes

<!-- Summary goes here -->
Updated the documentation to fix a typo in docs/userguide/declarative_config.rst in the "Using a ``src/`` layout" section. 
Closes: No ticket, small docs change <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests N/A documentation only change 
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
