### PR TITLE
Set library name patterns for Cygwin packages

### DIFF
--- a/setuptools/_distutils/cygwinccompiler.py
+++ b/setuptools/_distutils/cygwinccompiler.py
@@ -101,9 +101,11 @@ class CygwinCCompiler(UnixCCompiler):
     compiler_type = 'cygwin'
     obj_extension = ".o"
     static_lib_extension = ".a"
-    shared_lib_extension = ".dll"
+    shared_lib_extension = ".dll.a"
+    dylib_lib_extension = ".dll"
     static_lib_format = "lib%s%s"
-    shared_lib_format = "%s%s"
+    shared_lib_format = "lib%s%s"
+    dylib_lib_format = "cyg%s%s"
     exe_extension = ".exe"
 
     def __init__(self, verbose=0, dry_run=0, force=0):

--- a/setuptools/_distutils/tests/test_cygwinccompiler.py
+++ b/setuptools/_distutils/tests/test_cygwinccompiler.py
@@ -53,6 +53,15 @@ class CygwinCCompilerTestCase(support.TempdirManager,
         # and CONFIG_H_OK if __GNUC__ is found
         self.write_file(self.python_h, 'xxx __GNUC__ xxx')
         self.assertEqual(check_config_h()[0], CONFIG_H_OK)
+        
+    @unittest.skipIf(not os.path.exists("/usr/lib/libbash.dll.a"), "Don't know a linkable library")
+    def test_find_library_file(self):
+        from distutils.cygwinccompiler import CygwinCCompiler
+        compiler = CygwinCCompiler()
+        link_name = "bash"
+        linkable_file = compiler.find_library_file(["/usr/lib"], link_name)
+        self.assertIsNotNone(linkable_file)
+        self.assertTrue(os.path.exists(linkable_file))
 
     def test_get_msvcr(self):
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Set CygwinCCompiler library name patterns to be able to find static libraries, DLLs, and import libraries on Cygwin if the proper paths are passed.

<!-- Summary goes here -->

Closes #3302<!-- issue number here -->

### Pull Request Checklist
- [X] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
