### PR TITLE
Add support for type annotations to `attr:` ast parsing

### DIFF
--- a/changelog.d/3391.change.rst
+++ b/changelog.d/3391.change.rst
@@ -1,0 +1,1 @@
+Updated ``attr:`` to also extract simple constants with type annotations -- by :user:`karlotness`

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -85,6 +85,18 @@ class TestReadAttr:
         values = expand.read_attr('lib.mod.VALUES', {'lib': 'pkg/sub'}, tmp_path)
         assert values['c'] == (0, 1, 1)
 
+    def test_read_annotated_attr(self, tmp_path):
+        files = {
+            "pkg/__init__.py": "",
+            "pkg/sub/__init__.py": (
+                "VERSION: str = '0.1.1'\n"
+                "raise SystemExit(1)\n"
+            ),
+        }
+        write_files(files, tmp_path)
+        # Make sure this attribute can be read statically
+        assert expand.read_attr('pkg.sub.VERSION', root_dir=tmp_path) == '0.1.1'
+
     def test_import_order(self, tmp_path):
         """
         Sometimes the import machinery will import the parent package of a nested


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This extends the ast parsing setuptools does to load attributes without evaluating a module to also process simple assignments with type annotations. Those produce a different node `ast.AnnAssign` rather than `ast.Assign` and require slightly different handling since the node has a different attribute `target` vs `targets`.

Since that seemed like it might make the generators more complicated, I reworked things into for loops and made some other tweaks. I'd be happy to take a different approach though.

The existing `ast.Assign` nodes should pass through exactly the same processing. The `AttributeError` that could result should also be the same too, except that it won't be chained with a `StopIteration` if the outer for loop is exhausted (as it would be with the `next()` call).

This doesn't close any existing open issue that I can find. There is #2563 which looks related. I think in that case the attribute loading worked because setuptools fell back to evaluating the module when the ast processing likely failed.

That fallback works in some cases, but it causes problems in when the module isn't importable until after the build (for example, extension modules that need to be compiled). The ast parsing is really helpful in these cases, and it would be nice if it could also handle type annotations.

### Pull Request Checklist
- [X] Changes have tests
- [X] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
