### PR TITLE
Clarify modules used for pyproject.toml parsing are private

### DIFF
--- a/changelog.d/3385.misc.rst
+++ b/changelog.d/3385.misc.rst
@@ -1,0 +1,2 @@
+Modules used to parse and evaluate configuration from ``pyproject.toml`` files are
+intended for internal use only and that not part of the public API.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -4,6 +4,8 @@ metadata objects.
 The distribution and metadata objects are modeled after (an old version of)
 core metadata, therefore configs in the format specified for ``pyproject.toml``
 need to be processed before being applied.
+
+**PRIVATE MODULE**: API reserved for setuptools internal usage only.
 """
 import logging
 import os

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -14,6 +14,8 @@ We can split the process of interpreting configuration files into 2 steps:
 
 This module focus on the second step, and therefore allow sharing the expansion
 functions among several configuration file formats.
+
+**PRIVATE MODULE**: API reserved for setuptools internal usage only.
 """
 import ast
 import importlib

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -1,4 +1,8 @@
-"""Load setuptools configuration from ``pyproject.toml`` files"""
+"""
+Load setuptools configuration from ``pyproject.toml`` files.
+
+**PRIVATE MODULE**: API reserved for setuptools internal usage only.
+"""
 import logging
 import os
 import warnings

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -1,4 +1,8 @@
-"""Load setuptools configuration from ``setup.cfg`` files"""
+"""
+Load setuptools configuration from ``setup.cfg`` files.
+
+**API will be made private in the future**
+"""
 import os
 
 import warnings


### PR DESCRIPTION
Now that we are stating that configurations passed via `pyproject.toml` can be considered stable, we should also clarify that the code used to parse/expand/evaluate them are private (see #3232).

In the future we might rename the entire `setuptools.config` package to `setuptools._config`.

## Summary of changes

For the time being, I am adding an entry to the changelog and a note on the module's docstring.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
