### PR TITLE
Optional metadata

### DIFF
--- a/setuptools/_distutils/command/bdist_msi.py
+++ b/setuptools/_distutils/command/bdist_msi.py
@@ -231,11 +231,7 @@ class bdist_msi(Command):
         if os.path.exists(installer_name): os.unlink(installer_name)
 
         metadata = self.distribution.metadata
-        author = metadata.author
-        if not author:
-            author = metadata.maintainer
-        if not author:
-            author = "UNKNOWN"
+        author = metadata.author or metadata.maintainer
         version = metadata.get_version()
         # ProductVersion must be strictly numeric
         # XXX need to deal with prerelease versions

--- a/setuptools/_distutils/command/bdist_rpm.py
+++ b/setuptools/_distutils/command/bdist_rpm.py
@@ -399,7 +399,7 @@ class bdist_rpm(Command):
             '%define unmangled_version ' + self.distribution.get_version(),
             '%define release ' + self.release.replace('-','_'),
             '',
-            'Summary: ' + self.distribution.get_description(),
+            'Summary: ' + (self.distribution.get_description() or "UNKNOWN"),
             ]
 
         # Workaround for #14443 which affects some RPM based systems such as
@@ -438,7 +438,7 @@ class bdist_rpm(Command):
             spec_file.append('Source0: %{name}-%{unmangled_version}.tar.gz')
 
         spec_file.extend([
-            'License: ' + self.distribution.get_license(),
+            'License: ' + (self.distribution.get_license() or "UNKNOWN"),
             'Group: ' + self.group,
             'BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot',
             'Prefix: %{_prefix}', ])
@@ -464,7 +464,7 @@ class bdist_rpm(Command):
                 spec_file.append('%s: %s' % (field, val))
 
 
-        if self.distribution.get_url() != 'UNKNOWN':
+        if self.distribution.get_url():
             spec_file.append('Url: ' + self.distribution.get_url())
 
         if self.distribution_name:
@@ -483,7 +483,7 @@ class bdist_rpm(Command):
         spec_file.extend([
             '',
             '%description',
-            self.distribution.get_long_description()
+            self.distribution.get_long_description() or "",
             ])
 
         # put locale descriptions into spec file

--- a/setuptools/_distutils/command/check.py
+++ b/setuptools/_distutils/command/check.py
@@ -82,54 +82,19 @@ class check(Command):
         """Ensures that all required elements of meta-data are supplied.
 
         Required fields:
-            name, version, URL
-
-        Recommended fields:
-            (author and author_email) or (maintainer and maintainer_email))
+            name, version
 
         Warns if any are missing.
         """
         metadata = self.distribution.metadata
 
         missing = []
-        for attr in ('name', 'version', 'url'):
-            if not (hasattr(metadata, attr) and getattr(metadata, attr)):
+        for attr in 'name', 'version':
+            if not getattr(metadata, attr, None):
                 missing.append(attr)
 
         if missing:
-            self.warn("missing required meta-data: %s"  % ', '.join(missing))
-        if not (
-            self._check_contact("author", metadata) or
-            self._check_contact("maintainer", metadata)
-        ):
-            self.warn("missing meta-data: either (author and author_email) " +
-                      "or (maintainer and maintainer_email) " +
-                      "should be supplied")
-
-    def _check_contact(self, kind, metadata):
-        """
-        Returns True if the contact's name is specified and False otherwise.
-        This function will warn if the contact's email is not specified.
-        """
-        name = getattr(metadata, kind) or ''
-        email = getattr(metadata, kind + '_email') or ''
-
-        msg = ("missing meta-data: if '{}' supplied, " +
-               "'{}' should be supplied too")
-
-        if name and email:
-            return True
-
-        if name:
-            self.warn(msg.format(kind, kind + '_email'))
-            return True
-
-        addresses = [(alias, addr) for alias, addr in getaddresses([email])]
-        if any(alias and addr for alias, addr in addresses):
-            # The contact's name can be encoded in the email: `Name <email>`
-            return True
-
-        return False
+            self.warn("missing required meta-data: %s" % ', '.join(missing))
 
     def check_restructuredtext(self):
         """Checks if the long string fields are reST-compliant."""

