### PR TITLE
Add `inline_comment_prefixes` to `ConfigParser`

### DIFF
--- a/3330.change.rst
+++ b/3330.change.rst
@@ -1,0 +1,4 @@
+Changed ``ConfigParser`` instantiation to strip inline comments during the parsing
+of ``setup.cfg`` files.
+To prevent problems with URL values, users are expected to use at least one
+space character to separate the option value from the comment marker ``#``.

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -4,6 +4,7 @@ import os
 import warnings
 import functools
 from collections import defaultdict
+from configparser import ConfigParser
 from functools import partial
 from functools import wraps
 from typing import (TYPE_CHECKING, Callable, Any, Dict, Generic, Iterable, List,
@@ -29,6 +30,28 @@ while the second element of the tuple is the option value itself
 """
 AllCommandOptions = Dict["str", SingleCommandOptions]  # cmd name => its options
 Target = TypeVar("Target", bound=Union["Distribution", "DistributionMetadata"])
+
+
+_CONFIGPARSER_OPTS = {
+    "inline_comment_prefixes": (" #", "\t#")
+    # ^-- Avoid "#" because URLs can contain fragments (and still be valid).
+}
+
+
+def _get_parser() -> ConfigParser:
+    """Instantiate a ConfigParser object for reading the configuration.
+    Private API for internal setuptools use.
+    """
+    parser = ConfigParser(**_CONFIGPARSER_OPTS)
+    parser.optionxform = str
+    return parser
+
+
+def _reset_parser(parser: ConfigParser):
+    """Make the ConfigParser forget everything (so we retain the original filenames
+    that options come from). Private API for internal setuptools use.
+    """
+    parser.__init__(**_CONFIGPARSER_OPTS)
 
 
 def read_configuration(

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -707,8 +707,7 @@ class Distribution(_Distribution):
         if DEBUG:
             self.announce("Distribution.parse_config_files():")
 
-        parser = ConfigParser()
-        parser.optionxform = str
+        parser = setupcfg._get_parser()
         for filename in filenames:
             with io.open(filename, encoding='utf-8') as reader:
                 if DEBUG:
@@ -729,7 +728,7 @@ class Distribution(_Distribution):
 
             # Make the ConfigParser forget everything (so we retain
             # the original filenames that options come from)
-            parser.__init__()
+            setupcfg._reset_parser(parser)
 
         if 'global' not in self.command_options:
             return

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -676,8 +676,6 @@ class Distribution(_Distribution):
         this method provides the same functionality in subtly-improved
         ways.
         """
-        from configparser import ConfigParser
-
         # Ignore install directory options if we have a venv
         ignore_options = (
             []

--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -116,15 +116,15 @@ class TestMetadata:
         fake_env(
             tmpdir,
             '[metadata]\n'
-            'version = 10.1.1\n'
+            'version = 10.1.1  # comment\n'
             'description = Some description\n'
             'long_description_content_type = text/something\n'
             'long_description = file: README\n'
             'name = fake_name\n'
-            'keywords = one, two\n'
+            'keywords = one, two  # comment\n'
             'provides = package, package.sub\n'
             'license = otherlic\n'
-            'download_url = http://test.test.com/test/\n'
+            'download_url = http://test.test.com/test/#url-fragment\n'
             'maintainer_email = test@test.com\n',
         )
 
@@ -146,7 +146,7 @@ class TestMetadata:
             assert metadata.license == 'BSD 3-Clause License'
             assert metadata.name == 'fake_name'
             assert metadata.keywords == ['one', 'two']
-            assert metadata.download_url == 'http://test.test.com/test/'
+            assert metadata.download_url == 'http://test.test.com/test/#url-fragment'
             assert metadata.maintainer_email == 'test@test.com'
 
     def test_license_cfg(self, tmpdir):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

According to a recent an error report in #3322, prior to version 62.3 it would seem that `setuptools` could accept inline comments in `setup.cfg [metadata] version`, for example:

```ini
[metadata]
name = yt
version = 4.1.dev0  # keep in sync with yt/_version.__version__
```
This was actually surprising for me because `setuptools` simply instantiate [`ConfigParser` with no argument](https://github.com/pypa/setuptools/blob/v62.2.0/setuptools/dist.py#L705), which means inline comments are not stripped during the parsing. Moreover as shown in the diff between [62.2 and 62.3](https://github.com/pypa/setuptools/issues/3322#issuecomment-1129863630), no code path used for handling `version` seems to have been changed (with the exception of the update of the `pyparsing` dependency).

I really don't understand how the changes in v62.3 could have prevented inline comments from being stripped (v62.3 is mostly about adding warnings and seems completely unrelated), but the changes proposed in this PR seem to be the most appropriated way of handling inline comments (*iif we want to...*).

## Summary of changes

- Add `inline_comment_prefixes=(" #", "\t#")` to `ConfigParser` instantiation.
  - Here I avoided using `"#"` (single character) because URL values can have fragments (which start with `#`).

Closes #3322

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
