### PR TITLE
Docs: enable tooltips on documentation

### DIFF
--- a/changelog.d/3443.doc.rst
+++ b/changelog.d/3443.doc.rst
@@ -1,0 +1,2 @@
+Installed ``sphinx-hoverxref`` extension to show tooltips on internal an external references.
+-- by :user:`humitos`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,6 +102,19 @@ intersphinx_mapping.update({
     ),
 })
 
+# Support tooltips on references
+extensions += ['hoverxref.extension']
+hoverxref_auto_ref = True
+hoverxref_intersphinx = [
+    'python',
+    'pip',
+    'build',
+    'PyPUG',
+    'packaging',
+    'twine',
+    'importlib-resources',
+]
+
 # Add support for linking usernames
 github_url = 'https://github.com'
 github_repo_org = 'pypa'

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,7 +88,7 @@ docs =
 	jaraco.packaging >= 9
 	rst.linker >= 1.9
 	jaraco.tidelift >= 1.4
-	sphinx-hoverxref==1.1.3
+	sphinx-hoverxref < 2
 
 	# local
 	pygments-github-lexers==0.0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -88,6 +88,7 @@ docs =
 	jaraco.packaging >= 9
 	rst.linker >= 1.9
 	jaraco.tidelift >= 1.4
+	sphinx-hoverxref==1.1.3
 
 	# local
 	pygments-github-lexers==0.0.5


### PR DESCRIPTION
## Summary of changes

I'm suggesting installing the Sphinx extension [`sphinx-hoverxref`](https://github.com/readthedocs/sphinx-hoverxref/) to enable tooltips when hovering internal and external references (via intersphinx).

I set up a testing project on Read the Docs to show what it looks like in a live preview. Check it out at https://humitos-setuptools.readthedocs.io/en/docs-tooltips/userguide/quickstart.html


Let me know if this is something you like and if you want me to do any changes for the PR to be approved.

###  Quick Examples

Here is a small GIF showing it in action and internal reference.

![Peek 2022-07-13 12-20](https://user-images.githubusercontent.com/244656/178711931-c53212f6-c58b-4032-8c77-2402e32b949d.gif)

Another GIF showing an external reference pointing to twine:

![Peek 2022-07-13 12-26](https://user-images.githubusercontent.com/244656/178712844-da744c01-3fa9-4d0d-8b3b-a944e74e18d4.gif)

----

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
