### PR TITLE
Handle `config_settings` as they would be passed by pip

### DIFF
--- a/changelog.d/3380.change.rst
+++ b/changelog.d/3380.change.rst
@@ -1,0 +1,10 @@
+Improved the handling of the ``config_settings`` parameter in both PEP 517 and
+PEP 660 interfaces:
+
+- It is possible now to pass both ``--global-option`` and ``--build-option``.
+  As discussed in #1928, arbitrary arguments passed via ``--global-option``
+  should be placed before the name of the setuptools' internal command, while
+  ``--build-option`` should come after.
+
+- Users can pass ``editable-mode=strict`` to select a strict behaviour for the
+  editable installation.

--- a/changelog.d/3380.deprecation.rst
+++ b/changelog.d/3380.deprecation.rst
@@ -1,0 +1,7 @@
+Passing some types of parameters via ``--global-option`` to setuptools PEP 517/PEP 660 backend
+is now considered deprecated. The user can pass the same arbitrary parameter
+via ``--build-option`` (``--global-option`` is now reserved for flags like
+``--verbose`` or ``--quiet``).
+
+Both ``--build-option`` and ``--global-option`` are supported as a **transitional** effort (a.k.a. "escape hatch").
+In the future a proper list of allowed ``config_settings`` may be created.

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,3 +60,4 @@ filterwarnings=
 	ignore:Setuptools is replacing distutils
 
 	ignore:Support for project metadata in .pyproject.toml. is still experimental
+	ignore::setuptools.command.editable_wheel.InformationOnly

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -255,9 +255,9 @@ class _ConfigSettingsTranslator:
         ValueError: Invalid value for `editable-mode`: 'other'. Try: 'strict'.
         """
         cfg = config_settings or {}
-        if "editable-mode" not in cfg:
+        if "editable-mode" not in cfg and "editable_mode" not in cfg:
             return
-        mode = cfg["editable-mode"]
+        mode = cfg.get("editable-mode") or cfg.get("editable_mode")
         if mode != "strict":
             msg = f"Invalid value for `editable-mode`: {mode!r}. Try: 'strict'."
             raise ValueError(msg)
@@ -420,10 +420,14 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         self, wheel_directory, config_settings=None, metadata_directory=None
     ):
         # XXX can or should we hide our editable_wheel command normally?
-        return self._build_with_temp_dir(
-            ["editable_wheel", "--dist-info-dir", metadata_directory],
-            ".whl", wheel_directory, config_settings
-        )
+        print(f"{self._editable_args(config_settings)=}")
+        cmd = [
+            "editable_wheel",
+            "--dist-info-dir",
+            metadata_directory,
+            *self._editable_args(config_settings),
+        ]
+        return self._build_with_temp_dir(cmd, ".whl", wheel_directory, config_settings)
 
     def get_requires_for_build_editable(self, config_settings=None):
         return self.get_requires_for_build_wheel(config_settings)

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -180,11 +180,16 @@ class _ConfigSettingsTranslator:
             return [log_levels[level]]
         return []
 
-    def _dist_info_args(self, config_settings: _ConfigSettings) -> List[str]:
+    def __dist_info_args(self, config_settings: _ConfigSettings) -> List[str]:
         """
         The ``dist_info`` command accepts ``tag-date`` and ``tag-build``.
 
-        >>> fn = _ConfigSettingsTranslator()._dist_info_args
+        .. warning::
+           We cannot use this yet as it requires the ``sdist`` and ``bdist_wheel``
+           commands run in ``build_sdist`` and ``build_wheel`` to re-use the egg-info
+           directory created in ``prepare_metadata_for_build_wheel``.
+
+        >>> fn = _ConfigSettingsTranslator()._ConfigSettingsTranslator__dist_info_args
         >>> fn(None)
         []
         >>> fn({"tag-date": "False"})

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -290,18 +290,18 @@ class _ConfigSettingsTranslator:
         """
         args = self._get_config("--global-option", config_settings)
         global_opts = self._valid_global_options()
-        warn = []
+        bad_args = []
 
         for arg in args:
             if arg.strip("-") not in global_opts:
-                warn.append(arg)
+                bad_args.append(arg)
                 yield arg
 
         yield from self._get_config("--build-option", config_settings)
 
-        if warn:
+        if bad_args:
             msg = f"""
