### PR TITLE
Use the new `pytest-enabler` config section for xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ addopts = "--flake8"
 [tool.pytest-enabler.cov]
 addopts = "--cov"
 
-[pytest.enabler.xdist]
+[tool.pytest-enabler.xdist]
 addopts = "-n auto"
 
 [tool.towncrier]


### PR DESCRIPTION
This is a follow up on https://github.com/pypa/setuptools/commit/120d9270c50a07caad0c697ca1f4b865226dde99.

## Summary of changes

Change the `[pytest.enabler.xdist]` config to `[tool.pytest-enabler.xdist]` in `pyproject.toml`.


Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
