### PR TITLE
Add `prepare_metadata_for_build_editable` to `build_meta.__all__`

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -52,6 +52,7 @@ __all__ = ['get_requires_for_build_sdist',
            'build_wheel',
            'build_sdist',
            'get_requires_for_build_editable',
+           'prepare_metadata_for_build_editable',
            'build_editable',
            '__legacy__',
            'SetupRequirementsError']

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -278,8 +278,8 @@ def test_get_outputs(tmpdir_cwd):
     build_py.editable_mode = True
     build_py.ensure_finalized()
     build_lib = build_py.build_lib.replace(os.sep, "/")
-    outputs = [x.replace(os.sep, "/") for x in build_py.get_outputs()]
-    assert outputs == [
+    outputs = {x.replace(os.sep, "/") for x in build_py.get_outputs()}
+    assert outputs == {
         f"{build_lib}/mypkg/__init__.py",
         f"{build_lib}/mypkg/resource_file.txt",
         f"{build_lib}/mypkg/sub1/__init__.py",
@@ -287,7 +287,7 @@ def test_get_outputs(tmpdir_cwd):
         f"{build_lib}/mypkg/sub2/mod2.py",
         f"{build_lib}/mypkg/sub2/nested/__init__.py",
         f"{build_lib}/mypkg/sub2/nested/mod3.py",
-    ]
+    }
     mapping = {
         k.replace(os.sep, "/"): v.replace(os.sep, "/")
         for k, v in build_py.get_output_mapping().items()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

(*Another PR related to the PEP 660 implementation, carried out in the `feature/pep660` branch*)

## Summary of changes

- Adds `prepare_metadata_for_build_editable` to `build_meta.__all__` (this was noted as missing in
https://github.com/pypa/setuptools/pull/3265#discussion_r935208205).
- (Unrelated) replace list comparison with set comparison in test (to address test failure).

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
