### PR TITLE
Allow `dist_info` command to leave the `egg_info` directory to be used by other steps of the build

### DIFF
--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -1,7 +1,29 @@
 import os
+from typing import Union
+
+_Path = Union[str, os.PathLike]
 
 
 def ensure_directory(path):
     """Ensure that the parent directory of `path` exists"""
     dirname = os.path.dirname(path)
     os.makedirs(dirname, exist_ok=True)
+
+
+def same_path(p1: _Path, p2: _Path) -> bool:
+    """Differs from os.path.samefile because it does not require paths to exist.
+    Purely string based (no comparison between i-nodes).
+    >>> same_path("a/b", "./a/b")
+    True
+    >>> same_path("a/b", "a/./b")
+    True
+    >>> same_path("a/b", "././a/b")
+    True
+    >>> same_path("a/b", "./a/b/c/..")
+    True
+    >>> same_path("a/b", "../a/b/c")
+    False
+    >>> same_path("a", "a/b")
+    False
+    """
+    return os.path.normpath(p1) == os.path.normpath(p2)

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -80,7 +80,7 @@ class dist_info(Command):
     @contextmanager
     def _maybe_bkp_dir(self, dir_path: str, requires_bkp: bool):
         if requires_bkp:
-            bkp_name = f"__bkp__.{dir_path}.__bkp__"
+            bkp_name = f"{dir_path}.__bkp__"
             _rm(bkp_name, ignore_errors=True)
             _copy(dir_path, bkp_name, dirs_exist_ok=True, symlinks=True)
             try:

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -5,7 +5,10 @@ As defined in the wheel specification
 
 import os
 import re
+import shutil
+import sys
 import warnings
+from contextlib import contextmanager
 from inspect import cleandoc
 from pathlib import Path
 
@@ -28,9 +31,10 @@ class dist_info(Command):
         ('tag-date', 'd', "Add date stamp (e.g. 20050528) to version number"),
         ('tag-build=', 'b', "Specify explicit tag to add to version number"),
         ('no-date', 'D', "Don't include date stamp [default]"),
+        ('keep-egg-info', None, "*TRANSITIONAL* will be removed in the future"),
     ]
 
-    boolean_options = ['tag-date']
+    boolean_options = ['tag-date', 'keep-egg-info']
     negative_opt = {'no-date': 'tag-date'}
 
     def initialize_options(self):
@@ -40,6 +44,7 @@ class dist_info(Command):
         self.dist_info_dir = None
         self.tag_date = None
         self.tag_build = None
+        self.keep_egg_info = False
 
     def finalize_options(self):
         if self.egg_base:
@@ -72,14 +77,32 @@ class dist_info(Command):
         self.name = f"{name}-{version}"
         self.dist_info_dir = os.path.join(self.output_dir, f"{self.name}.dist-info")
 
+    @contextmanager
+    def _maybe_bkp_dir(self, dir_path: str, requires_bkp: bool):
+        if requires_bkp:
+            bkp_name = f"__bkp__.{dir_path}.__bkp__"
+            _rm(bkp_name, ignore_errors=True)
+            _copy(dir_path, bkp_name, dirs_exist_ok=True, symlinks=True)
+            try:
+                yield
+            finally:
+                _rm(dir_path, ignore_errors=True)
+                shutil.move(bkp_name, dir_path)
+        else:
+            yield
+
     def run(self):
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.egg_info.run()
         egg_info_dir = self.egg_info.egg_info
+        assert os.path.isdir(egg_info_dir), ".egg-info dir should have been created"
+
         log.info("creating '{}'".format(os.path.abspath(self.dist_info_dir)))
         bdist_wheel = self.get_finalized_command('bdist_wheel')
-        bdist_wheel.egg2dist(egg_info_dir, self.dist_info_dir)
-        assert os.path.exists(egg_info_dir) is False
+
+        # TODO: if bdist_wheel if merged into setuptools, just add "keep_egg_info" there
+        with self._maybe_bkp_dir(egg_info_dir, self.keep_egg_info):
+            bdist_wheel.egg2dist(egg_info_dir, self.dist_info_dir)
 
 
 def _safe(component: str) -> str:
@@ -106,3 +129,14 @@ def _version(version: str) -> str:
         """
         warnings.warn(cleandoc(msg))
         return _safe(v).strip("_")
+
+
+def _rm(dir_name, **opts):
+    if os.path.isdir(dir_name):
+        shutil.rmtree(dir_name, **opts)
+
+
+def _copy(src, dst, **opts):
+    if sys.version_info < (3, 8):
+        opts.pop("dirs_exist_ok", None)
+    shutil.copytree(src, dst, **opts)

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -43,6 +43,8 @@ from types import ModuleType
 
 from distutils.errors import DistutilsOptionError
 
+from .._path import same_path as _same_path
+
 if TYPE_CHECKING:
     from setuptools.dist import Distribution  # noqa
     from setuptools.discovery import ConfigDiscovery  # noqa
@@ -328,25 +330,6 @@ def find_packages(
             fill_package_dir.update(construct_package_dir(pkgs, path))
 
     return packages
-
-
-def _same_path(p1: _Path, p2: _Path) -> bool:
-    """Differs from os.path.samefile because it does not require paths to exist.
-    Purely string based (no comparison between i-nodes).
-    >>> _same_path("a/b", "./a/b")
-    True
-    >>> _same_path("a/b", "a/./b")
-    True
-    >>> _same_path("a/b", "././a/b")
-    True
-    >>> _same_path("a/b", "./a/b/c/..")
-    True
-    >>> _same_path("a/b", "../a/b/c")
-    False
-    >>> _same_path("a", "a/b")
-    False
-    """
-    return os.path.normpath(p1) == os.path.normpath(p2)
 
 
 def _nest_path(parent: _Path, path: _Path) -> str:

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -125,8 +125,8 @@ class TestDistInfo:
         expected_egg_info = 1 if keep_egg_info else 0
         assert len(list(out.glob("*.egg-info"))) == expected_egg_info
         assert len(list(tmp_path.glob("*.egg-info"))) == 0
-        assert len(list(out.glob("__bkp__.*.__bkp__"))) == 0
-        assert len(list(tmp_path.glob("__bkp__.*.__bkp__"))) == 0
+        assert len(list(out.glob("*.__bkp__"))) == 0
+        assert len(list(tmp_path.glob("*.__bkp__"))) == 0
 
 
 class TestWheelCompatibility:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->
(*Another PR of the PEP 660 series*)

Motivation: ``build_py`` needs `egg_info` to be able to list the output files (via ``get_outputs()``).
In a follow up PR, we can re-use the existing `egg_info` dir in ``editable_wheel`` when collecting the files in `get_outputs()`.

## Summary of changes

- Add an *internal* option to `dist_info` to keep the egg_info around
- Refactor `build_meta` to not remove the `egg_info` directory after the `prepare_*` hook.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
