### PR TITLE
Improve docs and behavior of editable installs

### DIFF
--- a/changelog.d/3414.change.rst
+++ b/changelog.d/3414.change.rst
@@ -1,0 +1,4 @@
+Users can *temporarily* specify an environment variable
+``SETUPTOOLS_ENABLE_FEATURE=legacy-editable`` as a escape hatch for the
+:pep:`660` behavior. This setting is **transitional** and may be removed in the
+future.

--- a/changelog.d/3414.doc.rst
+++ b/changelog.d/3414.doc.rst
@@ -1,0 +1,2 @@
+Updated :doc:`Development Mode </userguide/development_mode>` to reflect on the
+implementation of :pep:`660`.

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -131,6 +131,12 @@ Limitations
   <PyPUG:guides/packaging-namespace-packages>`.
   Please use :pep:`420`-style implicit namespaces.
 
+.. attention::
+   Editable installs are **not a perfect replacement for regular installs**
+   in a test environment. When in doubt, please test your projects as
+   installed via a regular wheel. There are tools in the Python ecosystem,
+   like :pypi:`tox` or :pypi:`nox`, that can help you with that.
+
 
 Legacy Behavior
 ---------------

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -48,7 +48,7 @@ Please note that, by default an editable install will expose at least all the
 files that would be available in a regular installation. However, depending on
 the file and directory organization in your project, it might also expose
 as a side effect files that would not be normally available.
-This is allowed so you can create iteratively create new Python modules.
+This is allowed so you can iteratively create new Python modules.
 Please have a look on the following section if you are looking for a different behaviour.
 
 .. admonition:: Virtual Environments
@@ -85,8 +85,8 @@ Please have a look on the following section if you are looking for a different b
 When thinking about editable installations, users might have the following
 expectations:
 
-1. It should allow developers to create add new files and have them
-   automatically exposed.
+1. It should allow developers to add new files (or split/rename existing ones)
+   and have them automatically exposed.
 2. It should behave as close as possible to a regular installation and help
    users to detect problems (e.g. new files not being included in the distribution).
 
@@ -120,22 +120,27 @@ Limitations
   executable script files, binary extensions, headers and metadata may be
   exposed as a *snapshot* of the version they were at the moment of the
   installation.
-- Adding new dependencies or entry-points to your project require
-  a fresh "editable" re-installation.
-- Console scripts and GUI scripts **MUST** be specified via entry-points
-  to work properly.
+- Adding new dependencies, entry-points or changing your project's metadata
+  require a fresh "editable" re-installation.
+- Console scripts and GUI scripts **MUST** be specified via :doc:`entry-points
+  </userguide/entry_point>` to work properly.
 - *Strict* editable installs require the file system to support
   either :wiki:`symbolic <symbolic link>` or :wiki:`hard links <hard link>`.
 - Editable installations may not work with
   :doc:`namespaces created with pkgutil or pkg_resouces
   <PyPUG:guides/packaging-namespace-packages>`.
   Please use :pep:`420`-style implicit namespaces.
+- Support for :pep:`420`-style implicit namespace packages for
+  projects structured using :ref:`flat-layout` is still **experimental**.
+  If you experience problems, you can try converting your package structure
+  to the :ref:`src-layout`.
 
 .. attention::
    Editable installs are **not a perfect replacement for regular installs**
    in a test environment. When in doubt, please test your projects as
    installed via a regular wheel. There are tools in the Python ecosystem,
-   like :pypi:`tox` or :pypi:`nox`, that can help you with that.
+   like :pypi:`tox` or :pypi:`nox`, that can help you with that
+   (when used with appropriate configuration).
 
 
 Legacy Behavior

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -1,34 +1,132 @@
-Development Mode
-================
+Development Mode (a.k.a. "Editable Installs")
+=============================================
 
-Under normal circumstances, the ``setuptools`` assume that you are going to
-build a distribution of your project, not use it in its "raw" or "unbuilt"
-form.  However, if you were to use the ``setuptools`` to build a distribution,
-you would have to rebuild and reinstall your project every time you made a
-change to it during development.
+When creating a Python project, developers usually want to implement and test
+changes iteratively, before cutting a release and preparing a distribution archive.
 
-Another problem that sometimes comes is that you may
-need to do development on two related projects at the same time.  You may need
-to put both projects' packages in the same directory to run them, but need to
-keep them separate for revision control purposes.  How can you do this?
+In normal circumstances this can be quite cumbersome and require the developers
+to manipulate the ``PATHONPATH`` environment variable or to continuous re-build
+and re-install the project.
 
-Setuptools allows you to deploy your projects for use in a common directory or
-staging area, but without copying any files.  Thus, you can edit each project's
-code in its checkout directory, and only need to run build commands when you
-change files that need to be compiled or the provided metadata and setuptools configuration.
+To facilitate iterative exploration and experimentation, setuptools allows
+users to instruct the Python interpreter and its import machinery to load the
+code under development directly from the project folder without having to
+copy the files to a different location in the disk.
+This means that changes in the Python source code can immediately take place
+without requiring a new installation.
 
-You can perform a ``pip`` installation passing the ``-e/--editable``
-flag (e.g., ``pip install -e .``). It works very similarly to
-``pip install .``, except that it doesn't actually install anything.
-Instead, it creates a special ``.egg-link`` file in the target directory
-(usually ``site-packages``) that links to your project's source code.
-It may also update an existing ``easy-install.pth`` file
-to include your project's source code, thereby making
-it available on ``sys.path`` for all programs using that Python installation.
+You can enter this "development mode" by performing an :doc:`editable installation
+<pip:topics/local-project-installs>` inside of a :term:`virtual environment`,
+using :doc:`pip's <pip:cli/pip_install>` ``-e/--editable`` flag, as shown bellow:
 
