### PR TITLE
sdist: Add files from build subcommands (`get_source_files`)

### DIFF
--- a/changelog.d/3412.change.rst
+++ b/changelog.d/3412.change.rst
@@ -1,0 +1,3 @@
+Added ability of collecting source files from custom build sub-commands to
+``sdist``. This allows plugins and customization scripts to automatically
+add required source files in the source distribution.

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -65,6 +65,11 @@ class SubCommand(Protocol):
        of ``get_output_mapping()``. Alternatively, ``setuptools`` **MAY** attempt to use
        :doc:`import hooks <python:reference/import>` to redirect any attempt to import
        to the directory with the original source code and other files built in place.
+
+    Please note that custom sub-commands **SHOULD NOT** rely on ``run()`` being
+    executed (or not) to provide correct return values for ``get_outputs()``,
+    ``get_output_mapping()`` or ``get_source_files()``. The ``get_*`` methods should
+    work independently of ``run()``.
     """
 
     editable_mode: bool = False
@@ -105,6 +110,17 @@ class SubCommand(Protocol):
 
     def run(self):
         """(Required by the original :class:`setuptools.Command` interface)"""
+
+    def get_source_files(self) -> List[str]:
+        """
+        Return a list of all files that are used by the command to create the expected
+        outputs.
+        For example, if your build command transpiles Java files into Python, you should
+        list here all the Java files.
+        The primary purpose of this function is to help populating the ``sdist``
+        with all the files necessary to build the distribution.
+        All files should be strings relative to the project root directory.
+        """
 
     def get_outputs(self) -> List[str]:
         """


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

(*Another PR of the PEP 660 series*)

## Summary of changes

- Expand the API defined for custom sub-commands by documenting `get_source_files()`
  - This function is already defined for all existing `build_*` subcommands. We are just asking custom implementations to also honour this interface.
- Add the return value of ``get_source_files()`` to the file list created in ``sdist``.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
