### PR TITLE
Fix finding library files

### DIFF
--- a/changelog.d/3476.change.rst
+++ b/changelog.d/3476.change.rst
@@ -1,0 +1,1 @@
+Fixed a regression introduced in 63.3.0 which broke e.g. the build from source of Pillow. Needed libraries where not found anymore. -- by :user:`timotheus.bachinger`

--- a/setuptools/_distutils/unixccompiler.py
+++ b/setuptools/_distutils/unixccompiler.py
@@ -373,8 +373,8 @@ class UnixCCompiler(CCompiler):
 
         searched = (
             os.path.join(root, lib_name)
-            for root in map(self._library_root, dirs)
             for lib_name in lib_names
+            for root in map(self._library_root, dirs)
         )
 
         found = filter(os.path.exists, searched)


### PR DESCRIPTION
* this was broken after refactoring: https://github.com/pypa/setuptools/commit/25dcca2902780146a1ee298f18648334eb3cddff

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Since setuptools 63.3.0, pillow couldn't be built anymore, see https://github.com/python-pillow/Pillow/issues/6471

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests: Building pillow is possible again after this change
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
