### PR TITLE
Should we add a `DeprecationWarning` to `pkg_resources.declare_namespace`?

### DIFF
--- a/changelog.d/3434.deprecation.rst
+++ b/changelog.d/3434.deprecation.rst
@@ -1,0 +1,3 @@
+Added deprecation warning for ``pkg_resources.declare_namespace``.
+Users that wish to implement namespace packages, are recommended to follow the
+practice described in PEP 420 and omit the ``__init__.py`` file entirely.

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -390,7 +390,10 @@ extensions).
 
 ``namespace_packages``
     .. warning::
-        ``namespace_packages`` is deprecated in favor of native/implicit
+        The ``namespace_packages`` implementation relies on ``pkg_resources``.
+        However, ``pkg_resources`` has some undesirable behaviours, and
+        Setuptools intends to obviate its usage in the future. Therefore,
+        ``namespace_packages`` was deprecated in favor of native/implicit
         namespaces (:pep:`420`). Check :doc:`the Python Packaging User Guide
         <PyPUG:guides/packaging-namespace-packages>` for more information.
 

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2288,6 +2288,12 @@ def _rebuild_mod_path(orig_path, package_name, module):
 def declare_namespace(packageName):
     """Declare that package 'packageName' is a namespace package"""
 
+    msg = (
+        "Implementing implicit namespace packages (as specified in PEP 420) "
+        "is preferred to `pkg_resources.declare_namespace`."
+    )
+    warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
     _imp.acquire_lock()
     try:
         if packageName in _namespace_packages:

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2290,7 +2290,9 @@ def declare_namespace(packageName):
 
     msg = (
         "Implementing implicit namespace packages (as specified in PEP 420) "
-        "is preferred to `pkg_resources.declare_namespace`."
+        "is preferred to `pkg_resources.declare_namespace`. "
+        "See https://setuptools.pypa.io/en/latest/references/"
+        "keywords.html#keyword-namespace-packages"
     )
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
 

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -830,10 +830,12 @@ class TestNamespaces:
             pkg2.ensure_dir()
             (pkg1 / '__init__.py').write_text(self.ns_str, encoding='utf-8')
             (pkg2 / '__init__.py').write_text(self.ns_str, encoding='utf-8')
-        import pkg1
+        with pytest.warns(DeprecationWarning, match="pkg_resources.declare_namespace"):
+            import pkg1
         assert "pkg1" in pkg_resources._namespace_packages
         # attempt to import pkg2 from site-pkgs2
-        import pkg1.pkg2
+        with pytest.warns(DeprecationWarning, match="pkg_resources.declare_namespace"):
+            import pkg1.pkg2
         # check the _namespace_packages dict
         assert "pkg1.pkg2" in pkg_resources._namespace_packages
         assert pkg_resources._namespace_packages["pkg1"] == ["pkg1.pkg2"]
@@ -874,8 +876,9 @@ class TestNamespaces:
             (subpkg / '__init__.py').write_text(
                 vers_str % number, encoding='utf-8')
 
-        import nspkg.subpkg
-        import nspkg
+        with pytest.warns(DeprecationWarning, match="pkg_resources.declare_namespace"):
+            import nspkg.subpkg
+            import nspkg
         expected = [
             str(site.realpath() / 'nspkg')
             for site in site_dirs

--- a/pytest.ini
+++ b/pytest.ini
@@ -83,3 +83,6 @@ filterwarnings=
 	# Can't use EncodingWarning as it doesn't exist on Python 3.9
 	default:'encoding' argument not specified
 	default:UTF-8 Mode affects locale.getpreferredencoding().
+
+	# Avoid errors when testing pkg_resources.declare_namespace
+	ignore:.*pkg_resources\.declare_namespace.*:DeprecationWarning

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -280,7 +280,9 @@ def check_nsp(dist, attr, value):
             )
         msg = (
             "The namespace_packages parameter is deprecated, "
-            "consider using implicit namespaces instead (PEP 420)."
+            "consider using implicit namespaces instead (PEP 420). "
+            "See https://setuptools.pypa.io/en/latest/references/"
+            "keywords.html#keyword-namespace-packages"
         )
         warnings.warn(msg, SetuptoolsDeprecationWarning)
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

I think it makes sense to add a warning recommending the migration to PEP 420. `pkg_resources` is in its majority "discouraged", isn't it?

## Summary of changes

- Add a `DeprecationWarning` to `pkg_resources.declare_namespace`.
  - By default, Python will not show `DeprecationWarning` to the final user (unless they opt-in for something more strict, in which case they should be familiar with more complex warning filters), so this approach should be OK. 

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