--- a/setuptools/_distutils/command/install.py
+++ b/setuptools/_distutils/command/install.py
@@ -397,20 +397,20 @@ class install(Command):
             abiflags = ''
         local_vars = {
             'dist_name': self.distribution.get_name(),
-                            'dist_version': self.distribution.get_version(),
-                            'dist_fullname': self.distribution.get_fullname(),
-                            'py_version': py_version,
-                            'py_version_short': '%d.%d' % sys.version_info[:2],
-                            'py_version_nodot': '%d%d' % sys.version_info[:2],
-                            'sys_prefix': prefix,
-                            'prefix': prefix,
-                            'sys_exec_prefix': exec_prefix,
-                            'exec_prefix': exec_prefix,
-                            'abiflags': abiflags,
-                            'platlibdir': getattr(sys, 'platlibdir', 'lib'),
-                            'implementation_lower': _get_implementation().lower(),
-                            'implementation': _get_implementation(),
-                           }
+            'dist_version': self.distribution.get_version(),
+            'dist_fullname': self.distribution.get_fullname(),
+            'py_version': py_version,
+            'py_version_short': '%d.%d' % sys.version_info[:2],
+            'py_version_nodot': '%d%d' % sys.version_info[:2],
+            'sys_prefix': prefix,
+            'prefix': prefix,
+            'sys_exec_prefix': exec_prefix,
+            'exec_prefix': exec_prefix,
+            'abiflags': abiflags,
+            'platlibdir': getattr(sys, 'platlibdir', 'lib'),
+            'implementation_lower': _get_implementation().lower(),
+            'implementation': _get_implementation(),
+        }
 
         # vars for compatibility on older Pythons
         compat_vars = dict(

--- a/setuptools/_distutils/command/install.py
+++ b/setuptools/_distutils/command/install.py
@@ -397,20 +397,20 @@ class install(Command):
             abiflags = ''
         local_vars = {
             'dist_name': self.distribution.get_name(),
-            'dist_version': self.distribution.get_version(),
-            'dist_fullname': self.distribution.get_fullname(),
-            'py_version': py_version,
-            'py_version_short': '%d.%d' % sys.version_info[:2],
-            'py_version_nodot': '%d%d' % sys.version_info[:2],
-            'sys_prefix': prefix,
-            'prefix': prefix,
-            'sys_exec_prefix': exec_prefix,
-            'exec_prefix': exec_prefix,
-            'abiflags': abiflags,
-            'platlibdir': getattr(sys, 'platlibdir', 'lib'),
-            'implementation_lower': _get_implementation().lower(),
-            'implementation': _get_implementation(),
-        }
+                            'dist_version': self.distribution.get_version(),
+                            'dist_fullname': self.distribution.get_fullname(),
+                            'py_version': py_version,
+                            'py_version_short': '%d.%d' % sys.version_info[:2],
+                            'py_version_nodot': '%d%d' % sys.version_info[:2],
+                            'sys_prefix': prefix,
+                            'prefix': prefix,
+                            'sys_exec_prefix': exec_prefix,
+                            'exec_prefix': exec_prefix,
+                            'abiflags': abiflags,
+                            'platlibdir': getattr(sys, 'platlibdir', 'lib'),
+                            'implementation_lower': _get_implementation().lower(),
+                            'implementation': _get_implementation(),
+                           }
 
         # vars for compatibility on older Pythons
         compat_vars = dict(

--- a/setuptools/_distutils/dist.py
+++ b/setuptools/_distutils/dist.py
@@ -1064,9 +1064,8 @@ class DistributionMetadata:
 
         def _read_field(name):
             value = msg[name]
-            if value == 'UNKNOWN':
-                return None
-            return value
+            if value:
+                return value
 
         def _read_list(name):
             values = msg.get_all(name, None)
@@ -1125,20 +1124,32 @@ class DistributionMetadata:
                 self.classifiers or self.download_url):
             version = '1.1'
 