-You can deploy the same project to multiple staging areas, e.g., if you have
-multiple projects on the same machine that are sharing the same project you're
-doing development work.
+.. code-block:: bash
+
+   $ cd your-python-project
+   $ python -m venv .venv
+   # Activate your environemt with:
+   #      `source .venv/bin/activate` on Unix/macOS
+   # or   `.venv\Scripts\activate` on Windows
+
+   $ pip install --editable .
+
+   # Now you have access to your package
+   # as if it was installed in .venv
+   $ python -c "import your_python_project"
+
+
+An "editable installation" works very similarly to a regular install with
+``pip install .``, except that it only installs your package dependencies,
+metadata and wrappers for :ref:`console and GUI scripts <console-scripts>`.
+Under the hood, setuptools will try to create a special :mod:`.pth file <site>`
+in the target directory (usually ``site-packages``) that extends the
+``PYTHONPATH`` or install a custom :doc:`import hook <python:reference/import>`.
 
 When you're done with a given development task, you can simply uninstall your
 package (as you would normally do with ``pip uninstall <package name>``).
+
+Please note that, by default an editable install will expose at least all the
+files that would be available in a regular installation. However, depending on
+the file and directory organization in your project, it might also expose
+as a side effect files that would not be normally available.
+This is allowed so you can create iteratively create new Python modules.
+Please have a look on the following section if you are looking for a different behaviour.
+
+.. admonition:: Virtual Environments
+
+   You can think virtual environments as "isolated Python runtime deployments"
+   that allow users to install different sets of libraries and tools without
+   messing with the global behaviour of the system.
+
+   They are the safest way of testing new projects and can be created easily
+   with the :mod:`venv` module from the standard library.
+
+   Please note however that depending on your operating system or distribution,
+   ``venv`` might not come installed by default with Python. For those cases,
+   you might need to use the OS package manager to install it.
+   For example, in Debian/Ubuntu-based systems you can obtain it via:
+
+   .. code-block:: bash
+
+       sudo apt install python3-venv
+
+   Alternatively, you can also try installing :pypi:`virtualenᴠ`.
+   More information is available on the Python Packaging User Guide on
+   :doc:`PyPUG:guides/installing-using-pip-and-virtual-environments`.
+
+.. note::
+    .. versionchanged:: v63.0.0
+       Editable installation hooks implemented according to :pep:`660`.
+       Support for :pep:`namespace packages <420>` is still **EXPERIMENTAL**.
+
+
+"Strict" editable installs
+--------------------------
+
+When thinking about editable installations, users might have the following
+expectations:
+
+1. It should allow developers to create add new files and have them
+   automatically exposed.
+2. It should behave as close as possible to a regular installation and help
+   users to detect problems (e.g. new files not being included in the distribution).
+
+Unfortunately these expectations are in conflict with each other.
+To solve this problem ``setuptools`` allows developers to choose a more
+*"strict"* mode for the editable installation. This can be done by passing
+a special *configuration setting* via :pypi:`pip`, as indicated bellow:
+
+.. code-block:: bash
+
+    pip install -e . --config-settings editable_mode=strict
+
+In this mode, new files **won't** be exposed and the editable installs will
+try to mimic as much as possible the behavior of a regular install.
+Under the hood, ``setuptools`` will create a tree of file links in an auxiliary
+directory (``$your_project_dir/build``) and add it to ``PYTHONPATH`` via a
+:mod:`.pth file <site>`. (Please be careful to not delete this repository
+by mistake otherwise your files may stop being accessible).
+
+
+.. note::
+    .. versionadded:: v63.0.0
+       *Strict* mode implemented as **EXPERIMENTAL**.
+
+
+Limitations
+-----------
+
+- The *editable* term is used to refer only to Python modules
+  inside the package directories. Non-Python files, external (data) files,
+  executable script files, binary extensions, headers and metadata may be
+  exposed as a *snapshot* of the version they were at the moment of the
+  installation.
+- Adding new dependencies or entry-points to your project require
+  a fresh "editable" re-installation.
+- Console scripts and GUI scripts **MUST** be specified via entry-points
+  to work properly.
+- *Strict* editable installs require the file system to support
+  either :wiki:`symbolic <symbolic link>` or :wiki:`hard links <hard link>`.
+- Editable installations may not work with
+  :doc:`namespaces created with pkgutil or pkg_resouces
+  <PyPUG:guides/packaging-namespace-packages>`.
+  Please use :pep:`420`-style implicit namespaces.

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -130,3 +130,15 @@ Limitations
   :doc:`namespaces created with pkgutil or pkg_resouces
   <PyPUG:guides/packaging-namespace-packages>`.
   Please use :pep:`420`-style implicit namespaces.
