### PR TITLE
[Docs] Fix reference for keywords

### DIFF
--- a/changelog.d/3397.doc.rst
+++ b/changelog.d/3397.doc.rst
@@ -1,0 +1,3 @@
+Fix reference for ``keywords`` to point to the Core Metadata Specification
+instead of PEP 314 (the live standard is kept always up-to-date and
+consolidates several PEPs together in a single document).

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -167,9 +167,7 @@ extensions).
 
 ``keywords``
     A list of strings or a comma-separated string providing descriptive
-    meta-data. See: `PEP 0314`_.
-
-.. _PEP 0314: https://www.python.org/dev/peps/pep-0314/
+    meta-data. See: :ref:`Core Metadata Specifications<core-metadata-keywords>`.
 
 .. _keyword/platforms:
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Fix reference for `keywords` to point to the live standard.

Closes #3396

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
