### PR TITLE
Update dependency management docs

### DIFF
--- a/changelog.d/3364.doc.rst
+++ b/changelog.d/3364.doc.rst
@@ -1,0 +1,2 @@
+Update documentation about dependency management, removing mention to
+the deprecated ``dependency_links`` and adding some small improvements.

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -95,6 +95,9 @@ or::
 
     $ pip install dist/meowpkg-0.0.1.tar.gz
 
+
+.. _backend-wrapper:
+
 Dynamic build dependencies and other ``build_meta`` tweaks
 ----------------------------------------------------------
 

--- a/docs/deprecated/dependency_links.rst
+++ b/docs/deprecated/dependency_links.rst
@@ -1,0 +1,77 @@
+Specifying dependencies that aren't in PyPI via ``dependency_links``
+====================================================================
+
+.. warning::
+    Dependency links support has been dropped by pip starting with version
+    19.0 (released 2019-01-22).
+
+If your project depends on packages that don't exist on PyPI, you *may* still be
+able to depend on them if they are available for download as:
+
+- an egg, in the standard distutils ``sdist`` format,
+- a single ``.py`` file, or
+- a VCS repository (Subversion, Mercurial, or Git).
+
+You need to add some URLs to the ``dependency_links`` argument to ``setup()``.
+
+The URLs must be either:
+
+1. direct download URLs,
+2. the URLs of web pages that contain direct download links, or
+3. the repository's URL
+
+In general, it's better to link to web pages, because it is usually less
+complex to update a web page than to release a new version of your project.
+You can also use a SourceForge ``showfiles.php`` link in the case where a
+package you depend on is distributed via SourceForge.
+
+If you depend on a package that's distributed as a single ``.py`` file, you
+must include an ``"#egg=project-version"`` suffix to the URL, to give a project
+name and version number.  (Be sure to escape any dashes in the name or version
+by replacing them with underscores.)  EasyInstall will recognize this suffix
+and automatically create a trivial ``setup.py`` to wrap the single ``.py`` file
+as an egg.
+
+In the case of a VCS checkout, you should also append ``#egg=project-version``
+in order to identify for what package that checkout should be used. You can
+append ``@REV`` to the URL's path (before the fragment) to specify a revision.
+Additionally, you can also force the VCS being used by prepending the URL with
+a certain prefix. Currently available are:
+
+-  ``svn+URL`` for Subversion,
+-  ``git+URL`` for Git, and
+-  ``hg+URL`` for Mercurial
+
+A more complete example would be:
+
+    ``vcs+proto://host/path@revision#egg=project-version``
+
+Be careful with the version. It should match the one inside the project files.
+If you want to disregard the version, you have to omit it both in the
+``requires`` and in the URL's fragment.
+
+This will do a checkout (or a clone, in Git and Mercurial parlance) to a
+temporary folder and run ``setup.py bdist_egg``.
+
+The ``dependency_links`` option takes the form of a list of URL strings.  For
+example, this will cause a search of the specified page for eggs or source
+distributions, if the package's dependencies aren't already installed:
+
+.. tab:: setup.cfg
+
+    .. code-block:: ini
+
+        [options]
+        #...
+        dependency_links = http://peak.telecommunity.com/snapshots/
+
+.. tab:: setup.py
+
+    .. code-block:: python
+
+        setup(
+            ...,
+            dependency_links=[
+                "http://peak.telecommunity.com/snapshots/",
+            ],
+        )

--- a/docs/deprecated/index.rst
+++ b/docs/deprecated/index.rst
@@ -14,6 +14,7 @@ objectives.
     :maxdepth: 1
 
     changed_keywords
+    dependency_links
     python_eggs
     easy_install
     distutils/index

--- a/docs/userguide/dependency_management.rst
+++ b/docs/userguide/dependency_management.rst
@@ -31,8 +31,8 @@ This needs to be specified in your ``pyproject.toml`` file
     #...
 
 Please note that you should also include here any other ``setuptools`` plugin
-(e.g. :pypi:`setuptools-scm`, :pypi:`setuptools-golang`, :pypi:`setuptools-rust`)
-or build-time dependency (e.g. :pypi:`Cython`, :pypi:`cppy`, :pypi:`pybind11`).
+(e.g., :pypi:`setuptools-scm`, :pypi:`setuptools-golang`, :pypi:`setuptools-rust`)
+or build-time dependency (e.g., :pypi:`Cython`, :pypi:`cppy`, :pypi:`pybind11`).
 
 .. note::
     In previous versions of ``setuptools``,
@@ -86,7 +86,7 @@ finesse to it, let's start with a simple example.
         # ...
 
 
-When your project is installed (e.g. using :pypi:`pip`), all of the dependencies not
+When your project is installed (e.g., using :pypi:`pip`), all of the dependencies not
 already installed will be located (via `PyPI`_), downloaded, built (if necessary),
 and installed and 2) Any scripts in your project will be installed with wrappers
 that verify the availability of the specified dependencies at runtime.
@@ -322,7 +322,7 @@ not need to change, but the right packages will still be installed if needed.
     This syntax indicates that the entry point (in this case a console script)
     is only valid when the PDF extra is installed. It is up to the installer
     to determine how to handle the situation where PDF was not indicated
-    (e.g. omit the console script, provide a warning when attempting to load
+    (e.g., omit the console script, provide a warning when attempting to load
     the entry point, assume the extras are present and let the implementation
     fail later).
 


### PR DESCRIPTION


<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Extract `depencency_liks` section to a new file:
  `deprecated/dependency_links.rst`
- Add note about directly URLs not being accepted in PyPI.
- Simplify intro about build system requirement.
- Simplify intro about optional dependencies.
- Fix confusion in example about "Project" and "Package".
- "Demote" section about extras in entry-points to a note.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
