### PR TITLE
Remove "residual" dependencies from `setup.py` when dependencies are set in `pyproject.toml`

### DIFF
--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -195,8 +195,10 @@ def _python_requires(dist: "Distribution", val: dict, _root_dir):
 
 
 def _dependencies(dist: "Distribution", val: list, _root_dir):
-    existing = getattr(dist, "install_requires", [])
-    _set_config(dist, "install_requires", existing + val)
+    if getattr(dist, "install_requires", []):
+        msg = "`install_requires` overwritten in `pyproject.toml` (dependencies)"
+        warnings.warn(msg)
+    _set_config(dist, "install_requires", val)
 
 
 def _optional_dependencies(dist: "Distribution", val: dict, _root_dir):

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -257,6 +257,15 @@ class TestPresetField:
         dist_value = _some_attrgetter(f"metadata.{attr}", attr)(dist)
         assert dist_value == value
 
+    def test_warning_overwritten_dependencies(self, tmp_path):
+        src = "[project]\nname='pkg'\nversion='0.1'\ndependencies=['click']\n"
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text(src, encoding="utf-8")
+        dist = makedist(tmp_path, install_requires=["wheel"])
+        with pytest.warns(match="`install_requires` overwritten"):
+            dist = pyprojecttoml.apply_configuration(dist, pyproject)
+        assert "wheel" not in dist.install_requires
+
     def test_optional_dependencies_dont_remove_env_markers(self, tmp_path):
         """
         Internally setuptools converts dependencies with markers to "extras".


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Dependencies set in `pyproject.toml` now completely overwrite `setup.py install_requires`.
- Add warning when the overwriting take place.


For the time being, no action is taken on `optional-dependencies`, because of the internal mechanism setuptools uses for handling environment markers (internally environment markers are transformed in `extras` so we need to merge existing optional dependencies to the ones given in `pyproject.toml`, see #3223).

Closes #3300

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
