### PR TITLE
Fix documentation local build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,7 @@ github_repo_slug = f'{github_repo_org}/{github_repo_name}'
 github_repo_url = f'{github_url}/{github_repo_slug}'
 github_sponsors_url = f'{github_url}/sponsors'
 extlinks = {
-    'user': (f'{github_sponsors_url}/%s', '@'),  # noqa: WPS323
+    'user': (f'{github_sponsors_url}/%s', '@%s'),  # noqa: WPS323
     'pypi': ('https://pypi.org/project/%s', '%s'),  # noqa: WPS323
     'wiki': ('https://wikipedia.org/wiki/%s', '%s'),  # noqa: WPS323
 }

--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -243,8 +243,8 @@ Sometimes, the ``include_package_data`` or ``package_data`` options alone
 aren't sufficient to precisely define what files you want included. For example,
 consider a scenario where you have ``include_package_data=True``, and you are using
 a revision control system with an appropriate plugin.
-Sometimes developers add directory-specific marker files (such as `.gitignore`,
-`.gitkeep`, `.gitattributes`, or `.hgignore`), these files are probably being
+Sometimes developers add directory-specific marker files (such as ``.gitignore``,
+``.gitkeep``, ``.gitattributes``, or ``.hgignore``), these files are probably being
 tracked by the revision control system, and therefore by default they will be
 included when the package is installed.
 


### PR DESCRIPTION
## Summary of changes

The docs were not building locally due to the following warnings:
 1. The `.gitattributes`, `.gitignore` etc. example added recently to the Data Files page was using single backticks instead of double backticks, causing these filenames to be interpreted as links rather than code.
 2. The `extlinks` extension seems have to recently started emitting the following warning:
     ```
     WARNING: extlinks: Sphinx-6.0 will require a caption string to contain exactly one '%s' and all other '%' need to be escaped as '%%'.
     ```
     Seems the issue is with the `user` entry in the `extlinks` defined in `docs/conf.py`, the caption string is `'@'`. I have fixed this by changing the caption string to `'@%s'`.

### Pull Request Checklist
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
