### PR TITLE
Document strict editable installs use the `build` directory

### DIFF
--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -106,6 +106,15 @@ directory (``$your_project_dir/build``) and add it to ``PYTHONPATH`` via a
 :mod:`.pth file <site>`. (Please be careful to not delete this repository
 by mistake otherwise your files may stop being accessible).
 
+.. warning::
+   Strict editable installs require auxiliary files to be placed in a
+   ``build/__editable__.*`` directory (relative to your project root).
+
+   Please be careful to not remove this directory while testing your project,
+   otherwise your editable installation may be compromised.
+
+   You can remove the ``build/__editable__.*`` directory after uninstalling.
+
 
 .. note::
     .. versionadded:: v63.0.0


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

As suggested in [this thread](https://discuss.python.org/t/help-testing-pep-660-support-in-setuptools/16904/11?u=abravalheri), a warning was added to tell users about the `build` directory being used to create the link tree.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
