### PR TITLE
Use `venv` to isolate `test_legacy_editable_install`

### DIFF
--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -5,7 +5,6 @@ import signal
 import tarfile
 import importlib
 import contextlib
-import subprocess
 from concurrent import futures
 import re
 from zipfile import ZipFile
@@ -833,7 +832,7 @@ class TestBuildMetaLegacyBackend(TestBuildMetaBackend):
         build_backend.build_sdist("temp")
 
 
-def test_legacy_editable_install(tmpdir, tmpdir_cwd):
+def test_legacy_editable_install(venv, tmpdir, tmpdir_cwd):
     pyproject = """
     [build-system]
     requires = ["setuptools"]
@@ -845,13 +844,13 @@ def test_legacy_editable_install(tmpdir, tmpdir_cwd):
     path.build({"pyproject.toml": DALS(pyproject), "mymod.py": ""})
 
     # First: sanity check
-    cmd = [sys.executable, "-m", "pip", "install", "--no-build-isolation", "-e", "."]
-    output = str(subprocess.check_output(cmd, cwd=tmpdir), "utf-8").lower()
+    cmd = ["pip", "install", "--no-build-isolation", "-e", "."]
+    output = str(venv.run(cmd, cwd=tmpdir), "utf-8").lower()
     assert "running setup.py develop for myproj" not in output
     assert "created wheel for myproj" in output
 
     # Then: real test
     env = {**os.environ, "SETUPTOOLS_ENABLE_FEATURES": "legacy-editable"}
-    cmd = [sys.executable, "-m", "pip", "install", "--no-build-isolation", "-e", "."]
-    output = str(subprocess.check_output(cmd, cwd=tmpdir, env=env), "utf-8").lower()
+    cmd = ["pip", "install", "--no-build-isolation", "-e", "."]
+    output = str(venv.run(cmd, cwd=tmpdir, env=env), "utf-8").lower()
     assert "running setup.py develop for myproj" in output


### PR DESCRIPTION
*(Another PR related to the PEP 660 implementation, carried out in the feature/pep660 branch)*


<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Use `venv` to prevent breaking test isolation.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
