### PR TITLE
Fix typo `find_namespaces:` to `find_namespace:`

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -186,9 +186,9 @@ found, as shown in the example below:
     .. code-block:: ini
 
         [options]
-        packages = find: # OR `find_namespaces:` if you want to use namespaces
+        packages = find: # OR `find_namespace:` if you want to use namespaces
 
-        [options.packages.find] # (always `find` even if `find_namespaces:` was used before)
+        [options.packages.find] # (always `find` even if `find_namespace:` was used before)
         # This section is optional
         # Each entry in this section is optional, and if not specified, the default values are:
         # `where=.`, `include=*` and `exclude=` (empty).


### PR DESCRIPTION
I believe the correct `setup.cfg` packaging option is `find_namespace:`, not `find_namespaces:`
I can't find any other references to `find_namespaces` in the docs or repository.

Using `find_namespaces:` causes packaging to fail. Example to reproduce:
```
.
├── pyproject.toml
├── setup.cfg
└── src
    ├── pkg1
    │   └── namespace
    │       └── __init__.py
    └── pkg2
        └── __init__.py
```

Contents of `pyproject.toml`:
```
[build-system]
requires = ["setuptools"]
build-backend = "setuptools.build_meta"
```

Contents of `setup.cfg`:
```
[metadata]
name = pkg_test

[options]
packages = find_namespaces:
package_dir =
    =src

[options.packages.find]
where = src
```

```
$ pip install .
> ...
> error: package directory 'src/find_namespaces:' does not exist
> ...
```

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
