### PR TITLE
Replaced single backticks with double ones

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,7 @@ Deprecations
 
 Changes
 ^^^^^^^
-* #1806: Allowed recursive globs (`**`) in `package_data`. -- by :user:`nullableVoidPtr`
+* #1806: Allowed recursive globs (``**``) in ``package_data``. -- by :user:`nullableVoidPtr`
 * #3206: Fixed behaviour when both ``install_requires`` (in ``setup.py``) and
   ``dependencies`` (in ``pyproject.toml``) are specified.
   The configuration in ``pyproject.toml`` will take precedence over ``setup.py``

--- a/changelog.d/3331.doc.rst
+++ b/changelog.d/3331.doc.rst
@@ -1,0 +1,1 @@
+Replaced single backticks with double ones in ``CHANGES.rst`` -- by :user:`codeandfire`


### PR DESCRIPTION
## Summary of changes

These two items `**` and `package_data` in the `CHANGES.rst` file were being identified as links rather than code due to the single backticks.
In turn leading to Sphinx emitting warnings about this and the docs failing to build.

Closes: No issue that I am aware of? However these warnings were preventing the docs from building on my machine.

### Pull Request Checklist
- [x] News fragment added in [`changelog.d/`].