+
+
+Legacy Behavior
+---------------
+
+If your project is not compatible with the new "editable installs" or you wish
+to use the legacy behavior (that mimics the old and deprecated
+``python setup.py develop`` command), you can set an environment variable:
+
+.. code-block::
+
+   SETUPTOOLS_USE_FEATURE="legacy-editable"

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -21,6 +21,8 @@ highlighting tool :pypi:`pygments` allows specifying additional styles
 using the entry point ``pygments.styles``.
 
 
+.. _console-scripts:
+
 Console Scripts
 ===============
 

--- a/docs/userguide/extension.rst
+++ b/docs/userguide/extension.rst
@@ -56,8 +56,8 @@ a ``foo`` command, you might add something like this to your project:
     distutils.commands =
          foo = mypackage.some_module:foo
 
-(Assuming, of course, that the ``foo`` class in ``mypackage.some_module`` is
-a ``setuptools.Command`` subclass.)
+Assuming, of course, that the ``foo`` class in ``mypackage.some_module`` is
+a ``setuptools.Command`` subclass (documented bellow).
 
 Once a project containing such entry points has been activated on ``sys.path``,
 (e.g. by running ``pip install``) the command(s) will be available to any
@@ -72,8 +72,20 @@ Custom commands should try to replicate the same overall behavior as the
 original classes, and when possible, even inherit from them.
 
 You should also consider handling exceptions such as ``CompileError``,
-``LinkError``, ``LibError``, among others.  These exceptions are available in
+``LinkError``, ``LibError``, among others. These exceptions are available in
 the ``setuptools.errors`` module.
+
+.. autoclass:: setuptools.Command
+   :members:
+
+
+Supporting sdists and editable installs in ``build`` sub-commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``build`` sub-commands (like ``build_py`` and ``build_ext``)
+are encouraged to implement the following protocol:
+
+.. autoclass:: setuptools.command.build.SubCommand
 
 
 Adding Arguments

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -119,7 +119,7 @@ class Command(_Command):
         Most of the time, each option/attribute/cache should only be set if it does not
         have any value yet (e.g. ``if self.attr is None: self.attr = val``).
 
