### PR TITLE
Reordering of User Guide's Table of Contents

### DIFF
--- a/changelog.d/3402.doc.rst
+++ b/changelog.d/3402.doc.rst
@@ -1,0 +1,1 @@
+Reordered the User Guide's Table of Contents -- by :user:`codeandfire`

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -1,5 +1,5 @@
-"Development Mode"
-==================
+Development Mode
+================
 
 Under normal circumstances, the ``setuptools`` assume that you are going to
 build a distribution of your project, not use it in its "raw" or "unbuilt"

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -26,16 +26,16 @@ Contents
 
     quickstart
     package_discovery
-    entry_point
     dependency_management
-    ext_modules
-    datafiles
     development_mode
+    entry_point
+    datafiles
+    ext_modules
     distribution
+    miscellaneous
     extension
     declarative_config
     pyproject_config
-    miscellaneous
 
 ---
 


### PR DESCRIPTION
## Summary of changes

Reorganized the User Guide's Table of Contents
    
This mostly follows the scheme given [here](https://github.com/pypa/setuptools/discussions/3400#discussioncomment-3003334), with the following exceptions:
   - "Controlling files in the distribution" is kept not immediately after the "Package Discovery" page, but rather towards the end, because a lot of the material in that page overlaps with material given in the "Package Discovery" and "Data Files" pages. Therefore, it seems to me that this page should be read _after_ the other two pages have been
       read.
   - "Development Mode" is kept not towards the end but introduced close to the beginning, because readers might want to start using it early on in their projects.
   - "Building Extension Modules" is kept immediately after the "Entry Points" and "Data Files" pages, since it is the last major topic we would like to discuss. The two topics that follow ("Specifying your Project's Version" and "Controlling Files in the Distribution") are lighter topics that can be read later by users after they have been able to get a basic start with their projects.
   - Have retained the pages "Extending or Customizing Setuptools",  "Configuring Setuptools using setup.cfg files" and "Configuring Setuptools using pyproject.toml files" for now.

Have also removed the quotes around the heading of the page on Development Mode, it seems unnecessary.

### Pull Request Checklist
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
