### PR TITLE
Make test_setup_install_includes_dependencies work with custom PYTHONPATH set

### DIFF
--- a/changelog.d/3336.misc.rst
+++ b/changelog.d/3336.misc.rst
@@ -1,0 +1,1 @@
+Modified ``test_setup_install_includes_dependencies`` to work with custom ``PYTHONPATH`` –- by :user:`hroncok`

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -475,10 +475,6 @@ class TestInstallRequires:
             '--install-platlib', str(install_root),
         ]
         env = {**os.environ, "__EASYINSTALL_INDEX": mock_index.url}
-        if "PYTHONPATH" in env:
-            env["PYTHONPATH"] = str(install_root) + os.pathsep + env["PYTHONPATH"]
-        else:
-            env["PYTHONPATH"] = str(install_root)
         cp = subprocess.run(
             cmd,
             cwd=str(project_root),

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -474,7 +474,11 @@ class TestInstallRequires:
             '--install-purelib', str(install_root),
             '--install-platlib', str(install_root),
         ]
-        env = {"PYTHONPATH": str(install_root), "__EASYINSTALL_INDEX": mock_index.url}
+        env = {**os.environ, "__EASYINSTALL_INDEX": mock_index.url}
+        if "PYTHONPATH" in env:
+            env["PYTHONPATH"] = str(install_root) + os.pathsep + env["PYTHONPATH"]
+        else:
+            env["PYTHONPATH"] = str(install_root)
         cp = subprocess.run(
             cmd,
             cwd=str(project_root),


### PR DESCRIPTION
This has the same reasoning as in https://github.com/pypa/setuptools/pull/3133 -- the test imported the previously installed setuptools version in our environment and since that version did not yet use `__EASYINSTALL_INDEX`, it reached https://pypi.org/simple/ instead. That way, we recognized it as a problem. If the installed version had already used `__EASYINSTALL_INDEX`, we would probably never realize that it is the installed version that is being tested here.

The three individual commits follow my train of thoughts, so I preserved them here separated, for easier review. 

 1. The test was very hard to grasp for me, so I removed the `pytest.raises` detour -- happy to revert if there was a reason for it
 2. I changed the test to modify the `$PYTHONPATH` value instead of overriding it, making it actually work in our environment
 3. When doing it, I realized adding `install_root` to `$PYTHONPATH` is not necessary for this test, so I removed it -- happy to squash that to the previous one if you prefer that

Thanks.

