### PR TITLE
[Docs] Add two footnotes about PEP 660 support

### DIFF
--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -212,8 +212,7 @@ however please keep in mind that all non-comment lines must conform with :pep:`5
 .. rubric:: Notes
 
 .. [#pep660-status] Editable install without ``setup.py`` will be supported from
-   ``setuptools >= 63.0.0``, but this feature will remain experimental for a while.
-   Check https://github.com/pypa/setuptools/issues/2816 for detail.
+   ``setuptools >= 64.0.0``. Check https://github.com/pypa/setuptools/issues/2816 for detail.
 
 .. [#setupcfg-caveats] ``pip`` may allow editable install only with ``pyproject.toml``
    and ``setup.cfg``. However, this behavior may not be consistent over various build

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -7,8 +7,8 @@ Configuring setuptools using ``pyproject.toml`` files
 .. note:: New in 61.0.0
 
 .. important::
-   For the time being, ``pip`` still might require a ``setup.py`` file
-   to support :doc:`editable installs <pip:cli/pip_install>`.
+   For the time being [#pep660-status]_, ``pip`` still might require a ``setup.py`` file
+   to support :doc:`editable installs <pip:cli/pip_install>` [#setupcfg-caveats]_.
 
    A simple script will suffice, for example:
 
@@ -210,6 +210,14 @@ however please keep in mind that all non-comment lines must conform with :pep:`5
 ----
 
 .. rubric:: Notes
+
+.. [#pep660-status] Editable install without ``setup.py`` will be supported from
+   ``setuptools >= 63.0.0``, but this feature will remain experimental for a while.
+   Check https://github.com/pypa/setuptools/issues/2816 for detail.
+
+.. [#setupcfg-caveats] ``pip`` may allow editable install only with ``pyproject.toml``
+   and ``setup.cfg``. However, this behavior may not be consistent over various build
+   tools, and having a ``setup.py`` is still recommended.
 
 .. [#entry-points] Dynamic ``scripts`` and ``gui-scripts`` are a special case.
    When resolving these metadata keys, ``setuptools`` will look for


### PR DESCRIPTION
It looks like that[PEP 660](https://peps.python.org/pep-0660/)  is implemented in pip 21.3 (see https://pip.pypa.io/en/stable/news/#v21-3).
Or isn't it still recommended to do `pip install -e` without `setup.py`? 🤔 
