### PR TITLE
Change warning about namespace packages and data files

### DIFF
--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -263,9 +263,10 @@ class _IncludePackageDataAbuse:
     ############################
     Python recognizes {importable!r} as an importable package,
     but it is not listed in the `packages` configuration of setuptools.
-    Currently {importable!r} is only added to the distribution because it may
-    contain data files, but this behavior is likely to change in future
-    versions of setuptools (and therefore is considered deprecated).
+
+    {importable!r} has been automatically added to the distribution only
+    because it may contain data files, but this behavior is likely to change
+    in future versions of setuptools (and therefore is considered deprecated).
 
     Please make sure that {importable!r} is included as a package by using
     the `packages` configuration field or the proper discovery methods


### PR DESCRIPTION
In https://github.com/pypa/setuptools/issues/3340#issuecomment-1150716323, it was suggested to modify a warning message to make it more clear for users.

## Summary of changes

- Modifies the warning in `build_py _IncludePackageDataAbuse` according to the users suggestion.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
