### PR TITLE
Changes to the User Guide's Entry Points page

### DIFF
--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -49,11 +49,10 @@ After installing the package, the function may be invoked through the
     Hello world
 
 Adding a console script entry point allows the package to define a
-user-friendly name for installers of the package to execute. Installers
-like pip will create wrapper scripts to execute a function. In the
-above example, to create a command ``hello-world`` that invokes
-``timmins.hello_world``, add a console script entry point to
-your configuration:
+user-friendly name for installers of the package to execute.
+In the above example, to create a command ``hello-world`` that invokes
+``timmins.hello_world``, add a console script entry point to your
+configuration:
 
 .. tab:: setup.cfg
 
@@ -169,6 +168,19 @@ will open a small application window with the title 'Hello world'.
     wrapped in a GUI executable, so they can be started without a console, but
     cannot use standard streams unless application code redirects them. Other
     platforms do not have the same distinction.
+
+.. note::
+
+    Console and GUI scripts work because behind the scenes, installers like Pip
+    create wrapper scripts around the function(s) being invoked. For example,
+    the ``hello-world`` entry point in the above two examples would create a
+    command ``hello-world`` launching a script like this: [#packaging_guide]_
+
+    .. code-block:: python
+
+        import sys
+        from timmins import hello_world
+        sys.exit(hello_world())
 
 .. _dynamic discovery of services and plugins:
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -21,7 +21,6 @@ defined thus::
     └── src
         └── timmins
             ├── __init__.py
-            ├── __main__.py
             └── ...
 
 with ``__init__.py`` as:
@@ -31,7 +30,10 @@ with ``__init__.py`` as:
     def hello_world():
         print("Hello world")
 
-and ``__main__.py`` providing a hook:
+Now, suppose that we would like to provide some way of executing the
+function ``hello_world()`` from the command-line. One way to do this
+is to create a file ``src/timmins/__main__.py`` providing a hook as
+follows:
 
 .. code-block:: python
 
@@ -40,15 +42,17 @@ and ``__main__.py`` providing a hook:
     if __name__ == '__main__':
         hello_world()
 
-After installing the package, the function may be invoked through the
-`runpy <https://docs.python.org/3/library/runpy.html>`_ module:
+Then, after installing the package ``timmins``, we may invoke the ``hello_world()``
+function as follows, through the `runpy <https://docs.python.org/3/library/runpy.html>`_
+module:
 
 .. code-block:: bash
 
     $ python -m timmins
     Hello world
 
-Adding a console script entry point allows the package to define a
+Instead of this approach using ``__main__.py``, a better way is to add
+a console script entry point, which allows the package to define a
 user-friendly name for installers of the package to execute.
 In the above example, to create a command ``hello-world`` that invokes
 ``timmins.hello_world``, add a console script entry point to your

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -266,7 +266,7 @@ to customize it, we can do the following. Let us introduce a new *group* of entr
 named ``timmins.display``, and expect plugin packages implementing this entry point
 to supply a ``display()``-like function. Next, to be able to automatically discover plugin
 packages that implement this entry point, we can use the
-`importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_ module,
+:mod:`importlib.metadata` module,
 as follows:
 
 .. code-block:: python
@@ -466,7 +466,7 @@ importlib.metadata
 ------------------
 
 The recommended approach for loading and importing entry points is the
-`importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_ module,
+:mod:`importlib.metadata` module,
 which is a part of the standard library since Python 3.8. For older versions of
 Python, its backport :pypi:`importlib_metadata` should be used. While using the
 backport, the only change that has to be made is to replace ``importlib.metadata``

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -104,9 +104,61 @@ where ``name`` is the name for the script you want to create, the left hand
 side of ``:`` is the module that contains your function and the right hand
 side is the object you want to invoke (e.g. a function).
 
+GUI Scripts
+===========
+
 In addition to ``console_scripts``, Setuptools supports ``gui_scripts``, which
 will launch a GUI application without running in a terminal window.
 
+For example, if we have a project with the same directory structure as before,
+with an ``__init__.py`` file containing the following:
+
+.. code-block:: python
+
+    import PySimpleGUI as sg
+
+    def hello_world():
+        sg.Window(title="Hello world", layout=[[]], margins=(100, 50)).read()
+
+Then, we can add a GUI script entry point:
+
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [options.entry_points]
+        gui_scripts =
+            hello-world = timmins:hello_world
+
+.. tab:: setup.py
+
+    .. code-block:: python
+	
+        from setuptools import setup
+
+        setup(
+            # ...,
+            entry_points={
+                'gui_scripts': [
+                    'hello-world=timmins:hello_world',
+                ]
+            }
+        )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        [project.gui-scripts]
+        hello-world = "timmins:hello_world"
+
+Now, running:
+
+.. code-block:: bash
+
+   $ hello-world
+
+will open a small application window with the title 'Hello world'.
 
 .. _dynamic discovery of services and plugins:
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -204,7 +204,7 @@ body of the function.
 Advertising Behavior
 ====================
 
-Console scripts are one use of the more general concept of entry points. Entry
+Console/GUI scripts are one use of the more general concept of entry points. Entry
 points more generally allow a packager to advertise behavior for discovery by
 other libraries and applications. This feature enables "plug-in"-like
 functionality, where one library solicits entry points and any number of other
@@ -215,7 +215,7 @@ A good example of this plug-in behavior can be seen in
 where pytest is a test framework that allows other libraries to extend
 or modify its functionality through the ``pytest11`` entry point.
 
-The console scripts work similarly, where libraries advertise their commands
+The console/GUI scripts work similarly, where libraries advertise their commands
 and tools like ``pip`` create wrapper scripts that invoke those commands.
 
 Entry Points for Plugins

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -477,10 +477,15 @@ with ``importlib_metadata``, i.e.
    from importlib_metadata import entry_points
    ...
 
-The project soliciting the entry points needs not to have any dependency
-or prior knowledge about the libraries implementing the entry points, and
+Summary
+-------
+
+In summary, entry points allow a package to open its functionalities for
+customization via plugins.
+The package soliciting the entry points need not have any dependency
+or prior knowledge about the plugins implementing the entry points, and
 downstream users are able to compose functionality by pulling together
-libraries implementing the entry points.
+plugins implementing the entry points.
 
 
 Dependency Management

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -160,6 +160,9 @@ Then, we can add a GUI script entry point:
         [project.gui-scripts]
         hello-world = "timmins:hello_world"
 
+.. note::
+   To be able to import `PySimpleGUI`, you need to add `pysimplegui` to your package dependencies.
+   See :doc:`/userguide/dependency_management` for more information.
 Now, running:
 
 .. code-block:: bash

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -477,36 +477,6 @@ with ``importlib_metadata``, i.e.
    from importlib_metadata import entry_points
    ...
 
-For example, to find the console script entry points from the example above:
-
-.. code-block:: pycon
-
-    >>> from importlib import metadata
-    >>> eps = metadata.entry_points()['console_scripts']
-
-``eps`` is now a list of ``EntryPoint`` objects, one of which corresponds
-to the ``hello-world = timmins:hello_world`` defined above.
-It also supplies a ``.load()``
-method to import and load that entry point (module or object).
-
-.. code-block:: ini
-
-    [options.entry_points]
-    my.plugins =
-        hello-world = timmins:hello_world
-
-Then, a different project wishing to load 'my.plugins' plugins could run
-the following routine to load (and invoke) such plugins:
-
-.. code-block:: pycon
-
-    >>> from importlib import metadata
-    >>> eps = metadata.entry_points()['my.plugins']
-    >>> for ep in eps:
-    ...     plugin = ep.load()
-    ...     plugin()
-    ...
-
 The project soliciting the entry points needs not to have any dependency
 or prior knowledge about the libraries implementing the entry points, and
 downstream users are able to compose functionality by pulling together

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -389,9 +389,22 @@ get the following:
 
 Therefore, our plugin works.
 
-For a project wishing to solicit entry points, Setuptools recommends the
-module (part of stdlib since Python 3.8) or its backport,
-:pypi:`importlib_metadata`.
+Let us discuss a few points in this example in more detail.
+
+importlib.metadata
+------------------
+
+The recommended approach for loading and importing entry points is the
+`importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_ module,
+which is a part of the standard library since Python 3.8. For older versions of
+Python, its backport :pypi:`importlib_metadata` should be used. While using the
+backport, the only change that has to be made is to replace ``importlib.metadata``
+with ``importlib_metadata``, i.e.
+
+.. code-block:: python
+
+   from importlib_metadata import entry_points
+   ...
 
 For example, to find the console script entry points from the example above:
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -69,15 +69,12 @@ your configuration:
         from setuptools import setup
 
         setup(
-            name='timmins',
-            version='0.0.1',
-            packages=['timmins'],
-			# ...
+            # ...,
             entry_points={
-				'console_scripts': [
-					'hello-world=timmins:hello_world',
-				]
-			}
+                'console_scripts': [
+                    'hello-world=timmins:hello_world',
+                ]
+            }
         )
 
 .. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -389,6 +389,79 @@ get the following:
 
 Therefore, our plugin works.
 
+Our plugin could have also defined multiple entry points under the group ``timmins.display``.
+For example, in ``src/timmins_plugin_fancy/__init__.py`` we could have two ``display()``-like
+functions, as follows:
+
+.. code-block:: python
+
+   def excl_display(text):
+       print('!!!', text, '!!!')
+
+   def lined_display(text):
+       print(''.join(['-' for _ in text]))
+       print(text)
+       print(''.join(['-' for _ in text]))
+
+The configuration of ``timmins-plugin-fancy`` would then change to:
+
+.. tab:: setup.cfg
+
+   .. code-block:: ini
+
+        [options.entry_points]
+        timmins.display =
+                excl = timmins_plugin_fancy:excl_display
+                lined = timmins_plugin_fancy:lined_display
+
+.. tab:: setup.py
+
+   .. code-block:: python
+
+        from setuptools import setup
+
+        setup(
+            # ...,
+            entry_points = {
+                'timmins.display' = [
+                    'excl=timmins_plugin_fancy:excl_display',
+                    'lined=timmins_plugin_fancy:lined_display',
+                ]
+            }
+        )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        [project.entry-points."timmins.display"]
+        excl = "timmins_plugin_fancy:excl_display"
+        lined = "timmins_plugin_fancy:lined_display"
+
+On the ``timmins`` side, we can also use a different strategy of loading entry
+points. For example, we can search for a specific display style:
+
+.. code-block:: python
+
+   display_eps = entry_points(group='timmins.display')
+   try:
+       display = display_eps['lined'].load()
+   except KeyError:
+       # if the 'lined' display is not available, use something else
+       ...
+
+Or we can also load all plugins under the given group. Though this might not
+be of much use in our current example, there are several scenarios in which this
+is useful:
+
+.. code-block:: python
+
+   display_eps = entry_points(group='timmins.display')
+   for ep in display_eps:
+       display = ep.load()
+       # do something with display
+       ...
+
 importlib.metadata
 ------------------
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -389,8 +389,6 @@ get the following:
 
 Therefore, our plugin works.
 
-Let us discuss a few points in this example in more detail.
-
 importlib.metadata
 ------------------
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -45,7 +45,8 @@ After installing the package, the function may be invoked through the
 
 .. code-block:: bash
 
-    python -m timmins
+    $ python -m timmins
+    Hello world
 
 Adding a console script entry point allows the package to define a
 user-friendly name for installers of the package to execute. Installers
@@ -86,7 +87,12 @@ your configuration:
 
 
 After installing the package, a user may invoke that function by simply calling
-``hello-world`` on the command line.
+``hello-world`` on the command line:
+
+.. code-block:: bash
+
+   $ hello-world
+   Hello world
 
 The syntax for entry points is specified as follows:
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -161,7 +161,7 @@ Then, we can add a GUI script entry point:
         hello-world = "timmins:hello_world"
 
 .. note::
-   To be able to import `PySimpleGUI`, you need to add `pysimplegui` to your package dependencies.
+   To be able to import ``PySimpleGUI``, you need to add ``pysimplegui`` to your package dependencies.
    See :doc:`/userguide/dependency_management` for more information.
 Now, running:
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -14,15 +14,15 @@ Console Scripts
 ===============
 
 First consider an example without entry points. Imagine a package
-defined thus:
+defined thus::
 
-.. code-block:: bash
-
-    timmins/
-        timmins/__init__.py
-        timmins/__main__.py
-        setup.cfg # or setup.py
-        #other necessary files
+    project_root_directory
+    ├── setup.py        # and/or setup.cfg, pyproject.toml
+    └── src
+        └── timmins
+            ├── __init__.py
+            ├── __main__.py
+            └── ...
 
 with ``__init__.py`` as:
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -179,7 +179,7 @@ body of the function.
 .. note::
 
     The difference between ``console_scripts`` and ``gui_scripts`` only affects
-    Windows systems. [#packaging_guide]_ ``console_scripts`` are wrapped in a console
+    Windows systems. [#use_for_scripts]_ ``console_scripts`` are wrapped in a console
     executable, so they are attached to a console and can use ``sys.stdin``,
     ``sys.stdout`` and ``sys.stderr`` for input and output. ``gui_scripts`` are
     wrapped in a GUI executable, so they can be started without a console, but
@@ -191,7 +191,7 @@ body of the function.
     Console and GUI scripts work because behind the scenes, installers like :pypi:`pip`
     create wrapper scripts around the function(s) being invoked. For example,
     the ``hello-world`` entry point in the above two examples would create a
-    command ``hello-world`` launching a script like this: [#packaging_guide]_
+    command ``hello-world`` launching a script like this: [#use_for_scripts]_
 
     .. code-block:: python
 
@@ -276,7 +276,15 @@ as follows:
 
 .. note::
    Each ``importlib.metadata.EntryPoint`` object is an object containing a ``name``, a
-   ``group``, and a ``value``.
+   ``group``, and a ``value``. For example, after setting up the plugin package as
+   described below, ``display_eps`` in the above code will look like this: [#package_metadata]_
+
+    .. code-block:: python
+
+        (
+            EntryPoint(name='excl', value='timmins_plugin_fancy:excl_display', group='timmins.display'),
+            ...,
+        )
 
 ``display_eps`` will now be a list of ``EntryPoint`` objects, each referring to ``display()``-like
 functions defined by one or more installed plugin packages. Then, to import a specific
@@ -450,5 +458,8 @@ installed.
    ``pyproject.toml`` is experimental and might change
    in the future. See :doc:`/userguide/pyproject_config`.
 
-.. [#packaging_guide]
+.. [#use_for_scripts]
    Reference: https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts
+
+.. [#package_metadata]
+   Reference: https://packaging.python.org/en/latest/guides/creating-and-discovering-plugins/#using-package-metadata

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -163,6 +163,7 @@ Then, we can add a GUI script entry point:
 .. note::
    To be able to import ``PySimpleGUI``, you need to add ``pysimplegui`` to your package dependencies.
    See :doc:`/userguide/dependency_management` for more information.
+
 Now, running:
 
 .. code-block:: bash

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -160,6 +160,16 @@ Now, running:
 
 will open a small application window with the title 'Hello world'.
 
+.. note::
+
+    The difference between ``console_scripts`` and ``gui_scripts`` only affects
+    Windows systems. [#packaging_guide]_ ``console_scripts`` are wrapped in a console
+    executable, so they are attached to a console and can use ``sys.stdin``,
+    ``sys.stdout`` and ``sys.stderr`` for input and output. ``gui_scripts`` are
+    wrapped in a GUI executable, so they can be started without a console, but
+    cannot use standard streams unless application code redirects them. Other
+    platforms do not have the same distinction.
+
 .. _dynamic discovery of services and plugins:
 
 Advertising Behavior
@@ -248,3 +258,6 @@ installed.
    Support for specifying package metadata and build configuration options via
    ``pyproject.toml`` is experimental and might change
    in the future. See :doc:`/userguide/pyproject_config`.
+
+.. [#packaging_guide]
+   Reference: https://packaging.python.org/en/latest/specifications/entry-points/#use-for-scripts

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -51,9 +51,8 @@ module:
     $ python -m timmins
     Hello world
 
-Instead of this approach using ``__main__.py``, a better way is to add
-a console script entry point, which allows the package to define a
-user-friendly name for installers of the package to execute.
+Instead of this approach using ``__main__.py``, you can also create a
+user-friendly CLI executable that can be called directly without ``python -m``.
 In the above example, to create a command ``hello-world`` that invokes
 ``timmins.hello_world``, add a console script entry point to your
 configuration:
@@ -101,7 +100,7 @@ Note that any function configured as a console script, i.e. ``hello_world()`` in
 this example, should not accept any arguments. If your function requires any input
 from the user, you can use regular command-line argument parsing utilities like
 `argparse <https://docs.python.org/3/library/argparse.html>`_ within the body of
-the function to parse user input.
+the function to parse user input given via :obj:`sys.argv`.
 
 The syntax for entry points is specified as follows:
 
@@ -185,7 +184,7 @@ body of the function.
 
 .. note::
 
-    Console and GUI scripts work because behind the scenes, installers like Pip
+    Console and GUI scripts work because behind the scenes, installers like :pypi:`pip`
     create wrapper scripts around the function(s) being invoked. For example,
     the ``hello-world`` entry point in the above two examples would create a
     command ``hello-world`` launching a script like this: [#packaging_guide]_

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -93,6 +93,12 @@ After installing the package, a user may invoke that function by simply calling
    $ hello-world
    Hello world
 
+Note that any function configured as a console script, i.e. ``hello_world()`` in
+this example, should not accept any arguments. If your function requires any input
+from the user, you can use regular command-line argument parsing utilities like
+`argparse <https://docs.python.org/3/library/argparse.html>`_ within the body of
+the function to parse user input.
+
 The syntax for entry points is specified as follows:
 
 .. code-block:: ini
@@ -158,6 +164,10 @@ Now, running:
    $ hello-world
 
 will open a small application window with the title 'Hello world'.
+
+Note that just as with console scripts, any function configured as a GUI script
+should not accept any arguments, and any user input can be parsed within the
+body of the function.
 
 .. note::
 

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -52,7 +52,7 @@ user-friendly name for installers of the package to execute. Installers
 like pip will create wrapper scripts to execute a function. In the
 above example, to create a command ``hello-world`` that invokes
 ``timmins.hello_world``, add a console script entry point to
-``setup.cfg``:
+your configuration:
 
 .. tab:: setup.cfg
 
@@ -79,6 +79,13 @@ above example, to create a command ``hello-world`` that invokes
 				]
 			}
         )
