### PR TITLE
Deprecation: Add stacklevel=2 to make calling code clear

### DIFF
--- a/setuptools/config/__init__.py
+++ b/setuptools/config/__init__.py
@@ -25,7 +25,7 @@ def _deprecation_notice(fn: Fn) -> Fn:
         to access a backward compatible API, but this module is provisional
         and might be removed in the future.
         """
-        warnings.warn(dedent(msg), SetuptoolsDeprecationWarning)
+        warnings.warn(dedent(msg), SetuptoolsDeprecationWarning, stacklevel=2)
         return fn(*args, **kwargs)
 
     return cast(Fn, _wrapper)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

### Before

Points to deprecation itself in setuptools, `/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/setuptools/config/__init__.py`:

```
================================================================== warnings summary ==================================================================
pyroma/tests.py::RatingsTest::test_only_config
  /Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/site-packages/setuptools/config/__init__.py:28: SetuptoolsDeprecationWarning: As setuptools moves its configuration towards `pyproject.toml`,
  `setuptools.config.read_configuration` became deprecated.

  For the time being, you can use the `setuptools.config.setupcfg` module
  to access a backward compatible API, but this module is provisional
  and might be removed in the future.

    warnings.warn(dedent(msg), SetuptoolsDeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 12 passed, 1 warning in 3.83s ============================================================
```

### After

Points to caller of deprecation in user's project, for example `/private/tmp/pyroma/pyroma/projectdata.py`:

```
================================================================== warnings summary ==================================================================
pyroma/tests.py::RatingsTest::test_only_config
  /private/tmp/pyroma/pyroma/projectdata.py:50: SetuptoolsDeprecationWarning: As setuptools moves its configuration towards `pyproject.toml`,
  `setuptools.config.read_configuration` became deprecated.

  For the time being, you can use the `setuptools.config.setupcfg` module
  to access a backward compatible API, but this module is provisional
  and might be removed in the future.

    data = config.read_configuration("setup.cfg")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================== 12 passed, 1 warning in 3.73s ============================================================
```

Docs: https://docs.python.org/3/library/warnings.html#available-functions


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
