### PR TITLE
Update logging recommendation to not use distutils

### DIFF
--- a/changelog.d/3394.doc.rst
+++ b/changelog.d/3394.doc.rst
@@ -1,0 +1,3 @@
+This updates the documentation for the ``file_finders`` hook so that
+the logging recommendation aligns with the suggestion to not use
+``distutils`` directly.

--- a/docs/userguide/extension.rst
+++ b/docs/userguide/extension.rst
@@ -276,7 +276,7 @@ A few important points for writing revision control file finders:
 
 * Your finder function SHOULD NOT raise any errors, and SHOULD deal gracefully
   with the absence of needed programs (i.e., ones belonging to the revision
-  control system itself.  It *may*, however, use ``distutils.log.warn()`` to
+  control system itself.  It *may*, however, use ``logging.warning()`` to
   inform the user of the missing program(s).
 
 


### PR DESCRIPTION
## Summary of changes
This updates the documentation for the `file_finders` hook so that the logging recommendation aligns with the [suggestion to not use `distutils` directly](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools).


### Pull Request Checklist
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