+
+.. tab:: pyproject.toml (**EXPERIMENTAL**) [#experimental]_
+
+   .. code-block:: toml
+
+        [project.scripts]
+        hello-world = "timmins:hello_world"
 
 
 After installing the package, a user may invoke that function by simply calling
@@ -179,3 +186,10 @@ In this case, the ``hello-world`` script is only viable if the ``pretty-printer`
 extra is indicated, and so a plugin host might exclude that entry point
 (i.e. not install a console script) if the relevant extra dependencies are not
 installed.
+
+----
+
+.. [#experimental]
+   Support for specifying package metadata and build configuration options via
+   ``pyproject.toml`` is experimental and might change
+   in the future. See :doc:`/userguide/pyproject_config`.


### PR DESCRIPTION
## Summary of changes

Console scripts section:
 - Added `pyproject.toml` snippet
 - Modified `setup.py` snippet (corrected indentation and removed unnecessary name, version, etc. fields)
 - Changed the example to use src-layout
 - Some changes in the wording etc.

Added GUI Scripts section:
 - Included `setup.cfg` / `setup.py` / `pyproject.toml` snippets
 - Added an example Hello world function that can be invoked through a GUI script

Other changes:
 - Added note on distinction between Console and GUI scripts
 - Added note on how installers like Pip create wrapper scripts around invoked functions
 - Included few lines stating that invoked functions should not accept any arguments and parse user input within the function body

_Have not finished this yet. Will update here with further changes._

### Pull Request Checklist
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
