### PR TITLE
Changes to the User Guide's Data Files page

### DIFF
--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -9,13 +9,35 @@ by including the data files **inside the package directory**.
 
 Setuptools offers three ways to specify this most common type of data files to
 be included in your package's [#datafiles]_.
-First, you can simply use the ``include_package_data`` keyword, e.g.::
+First, you can simply use the ``include_package_data`` keyword, e.g.:
 
-    from setuptools import setup, find_packages
+.. tab:: setup.cfg
+
+   .. code-block:: ini
+
+        [options]
+        # ...
+        include_package_data = True
+
+.. tab:: setup.py
+
+   .. code-block:: python
+
+    from setuptools import setup
     setup(
-        ...
+        # ...,
         include_package_data=True
     )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        [tool.setuptools]
+        # ...
+        # By default, include-package-data is true in pyproject.toml, so you do
+        # NOT have to specify this line.
+        include-package-data = true
 
 This tells setuptools to install any data files it finds in your packages.
 The data files must be specified via the |MANIFEST.in|_ file.
@@ -26,67 +48,187 @@ Control Systems` for information on how to write such plugins.)
 
 If you want finer-grained control over what files are included (for example,
 if you have documentation files in your package directories and want to exclude
-them from installation), then you can also use the ``package_data`` keyword,
-e.g.::
+them from installation), then you can also use the ``package_data`` keyword.
+For example, if the package tree looks like this::
 
-    from setuptools import setup, find_packages
-    setup(
-        ...
-        package_data={
-            # If any package contains *.txt or *.rst files, include them:
-            "": ["*.txt", "*.rst"],
-            # And include any *.msg files found in the "hello" package, too:
-            "hello": ["*.msg"],
-        }
-    )
+    project_root_directory
+    ├── setup.py        # and/or setup.cfg, pyproject.toml
+    └── src
+        └── mypkg
+            ├── __init__.py
+            ├── data1.rst
+            ├── data2.rst
+            ├── data1.txt
+            └── data2.txt
+
+You can use the following configuration to capture the ``.txt`` and ``.rst`` files as
+data files:
+
+.. tab:: setup.cfg
+
+   .. code-block:: ini
+
+        # ...
+        [options.package_data]
+        mypkg =
+            *.txt
+            *.rst
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        from setuptools import setup
+        setup(
+            # ...,
+            package_data={"mypkg": ["*.txt", "*.rst"]}
+        )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        # ...
+        [tool.setuptools.package_data]
+        mypkg = ["*.txt", "*.rst"]
 
 The ``package_data`` argument is a dictionary that maps from package names to
 lists of glob patterns.  The globs may include subdirectory names, if the data
 files are contained in a subdirectory of the package.  For example, if the
 package tree looks like this::
 
-    setup.py
-    src/
-        mypkg/
-            __init__.py
-            mypkg.txt
-            data/
-                somefile.dat
-                otherdata.dat
+    project_root_directory
+    ├── setup.py        # and/or setup.cfg, pyproject.toml
+    └── src
+        └── mypkg
+            ├── data
+            │   ├── data1.rst
+            │   └── data2.rst
+            ├── __init__.py
+            ├── data1.txt
+            └── data2.txt
 
-The setuptools setup file might look like this::
+The configuration might look like this:
 
-    from setuptools import setup, find_packages
-    setup(
-        ...
-        packages=find_packages("src"),  # include all packages under src
-        package_dir={"": "src"},   # tell distutils packages are under src
+.. tab:: setup.cfg
 
-        package_data={
-            # If any package contains *.txt files, include them:
-            "": ["*.txt"],
-            # And include any *.dat files found in the "data" subdirectory
-            # of the "mypkg" package, also:
-            "mypkg": ["data/*.dat"],
-        }
-    )
+   .. code-block:: ini
 
-Notice that if you list patterns in ``package_data`` under the empty string,
-these patterns are used to find files in every package, even ones that also
-have their own patterns listed.  Thus, in the above example, the ``mypkg.txt``
-file gets included even though it's not listed in the patterns for ``mypkg``.
+        [options]
+        # ...
+        packages =
+            mypkg
+        package_dir =
+            mypkg = src
+
+        [options.package_data]
+        mypkg =
+            *.txt
+            data/*.rst
+
+.. tab:: setup.py
+
+   .. code-block:: python
+
+        from setuptools import setup
+        setup(
+            # ...,
+            packages=["mypkg"],
+            package_dir={"mypkg": "src"},
+            package_data={"mypkg": ["*.txt", "data/*.rst"]}
+        )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        [tool.setuptools]
+        # ...
+        packages = ["mypkg"]
+        package-dir = { mypkg = "src" }
+
+        [tool.setuptools.package-data]
+        mypkg = ["*.txt", "data/*.rst"]
+
+In other words, if datafiles are contained in a subdirectory of a package that isn't a
+package itself (no ``__init__.py``), then the subdirectory names (or ``*`` to include
+all subdirectories) are required in the ``package_data`` argument (as shown above with
+``"data/*.rst"``).
+
+If you have multiple top-level packages and a common pattern of data files for both packages, for example::
+
+    project_root_directory
+    ├── setup.py        # and/or setup.cfg, pyproject.toml
+    └── src
+        ├── mypkg1
+        │   ├── data1.rst
+        │   ├── data1.txt
+        │   └── __init__.py
+        └── mypkg2
+            ├── data2.txt
+            └── __init__.py
+
+then you can supply a configuration like this to capture both ``mypkg1/data1.txt`` and
+``mypkg2/data2.txt``, as well as ``mypkg1/data1.rst``.
+
+.. tab:: setup.cfg
+
+   .. code-block:: ini
+
+        [options]
+        packages = 
+            mypkg1
+            mypkg2
+        package_dir =
+            mypkg1 = src
+            mypkg2 = src
+
+        [options.package_data]
+        * =
+          *.txt
+        mypkg1 =
+          data1.rst
+
+.. tab:: setup.py
+
+   .. code-block:: python
+
+        from setuptools import setup
+        setup(
+            # ...,
+            packages=["mypkg1", "mypkg2"],
+            package_dir={"mypkg1": "src", "mypkg2": "src"},
+            package_data={"": ["*.txt"], "mypkg1": ["data1.rst"]},
+        )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        [tool.setuptools]
+        # ...
+        packages = ["mypkg1", "mypkg2"]
+        package-dir = { mypkg1 = "src", mypkg2 = "src" }
+        
+        [tool.setuptools.package-data]
+        "*" = ["*.txt"]
+        mypkg1 = ["data1.rst"]
+
+Notice that if you list patterns in ``package_data`` under the empty string ``""`` in
+``setup.py``, and the asterisk ``*`` in ``setup.cfg`` and ``pyproject.toml``, these
+patterns are used to find files in every package. For example, both files
+``mypkg1/data1.txt`` and ``mypkg2/data2.txt`` are captured as data files. Also note
+how other patterns specified for individual packages continue to work, i.e.
+``mypkg1/data1.rst`` is captured as well.
 
 Also notice that if you use paths, you *must* use a forward slash (``/``) as
 the path separator, even if you are on Windows.  Setuptools automatically
 converts slashes to appropriate platform-specific separators at build time.
 
-If datafiles are contained in a subdirectory of a package that isn't a package
-itself (no ``__init__.py``), then the subdirectory names (or ``*``) are required
-in the ``package_data`` argument (as shown above with ``"data/*.dat"``).
-
-When building an ``sdist``, the datafiles are also drawn from the
-``package_name.egg-info/SOURCES.txt`` file, so make sure that this is removed if
-the ``setup.py`` ``package_data`` list is updated before calling ``setup.py``.
+.. note::
+    When building an ``sdist``, the datafiles are also drawn from the
+    ``package_name.egg-info/SOURCES.txt`` file, so make sure that this is removed if
+    the ``setup.py`` ``package_data`` list is updated before calling ``setup.py``.
 
 .. note::
    If using the ``include_package_data`` argument, files specified by
@@ -101,26 +243,56 @@ aren't sufficient to precisely define what files you want included.  For
 example, you may want to include package README files in your revision control
 system and source distributions, but exclude them from being installed.  So,
 setuptools offers an ``exclude_package_data`` option as well, that allows you
-to do things like this::
+to do things like this:
 
-    from setuptools import setup, find_packages
-    setup(
-        ...
-        packages=find_packages("src"),  # include all packages under src
-        package_dir={"": "src"},   # tell distutils packages are under src
+.. tab:: setup.cfg
 
-        include_package_data=True,    # include everything in source control
+   .. code-block:: ini
 
-        # ...but exclude README.txt from all packages
-        exclude_package_data={"": ["README.txt"]},
-    )
+        [options]
+        # ...
+        packages =
+            mypkg
+        package_dir =
+            mypkg = src
+        include_package_data = True
+
+        [options.exclude_package_data]
+        mypkg =
+            README.txt
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        from setuptools import setup
+        setup(
+            # ...,
+            packages=["mypkg"],
+            package_dir={"mypkg": "src"},
+            include_package_data=True,
+            exclude_package_data={"mypkg": ["README.txt"]},
+        )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        [tool.setuptools]
+        # ...
+        packages = ["mypkg"]
+        package-dir = { mypkg = "src" }
+
+        [tool.setuptools.exclude-package-data]
+        mypkg = ["README.txt"]
 
 The ``exclude_package_data`` option is a dictionary mapping package names to
 lists of wildcard patterns, just like the ``package_data`` option.  And, just
-as with that option, a key of ``""`` will apply the given pattern(s) to all
-packages.  However, any files that match these patterns will be *excluded*
-from installation, even if they were listed in ``package_data`` or were
-included as a result of using ``include_package_data``.
+as with that option, you can use the empty string key ``""`` in ``setup.py`` and the
+asterisk ``*`` in ``setup.cfg`` and ``pyproject.toml`` to match all top-level packages.
+However, any files that match these patterns will be *excluded* from installation,
+even if they were listed in ``package_data`` or were included as a result of using
+``include_package_data``.
 
 In summary, the three options allow you to:
 
@@ -138,13 +310,14 @@ In summary, the three options allow you to:
     included when a package is installed, even if they would otherwise have
     been included due to the use of the preceding options.
 
-NOTE: Due to the way the distutils build process works, a data file that you
-include in your project and then stop including may be "orphaned" in your
-project's build directories, requiring you to run ``setup.py clean --all`` to
-fully remove them.  This may also be important for your users and contributors
-if they track intermediate revisions of your project using Subversion; be sure
-to let them know when you make changes that remove files from inclusion so they
-can run ``setup.py clean --all``.
+.. note::
+    Due to the way the distutils build process works, a data file that you
+    include in your project and then stop including may be "orphaned" in your
+    project's build directories, requiring you to run ``setup.py clean --all`` to
+    fully remove them.  This may also be important for your users and contributors
+    if they track intermediate revisions of your project using Subversion; be sure
+    to let them know when you make changes that remove files from inclusion so they
+    can run ``setup.py clean --all``.
 
 
 .. _Accessing Data Files at Runtime:
@@ -188,6 +361,11 @@ run time be included **inside the package**.
 
 
 ----
+
+.. [#experimental]
+   Support for specifying package metadata and build configuration options via
+   ``pyproject.toml`` is experimental and might change
+   in the future. See :doc:`/userguide/pyproject_config`.
 
 .. [#datafiles] ``setuptools`` consider a *package data file* any non-Python
    file **inside the package directory** (i.e., that co-exists in the same


### PR DESCRIPTION
## Summary of Changes
 
 - All code snippets were given for `setup.py`. Have added corresponding snippets for `setup.cfg` and `pyproject.toml`.
  - To avoid incentivizing multiple top-level packages, have modified all the package trees and code snippets to include only a single package `mypkg`. Have added a separate example to illustrate the functionality of using the empty string `""` / the asterisk `*` for capturing data files from multiple packages. Have also modified the `setup.py` code snippets and removed the `find_packages("src")` call since there is only a single package in each case (except one); have opted to explicitly name the package instead.
  - Have added a package tree example for the first `package_data` snippet. Have also added a package tree / code snippet example to show how `package_data` patterns should include subdirectories, separating it from the example showing the empty string `""` / asterisk `*` functionality.
  - Tried to have consistent naming for all directories and data files used in the package trees and code snippets. All directories have been named `mypkg` and data files have been named `data1.txt`, `data2.rst` etc. 
  - Have reformatted package tree examples. Reformatting has been done by replacing the only-indentation based directory structure diagram with a line-based tree layout; I think this looks neater.
  - Have added `.. note::` blocks for paragraphs that would be more appropriately phrased as a Note. Other minor changes to text content have been made.

### Pull Request Checklist
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
