### PR TITLE
Deprecate upload_docs command

### DIFF
--- a/changelog.d/2971.change.rst
+++ b/changelog.d/2971.change.rst
@@ -1,0 +1,1 @@
+``upload_docs`` command is deprecated once again.

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -59,7 +59,7 @@ class upload_docs(upload):
         self.target_dir = None
 
     def finalize_options(self):
-        log.warn("Upload_docs command is deprecated. Use RTD instead.")
+        log.warn("Upload_docs command is deprecated. Use Read the Docs (https://readthedocs.org) instead.")
         upload.finalize_options(self)
         if self.upload_dir is None:
             if self.has_sphinx():

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -59,7 +59,9 @@ class upload_docs(upload):
         self.target_dir = None
 
     def finalize_options(self):
-        log.warn("Upload_docs command is deprecated. Use Read the Docs (https://readthedocs.org) instead.")
+        log.warn(
+            "Upload_docs command is deprecated. Use Read the Docs "
+            "(https://readthedocs.org) instead.")
         upload.finalize_options(self)
         if self.upload_dir is None:
             if self.has_sphinx():

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -59,6 +59,7 @@ class upload_docs(upload):
         self.target_dir = None
 
     def finalize_options(self):
+        log.warn("Upload_docs command is deprecated. Use RTD instead.")
         upload.finalize_options(self)
         if self.upload_dir is None:
             if self.has_sphinx():
@@ -70,8 +71,6 @@ class upload_docs(upload):
         else:
             self.ensure_dirname('upload_dir')
             self.target_dir = self.upload_dir
-        if 'pypi.python.org' in self.repository:
-            log.warn("Upload_docs command is deprecated for PyPi. Use RTD instead.")
         self.announce('Using upload directory %s' % self.target_dir)
 
     def create_zipfile(self, filename):


### PR DESCRIPTION
This reverts commit 995d309317c6895a123c03df28bc8f51f6ead5f5.

Ref #2971.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