-    .. method: run(self)
+    .. method:: run(self)
 
         Execute the actions intended by the command.
         (Side effects **SHOULD** only take place when ``run`` is executed,

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -44,20 +44,20 @@ class SubCommand(Protocol):
     1. ``setuptools`` will set the ``editable_mode`` flag will be set to ``True``
     2. ``setuptools`` will execute the ``run()`` command.
 
-         .. important::
-            Subcommands **SHOULD** take advantage of ``editable_mode=True`` to adequate
-            its behaviour or perform optimisations.
+       .. important::
+          Subcommands **SHOULD** take advantage of ``editable_mode=True`` to adequate
+          its behaviour or perform optimisations.
 
-            For example, if a subcommand don't need to generate any extra file and
-            everything it does is to copy a source file into the build directory,
-            ``run()`` **SHOULD** simply "early return".
+          For example, if a subcommand don't need to generate any extra file and
+          everything it does is to copy a source file into the build directory,
+          ``run()`` **SHOULD** simply "early return".
 
-            Similarly, if the subcommand creates files that would be placed alongside
-            Python files in the final distribution, during an editable install
-            the command **SHOULD** generate these files "in place" (i.e. write them to
-            the original source directory, instead of using the build directory).
-            Note that ``get_output_mapping()`` should reflect that and include mappings
-            for "in place" builds accordingly.
+          Similarly, if the subcommand creates files that would be placed alongside
+          Python files in the final distribution, during an editable install
+          the command **SHOULD** generate these files "in place" (i.e. write them to
+          the original source directory, instead of using the build directory).
+          Note that ``get_output_mapping()`` should reflect that and include mappings
+          for "in place" builds accordingly.
 
     3. ``setuptools`` use any knowledge it can derive from the return values of
        ``get_outputs()`` and ``get_output_mapping()`` to create an editable wheel.

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -339,7 +339,8 @@ class _LinkTree(_StaticPth):
         self._file(src_file, dest, link=link)
 
     def _create_links(self, outputs, output_mapping):
-        link_type = "sym" if _can_symlink_files() else "hard"
+        self.auxiliary_dir.mkdir(parents=True, exist_ok=True)
+        link_type = "sym" if _can_symlink_files(self.auxiliary_dir) else "hard"
         mappings = {
             self._normalize_output(k): v
             for k, v in output_mapping.items()
@@ -403,8 +404,8 @@ class _TopLevelFinder:
         ...
 
 
-def _can_symlink_files() -> bool:
-    with TemporaryDirectory() as tmp:
+def _can_symlink_files(base_dir: Path) -> bool:
+    with TemporaryDirectory(dir=str(base_dir.resolve())) as tmp:
         path1, path2 = Path(tmp, "file1.txt"), Path(tmp, "file2.txt")
         path1.write_text("file1", encoding="utf-8")
         with suppress(AttributeError, NotImplementedError, OSError):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -5,6 +5,7 @@ import signal
 import tarfile
 import importlib
 import contextlib
+import subprocess
 from concurrent import futures
 import re
 from zipfile import ZipFile
@@ -830,3 +831,27 @@ class TestBuildMetaLegacyBackend(TestBuildMetaBackend):
 
         build_backend = self.get_build_backend()
         build_backend.build_sdist("temp")
+
+
+def test_legacy_editable_install(tmpdir, tmpdir_cwd):
+    pyproject = """
+    [build-system]
+    requires = ["setuptools"]
+    build-backend = "setuptools.build_meta"
+    [project]
+    name = "myproj"
+    version = "42"
+    """
+    path.build({"pyproject.toml": DALS(pyproject), "mymod.py": ""})
+
+    # First: sanity check
+    cmd = [sys.executable, "-m", "pip", "install", "--no-build-isolation", "-e", "."]
+    output = str(subprocess.check_output(cmd, cwd=tmpdir), "utf-8").lower()
+    assert "running setup.py develop for myproj" not in output
+    assert "created wheel for myproj" in output
+
+    # Then: real test
+    env = {**os.environ, "SETUPTOOLS_ENABLE_FEATURES": "legacy-editable"}
+    cmd = [sys.executable, "-m", "pip", "install", "--no-build-isolation", "-e", "."]
+    output = str(subprocess.check_output(cmd, cwd=tmpdir, env=env), "utf-8").lower()
+    assert "running setup.py develop for myproj" in output


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

(*Another PR of the PEP 660 series*)

## Summary of changes

- Test symlinks in the target directory instead of temp dir
- Update development mode docs
- Allow users to specify `SETUPTOOLS_ENABLE_FEATURE=legacy-editable`

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