+        # required fields
         file.write('Metadata-Version: %s\n' % version)
         file.write('Name: %s\n' % self.get_name())
         file.write('Version: %s\n' % self.get_version())
-        file.write('Summary: %s\n' % self.get_description())
-        file.write('Home-page: %s\n' % self.get_url())
-        file.write('Author: %s\n' % self.get_contact())
-        file.write('Author-email: %s\n' % self.get_contact_email())
-        file.write('License: %s\n' % self.get_license())
+
+        # optional fields
+        summary = self.get_description()
+        if summary:
+            file.write('Summary: %s\n' % summary)
+        home_page = self.get_url()
+        if home_page:
+            file.write('Home-page: %s\n' % home_page)
+        author = self.get_contact()
+        if author:
+            file.write('Author: %s\n' % author)
+        author_email = self.get_contact_email()
+        if author_email:
+            file.write('Author-email: %s\n' % author_email)
+        license = self.get_license()
+        if license:
+            file.write('License: %s\n' % license)
         if self.download_url:
             file.write('Download-URL: %s\n' % self.download_url)
-
-        long_desc = rfc822_escape(self.get_long_description())
-        file.write('Description: %s\n' % long_desc)
-
+        long_desc = self.get_long_description()
+        if long_desc:
+            file.write('Description: %s\n' % rfc822_escape(long_desc))
         keywords = ','.join(self.get_keywords())
         if keywords:
             file.write('Keywords: %s\n' % keywords)
@@ -1152,6 +1163,7 @@ class DistributionMetadata:
         self._write_list(file, 'Obsoletes', self.get_obsoletes())
 
     def _write_list(self, file, name, values):
+        values = values or []
         for value in values:
             file.write('%s: %s\n' % (name, value))
 
@@ -1167,35 +1179,35 @@ class DistributionMetadata:
         return "%s-%s" % (self.get_name(), self.get_version())
 
     def get_author(self):
-        return self.author or "UNKNOWN"
+        return self.author
 
     def get_author_email(self):
-        return self.author_email or "UNKNOWN"
+        return self.author_email
 
     def get_maintainer(self):
-        return self.maintainer or "UNKNOWN"
+        return self.maintainer
 
     def get_maintainer_email(self):
-        return self.maintainer_email or "UNKNOWN"
+        return self.maintainer_email
 
     def get_contact(self):
-        return self.maintainer or self.author or "UNKNOWN"
+        return self.maintainer or self.author
 
     def get_contact_email(self):
-        return self.maintainer_email or self.author_email or "UNKNOWN"
+        return self.maintainer_email or self.author_email
 
     def get_url(self):
-        return self.url or "UNKNOWN"
+        return self.url
 
     def get_license(self):
-        return self.license or "UNKNOWN"
+        return self.license
     get_licence = get_license
 
     def get_description(self):
-        return self.description or "UNKNOWN"
+        return self.description
 
     def get_long_description(self):
-        return self.long_description or "UNKNOWN"
+        return self.long_description
 
     def get_keywords(self):
         return self.keywords or []
@@ -1204,7 +1216,7 @@ class DistributionMetadata:
         self.keywords = _ensure_list(value, 'keywords')
 
     def get_platforms(self):
-        return self.platforms or ["UNKNOWN"]
+        return self.platforms
 
     def set_platforms(self, value):
         self.platforms = _ensure_list(value, 'platforms')
@@ -1216,7 +1228,7 @@ class DistributionMetadata:
         self.classifiers = _ensure_list(value, 'classifiers')
 
     def get_download_url(self):
-        return self.download_url or "UNKNOWN"
+        return self.download_url
 
     # PEP 314
     def get_requires(self):

