### PR TITLE
Warn about deprecation of behaviour that considers modules/packages as "data" when `include_package_data=True`

### DIFF
--- a/changelog.d/3308.deprecation.rst
+++ b/changelog.d/3308.deprecation.rst
@@ -1,0 +1,8 @@
+Relying on ``include_package_data`` to ensure sub-packages are automatically
+added to the build wheel distribution (as "data") is now considered a
+deprecated practice.
+
+This behaviour was controversial and caused inconsistencies (#3260).
+
+Instead, projects are encouraged to properly configure ``packages`` or use
+discovery tools. General information can be found in :doc:`userguide/package_discovery`.

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -131,7 +131,7 @@ the packages in your project directory:
         [options]
         packages = find: # OR `find_namespaces:` if you want to use namespaces
 
-        [options.packages.find] (always `find` even if `find_namespaces:` was used before)
+        [options.packages.find] # (always `find` even if `find_namespaces:` was used before)
         # This section is optional
         # Each entry in this section is optional, and if not specified, the default values are:
         # `where=.`, `include=*` and `exclude=` (empty).

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -3,8 +3,13 @@ import stat
 import shutil
 
 import pytest
+import jaraco.path
+from path import Path
 
+from setuptools import SetuptoolsDeprecationWarning
 from setuptools.dist import Distribution
+
+from .textwrap import DALS
 
 
 def test_directories_in_package_data_glob(tmpdir_cwd):
@@ -79,3 +84,69 @@ def test_executable_data(tmpdir_cwd):
 
     assert os.stat('build/lib/pkg/run-me').st_mode & stat.S_IEXEC, \
         "Script is not executable"
+
+
+def test_excluded_subpackages(tmp_path):
+    files = {
+        "setup.cfg": DALS("""
+            [metadata]
+            name = mypkg
+            version = 42
+
+            [options]
+            include_package_data = True
+            packages = find:
+
+            [options.packages.find]
+            exclude = *.tests*
+            """),
+        "mypkg": {
+            "__init__.py": "",
+            "resource_file.txt": "",
+            "tests": {
+                "__init__.py": "",
+                "test_mypkg.py": "",
+                "test_file.txt": "",
+            }
+        },
+        "MANIFEST.in": DALS("""
+            global-include *.py *.txt
+            global-exclude *.py[cod]
+            prune dist
+            prune build
+            prune *.egg-info
+            """)
+    }
+
+    with Path(tmp_path):
+        jaraco.path.build(files)
+        dist = Distribution({"script_name": "%PEP 517%"})
+        dist.parse_config_files()
+
+        build_py = dist.get_command_obj("build_py")
+        msg = r"Python recognizes 'mypkg\.tests' as an importable package"
+        with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
+            # TODO: To fix #3260 we need some transition period to deprecate the
+            # existing behavior of `include_package_data`. After the transition, we
+            # should remove the warning and fix the behaviour.
+            build_py.finalize_options()
+            build_py.run()
+
+        build_dir = Path(dist.get_command_obj("build_py").build_lib)
+        assert (build_dir / "mypkg/__init__.py").exists()
+        assert (build_dir / "mypkg/resource_file.txt").exists()
+
+        # Setuptools is configured to ignore `mypkg.tests`, therefore the following
+        # files/dirs should not be included in the distribution.
+        for f in [
+            "mypkg/tests/__init__.py",
+            "mypkg/tests/test_mypkg.py",
+            "mypkg/tests/test_file.txt",
+            "mypkg/tests",
+        ]:
+            with pytest.raises(AssertionError):
+                # TODO: Enforce the following assertion once #3260 is fixed
+                # (remove context manager and the following xfail).
+                assert not (build_dir / f).exists()
+
+        pytest.xfail("#3260")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

When discovering files in `build_py`, warn (`SetuptoolsDeprectationWarning`) if files and directories that correspond to a sub-package are included as "data".

This is the first step towards #3260 (we first need to issue a deprecation so packages relying on this behaviour can implement the required changes)

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
