### PR TITLE
Clarify that `pyproject.toml` config will not be removed

### DIFF
--- a/docs/userguide/dependency_management.rst
+++ b/docs/userguide/dependency_management.rst
@@ -439,5 +439,5 @@ This can be configured as shown in the example below.
    While the ``[build-system]`` table should always be specified in the
    ``pyproject.toml`` file, support for adding package metadata and build configuration
    options via the ``[project]`` and ``[tool.setuptools]`` tables is still
-   experimental and might change (or be completely removed) in future releases.
+   experimental and might change in future releases.
    See :doc:`/userguide/pyproject_config`.

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -567,8 +567,8 @@ The project layout remains the same and ``setup.cfg`` remains the same.
 
 .. [#experimental]
    Support for specifying package metadata and build configuration options via
-   ``pyproject.toml`` is experimental and might change (or be completely
-   removed) in the future. See :doc:`/userguide/pyproject_config`.
+   ``pyproject.toml`` is experimental and might change
+   in the future. See :doc:`/userguide/pyproject_config`.
 .. [#layout1] https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure
 .. [#layout2] https://blog.ionelmc.ro/2017/09/25/rehashing-the-src-layout/
 

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -10,7 +10,7 @@ Configuring setuptools using ``pyproject.toml`` files
    Support for declaring :doc:`project metadata
    <PyPUG:specifications/declaring-project-metadata>` or configuring
    ``setuptools`` via ``pyproject.toml`` files is still experimental and might
-   change (or be removed) in future releases.
+   change in future releases.
 
 .. important::
    For the time being, ``pip`` still might require a ``setup.py`` file

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -410,5 +410,5 @@ up-to-date references that can help you when it is time to distribute your work.
    While the ``[build-system]`` table should always be specified in the
    ``pyproject.toml`` file, support for adding package metadata and build configuration
    options via the ``[project]`` and ``[tool.setuptools]`` tables is still
-   experimental and might change (or be completely removed) in future releases.
+   experimental and might change in future releases.
    See :doc:`/userguide/pyproject_config`.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The current documentation regarding `pyproject.toml` claims that support for using it to specify package metadata and build configuration options might be "completely removed" in a future setuptools release.

However, nowadays it is clear (https://github.com/pypa/setuptools/issues/1688#issuecomment-1079706929 and #3214) that `pyproject.toml` is not going to be removed, and is in fact intended to be the preferred format at some point in the future.

This makes an incremental change toward that future by clarifying that `pyproject.toml` support will not be removed in a future release of setuptools.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
