### PR TITLE
Merge with pypa/distutils@152c13d

### DIFF
--- a/changelog.d/3430.change.rst
+++ b/changelog.d/3430.change.rst
@@ -1,0 +1,1 @@
+Merge with pypa/distutils@152c13d including pypa/distutils#155 (improved compatibility for editable installs on homebrew Python 3.9), pypa/distutils#150 (better handling of runtime_library_dirs on cygwin), and pypa/distutils#151 (remove warnings for namespace packages).

--- a/setuptools/_distutils/command/_framework_compat.py
+++ b/setuptools/_distutils/command/_framework_compat.py
@@ -1,0 +1,52 @@
+"""
+Backward compatibility for homebrew builds on macOS.
+"""
+
+
+import sys
+import os
+import functools
+import subprocess
+
+
+@functools.lru_cache()
+def enabled():
+    """
+    Only enabled for Python 3.9 framework builds except ensurepip and venv.
+    """
+    PY39 = (3, 9) < sys.version_info < (3, 10)
+    framework = sys.platform == 'darwin' and sys._framework
+    venv = sys.prefix != sys.base_prefix
+    ensurepip = os.environ.get("ENSUREPIP_OPTIONS")
+    return PY39 and framework and not venv and not ensurepip
+
+
+schemes = dict(
+    osx_framework_library=dict(
+        stdlib='{installed_base}/{platlibdir}/python{py_version_short}',
+        platstdlib='{platbase}/{platlibdir}/python{py_version_short}',
+        purelib='{homebrew_prefix}/lib/python{py_version_short}/site-packages',
+        platlib='{homebrew_prefix}/{platlibdir}/python{py_version_short}/site-packages',
+        include='{installed_base}/include/python{py_version_short}{abiflags}',
+        platinclude='{installed_platbase}/include/python{py_version_short}{abiflags}',
+        scripts='{homebrew_prefix}/bin',
+        data='{homebrew_prefix}',
+    )
+)
+
+
+@functools.lru_cache()
+def vars():
+    if not enabled():
+        return {}
+    homebrew_prefix = subprocess.check_output(['brew', '--prefix'], text=True).strip()
+    return locals()
+
+
+def scheme(name):
+    """
+    Override the selected scheme for posix_prefix.
+    """
+    if not enabled() or not name.endswith('_prefix'):
+        return name
+    return 'osx_framework_library'

--- a/setuptools/_distutils/command/build_py.py
+++ b/setuptools/_distutils/command/build_py.py
@@ -201,16 +201,11 @@ class build_py(Command):
                     "but is not a directory" % package_dir
                 )
 
-        # Require __init__.py for all but the "root package"
+        # Directories without __init__.py are namespace packages (PEP 420).
         if package:
             init_py = os.path.join(package_dir, "__init__.py")
             if os.path.isfile(init_py):
                 return init_py
-            else:
-                log.warn(
-                    ("package init file '%s' not found " + "(or not a regular file)"),
-                    init_py,
-                )
 
         # Either not in a package at all (__init__.py not expected), or
         # __init__.py doesn't exist -- so don't return the filename.

--- a/setuptools/_distutils/command/install.py
+++ b/setuptools/_distutils/command/install.py
@@ -17,6 +17,7 @@ from distutils.file_util import write_file
 from distutils.util import convert_path, subst_vars, change_root
 from distutils.util import get_platform
 from distutils.errors import DistutilsOptionError
+from . import _framework_compat as fw
 from .. import _collections
 
 from site import USER_BASE
@@ -82,6 +83,10 @@ if HAS_USER_SITE:
         'data': '{userbase}',
     }
 
+
+INSTALL_SCHEMES.update(fw.schemes)
+
+
 # The keys to an installation scheme; if any new types of files are to be
 # installed, be sure to add an entry to every installation scheme above,
 # and to SCHEME_KEYS here.
@@ -136,7 +141,7 @@ def _resolve_scheme(name):
     try:
         resolved = sysconfig.get_preferred_scheme(key)
     except Exception:
-        resolved = _pypy_hack(name)
+        resolved = fw.scheme(_pypy_hack(name))
     return resolved
 
 
@@ -426,7 +431,7 @@ class install(Command):
             local_vars['usersite'] = self.install_usersite
 
         self.config_vars = _collections.DictStack(
-            [compat_vars, sysconfig.get_config_vars(), local_vars]
+            [fw.vars(), compat_vars, sysconfig.get_config_vars(), local_vars]
         )
 
         self.expand_basedirs()

--- a/setuptools/_distutils/tests/test_cygwinccompiler.py
+++ b/setuptools/_distutils/tests/test_cygwinccompiler.py
@@ -48,6 +48,12 @@ class CygwinCCompilerTestCase(support.TempdirManager, unittest.TestCase):
         self.assertTrue(os.path.exists(linkable_file))
         self.assertEquals(linkable_file, "/usr/lib/lib{:s}.dll.a".format(link_name))
 
+    @unittest.skipIf(sys.platform != "cygwin", "Not running on Cygwin")
+    def test_runtime_library_dir_option(self):
+        from distutils.cygwinccompiler import CygwinCCompiler
+        compiler = CygwinCCompiler()
+        self.assertEqual(compiler.runtime_library_dir_option('/foo'), [])
+
     def test_check_config_h(self):
 
         # check_config_h looks for "GCC" in sys.version first


### PR DESCRIPTION
- Improve handling if runtime_library_dirs is set with cygwin/mingw
- Add test capturing expectations
- Remove warnings on namespace packages
- Add support for Homebrew on Python 3.9 instead of relying on distutils.cfg as found in the stdlib. Fixes pypa/distutils#152.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
