### PR TITLE
Expose a subset of distutils C-compiler interface as public API

### DIFF
--- a/changelog.d/3445.changes.rst
+++ b/changelog.d/3445.changes.rst
@@ -1,0 +1,2 @@
+Re-exposed a subset of ``distutils.ccompiler`` and ``distutils.sysconfig``
+modules as ``setuptools.ccompiler``.

--- a/docs/deprecated/distutils-legacy.rst
+++ b/docs/deprecated/distutils-legacy.rst
@@ -19,6 +19,12 @@ As Distutils is deprecated, any usage of functions or objects from distutils is 
 
 ``distutils.command.{build_clib,build_ext,build_py,sdist}`` → ``setuptools.command.*``
 
+``distutils.ccompiler.CCompiler`` → ``setuptools.ccompiler.CCompiler``
+
+``distutils.ccompiler.new_compiler`` → ``setuptools.ccompiler.new_compiler``
+
+``distutils.sysconfig.customize_compiler`` → ``setuptools.ccompiler.customize_compiler``
+
 ``distutils.log`` → :mod:`logging` (standard library)
 
 ``distutils.version.*`` → :doc:`packaging.version.* <packaging:version>`

--- a/setuptools/ccompiler.py
+++ b/setuptools/ccompiler.py
@@ -1,6 +1,18 @@
 # Expose a subset of distutils as public API
 # to help with migration to Python 3.12
 
-from ._distutils.ccompiler import CCompiler
-from ._distutils.sysconfig import customize_compiler
-from ._distutils.ccompiler import new_compiler
+from distutils.ccompiler import CCompiler
+from distutils.ccompiler import new_compiler
+
+
+def customize_compiler(compiler: CCompiler):
+    """Do any platform-specific customization of a CCompiler instance.
+
+    Mainly needed on Unix, so we can plug in the information that
+    varies across Unices and is stored in Python's Makefile.
+    """
+    # Importing `distutils.sysconfig` directly may change the global state.
+    # We adopt a lazy approach instead.
+    from distutils.sysconfig import customize_compiler as _customize
+
+    return _customize(compiler)

--- a/setuptools/ccompiler.py
+++ b/setuptools/ccompiler.py
@@ -5,6 +5,13 @@ from distutils.ccompiler import CCompiler
 from distutils.ccompiler import new_compiler
 
 
+__all__ = [
+    "CCompiler",
+    "new_compiler",
+    "customize_compiler",
+]
+
+
 def customize_compiler(compiler: CCompiler):
     """Do any platform-specific customization of a CCompiler instance.
 

--- a/setuptools/ccompiler.py
+++ b/setuptools/ccompiler.py
@@ -1,0 +1,6 @@
+# Expose a subset of distutils as public API
+# to help with migration to Python 3.12
+
+from ._distutils.ccompiler import CCompiler
+from ._distutils.sysconfig import customize_compiler
+from ._distutils.ccompiler import new_compiler

--- a/setuptools/tests/test_ccompiler.py
+++ b/setuptools/tests/test_ccompiler.py
@@ -2,7 +2,23 @@ from setuptools.ccompiler import CCompiler
 from setuptools.ccompiler import customize_compiler
 from setuptools.ccompiler import new_compiler
 
-def test_ccompiler_namespace():
+import pytest
+
+
+def test_ccompiler_namespace(_avoid_permanent_changes_in_sysconfig):
     ccompiler = new_compiler()
     customize_compiler(ccompiler)
     assert hasattr(ccompiler, "compile")
+
+
+@pytest.fixture
+def _avoid_permanent_changes_in_sysconfig(monkeypatch):
+    import importlib
+    import sys
+
+    # Avoid caching `distutils.sysconfig` and force it to be re-imported later.
+    # This should "cancel out" any permanent changes that comes as a side-effect of
+    # import thing `distutils.sysconfig`.
+    monkeypatch.setattr(sys, "modules", sys.modules.copy())
+    yield
+    importlib.invalidate_caches()

--- a/setuptools/tests/test_ccompiler.py
+++ b/setuptools/tests/test_ccompiler.py
@@ -1,0 +1,8 @@
+from setuptools.ccompiler import CCompiler
+from setuptools.ccompiler import customize_compiler
+from setuptools.ccompiler import new_compiler
+
+def test_ccompiler_namespace():
+    ccompiler = new_compiler()
+    customize_compiler(ccompiler)
+    assert hasattr(ccompiler, "compile")

--- a/setuptools/tests/test_ccompiler.py
+++ b/setuptools/tests/test_ccompiler.py
@@ -9,6 +9,7 @@ def test_ccompiler_namespace(_avoid_permanent_changes_in_sysconfig):
     ccompiler = new_compiler()
     customize_compiler(ccompiler)
     assert hasattr(ccompiler, "compile")
+    assert CCompiler.compiler_type is None
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary of changes

Re-expose a subset of distutils C-compiler interface as `setuptools.ccompiler`, as suggested by @abravalheri.
I went with the most conservative approach and exposed only the components I know are needed downstream.
I'll happily add more of them on request (ping @minrk), or expose the whole `distutils.ccompiler` module if prefered by maintainers.

Closes #2806

I'm not sure what kind of tests this would require. Would it suffice to check that these names are defined ?

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_
