### PR TITLE
[Doc] Ensure members of the build subcommand protocol are listed by autodoc

### DIFF
--- a/docs/userguide/extension.rst
+++ b/docs/userguide/extension.rst
@@ -86,6 +86,7 @@ Supporting sdists and editable installs in ``build`` sub-commands
 are encouraged to implement the following protocol:
 
 .. autoclass:: setuptools.command.build.SubCommand
+   :members:
 
 
 Adding Arguments

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -41,7 +41,7 @@ class SubCommand(Protocol):
     When creating an :pep:`editable wheel <660>`, ``setuptools`` will try to evaluate
     custom ``build`` subcommands using the following procedure:
 
-    1. ``setuptools`` will set the ``editable_mode`` flag will be set to ``True``
+    1. ``setuptools`` will set the ``editable_mode`` attribute to ``True``
     2. ``setuptools`` will execute the ``run()`` command.
 
        .. important::


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

(*Another PR of the PEP 660 series*)

Probably this section of the docs needs some reorganizing to be more clear. But for the time being it is better than nothing...

## Summary of changes

- Add `:members:` to `setuptools.command.build.SubCommand` to ensure `get_output_mapping()` is displayed in the docs.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