-            The arguments {warn!r} were given via `--global-option`.
+            The arguments {bad_args!r} were given via `--global-option`.
             Please use `--build-option` instead,
             `--global-option` is reserved to flags like `--verbose` or `--quiet`.
             """

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -25,13 +25,21 @@ class dist_info(Command):
                            " DEPRECATED: use --output-dir."),
         ('output-dir=', 'o', "directory inside of which the .dist-info will be"
                              "created (default: top of the source tree)"),
+        ('tag-date', 'd', "Add date stamp (e.g. 20050528) to version number"),
+        ('tag-build=', 'b', "Specify explicit tag to add to version number"),
+        ('no-date', 'D', "Don't include date stamp [default]"),
     ]
+
+    boolean_options = ['tag-date']
+    negative_opt = {'no-date': 'tag-date'}
 
     def initialize_options(self):
         self.egg_base = None
         self.output_dir = None
         self.name = None
         self.dist_info_dir = None
+        self.tag_date = None
+        self.tag_build = None
 
     def finalize_options(self):
         if self.egg_base:
@@ -43,8 +51,14 @@ class dist_info(Command):
         project_dir = dist.src_root or os.curdir
         self.output_dir = Path(self.output_dir or project_dir)
 
-        egg_info = self.reinitialize_command('egg_info')
+        self.set_undefined_options(
+            "egg_info", ("tag_date", "tag_date"), ("tag_build", "tag_build")
+        )
+
+        egg_info = self.reinitialize_command("egg_info")
         egg_info.egg_base = str(self.output_dir)
+        egg_info.tag_date = self.tag_date
+        egg_info.tag_build = self.tag_build
         egg_info.finalize_options()
         self.egg_info = egg_info
 

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -51,14 +51,19 @@ class dist_info(Command):
         project_dir = dist.src_root or os.curdir
         self.output_dir = Path(self.output_dir or project_dir)
 
-        self.set_undefined_options(
-            "egg_info", ("tag_date", "tag_date"), ("tag_build", "tag_build")
-        )
-
         egg_info = self.reinitialize_command("egg_info")
         egg_info.egg_base = str(self.output_dir)
-        egg_info.tag_date = self.tag_date
-        egg_info.tag_build = self.tag_build
+
+        if self.tag_date:
+            egg_info.tag_date = self.tag_date
+        else:
+            self.tag_date = egg_info.tag_date
+
+        if self.tag_build:
+            egg_info.tag_build = self.tag_build
+        else:
+            self.tag_build = egg_info.tag_build
+
         egg_info.finalize_options()
         self.egg_info = egg_info
 

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -624,9 +624,14 @@ class TestBuildMetaBackend:
         }
     }
 
-    @pytest.mark.filterwarnings("error::setuptools.SetuptoolsDeprecationWarning")
     # For some reason `pytest.warns` does no seem to work here
-    # but `pytest.raises` does works, together with an error filter.
+    # but `pytest.raises` does works (in systems other then macOS),
+    # together with an error filter.
+    @pytest.mark.xfail(
+        sys.platform == "darwin",
+        reason="inconsistent behaviour in macOS"
+    )
+    @pytest.mark.filterwarnings("error::setuptools.SetuptoolsDeprecationWarning")
     def test_editable_with_config_settings_warning(self, tmpdir_cwd):
         path.build({**self._simple_pyproject_example, '_meta': {}})
         build_backend = self.get_build_backend()

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -2,6 +2,7 @@
 """
 import pathlib
 import re
+import shutil
 import subprocess
 import sys
 from functools import partial
@@ -90,6 +91,26 @@ class TestDistInfo:
         assert msg.search(output)
         dist_info = next(tmp_path.glob("*.dist-info"))
         assert dist_info.name.startswith("proj-42")
+
+    def test_tag_arguments(self, tmp_path):
+        config = """
+        [metadata]
+        name=proj
+        version=42
+        [egg_info]
+        tag_date=1
+        tag_build=.post
+        """
+        (tmp_path / "setup.cfg").write_text(config, encoding="utf-8")
+
+        print(run_command("dist_info", "--no-date", cwd=tmp_path))
+        dist_info = next(tmp_path.glob("*.dist-info"))
+        assert dist_info.name.startswith("proj-42")
+        shutil.rmtree(dist_info)
+
+        print(run_command("dist_info", "--tag-build", ".a", cwd=tmp_path))
+        dist_info = next(tmp_path.glob("*.dist-info"))
+        assert dist_info.name.startswith("proj-42a")
 
     def test_output_dir(self, tmp_path):
         config = "[metadata]\nname=proj\nversion=42\n"


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

This PR is a continuation of the work done to implement PEP 660.

The main objective of this PR is to add support for `config_settings` to select which mode is going to be used by the `build_editable` hook.

But since I was already working with it and adding some tests, I ended up fixing other some other items.

## Summary of changes

- Improvements in terms of the handling of ``config_settings``:

  - Allow frontends and installers to select the strict editable mode via the ``config_settings`` argument passed to the PEP 660 hooks.
    Now users should be able to run:
  
    ```bash
    pip install -e . --config-settings editable-mode=strict
    ```
  
  - Separate config settings given by ``--global-option`` and ``--build-option``. The motivation (and approach) for this change is described in #1928.
    When calling setuptools internal commands ``--global-option`` is placed before the command name, while ``--build-option`` is placed after.
    For the time being the implementation strives to maintain backwards compatibility, however passing *all* arbitrary arguments via ``--global-option`` is now deprecated (a warning is issued).

- Added tests for using `config_settings` via PEP 660 interface, which also lead to some bug fixing.

- Added "informational warnings" about off-band link tree repository for strict installs.


Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
