### PR TITLE
Clarify glob pattern matching for dotfiles in User's Guide (#3350)

### DIFF
--- a/changelog.d/3350.doc.rst
+++ b/changelog.d/3350.doc.rst
@@ -1,0 +1,1 @@
+Added note explaining ``package_data`` glob pattern matching for dotfiles -- by :user:`comabrewer`

--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -157,6 +157,11 @@ require to be added by a revision control system plugin.
         the path separator, even if you are on Windows.  Setuptools automatically
         converts slashes to appropriate platform-specific separators at build time.
 
+.. note::
+        Glob patterns do not automatically match dotfiles (directory or file names
+        starting with a dot (``.``)). To include such files, you must explicitly start
+        the pattern with a dot, e.g. ``.*`` to match ``.gitignore``.
+
 If you have multiple top-level packages and a common pattern of data files for all these
 packages, for example::
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Clarify glob pattern matching for dotfiles in User's Guide (Data Files section).
Please comment or directly edit any issues with suggested change, such as phrasing or location of the documentation change.

Closes #3350

### Pull Request Checklist
- [X] Doc changes only - `tox -e docs` has been tested locally
- [X] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
