### PR TITLE
Fix: Adding str() to fix TypeError

### DIFF
--- a/pkg_resources/_vendor/packaging/version.py
+++ b/pkg_resources/_vendor/packaging/version.py
@@ -261,7 +261,7 @@ class Version(_BaseVersion):
     def __init__(self, version: str) -> None:
 
         # Validate the version and parse it into pieces
-        match = self._regex.search(version)
+        match = self._regex.search(str(version))
         if not match:
             raise InvalidVersion(f"Invalid version: '{version}'")
 


### PR DESCRIPTION
fixing TypeError: expected string or bytes-like object on pkg_resources/_vendor/packaging/version.py error

## Summary of changes

Wrapped the `version` variable with `str()`

Closes #3416 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