--- a/setuptools/_distutils/tests/test_check.py
+++ b/setuptools/_distutils/tests/test_check.py
@@ -43,7 +43,7 @@ class CheckTestCase(support.LoggingSilencer,
         # by default, check is checking the metadata
         # should have some warnings
         cmd = self._run()
-        self.assertEqual(cmd._warnings, 2)
+        self.assertEqual(cmd._warnings, 1)
 
         # now let's add the required fields
         # and run it again, to make sure we don't get
@@ -81,17 +81,16 @@ class CheckTestCase(support.LoggingSilencer,
             cmd = self._run(metadata)
             self.assertEqual(cmd._warnings, 0)
 
-            # the check should warn if only email is given and it does not
-            # contain the name
+            # the check should not warn if only email is given
             metadata[kind + '_email'] = 'name@email.com'
             cmd = self._run(metadata)
-            self.assertEqual(cmd._warnings, 1)
+            self.assertEqual(cmd._warnings, 0)
 
-            # the check should warn if only the name is given
+            # the check should not warn if only the name is given
             metadata[kind] = "Name"
             del metadata[kind + '_email']
             cmd = self._run(metadata)
-            self.assertEqual(cmd._warnings, 1)
+            self.assertEqual(cmd._warnings, 0)
 
     @unittest.skipUnless(HAS_DOCUTILS, "won't test without docutils")
     def test_check_document(self):

--- a/setuptools/_distutils/tests/test_dist.py
+++ b/setuptools/_distutils/tests/test_dist.py
@@ -519,7 +519,7 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         self.assertEqual(metadata.description, "xxx")
         self.assertEqual(metadata.download_url, 'http://example.com')
         self.assertEqual(metadata.keywords, ['one', 'two'])
-        self.assertEqual(metadata.platforms, ['UNKNOWN'])
+        self.assertEqual(metadata.platforms, None)
         self.assertEqual(metadata.obsoletes, None)
         self.assertEqual(metadata.requires, ['foo'])
 

--- a/setuptools/_distutils/tests/test_install.py
+++ b/setuptools/_distutils/tests/test_install.py
@@ -187,7 +187,9 @@ class InstallTestCase(support.TempdirManager,
 
     def test_record(self):
         install_dir = self.mkdtemp()
-        project_dir, dist = self.create_dist(py_modules=['hello'],
+        project_dir, dist = self.create_dist(name="testdist",
+                                             version="0.1",
+                                             py_modules=['hello'],
                                              scripts=['sayhi'])
         os.chdir(project_dir)
         self.write_file('hello.py', "def main(): print('o hai')")
@@ -209,7 +211,7 @@ class InstallTestCase(support.TempdirManager,
         found = [os.path.basename(line) for line in content.splitlines()]
         expected = ['hello.py', 'hello.%s.pyc' % sys.implementation.cache_tag,
                     'sayhi',
-                    'UNKNOWN-0.0.0-py%s.%s.egg-info' % sys.version_info[:2]]
+                    'testdist-0.1-py%s.%s.egg-info' % sys.version_info[:2]]
         self.assertEqual(found, expected)
 
     def test_record_extensions(self):
@@ -217,8 +219,11 @@ class InstallTestCase(support.TempdirManager,
         if cmd is not None:
             self.skipTest('The %r command is not found' % cmd)
         install_dir = self.mkdtemp()
-        project_dir, dist = self.create_dist(ext_modules=[
-            Extension('xx', ['xxmodule.c'])])
+        project_dir, dist = self.create_dist(
+            name="testdist",
+            version="0.1",
+            ext_modules=[Extension('xx', ['xxmodule.c'])],
+        )
         os.chdir(project_dir)
         support.copy_xxmodule_c(project_dir)
 
@@ -242,7 +247,7 @@ class InstallTestCase(support.TempdirManager,
 
         found = [os.path.basename(line) for line in content.splitlines()]
         expected = [_make_ext_name('xx'),
-                    'UNKNOWN-0.0.0-py%s.%s.egg-info' % sys.version_info[:2]]
+                    'testdist-0.1-py%s.%s.egg-info' % sys.version_info[:2]]
         self.assertEqual(found, expected)
 
     def test_debug_mode(self):

--- a/setuptools/_distutils/tests/test_register.py
+++ b/setuptools/_distutils/tests/test_register.py
@@ -154,8 +154,8 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         req1 = dict(self.conn.reqs[0].headers)
         req2 = dict(self.conn.reqs[1].headers)
 
-        self.assertEqual(req1['Content-length'], '1374')
-        self.assertEqual(req2['Content-length'], '1374')
+        self.assertEqual(req1['Content-length'], '1359')
+        self.assertEqual(req2['Content-length'], '1359')
         self.assertIn(b'xxx', self.conn.reqs[1].data)
 
     def test_password_not_in_file(self):

--- a/setuptools/_distutils/tests/test_sdist.py
+++ b/setuptools/_distutils/tests/test_sdist.py
@@ -251,7 +251,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         cmd.run()
         warnings = [msg for msg in self.get_logs(WARN) if
                     msg.startswith('warning: check:')]
-        self.assertEqual(len(warnings), 2)
+        self.assertEqual(len(warnings), 1)
 
         # trying with a complete set of metadata
         self.clear_logs()

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -171,21 +171,7 @@ def _people(dist: "Distribution", val: List[dict], _root_dir: _Path, kind: str):
 
 
 def _project_urls(dist: "Distribution", val: dict, _root_dir):
-    special = {"downloadurl": "download_url", "homepage": "url"}
-    for key, url in val.items():
-        norm_key = json_compatible_key(key).replace("_", "")
-        _set_config(dist, special.get(norm_key, key), url)
-    # If `homepage` is missing, distutils will warn the following message:
-    #     "warning: check: missing required meta-data: url"
-    # In the context of PEP 621, users might ask themselves: "which url?".
-    # Let's add a warning before distutils check to help users understand the problem:
-    if not dist.metadata.url:
-        msg = (
-            "Missing `Homepage` url.\nIt is advisable to link some kind of reference "
-            "for your project (e.g. source code or documentation).\n"
-        )
-        _logger.warning(msg)
-    _set_config(dist, "project_urls", val.copy())
+    _set_config(dist, "project_urls", val)
 
 
 def _python_requires(dist: "Distribution", val: dict, _root_dir):

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -102,7 +102,7 @@ def _read_list_from_msg(msg: "Message", field: str) -> Optional[List[str]]:
 
 def _read_payload_from_msg(msg: "Message") -> Optional[str]:
     value = msg.get_payload().strip()
-    if value == 'UNKNOWN':
+    if value == 'UNKNOWN' or not value:
         return None
     return value
 
@@ -174,7 +174,10 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     write_field('Metadata-Version', str(version))
     write_field('Name', self.get_name())
     write_field('Version', self.get_version())
-    write_field('Summary', single_line(self.get_description()))
+
+    summary = self.get_description()
+    if summary:
+        write_field('Summary', single_line(summary))
 
     optional_fields = (
         ('Home-page', 'url'),
@@ -190,8 +193,10 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
         if attr_val is not None:
             write_field(field, attr_val)
 
-    license = rfc822_escape(self.get_license())
-    write_field('License', license)
+    license = self.get_license()
+    if license:
+        write_field('License', rfc822_escape(license))
+
     for project_url in self.project_urls.items():
         write_field('Project-URL', '%s, %s' % project_url)
 
@@ -199,7 +204,8 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     if keywords:
         write_field('Keywords', keywords)
 
-    for platform in self.get_platforms():
+    platforms = self.get_platforms() or []
+    for platform in platforms:
         write_field('Platform', platform)
 
     self._write_list(file, 'Classifier', self.get_classifiers())
@@ -222,7 +228,11 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
 
     self._write_list(file, 'License-File', self.license_files or [])
 
-    file.write("\n%s\n\n" % self.get_long_description())
+    long_description = self.get_long_description()
+    if long_description:
+        file.write("\n%s" % long_description)
+        if not long_description.endswith("\n"):
+            file.write("\n")
 
 
 sequence = tuple, list


### PR DESCRIPTION
Companion to https://github.com/pypa/distutils/pull/138

- Stop backfilling `Project-URL: homepage, https://example.org` into `Home-page: https://example.org`
- Similar with Download-URL
- Remove warnings about missing url / author / maintainer etc, these are all optional fields in the spec
- Prevent adding in extra whitespace to the long description
- Prevent "UNKNOWN" strings from creeping in when fields weren't specified by user

Related: https://github.com/pypa/warehouse/issues/11220