### PR TITLE
Fix _is_gcc() for cross-compiler prefixes and handle cland and clang++

### DIFF
--- a/changelog.d/3326.change.rst
+++ b/changelog.d/3326.change.rst
@@ -1,0 +1,1 @@
+Fixed ``_is_gcc()`` to handle machine triplet prefix and handle ``clang`` and ``clang++`` -- by :user:`zboszor`

--- a/setuptools/_distutils/unixccompiler.py
+++ b/setuptools/_distutils/unixccompiler.py
@@ -260,7 +260,8 @@ class UnixCCompiler(CCompiler):
         return "-L" + dir
 
     def _is_gcc(self, compiler_name):
-        return "gcc" in compiler_name or "g++" in compiler_name
+        cnpat = re.compile('.*(gcc|g\+\+|clang|clang\+\+)$')
+        return not (cnpat.match(compiler_name) is None)
 
     def runtime_library_dir_option(self, dir):
         # XXX Hackish, at the very least.  See Python bug #445902:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This patch fixes building python modules using cython for their build in the Yocto cross-compiler framework.
Compilers are not just called `gcc`, `g++` or `clang`, they may have a `<machine-triplet>-` prefix in the executable name.
Therefore, use a regex match instead of the string equality check.
Also, handle clang and clang++ along the same lines. The same `unixccompiler.py` file in the Python core already handles clang, although it doesn't handle the machine triplet prefix.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
