### PR TITLE
Merge with pypa/distutils@c397f4c

### DIFF
--- a/changelog.d/3480.misc.rst
+++ b/changelog.d/3480.misc.rst
@@ -1,0 +1,1 @@
+Merge with pypa/distutils@c397f4c

--- a/setuptools/_distutils/_msvccompiler.py
+++ b/setuptools/_distutils/_msvccompiler.py
@@ -144,12 +144,12 @@ def _get_vc_env(plat_spec):
 
     try:
         out = subprocess.check_output(
-            'cmd /u /c "{}" {} && set'.format(vcvarsall, plat_spec),
+            f'cmd /u /c "{vcvarsall}" {plat_spec} && set',
             stderr=subprocess.STDOUT,
         ).decode('utf-16le', errors='replace')
     except subprocess.CalledProcessError as exc:
         log.error(exc.output)
-        raise DistutilsPlatformError("Error executing {}".format(exc.cmd))
+        raise DistutilsPlatformError(f"Error executing {exc.cmd}")
 
     env = {
         key.lower(): value
@@ -232,7 +232,7 @@ class MSVCCompiler(CCompiler):
         # sanity check for platforms to prevent obscure errors later.
         if plat_name not in PLAT_TO_VCVARS:
             raise DistutilsPlatformError(
-                "--plat-name must be one of {}".format(tuple(PLAT_TO_VCVARS))
+                f"--plat-name must be one of {tuple(PLAT_TO_VCVARS)}"
             )
 
         # Get the vcvarsall.bat spec for the requested platform.
@@ -341,7 +341,7 @@ class MSVCCompiler(CCompiler):
                 # Better to raise an exception instead of silently continuing
                 # and later complain about sources and targets having
                 # different lengths
-                raise CompileError("Don't know how to compile {}".format(p))
+                raise CompileError(f"Don't know how to compile {p}")
 
         return list(map(make_out_path, source_filenames))
 
@@ -425,9 +425,7 @@ class MSVCCompiler(CCompiler):
                 continue
             else:
                 # how to handle this file?
-                raise CompileError(
-                    "Don't know how to compile {} to {}".format(src, obj)
-                )
+                raise CompileError(f"Don't know how to compile {src} to {obj}")
 
             args = [self.cc] + compile_opts + pp_opts
             if add_cpp_opts:

--- a/setuptools/_distutils/bcppcompiler.py
+++ b/setuptools/_distutils/bcppcompiler.py
@@ -234,7 +234,7 @@ class BCPPCompiler(CCompiler):
                 def_file = os.path.join(temp_dir, '%s.def' % modname)
                 contents = ['EXPORTS']
                 for sym in export_symbols or []:
-                    contents.append('  %s=_%s' % (sym, sym))
+                    contents.append('  {}=_{}'.format(sym, sym))
                 self.execute(write_file, (def_file, contents), "writing %s" % def_file)
 
             # Borland C++ has problems with '/' in paths
@@ -346,7 +346,7 @@ class BCPPCompiler(CCompiler):
             (base, ext) = os.path.splitext(os.path.normcase(src_name))
             if ext not in (self.src_extensions + ['.rc', '.res']):
                 raise UnknownFileError(
-                    "unknown file type '%s' (from '%s')" % (ext, src_name)
+                    "unknown file type '{}' (from '{}')".format(ext, src_name)
                 )
             if strip_dir:
                 base = os.path.basename(base)

--- a/setuptools/_distutils/ccompiler.py
+++ b/setuptools/_distutils/ccompiler.py
@@ -930,7 +930,7 @@ int main (int argc, char **argv) {
             base = base[os.path.isabs(base) :]  # If abs, chop off leading /
             if ext not in self.src_extensions:
                 raise UnknownFileError(
-                    "unknown file type '%s' (from '%s')" % (ext, src_name)
+                    "unknown file type '{}' (from '{}')".format(ext, src_name)
                 )
             if strip_dir:
                 base = os.path.basename(base)

--- a/setuptools/_distutils/cmd.py
+++ b/setuptools/_distutils/cmd.py
@@ -163,7 +163,7 @@ class Command:
             if option[-1] == "=":
                 option = option[:-1]
             value = getattr(self, option)
-            self.announce(indent + "%s = %s" % (option, value), level=log.INFO)
+            self.announce(indent + "{} = {}".format(option, value), level=log.INFO)
 
     def run(self):
         """A command's raison d'etre: carry out the action it exists to
@@ -215,7 +215,7 @@ class Command:
             return default
         elif not isinstance(val, str):
             raise DistutilsOptionError(
-                "'%s' must be a %s (got `%s`)" % (option, what, val)
+                "'{}' must be a {} (got `{}`)".format(option, what, val)
             )
         return val
 
@@ -243,7 +243,7 @@ class Command:
                 ok = False
             if not ok:
                 raise DistutilsOptionError(
-                    "'%s' must be a list of strings (got %r)" % (option, val)
+                    "'{}' must be a list of strings (got {!r})".format(option, val)
                 )
 
     def _ensure_tested_string(self, option, tester, what, error_fmt, default=None):
@@ -424,7 +424,7 @@ class Command:
             raise TypeError("'infiles' must be a string, or a list or tuple of strings")
 
         if exec_msg is None:
-            exec_msg = "generating %s from %s" % (outfile, ', '.join(infiles))
+            exec_msg = "generating {} from {}".format(outfile, ', '.join(infiles))
 
         # If 'outfile' must be regenerated (either because it doesn't
         # exist, is out-of-date, or the 'force' flag is true) then

--- a/setuptools/_distutils/command/bdist.py
+++ b/setuptools/_distutils/command/bdist.py
@@ -20,12 +20,6 @@ def show_formats():
     pretty_printer.print_help("List of available distribution formats:")
 
 
-class ListCompat(dict):
-    # adapter to allow for Setuptools compatibility in format_commands
-    def append(self, item):
-        return
-
-
 class bdist(Command):
 
     description = "create a built (binary) distribution"
@@ -71,22 +65,17 @@ class bdist(Command):
     default_format = {'posix': 'gztar', 'nt': 'zip'}
 
     # Define commands in preferred order for the --help-formats option
-    format_commands = ListCompat(
-        {
-            'rpm': ('bdist_rpm', "RPM distribution"),
-            'gztar': ('bdist_dumb', "gzip'ed tar file"),
-            'bztar': ('bdist_dumb', "bzip2'ed tar file"),
-            'xztar': ('bdist_dumb', "xz'ed tar file"),
-            'ztar': ('bdist_dumb', "compressed tar file"),
-            'tar': ('bdist_dumb', "tar file"),
-            'wininst': ('bdist_wininst', "Windows executable installer"),
-            'zip': ('bdist_dumb', "ZIP file"),
-            'msi': ('bdist_msi', "Microsoft Installer"),
-        }
+    format_commands = dict(
+        rpm=('bdist_rpm', "RPM distribution"),
+        gztar=('bdist_dumb', "gzip'ed tar file"),
+        bztar=('bdist_dumb', "bzip2'ed tar file"),
+        xztar=('bdist_dumb', "xz'ed tar file"),
+        ztar=('bdist_dumb', "compressed tar file"),
+        tar=('bdist_dumb', "tar file"),
+        wininst=('bdist_wininst', "Windows executable installer"),
+        zip=('bdist_dumb', "ZIP file"),
+        msi=('bdist_msi', "Microsoft Installer"),
     )
-
-    # for compatibility until Setuptools references only format_commands
-    format_command = format_commands
 
     def initialize_options(self):
         self.bdist_base = None

--- a/setuptools/_distutils/command/bdist_dumb.py
+++ b/setuptools/_distutils/command/bdist_dumb.py
@@ -105,7 +105,9 @@ class bdist_dumb(Command):
 
         # And make an archive relative to the root of the
         # pseudo-installation tree.
-        archive_basename = "%s.%s" % (self.distribution.get_fullname(), self.plat_name)
+        archive_basename = "{}.{}".format(
+            self.distribution.get_fullname(), self.plat_name
+        )
 
         pseudoinstall_root = os.path.join(self.dist_dir, archive_basename)
         if not self.relative:

--- a/setuptools/_distutils/command/bdist_msi.py
+++ b/setuptools/_distutils/command/bdist_msi.py
@@ -253,7 +253,7 @@ class bdist_msi(Command):
             if not target_version:
                 assert self.skip_build, "Should have already checked this"
                 target_version = '%d.%d' % sys.version_info[:2]
-            plat_specifier = ".%s-%s" % (self.plat_name, target_version)
+            plat_specifier = ".{}-{}".format(self.plat_name, target_version)
             build = self.get_finalized_command('build')
             build.build_lib = os.path.join(build.build_base, 'lib' + plat_specifier)
 
@@ -286,7 +286,7 @@ class bdist_msi(Command):
         # in Add-Remove-Programs (APR)
         fullname = self.distribution.get_fullname()
         if self.target_version:
-            product_name = "Python %s %s" % (self.target_version, fullname)
+            product_name = "Python {} {}".format(self.target_version, fullname)
         else:
             product_name = "Python %s" % (fullname)
         self.db = msilib.init_database(
@@ -347,7 +347,7 @@ class bdist_msi(Command):
                 for file in os.listdir(dir.absolute):
                     afile = os.path.join(dir.absolute, file)
                     if os.path.isdir(afile):
-                        short = "%s|%s" % (dir.make_short(file), file)
+                        short = "{}|{}".format(dir.make_short(file), file)
                         default = file + version
                         newdir = Directory(db, cab, dir, file, default, short)
                         todo.append(newdir)
@@ -1103,12 +1103,12 @@ class bdist_msi(Command):
     def get_installer_filename(self, fullname):
         # Factored out to allow overriding in subclasses
         if self.target_version:
-            base_name = "%s.%s-py%s.msi" % (
+            base_name = "{}.{}-py{}.msi".format(
                 fullname,
                 self.plat_name,
                 self.target_version,
             )
         else:
-            base_name = "%s.%s.msi" % (fullname, self.plat_name)
+            base_name = "{}.{}.msi".format(fullname, self.plat_name)
         installer_name = os.path.join(self.dist_dir, base_name)
         return installer_name

--- a/setuptools/_distutils/command/bdist_rpm.py
+++ b/setuptools/_distutils/command/bdist_rpm.py
@@ -353,7 +353,7 @@ class bdist_rpm(Command):
         nvr_string = "%{name}-%{version}-%{release}"
         src_rpm = nvr_string + ".src.rpm"
         non_src_rpm = "%{arch}/" + nvr_string + ".%{arch}.rpm"
-        q_cmd = r"rpm -q --qf '%s %s\n' --specfile '%s'" % (
+        q_cmd = r"rpm -q --qf '{} {}\n' --specfile '{}'".format(
             src_rpm,
             non_src_rpm,
             spec_path,
@@ -488,9 +488,9 @@ class bdist_rpm(Command):
         ):
             val = getattr(self, field.lower())
             if isinstance(val, list):
-                spec_file.append('%s: %s' % (field, ' '.join(val)))
+                spec_file.append('{}: {}'.format(field, ' '.join(val)))
             elif val is not None:
-                spec_file.append('%s: %s' % (field, val))
+                spec_file.append('{}: {}'.format(field, val))
 
         if self.distribution.get_url():
             spec_file.append('Url: ' + self.distribution.get_url())
@@ -527,7 +527,7 @@ class bdist_rpm(Command):
 
         # rpm scripts
         # figure out default build script
-        def_setup_call = "%s %s" % (self.python, os.path.basename(sys.argv[0]))
+        def_setup_call = "{} {}".format(self.python, os.path.basename(sys.argv[0]))
         def_build = "%s build" % def_setup_call
         if self.use_rpm_opt_flags:
             def_build = 'env CFLAGS="$RPM_OPT_FLAGS" ' + def_build

--- a/setuptools/_distutils/command/bdist_wininst.py
+++ b/setuptools/_distutils/command/bdist_wininst.py
@@ -185,7 +185,7 @@ class bdist_wininst(Command):
             if not target_version:
                 assert self.skip_build, "Should have already checked this"
                 target_version = '%d.%d' % sys.version_info[:2]
-            plat_specifier = ".%s-%s" % (self.plat_name, target_version)
+            plat_specifier = ".{}-{}".format(self.plat_name, target_version)
             build = self.get_finalized_command('build')
             build.build_lib = os.path.join(build.build_base, 'lib' + plat_specifier)
 
@@ -259,8 +259,8 @@ class bdist_wininst(Command):
         ]:
             data = getattr(metadata, name, "")
             if data:
-                info = info + ("\n    %s: %s" % (name.capitalize(), escape(data)))
-                lines.append("%s=%s" % (name, escape(data)))
+                info = info + ("\n    {}: {}".format(name.capitalize(), escape(data)))
+                lines.append("{}={}".format(name, escape(data)))
 
         # The [setup] section contains entries controlling
         # the installer runtime.
@@ -280,7 +280,7 @@ class bdist_wininst(Command):
         import time
         import distutils
 
-        build_info = "Built %s with distutils-%s" % (
+        build_info = "Built {} with distutils-{}".format(
             time.ctime(time.time()),
             distutils.__version__,
         )
@@ -319,7 +319,7 @@ class bdist_wininst(Command):
                 # We need to normalize newlines, so we open in text mode and
                 # convert back to bytes. "latin-1" simply avoids any possible
                 # failures.
-                with open(self.pre_install_script, "r", encoding="latin-1") as script:
+                with open(self.pre_install_script, encoding="latin-1") as script:
                     script_data = script.read().encode("latin-1")
                 cfgdata = cfgdata + script_data + b"\n\0"
             else:
@@ -349,11 +349,11 @@ class bdist_wininst(Command):
             # it's better to include this in the name
             installer_name = os.path.join(
                 self.dist_dir,
-                "%s.%s-py%s.exe" % (fullname, self.plat_name, self.target_version),
+                "{}.{}-py{}.exe".format(fullname, self.plat_name, self.target_version),
             )
         else:
             installer_name = os.path.join(
-                self.dist_dir, "%s.%s.exe" % (fullname, self.plat_name)
+                self.dist_dir, "{}.{}.exe".format(fullname, self.plat_name)
             )
         return installer_name
 
@@ -410,7 +410,7 @@ class bdist_wininst(Command):
         else:
             sfix = ''
 
-        filename = os.path.join(directory, "wininst-%s%s.exe" % (bv, sfix))
+        filename = os.path.join(directory, "wininst-{}{}.exe".format(bv, sfix))
         f = open(filename, "rb")
         try:
             return f.read()

--- a/setuptools/_distutils/command/build.py
+++ b/setuptools/_distutils/command/build.py
@@ -79,7 +79,7 @@ class build(Command):
                     "using './configure --help' on your platform)"
                 )
 
-        plat_specifier = ".%s-%s" % (self.plat_name, sys.implementation.cache_tag)
+        plat_specifier = ".{}-{}".format(self.plat_name, sys.implementation.cache_tag)
 
         # Make it so Python 2.x and Python 2.x with --with-pydebug don't
         # share the same build directories. Doing so confuses the build

--- a/setuptools/_distutils/command/build_ext.py
+++ b/setuptools/_distutils/command/build_ext.py
@@ -498,7 +498,7 @@ class build_ext(Command):
         except (CCompilerError, DistutilsError, CompileError) as e:
             if not ext.optional:
                 raise
-            self.warn('building extension "%s" failed: %s' % (ext.name, e))
+            self.warn('building extension "{}" failed: {}'.format(ext.name, e))
 
     def build_extension(self, ext):
         sources = ext.sources

--- a/setuptools/_distutils/command/check.py
+++ b/setuptools/_distutils/command/check.py
@@ -117,7 +117,7 @@ class check(Command):
             if line is None:
                 warning = warning[1]
             else:
-                warning = '%s (line %s)' % (warning[1], line)
+                warning = '{} (line {})'.format(warning[1], line)
             self.warn(warning)
 
     def _check_rst_data(self, data):

--- a/setuptools/_distutils/command/register.py
+++ b/setuptools/_distutils/command/register.py
@@ -174,7 +174,7 @@ Your selection [default 1]: ''',
             auth.add_password(self.realm, host, username, password)
             # send the info to the server and report the result
             code, result = self.post_to_server(self.build_post_data('submit'), auth)
-            self.announce('Server response (%s): %s' % (code, result), log.INFO)
+            self.announce('Server response ({}): {}'.format(code, result), log.INFO)
 
             # possibly save the login
             if code == 200:
@@ -224,7 +224,7 @@ Your selection [default 1]: ''',
                 log.info('Server response (%s): %s', code, result)
             else:
                 log.info('You will receive an email shortly.')
-                log.info(('Follow the instructions in it to ' 'complete registration.'))
+                log.info('Follow the instructions in it to ' 'complete registration.')
         elif choice == '3':
             data = {':action': 'password_reset'}
             data['email'] = ''
@@ -265,7 +265,7 @@ Your selection [default 1]: ''',
         '''Post a query to the server, and return a string response.'''
         if 'name' in data:
             self.announce(
-                'Registering %s to %s' % (data['name'], self.repository), log.INFO
+                'Registering {} to {}'.format(data['name'], self.repository), log.INFO
             )
         # Build up the MIME payload for the urllib2 POST data
         boundary = '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254'

--- a/setuptools/_distutils/command/sdist.py
+++ b/setuptools/_distutils/command/sdist.py
@@ -402,7 +402,7 @@ class sdist(Command):
             seps = '/'
 
         vcs_dirs = ['RCS', 'CVS', r'\.svn', r'\.hg', r'\.git', r'\.bzr', '_darcs']
-        vcs_ptrn = r'(^|%s)(%s)(%s).*' % (seps, '|'.join(vcs_dirs), seps)
+        vcs_ptrn = r'(^|{})({})({}).*'.format(seps, '|'.join(vcs_dirs), seps)
         self.filelist.exclude_pattern(vcs_ptrn, is_regex=1)
 
     def write_manifest(self):

--- a/setuptools/_distutils/command/upload.py
+++ b/setuptools/_distutils/command/upload.py
@@ -170,7 +170,7 @@ class upload(PyPIRCCommand):
         body.write(end_boundary)
         body = body.getvalue()
 
-        msg = "Submitting %s to %s" % (filename, self.repository)
+        msg = "Submitting {} to {}".format(filename, self.repository)
         self.announce(msg, log.INFO)
 
         # build the Request
@@ -194,12 +194,12 @@ class upload(PyPIRCCommand):
             raise
 
         if status == 200:
-            self.announce('Server response (%s): %s' % (status, reason), log.INFO)
+            self.announce('Server response ({}): {}'.format(status, reason), log.INFO)
             if self.show_response:
                 text = self._read_pypi_response(result)
                 msg = '\n'.join(('-' * 75, text, '-' * 75))
                 self.announce(msg, log.INFO)
         else:
-            msg = 'Upload failed (%s): %s' % (status, reason)
+            msg = 'Upload failed ({}): {}'.format(status, reason)
             self.announce(msg, log.ERROR)
             raise DistutilsError(msg)

--- a/setuptools/_distutils/core.py
+++ b/setuptools/_distutils/core.py
@@ -149,7 +149,7 @@ def setup(**attrs):  # noqa: C901
         if 'name' not in attrs:
             raise SystemExit("error in setup command: %s" % msg)
         else:
-            raise SystemExit("error in %s setup command: %s" % (attrs['name'], msg))
+            raise SystemExit("error in {} setup command: {}".format(attrs['name'], msg))
 
     if _setup_stop_after == "init":
         return dist
@@ -203,10 +203,10 @@ def run_commands(dist):
         raise SystemExit("interrupted")
     except OSError as exc:
         if DEBUG:
-            sys.stderr.write("error: %s\n" % (exc,))
+            sys.stderr.write("error: {}\n".format(exc))
             raise
         else:
-            raise SystemExit("error: %s" % (exc,))
+            raise SystemExit("error: {}".format(exc))
 
     except (DistutilsError, CCompilerError) as msg:
         if DEBUG:
@@ -249,7 +249,7 @@ def run_setup(script_name, script_args=None, stop_after="run"):
     used to drive the Distutils.
     """
     if stop_after not in ('init', 'config', 'commandline', 'run'):
-        raise ValueError("invalid value for 'stop_after': %r" % (stop_after,))
+        raise ValueError("invalid value for 'stop_after': {!r}".format(stop_after))
 
     global _setup_stop_after, _setup_distribution
     _setup_stop_after = stop_after

--- a/setuptools/_distutils/cygwinccompiler.py
+++ b/setuptools/_distutils/cygwinccompiler.py
@@ -125,7 +125,9 @@ class CygwinCCompiler(UnixCCompiler):
         super().__init__(verbose, dry_run, force)
 
         status, details = check_config_h()
-        self.debug_print("Python's GCC status: %s (details: %s)" % (status, details))
+        self.debug_print(
+            "Python's GCC status: {} (details: {})".format(status, details)
+        )
         if status is not CONFIG_H_OK:
             self.warn(
                 "Python's pyconfig.h doesn't seem to support your compiler. "
@@ -144,7 +146,7 @@ class CygwinCCompiler(UnixCCompiler):
             compiler_so='%s -mcygwin -mdll -O -Wall' % self.cc,
             compiler_cxx='%s -mcygwin -O -Wall' % self.cxx,
             linker_exe='%s -mcygwin' % self.cc,
-            linker_so=('%s -mcygwin %s' % (self.linker_dll, shared_option)),
+            linker_so=('{} -mcygwin {}'.format(self.linker_dll, shared_option)),
         )
 
         # Include the appropriate MSVC runtime library if Python was built
@@ -291,7 +293,7 @@ class CygwinCCompiler(UnixCCompiler):
             base, ext = os.path.splitext(os.path.normcase(src_name))
             if ext not in (self.src_extensions + ['.rc', '.res']):
                 raise UnknownFileError(
-                    "unknown file type '%s' (from '%s')" % (ext, src_name)
+                    "unknown file type '{}' (from '{}')".format(ext, src_name)
                 )
             if strip_dir:
                 base = os.path.basename(base)
@@ -325,7 +327,7 @@ class Mingw32CCompiler(CygwinCCompiler):
             compiler_so='%s -mdll -O -Wall' % self.cc,
             compiler_cxx='%s -O -Wall' % self.cxx,
             linker_exe='%s' % self.cc,
-            linker_so='%s %s' % (self.linker_dll, shared_option),
+            linker_so='{} {}'.format(self.linker_dll, shared_option),
         )
 
         # Maybe we should also append -mthreads, but then the finished
@@ -396,7 +398,7 @@ def check_config_h():
         finally:
             config_h.close()
     except OSError as exc:
-        return (CONFIG_H_UNCERTAIN, "couldn't read '%s': %s" % (fn, exc.strerror))
+        return (CONFIG_H_UNCERTAIN, "couldn't read '{}': {}".format(fn, exc.strerror))
 
 
 def is_cygwincc(cc):

--- a/setuptools/_distutils/dir_util.py
+++ b/setuptools/_distutils/dir_util.py
@@ -34,7 +34,7 @@ def mkpath(name, mode=0o777, verbose=1, dry_run=0):  # noqa: C901
     # Detect a common bug -- name is None
     if not isinstance(name, str):
         raise DistutilsInternalError(
-            "mkpath: 'name' must be a string (got %r)" % (name,)
+            "mkpath: 'name' must be a string (got {!r})".format(name)
         )
 
     # XXX what's the better way to handle verbosity? print as we create
@@ -76,7 +76,7 @@ def mkpath(name, mode=0o777, verbose=1, dry_run=0):  # noqa: C901
             except OSError as exc:
                 if not (exc.errno == errno.EEXIST and os.path.isdir(head)):
                     raise DistutilsFileError(
-                        "could not create '%s': %s" % (head, exc.args[-1])
+                        "could not create '{}': {}".format(head, exc.args[-1])
                     )
             created_dirs.append(head)
 
@@ -144,7 +144,7 @@ def copy_tree(  # noqa: C901
             names = []
         else:
             raise DistutilsFileError(
-                "error listing files in '%s': %s" % (src, e.strerror)
+                "error listing files in '{}': {}".format(src, e.strerror)
             )
 
     if not dry_run:

--- a/setuptools/_distutils/dist.py
+++ b/setuptools/_distutils/dist.py
@@ -825,7 +825,7 @@ Common commands: (see '--help-commands' for more)
             return klass
 
         for pkgname in self.get_command_packages():
-            module_name = "%s.%s" % (pkgname, command)
+            module_name = "{}.{}".format(pkgname, command)
             klass_name = command
 
             try:
@@ -893,7 +893,7 @@ Common commands: (see '--help-commands' for more)
             self.announce("  setting options for '%s' command:" % command_name)
         for (option, (source, value)) in option_dict.items():
             if DEBUG:
-                self.announce("    %s = %s (from %s)" % (option, value, source))
+                self.announce("    {} = {} (from {})".format(option, value, source))
             try:
                 bool_opts = [translate_longopt(o) for o in command_obj.boolean_options]
             except AttributeError:
@@ -1159,7 +1159,7 @@ class DistributionMetadata:
 
         def maybe_write(header, val):
             if val:
-                file.write("{}: {}\n".format(header, val))
+                file.write(f"{header}: {val}\n")
 
         # optional fields
         maybe_write("Summary", self.get_description())
@@ -1182,7 +1182,7 @@ class DistributionMetadata:
     def _write_list(self, file, name, values):
         values = values or []
         for value in values:
-            file.write('%s: %s\n' % (name, value))
+            file.write('{}: {}\n'.format(name, value))
 
     # -- Metadata query methods ----------------------------------------
 
@@ -1193,7 +1193,7 @@ class DistributionMetadata:
         return self.version or "0.0.0"
 
     def get_fullname(self):
-        return "%s-%s" % (self.get_name(), self.get_version())
+        return "{}-{}".format(self.get_name(), self.get_version())
 
     def get_author(self):
         return self.author

--- a/setuptools/_distutils/extension.py
+++ b/setuptools/_distutils/extension.py
@@ -134,7 +134,7 @@ class Extension:
             warnings.warn(msg)
 
     def __repr__(self):
-        return '<%s.%s(%r) at %#x>' % (
+        return '<{}.{}({!r}) at {:#x}>'.format(
             self.__class__.__module__,
             self.__class__.__qualname__,
             self.name,

--- a/setuptools/_distutils/fancy_getopt.py
+++ b/setuptools/_distutils/fancy_getopt.py
@@ -22,7 +22,7 @@ longopt_pat = r'[a-zA-Z](?:[a-zA-Z0-9-]*)'
 longopt_re = re.compile(r'^%s$' % longopt_pat)
 
 # For recognizing "negative alias" options, eg. "quiet=!verbose"
-neg_alias_re = re.compile("^(%s)=!(%s)$" % (longopt_pat, longopt_pat))
+neg_alias_re = re.compile("^({})=!({})$".format(longopt_pat, longopt_pat))
 
 # This is used to translate long options to legitimate Python identifiers
 # (for use as attributes of some object).
@@ -157,7 +157,7 @@ class FancyGetopt:
             else:
                 # the option table is part of the code, so simply
                 # assert that it is correct
-                raise ValueError("invalid option tuple: %r" % (option,))
+                raise ValueError("invalid option tuple: {!r}".format(option))
 
             # Type- and value-check the option names
             if not isinstance(long, str) or len(long) < 2:
@@ -359,7 +359,7 @@ class FancyGetopt:
             # Case 2: we have a short option, so we have to include it
             # just after the long option
             else:
-                opt_names = "%s (-%s)" % (long, short)
+                opt_names = "{} (-{})".format(long, short)
                 if text:
                     lines.append("  --%-*s  %s" % (max_opt, opt_names, text[0]))
                 else:

--- a/setuptools/_distutils/file_util.py
+++ b/setuptools/_distutils/file_util.py
@@ -26,27 +26,29 @@ def _copy_file_contents(src, dst, buffer_size=16 * 1024):  # noqa: C901
         try:
             fsrc = open(src, 'rb')
         except OSError as e:
-            raise DistutilsFileError("could not open '%s': %s" % (src, e.strerror))
+            raise DistutilsFileError("could not open '{}': {}".format(src, e.strerror))
 
         if os.path.exists(dst):
             try:
                 os.unlink(dst)
             except OSError as e:
                 raise DistutilsFileError(
-                    "could not delete '%s': %s" % (dst, e.strerror)
+                    "could not delete '{}': {}".format(dst, e.strerror)
                 )
 
         try:
             fdst = open(dst, 'wb')
         except OSError as e:
-            raise DistutilsFileError("could not create '%s': %s" % (dst, e.strerror))
+            raise DistutilsFileError(
+                "could not create '{}': {}".format(dst, e.strerror)
+            )
 
         while True:
             try:
                 buf = fsrc.read(buffer_size)
             except OSError as e:
                 raise DistutilsFileError(
-                    "could not read from '%s': %s" % (src, e.strerror)
+                    "could not read from '{}': {}".format(src, e.strerror)
                 )
 
             if not buf:
@@ -56,7 +58,7 @@ def _copy_file_contents(src, dst, buffer_size=16 * 1024):  # noqa: C901
                 fdst.write(buf)
             except OSError as e:
                 raise DistutilsFileError(
-                    "could not write to '%s': %s" % (dst, e.strerror)
+                    "could not write to '{}': {}".format(dst, e.strerror)
                 )
     finally:
         if fdst:
@@ -198,12 +200,12 @@ def move_file(src, dst, verbose=1, dry_run=0):  # noqa: C901
         dst = os.path.join(dst, basename(src))
     elif exists(dst):
         raise DistutilsFileError(
-            "can't move '%s': destination '%s' already exists" % (src, dst)
+            "can't move '{}': destination '{}' already exists".format(src, dst)
         )
 
     if not isdir(dirname(dst)):
         raise DistutilsFileError(
-            "can't move '%s': destination '%s' not a valid path" % (src, dst)
+            "can't move '{}': destination '{}' not a valid path".format(src, dst)
         )
 
     copy_it = False
@@ -214,7 +216,9 @@ def move_file(src, dst, verbose=1, dry_run=0):  # noqa: C901
         if num == errno.EXDEV:
             copy_it = True
         else:
-            raise DistutilsFileError("couldn't move '%s' to '%s': %s" % (src, dst, msg))
+            raise DistutilsFileError(
+                "couldn't move '{}' to '{}': {}".format(src, dst, msg)
+            )
 
     if copy_it:
         copy_file(src, dst, verbose=verbose)

--- a/setuptools/_distutils/filelist.py
+++ b/setuptools/_distutils/filelist.py
@@ -159,7 +159,7 @@ class FileList:
                     )
 
         elif action == 'recursive-include':
-            self.debug_print("recursive-include %s %s" % (dir, ' '.join(patterns)))
+            self.debug_print("recursive-include {} {}".format(dir, ' '.join(patterns)))
             for pattern in patterns:
                 if not self.include_pattern(pattern, prefix=dir):
                     msg = (
@@ -168,7 +168,7 @@ class FileList:
                     log.warn(msg, pattern, dir)
 
         elif action == 'recursive-exclude':
-            self.debug_print("recursive-exclude %s %s" % (dir, ' '.join(patterns)))
+            self.debug_print("recursive-exclude {} {}".format(dir, ' '.join(patterns)))
             for pattern in patterns:
                 if not self.exclude_pattern(pattern, prefix=dir):
                     log.warn(
@@ -363,9 +363,9 @@ def translate_pattern(pattern, anchor=1, prefix=None, is_regex=0):
         if os.sep == '\\':
             sep = r'\\'
         pattern_re = pattern_re[len(start) : len(pattern_re) - len(end)]
-        pattern_re = r'%s\A%s%s.*%s%s' % (start, prefix_re, sep, pattern_re, end)
+        pattern_re = r'{}\A{}{}.*{}{}'.format(start, prefix_re, sep, pattern_re, end)
     else:  # no prefix -- respect anchor flag
         if anchor:
-            pattern_re = r'%s\A%s' % (start, pattern_re[len(start) :])
+            pattern_re = r'{}\A{}'.format(start, pattern_re[len(start) :])
 
     return re.compile(pattern_re)

--- a/setuptools/_distutils/msvc9compiler.py
+++ b/setuptools/_distutils/msvc9compiler.py
@@ -167,7 +167,7 @@ you can try compiling with MingW32, by passing "-c mingw32" to setup.py."""
                 except RegError:
                     continue
                 key = RegEnumKey(h, 0)
-                d = Reg.get_value(base, r"%s\%s" % (p, key))
+                d = Reg.get_value(base, r"{}\{}".format(p, key))
                 self.macros["$(FrameworkVersion)"] = d["version"]
 
     def sub(self, s):
@@ -273,7 +273,7 @@ def query_vcvarsall(version, arch="x86"):
         raise DistutilsPlatformError("Unable to find vcvarsall.bat")
     log.debug("Calling 'vcvarsall.bat %s' (version=%s)", arch, version)
     popen = subprocess.Popen(
-        '"%s" %s & set' % (vcvarsall, arch),
+        '"{}" {} & set'.format(vcvarsall, arch),
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
@@ -362,7 +362,9 @@ class MSVCCompiler(CCompiler):
         # sanity check for platforms to prevent obscure errors later.
         ok_plats = 'win32', 'win-amd64'
         if plat_name not in ok_plats:
-            raise DistutilsPlatformError("--plat-name must be one of %s" % (ok_plats,))
+            raise DistutilsPlatformError(
+                "--plat-name must be one of {}".format(ok_plats)
+            )
 
         if (
             "DISTUTILS_USE_SDK" in os.environ
@@ -555,7 +557,9 @@ class MSVCCompiler(CCompiler):
                 continue
             else:
                 # how to handle this file?
-                raise CompileError("Don't know how to compile %s to %s" % (src, obj))
+                raise CompileError(
+                    "Don't know how to compile {} to {}".format(src, obj)
+                )
 
             output_opt = "/Fo" + obj
             try:
@@ -678,7 +682,7 @@ class MSVCCompiler(CCompiler):
             mfinfo = self.manifest_get_embed_info(target_desc, ld_args)
             if mfinfo is not None:
                 mffilename, mfid = mfinfo
-                out_arg = '-outputresource:%s;%s' % (output_filename, mfid)
+                out_arg = '-outputresource:{};{}'.format(output_filename, mfid)
                 try:
                     self.spawn(['mt.exe', '-nologo', '-manifest', mffilename, out_arg])
                 except DistutilsExecError as msg:

--- a/setuptools/_distutils/msvccompiler.py
+++ b/setuptools/_distutils/msvccompiler.py
@@ -150,7 +150,7 @@ you can try compiling with MingW32, by passing "-c mingw32" to setup.py."""
             except RegError:
                 continue
             key = RegEnumKey(h, 0)
-            d = read_values(base, r"%s\%s" % (p, key))
+            d = read_values(base, r"{}\{}".format(p, key))
             self.macros["$(FrameworkVersion)"] = d["version"]
 
     def sub(self, s):
@@ -446,7 +446,9 @@ class MSVCCompiler(CCompiler):
                 continue
             else:
                 # how to handle this file?
-                raise CompileError("Don't know how to compile %s to %s" % (src, obj))
+                raise CompileError(
+                    "Don't know how to compile {} to {}".format(src, obj)
+                )
 
             output_opt = "/Fo" + obj
             try:
@@ -629,7 +631,7 @@ class MSVCCompiler(CCompiler):
 
         path = path + " dirs"
         if self.__version >= 7:
-            key = r"%s\%0.1f\VC\VC_OBJECTS_PLATFORM_INFO\Win32\Directories" % (
+            key = r"{}\{:0.1f}\VC\VC_OBJECTS_PLATFORM_INFO\Win32\Directories".format(
                 self.__root,
                 self.__version,
             )

--- a/setuptools/_distutils/py38compat.py
+++ b/setuptools/_distutils/py38compat.py
@@ -5,4 +5,4 @@ def aix_platform(osname, version, release):
         return _aix_support.aix_platform()
     except ImportError:
         pass
-    return "%s-%s.%s" % (osname, version, release)
+    return "{}-{}.{}".format(osname, version, release)

--- a/setuptools/_distutils/spawn.py
+++ b/setuptools/_distutils/spawn.py
@@ -60,13 +60,15 @@ def spawn(cmd, search_path=1, verbose=0, dry_run=0, env=None):  # noqa: C901
     except OSError as exc:
         if not DEBUG:
             cmd = cmd[0]
-        raise DistutilsExecError("command %r failed: %s" % (cmd, exc.args[-1])) from exc
+        raise DistutilsExecError(
+            "command {!r} failed: {}".format(cmd, exc.args[-1])
+        ) from exc
 
     if exitcode:
         if not DEBUG:
             cmd = cmd[0]
         raise DistutilsExecError(
-            "command %r failed with exit code %s" % (cmd, exitcode)
+            "command {!r} failed with exit code {}".format(cmd, exitcode)
         )
 
 

--- a/setuptools/_distutils/tests/test_archive_util.py
+++ b/setuptools/_distutils/tests/test_archive_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for distutils.archive_util."""
 import unittest
 import os
@@ -57,9 +56,7 @@ def can_fs_encode(filename):
     return True
 
 
-class ArchiveUtilTestCase(
-    support.TempdirManager, support.LoggingSilencer, unittest.TestCase
-):
+class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
     @pytest.mark.usefixtures('needs_zlib')
     def test_make_tarball(self, name='archive'):
         # creating something to tar
@@ -117,8 +114,8 @@ class ArchiveUtilTestCase(
 
         # check if the compressed tarball was created
         tarball = base_name + suffix
-        self.assertTrue(os.path.exists(tarball))
-        self.assertEqual(self._tarinfo(tarball), self._created_files)
+        assert os.path.exists(tarball)
+        assert self._tarinfo(tarball) == self._created_files
 
     def _tarinfo(self, path):
         tar = tarfile.open(path)
@@ -169,7 +166,7 @@ class ArchiveUtilTestCase(
 
         # check if the compressed tarball was created
         tarball = base_name + '.tar.gz'
-        self.assertTrue(os.path.exists(tarball))
+        assert os.path.exists(tarball)
 
         # now create another tarball using `tar`
         tarball2 = os.path.join(tmpdir, 'archive2.tar.gz')
@@ -183,10 +180,10 @@ class ArchiveUtilTestCase(
         finally:
             os.chdir(old_dir)
 
-        self.assertTrue(os.path.exists(tarball2))
+        assert os.path.exists(tarball2)
         # let's compare both tarballs
-        self.assertEqual(self._tarinfo(tarball), self._created_files)
-        self.assertEqual(self._tarinfo(tarball2), self._created_files)
+        assert self._tarinfo(tarball) == self._created_files
+        assert self._tarinfo(tarball2) == self._created_files
 
         # trying an uncompressed one
         base_name = os.path.join(tmpdir2, 'archive')
@@ -197,7 +194,7 @@ class ArchiveUtilTestCase(
         finally:
             os.chdir(old_dir)
         tarball = base_name + '.tar'
-        self.assertTrue(os.path.exists(tarball))
+        assert os.path.exists(tarball)
 
         # now for a dry_run
         base_name = os.path.join(tmpdir2, 'archive')
@@ -208,7 +205,7 @@ class ArchiveUtilTestCase(
         finally:
             os.chdir(old_dir)
         tarball = base_name + '.tar'
-        self.assertTrue(os.path.exists(tarball))
+        assert os.path.exists(tarball)
 
     @unittest.skipUnless(
         find_executable('compress'), 'The compress program is required'
@@ -227,8 +224,8 @@ class ArchiveUtilTestCase(
         finally:
             os.chdir(old_dir)
         tarball = base_name + '.tar.Z'
-        self.assertTrue(os.path.exists(tarball))
-        self.assertEqual(len(w.warnings), 1)
+        assert os.path.exists(tarball)
+        assert len(w.warnings) == 1
 
         # same test with dry_run
         os.remove(tarball)
@@ -240,8 +237,8 @@ class ArchiveUtilTestCase(
                 make_tarball(base_name, 'dist', compress='compress', dry_run=True)
         finally:
             os.chdir(old_dir)
-        self.assertFalse(os.path.exists(tarball))
-        self.assertEqual(len(w.warnings), 1)
+        assert not os.path.exists(tarball)
+        assert len(w.warnings) == 1
 
     @pytest.mark.usefixtures('needs_zlib')
     @unittest.skipUnless(ZIP_SUPPORT, 'Need zip support to run')
@@ -254,9 +251,9 @@ class ArchiveUtilTestCase(
 
         # check if the compressed tarball was created
         tarball = base_name + '.zip'
-        self.assertTrue(os.path.exists(tarball))
+        assert os.path.exists(tarball)
         with zipfile.ZipFile(tarball) as zf:
-            self.assertEqual(sorted(zf.namelist()), self._zip_created_files)
+            assert sorted(zf.namelist()) == self._zip_created_files
 
     @unittest.skipUnless(ZIP_SUPPORT, 'Need zip support to run')
     def test_make_zipfile_no_zlib(self):
@@ -279,23 +276,23 @@ class ArchiveUtilTestCase(
             make_zipfile(base_name, 'dist')
 
         tarball = base_name + '.zip'
-        self.assertEqual(
-            called, [((tarball, "w"), {'compression': zipfile.ZIP_STORED})]
-        )
-        self.assertTrue(os.path.exists(tarball))
+        assert called == [((tarball, "w"), {'compression': zipfile.ZIP_STORED})]
+        assert os.path.exists(tarball)
         with zipfile.ZipFile(tarball) as zf:
-            self.assertEqual(sorted(zf.namelist()), self._zip_created_files)
+            assert sorted(zf.namelist()) == self._zip_created_files
 
     def test_check_archive_formats(self):
-        self.assertEqual(check_archive_formats(['gztar', 'xxx', 'zip']), 'xxx')
-        self.assertIsNone(
+        assert check_archive_formats(['gztar', 'xxx', 'zip']) == 'xxx'
+        assert (
             check_archive_formats(['gztar', 'bztar', 'xztar', 'ztar', 'tar', 'zip'])
+            is None
         )
 
     def test_make_archive(self):
         tmpdir = self.mkdtemp()
         base_name = os.path.join(tmpdir, 'archive')
-        self.assertRaises(ValueError, make_archive, base_name, 'xxx')
+        with pytest.raises(ValueError):
+            make_archive(base_name, 'xxx')
 
     def test_make_archive_cwd(self):
         current_dir = os.getcwd()
@@ -309,7 +306,7 @@ class ArchiveUtilTestCase(
                 make_archive('xxx', 'xxx', root_dir=self.mkdtemp())
             except Exception:
                 pass
-            self.assertEqual(os.getcwd(), current_dir)
+            assert os.getcwd() == current_dir
         finally:
             del ARCHIVE_FORMATS['xxx']
 
@@ -317,36 +314,36 @@ class ArchiveUtilTestCase(
         base_dir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
         res = make_archive(base_name, 'tar', base_dir, 'dist')
-        self.assertTrue(os.path.exists(res))
-        self.assertEqual(os.path.basename(res), 'archive.tar')
-        self.assertEqual(self._tarinfo(res), self._created_files)
+        assert os.path.exists(res)
+        assert os.path.basename(res) == 'archive.tar'
+        assert self._tarinfo(res) == self._created_files
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_make_archive_gztar(self):
         base_dir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
         res = make_archive(base_name, 'gztar', base_dir, 'dist')
-        self.assertTrue(os.path.exists(res))
-        self.assertEqual(os.path.basename(res), 'archive.tar.gz')
-        self.assertEqual(self._tarinfo(res), self._created_files)
+        assert os.path.exists(res)
+        assert os.path.basename(res) == 'archive.tar.gz'
+        assert self._tarinfo(res) == self._created_files
 
     @unittest.skipUnless(bz2, 'Need bz2 support to run')
     def test_make_archive_bztar(self):
         base_dir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
         res = make_archive(base_name, 'bztar', base_dir, 'dist')
-        self.assertTrue(os.path.exists(res))
-        self.assertEqual(os.path.basename(res), 'archive.tar.bz2')
-        self.assertEqual(self._tarinfo(res), self._created_files)
+        assert os.path.exists(res)
+        assert os.path.basename(res) == 'archive.tar.bz2'
+        assert self._tarinfo(res) == self._created_files
 
     @unittest.skipUnless(lzma, 'Need xz support to run')
     def test_make_archive_xztar(self):
         base_dir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
         res = make_archive(base_name, 'xztar', base_dir, 'dist')
-        self.assertTrue(os.path.exists(res))
-        self.assertEqual(os.path.basename(res), 'archive.tar.xz')
-        self.assertEqual(self._tarinfo(res), self._created_files)
+        assert os.path.exists(res)
+        assert os.path.basename(res) == 'archive.tar.xz'
+        assert self._tarinfo(res) == self._created_files
 
     def test_make_archive_owner_group(self):
         # testing make_archive with owner and group, with various combinations
@@ -363,20 +360,20 @@ class ArchiveUtilTestCase(
         res = make_archive(
             base_name, 'zip', root_dir, base_dir, owner=owner, group=group
         )
-        self.assertTrue(os.path.exists(res))
+        assert os.path.exists(res)
 
         res = make_archive(base_name, 'zip', root_dir, base_dir)
-        self.assertTrue(os.path.exists(res))
+        assert os.path.exists(res)
 
         res = make_archive(
             base_name, 'tar', root_dir, base_dir, owner=owner, group=group
         )
-        self.assertTrue(os.path.exists(res))
+        assert os.path.exists(res)
 
         res = make_archive(
             base_name, 'tar', root_dir, base_dir, owner='kjhkjhkjg', group='oihohoh'
         )
-        self.assertTrue(os.path.exists(res))
+        assert os.path.exists(res)
 
     @pytest.mark.usefixtures('needs_zlib')
     @require_unix_id
@@ -396,13 +393,13 @@ class ArchiveUtilTestCase(
             os.chdir(old_dir)
 
         # check if the compressed tarball was created
-        self.assertTrue(os.path.exists(archive_name))
+        assert os.path.exists(archive_name)
 
         # now checks the rights
         archive = tarfile.open(archive_name)
         try:
             for member in archive.getmembers():
-                self.assertEqual(member.uid, 0)
-                self.assertEqual(member.gid, 0)
+                assert member.uid == 0
+                assert member.gid == 0
         finally:
             archive.close()

--- a/setuptools/_distutils/tests/test_bdist.py
+++ b/setuptools/_distutils/tests/test_bdist.py
@@ -1,13 +1,12 @@
 """Tests for distutils.command.bdist."""
 import os
-import unittest
 import warnings
 
 from distutils.command.bdist import bdist
 from distutils.tests import support
 
 
-class BuildTestCase(support.TempdirManager, unittest.TestCase):
+class TestBuild(support.TempdirManager):
     def test_formats(self):
         # let's create a command and make sure
         # we can set the format
@@ -15,7 +14,7 @@ class BuildTestCase(support.TempdirManager, unittest.TestCase):
         cmd = bdist(dist)
         cmd.formats = ['msi']
         cmd.ensure_finalized()
-        self.assertEqual(cmd.formats, ['msi'])
+        assert cmd.formats == ['msi']
 
         # what formats does bdist offer?
         formats = [
@@ -30,7 +29,7 @@ class BuildTestCase(support.TempdirManager, unittest.TestCase):
             'ztar',
         ]
         found = sorted(cmd.format_commands)
-        self.assertEqual(found, formats)
+        assert found == formats
 
     def test_skip_build(self):
         # bug #10946: bdist --skip-build should trickle down to subcommands
@@ -56,6 +55,4 @@ class BuildTestCase(support.TempdirManager, unittest.TestCase):
             if getattr(subcmd, '_unsupported', False):
                 # command is not supported on this build
                 continue
-            self.assertTrue(
-                subcmd.skip_build, '%s should take --skip-build from bdist' % name
-            )
+            assert subcmd.skip_build, '%s should take --skip-build from bdist' % name

--- a/setuptools/_distutils/tests/test_bdist_dumb.py
+++ b/setuptools/_distutils/tests/test_bdist_dumb.py
@@ -3,7 +3,6 @@
 import os
 import sys
 import zipfile
-import unittest
 
 import pytest
 
@@ -21,23 +20,14 @@ setup(name='foo', version='0.1', py_modules=['foo'],
 """
 
 
+@support.combine_markers
 @pytest.mark.usefixtures('save_env')
-class BuildDumbTestCase(
+@pytest.mark.usefixtures('save_argv')
+@pytest.mark.usefixtures('save_cwd')
+class TestBuildDumb(
     support.TempdirManager,
     support.LoggingSilencer,
-    unittest.TestCase,
 ):
-    def setUp(self):
-        super(BuildDumbTestCase, self).setUp()
-        self.old_location = os.getcwd()
-        self.old_sys_argv = sys.argv, sys.argv[:]
-
-    def tearDown(self):
-        os.chdir(self.old_location)
-        sys.argv = self.old_sys_argv[0]
-        sys.argv[:] = self.old_sys_argv[1]
-        super(BuildDumbTestCase, self).tearDown()
-
     @pytest.mark.usefixtures('needs_zlib')
     def test_simple_built(self):
 
@@ -75,9 +65,9 @@ class BuildDumbTestCase(
 
         # see what we have
         dist_created = os.listdir(os.path.join(pkg_dir, 'dist'))
-        base = "%s.%s.zip" % (dist.get_fullname(), cmd.plat_name)
+        base = "{}.{}.zip".format(dist.get_fullname(), cmd.plat_name)
 
-        self.assertEqual(dist_created, [base])
+        assert dist_created == [base]
 
         # now let's check what we have in the zip file
         fp = zipfile.ZipFile(os.path.join('dist', base))
@@ -90,4 +80,4 @@ class BuildDumbTestCase(
         wanted = ['foo-0.1-py%s.%s.egg-info' % sys.version_info[:2], 'foo.py']
         if not sys.dont_write_bytecode:
             wanted.append('foo.%s.pyc' % sys.implementation.cache_tag)
-        self.assertEqual(contents, sorted(wanted))
+        assert contents == sorted(wanted)

--- a/setuptools/_distutils/tests/test_bdist_msi.py
+++ b/setuptools/_distutils/tests/test_bdist_msi.py
@@ -1,15 +1,15 @@
 """Tests for distutils.command.bdist_msi."""
-import sys
-import unittest
+import pytest
+
 from distutils.tests import support
 
 from .py38compat import check_warnings
 
 
-@unittest.skipUnless(sys.platform == 'win32', 'these tests require Windows')
-class BDistMSITestCase(
-    support.TempdirManager, support.LoggingSilencer, unittest.TestCase
-):
+pytest.importorskip('msilib')
+
+
+class TestBDistMSI(support.TempdirManager, support.LoggingSilencer):
     def test_minimal(self):
         # minimal test XXX need more tests
         from distutils.command.bdist_msi import bdist_msi

--- a/setuptools/_distutils/tests/test_bdist_wininst.py
+++ b/setuptools/_distutils/tests/test_bdist_wininst.py
@@ -17,9 +17,7 @@ from distutils.tests import support
     getattr(bdist_wininst, '_unsupported', False),
     'bdist_wininst is not supported in this install',
 )
-class BuildWinInstTestCase(
-    support.TempdirManager, support.LoggingSilencer, unittest.TestCase
-):
+class TestBuildWinInst(support.TempdirManager, support.LoggingSilencer):
     def test_get_exe_bytes(self):
 
         # issue5731: command was broken on non-windows platforms
@@ -34,4 +32,4 @@ class BuildWinInstTestCase(
         # and make sure it finds it and returns its content
         # no matter what platform we have
         exe_file = cmd.get_exe_bytes()
-        self.assertGreater(len(exe_file), 10)
+        assert len(exe_file) > 10

--- a/setuptools/_distutils/tests/test_build.py
+++ b/setuptools/_distutils/tests/test_build.py
@@ -15,32 +15,32 @@ class BuildTestCase(support.TempdirManager, support.LoggingSilencer, unittest.Te
         cmd.finalize_options()
 
         # if not specified, plat_name gets the current platform
-        self.assertEqual(cmd.plat_name, get_platform())
+        assert cmd.plat_name == get_platform()
 
         # build_purelib is build + lib
         wanted = os.path.join(cmd.build_base, 'lib')
-        self.assertEqual(cmd.build_purelib, wanted)
+        assert cmd.build_purelib == wanted
 
         # build_platlib is 'build/lib.platform-cache_tag[-pydebug]'
         # examples:
         #   build/lib.macosx-10.3-i386-cpython39
-        plat_spec = '.%s-%s' % (cmd.plat_name, sys.implementation.cache_tag)
+        plat_spec = '.{}-{}'.format(cmd.plat_name, sys.implementation.cache_tag)
         if hasattr(sys, 'gettotalrefcount'):
-            self.assertTrue(cmd.build_platlib.endswith('-pydebug'))
+            assert cmd.build_platlib.endswith('-pydebug')
             plat_spec += '-pydebug'
         wanted = os.path.join(cmd.build_base, 'lib' + plat_spec)
-        self.assertEqual(cmd.build_platlib, wanted)
+        assert cmd.build_platlib == wanted
 
         # by default, build_lib = build_purelib
-        self.assertEqual(cmd.build_lib, cmd.build_purelib)
+        assert cmd.build_lib == cmd.build_purelib
 
         # build_temp is build/temp.<plat>
         wanted = os.path.join(cmd.build_base, 'temp' + plat_spec)
-        self.assertEqual(cmd.build_temp, wanted)
+        assert cmd.build_temp == wanted
 
         # build_scripts is build/scripts-x.x
         wanted = os.path.join(cmd.build_base, 'scripts-%d.%d' % sys.version_info[:2])
-        self.assertEqual(cmd.build_scripts, wanted)
+        assert cmd.build_scripts == wanted
 
         # executable is os.path.normpath(sys.executable)
-        self.assertEqual(cmd.executable, os.path.normpath(sys.executable))
+        assert cmd.executable == os.path.normpath(sys.executable)

--- a/setuptools/_distutils/tests/test_build_clib.py
+++ b/setuptools/_distutils/tests/test_build_clib.py
@@ -8,40 +8,38 @@ from test.support import missing_compiler_executable
 from distutils.command.build_clib import build_clib
 from distutils.errors import DistutilsSetupError
 from distutils.tests import support
+import pytest
 
 
-class BuildCLibTestCase(
-    support.TempdirManager, support.LoggingSilencer, unittest.TestCase
-):
+class TestBuildCLib(support.TempdirManager, support.LoggingSilencer):
     def test_check_library_dist(self):
         pkg_dir, dist = self.create_dist()
         cmd = build_clib(dist)
 
         # 'libraries' option must be a list
-        self.assertRaises(DistutilsSetupError, cmd.check_library_list, 'foo')
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_library_list('foo')
 
         # each element of 'libraries' must a 2-tuple
-        self.assertRaises(DistutilsSetupError, cmd.check_library_list, ['foo1', 'foo2'])
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_library_list(['foo1', 'foo2'])
 
         # first element of each tuple in 'libraries'
         # must be a string (the library name)
-        self.assertRaises(
-            DistutilsSetupError, cmd.check_library_list, [(1, 'foo1'), ('name', 'foo2')]
-        )
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_library_list([(1, 'foo1'), ('name', 'foo2')])
 
         # library name may not contain directory separators
-        self.assertRaises(
-            DistutilsSetupError,
-            cmd.check_library_list,
-            [('name', 'foo1'), ('another/name', 'foo2')],
-        )
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_library_list(
+                [('name', 'foo1'), ('another/name', 'foo2')],
+            )
 
         # second element of each tuple must be a dictionary (build info)
-        self.assertRaises(
-            DistutilsSetupError,
-            cmd.check_library_list,
-            [('name', {}), ('another', 'foo2')],
-        )
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_library_list(
+                [('name', {}), ('another', 'foo2')],
+            )
 
         # those work
         libs = [('name', {}), ('name', {'ok': 'good'})]
@@ -54,22 +52,24 @@ class BuildCLibTestCase(
         # "in 'libraries' option 'sources' must be present and must be
         # a list of source filenames
         cmd.libraries = [('name', {})]
-        self.assertRaises(DistutilsSetupError, cmd.get_source_files)
+        with pytest.raises(DistutilsSetupError):
+            cmd.get_source_files()
 
         cmd.libraries = [('name', {'sources': 1})]
-        self.assertRaises(DistutilsSetupError, cmd.get_source_files)
+        with pytest.raises(DistutilsSetupError):
+            cmd.get_source_files()
 
         cmd.libraries = [('name', {'sources': ['a', 'b']})]
-        self.assertEqual(cmd.get_source_files(), ['a', 'b'])
+        assert cmd.get_source_files() == ['a', 'b']
 
         cmd.libraries = [('name', {'sources': ('a', 'b')})]
-        self.assertEqual(cmd.get_source_files(), ['a', 'b'])
+        assert cmd.get_source_files() == ['a', 'b']
 
         cmd.libraries = [
             ('name', {'sources': ('a', 'b')}),
             ('name2', {'sources': ['c', 'd']}),
         ]
-        self.assertEqual(cmd.get_source_files(), ['a', 'b', 'c', 'd'])
+        assert cmd.get_source_files() == ['a', 'b', 'c', 'd']
 
     def test_build_libraries(self):
 
@@ -86,7 +86,8 @@ class BuildCLibTestCase(
 
         # build_libraries is also doing a bit of typo checking
         lib = [('name', {'sources': 'notvalid'})]
-        self.assertRaises(DistutilsSetupError, cmd.build_libraries, lib)
+        with pytest.raises(DistutilsSetupError):
+            cmd.build_libraries(lib)
 
         lib = [('name', {'sources': list()})]
         cmd.build_libraries(lib)
@@ -100,14 +101,15 @@ class BuildCLibTestCase(
 
         cmd.include_dirs = 'one-dir'
         cmd.finalize_options()
-        self.assertEqual(cmd.include_dirs, ['one-dir'])
+        assert cmd.include_dirs == ['one-dir']
 
         cmd.include_dirs = None
         cmd.finalize_options()
-        self.assertEqual(cmd.include_dirs, [])
+        assert cmd.include_dirs == []
 
         cmd.distribution.libraries = 'WONTWORK'
-        self.assertRaises(DistutilsSetupError, cmd.finalize_options)
+        with pytest.raises(DistutilsSetupError):
+            cmd.finalize_options()
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_run(self):
@@ -133,4 +135,4 @@ class BuildCLibTestCase(
         cmd.run()
 
         # let's check the result
-        self.assertIn('libfoo.a', os.listdir(build_temp))
+        assert 'libfoo.a' in os.listdir(build_temp)

--- a/setuptools/_distutils/tests/test_build_ext.py
+++ b/setuptools/_distutils/tests/test_build_ext.py
@@ -2,6 +2,7 @@ import sys
 import os
 from io import StringIO
 import textwrap
+import site
 
 from distutils.core import Distribution
 from distutils.command.build_ext import build_ext
@@ -11,6 +12,7 @@ from distutils.tests.support import (
     LoggingSilencer,
     copy_xxmodule_c,
     fixup_build_ext,
+    combine_markers,
 )
 from distutils.extension import Extension
 from distutils.errors import (
@@ -24,41 +26,37 @@ import unittest
 from test import support
 from . import py38compat as os_helper
 from test.support.script_helper import assert_python_ok
+import pytest
+import re
 
 # http://bugs.python.org/issue4373
 # Don't load the xx module more than once.
 ALREADY_TESTED = False
 
 
-class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
-    def setUp(self):
-        # Create a simple test environment
-        super(BuildExtTestCase, self).setUp()
-        self.tmp_dir = self.mkdtemp()
-        import site
+@pytest.fixture()
+def user_site_dir(request):
+    self = request.instance
+    self.tmp_dir = self.mkdtemp()
+    from distutils.command import build_ext
 
-        self.old_user_base = site.USER_BASE
-        site.USER_BASE = self.mkdtemp()
-        from distutils.command import build_ext
+    orig_user_base = site.USER_BASE
 
-        build_ext.USER_BASE = site.USER_BASE
+    site.USER_BASE = self.mkdtemp()
+    build_ext.USER_BASE = site.USER_BASE
 
-        # bpo-30132: On Windows, a .pdb file may be created in the current
-        # working directory. Create a temporary working directory to cleanup
-        # everything at the end of the test.
-        change_cwd = os_helper.change_cwd(self.tmp_dir)
-        change_cwd.__enter__()
-        self.addCleanup(change_cwd.__exit__, None, None, None)
+    # bpo-30132: On Windows, a .pdb file may be created in the current
+    # working directory. Create a temporary working directory to cleanup
+    # everything at the end of the test.
+    with os_helper.change_cwd(self.tmp_dir):
+        yield
 
-    def tearDown(self):
-        import site
+    site.USER_BASE = orig_user_base
+    build_ext.USER_BASE = orig_user_base
 
-        site.USER_BASE = self.old_user_base
-        from distutils.command import build_ext
 
-        build_ext.USER_BASE = self.old_user_base
-        super(BuildExtTestCase, self).tearDown()
-
+@pytest.mark.usefixtures('user_site_dir')
+class TestBuildExt(TempdirManager, LoggingSilencer):
     def build_ext(self, *args, **kwargs):
         return build_ext(*args, **kwargs)
 
@@ -93,7 +91,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
             ALREADY_TESTED = type(self).__name__
 
         code = textwrap.dedent(
-            """
+            f"""
             tmp_dir = {self.tmp_dir!r}
 
             import sys
@@ -119,9 +117,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
 
 
             unittest.main()
-        """.format(
-                **locals()
-            )
+        """
         )
         assert_python_ok('-c', code)
 
@@ -145,7 +141,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
                 _config_vars['Py_ENABLE_SHARED'] = old_var
 
         # make sure we get some library dirs under solaris
-        self.assertGreater(len(cmd.library_dirs), 0)
+        assert len(cmd.library_dirs) > 0
 
     def test_user_site(self):
         import site
@@ -155,7 +151,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
 
         # making sure the user option is there
         options = [name for name, short, lable in cmd.user_options]
-        self.assertIn('user', options)
+        assert 'user' in options
 
         # setting a value
         cmd.user = 1
@@ -171,9 +167,9 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
 
         # see if include_dirs and library_dirs
         # were set
-        self.assertIn(lib, cmd.library_dirs)
-        self.assertIn(lib, cmd.rpath)
-        self.assertIn(incl, cmd.include_dirs)
+        assert lib in cmd.library_dirs
+        assert lib in cmd.rpath
+        assert incl in cmd.include_dirs
 
     def test_optional_extension(self):
 
@@ -183,9 +179,8 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         dist = Distribution({'name': 'xx', 'ext_modules': modules})
         cmd = self.build_ext(dist)
         cmd.ensure_finalized()
-        self.assertRaises(
-            (UnknownFileError, CompileError), cmd.run
-        )  # should raise an error
+        with pytest.raises((UnknownFileError, CompileError)):
+            cmd.run()  # should raise an error
 
         modules = [Extension('foo', ['xxx'], optional=True)]
         dist = Distribution({'name': 'xx', 'ext_modules': modules})
@@ -203,40 +198,40 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
 
         py_include = sysconfig.get_python_inc()
         for p in py_include.split(os.path.pathsep):
-            self.assertIn(p, cmd.include_dirs)
+            assert p in cmd.include_dirs
 
         plat_py_include = sysconfig.get_python_inc(plat_specific=1)
         for p in plat_py_include.split(os.path.pathsep):
-            self.assertIn(p, cmd.include_dirs)
+            assert p in cmd.include_dirs
 
         # make sure cmd.libraries is turned into a list
         # if it's a string
         cmd = self.build_ext(dist)
         cmd.libraries = 'my_lib, other_lib lastlib'
         cmd.finalize_options()
-        self.assertEqual(cmd.libraries, ['my_lib', 'other_lib', 'lastlib'])
+        assert cmd.libraries == ['my_lib', 'other_lib', 'lastlib']
 
         # make sure cmd.library_dirs is turned into a list
         # if it's a string
         cmd = self.build_ext(dist)
         cmd.library_dirs = 'my_lib_dir%sother_lib_dir' % os.pathsep
         cmd.finalize_options()
-        self.assertIn('my_lib_dir', cmd.library_dirs)
-        self.assertIn('other_lib_dir', cmd.library_dirs)
+        assert 'my_lib_dir' in cmd.library_dirs
+        assert 'other_lib_dir' in cmd.library_dirs
 
         # make sure rpath is turned into a list
         # if it's a string
         cmd = self.build_ext(dist)
         cmd.rpath = 'one%stwo' % os.pathsep
         cmd.finalize_options()
-        self.assertEqual(cmd.rpath, ['one', 'two'])
+        assert cmd.rpath == ['one', 'two']
 
         # make sure cmd.link_objects is turned into a list
         # if it's a string
         cmd = build_ext(dist)
         cmd.link_objects = 'one two,three'
         cmd.finalize_options()
-        self.assertEqual(cmd.link_objects, ['one', 'two', 'three'])
+        assert cmd.link_objects == ['one', 'two', 'three']
 
         # XXX more tests to perform for win32
 
@@ -245,25 +240,25 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         cmd = self.build_ext(dist)
         cmd.define = 'one,two'
         cmd.finalize_options()
-        self.assertEqual(cmd.define, [('one', '1'), ('two', '1')])
+        assert cmd.define == [('one', '1'), ('two', '1')]
 
         # make sure undef is turned into a list of
         # strings if they are ','-separated strings
         cmd = self.build_ext(dist)
         cmd.undef = 'one,two'
         cmd.finalize_options()
-        self.assertEqual(cmd.undef, ['one', 'two'])
+        assert cmd.undef == ['one', 'two']
 
         # make sure swig_opts is turned into a list
         cmd = self.build_ext(dist)
         cmd.swig_opts = None
         cmd.finalize_options()
-        self.assertEqual(cmd.swig_opts, [])
+        assert cmd.swig_opts == []
 
         cmd = self.build_ext(dist)
         cmd.swig_opts = '1 2'
         cmd.finalize_options()
-        self.assertEqual(cmd.swig_opts, ['1', '2'])
+        assert cmd.swig_opts == ['1', '2']
 
     def test_check_extensions_list(self):
         dist = Distribution()
@@ -271,35 +266,39 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         cmd.finalize_options()
 
         # 'extensions' option must be a list of Extension instances
-        self.assertRaises(DistutilsSetupError, cmd.check_extensions_list, 'foo')
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_extensions_list('foo')
 
         # each element of 'ext_modules' option must be an
         # Extension instance or 2-tuple
         exts = [('bar', 'foo', 'bar'), 'foo']
-        self.assertRaises(DistutilsSetupError, cmd.check_extensions_list, exts)
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_extensions_list(exts)
 
         # first element of each tuple in 'ext_modules'
         # must be the extension name (a string) and match
         # a python dotted-separated name
         exts = [('foo-bar', '')]
-        self.assertRaises(DistutilsSetupError, cmd.check_extensions_list, exts)
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_extensions_list(exts)
 
         # second element of each tuple in 'ext_modules'
         # must be a dictionary (build info)
         exts = [('foo.bar', '')]
-        self.assertRaises(DistutilsSetupError, cmd.check_extensions_list, exts)
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_extensions_list(exts)
 
         # ok this one should pass
         exts = [('foo.bar', {'sources': [''], 'libraries': 'foo', 'some': 'bar'})]
         cmd.check_extensions_list(exts)
         ext = exts[0]
-        self.assertIsInstance(ext, Extension)
+        assert isinstance(ext, Extension)
 
         # check_extensions_list adds in ext the values passed
         # when they are in ('include_dirs', 'library_dirs', 'libraries'
         # 'extra_objects', 'extra_compile_args', 'extra_link_args')
-        self.assertEqual(ext.libraries, 'foo')
-        self.assertFalse(hasattr(ext, 'some'))
+        assert ext.libraries == 'foo'
+        assert not hasattr(ext, 'some')
 
         # 'macros' element of build info dict must be 1- or 2-tuple
         exts = [
@@ -313,19 +312,20 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
                 },
             )
         ]
-        self.assertRaises(DistutilsSetupError, cmd.check_extensions_list, exts)
+        with pytest.raises(DistutilsSetupError):
+            cmd.check_extensions_list(exts)
 
         exts[0][1]['macros'] = [('1', '2'), ('3',)]
         cmd.check_extensions_list(exts)
-        self.assertEqual(exts[0].undef_macros, ['3'])
-        self.assertEqual(exts[0].define_macros, [('1', '2')])
+        assert exts[0].undef_macros == ['3']
+        assert exts[0].define_macros == [('1', '2')]
 
     def test_get_source_files(self):
         modules = [Extension('foo', ['xxx'], optional=False)]
         dist = Distribution({'name': 'xx', 'ext_modules': modules})
         cmd = self.build_ext(dist)
         cmd.ensure_finalized()
-        self.assertEqual(cmd.get_source_files(), ['xxx'])
+        assert cmd.get_source_files() == ['xxx']
 
     def test_unicode_module_names(self):
         modules = [
@@ -335,10 +335,10 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         dist = Distribution({'name': 'xx', 'ext_modules': modules})
         cmd = self.build_ext(dist)
         cmd.ensure_finalized()
-        self.assertRegex(cmd.get_ext_filename(modules[0].name), r'foo(_d)?\..*')
-        self.assertRegex(cmd.get_ext_filename(modules[1].name), r'föö(_d)?\..*')
-        self.assertEqual(cmd.get_export_symbols(modules[0]), ['PyInit_foo'])
-        self.assertEqual(cmd.get_export_symbols(modules[1]), ['PyInitU_f_1gaa'])
+        assert re.search(r'foo(_d)?\..*', cmd.get_ext_filename(modules[0].name))
+        assert re.search(r'föö(_d)?\..*', cmd.get_ext_filename(modules[1].name))
+        assert cmd.get_export_symbols(modules[0]) == ['PyInit_foo']
+        assert cmd.get_export_symbols(modules[1]) == ['PyInitU_f_1gaa']
 
     def test_compiler_option(self):
         # cmd.compiler is an option and
@@ -349,7 +349,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         cmd.compiler = 'unix'
         cmd.ensure_finalized()
         cmd.run()
-        self.assertEqual(cmd.compiler, 'unix')
+        assert cmd.compiler == 'unix'
 
     def test_get_outputs(self):
         cmd = support.missing_compiler_executable()
@@ -363,7 +363,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         cmd = self.build_ext(dist)
         fixup_build_ext(cmd)
         cmd.ensure_finalized()
-        self.assertEqual(len(cmd.get_outputs()), 1)
+        assert len(cmd.get_outputs()) == 1
 
         cmd.build_lib = os.path.join(self.tmp_dir, 'build')
         cmd.build_temp = os.path.join(self.tmp_dir, 'tempt')
@@ -379,20 +379,20 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
             so_file = cmd.get_outputs()[0]
         finally:
             os.chdir(old_wd)
-        self.assertTrue(os.path.exists(so_file))
+        assert os.path.exists(so_file)
         ext_suffix = sysconfig.get_config_var('EXT_SUFFIX')
-        self.assertTrue(so_file.endswith(ext_suffix))
+        assert so_file.endswith(ext_suffix)
         so_dir = os.path.dirname(so_file)
-        self.assertEqual(so_dir, other_tmp_dir)
+        assert so_dir == other_tmp_dir
 
         cmd.inplace = 0
         cmd.compiler = None
         cmd.run()
         so_file = cmd.get_outputs()[0]
-        self.assertTrue(os.path.exists(so_file))
-        self.assertTrue(so_file.endswith(ext_suffix))
+        assert os.path.exists(so_file)
+        assert so_file.endswith(ext_suffix)
         so_dir = os.path.dirname(so_file)
-        self.assertEqual(so_dir, cmd.build_lib)
+        assert so_dir == cmd.build_lib
 
         # inplace = 0, cmd.package = 'bar'
         build_py = cmd.get_finalized_command('build_py')
@@ -400,7 +400,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         path = cmd.get_ext_fullpath('foo')
         # checking that the last directory is the build_dir
         path = os.path.split(path)[0]
-        self.assertEqual(path, cmd.build_lib)
+        assert path == cmd.build_lib
 
         # inplace = 1, cmd.package = 'bar'
         cmd.inplace = 1
@@ -414,7 +414,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         # checking that the last directory is bar
         path = os.path.split(path)[0]
         lastdir = os.path.split(path)[-1]
-        self.assertEqual(lastdir, 'bar')
+        assert lastdir == 'bar'
 
     def test_ext_fullpath(self):
         ext = sysconfig.get_config_var('EXT_SUFFIX')
@@ -430,14 +430,14 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         curdir = os.getcwd()
         wanted = os.path.join(curdir, 'src', 'lxml', 'etree' + ext)
         path = cmd.get_ext_fullpath('lxml.etree')
-        self.assertEqual(wanted, path)
+        assert wanted == path
 
         # building lxml.etree not inplace
         cmd.inplace = 0
         cmd.build_lib = os.path.join(curdir, 'tmpdir')
         wanted = os.path.join(curdir, 'tmpdir', 'lxml', 'etree' + ext)
         path = cmd.get_ext_fullpath('lxml.etree')
-        self.assertEqual(wanted, path)
+        assert wanted == path
 
         # building twisted.runner.portmap not inplace
         build_py = cmd.get_finalized_command('build_py')
@@ -445,15 +445,16 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         cmd.distribution.packages = ['twisted', 'twisted.runner.portmap']
         path = cmd.get_ext_fullpath('twisted.runner.portmap')
         wanted = os.path.join(curdir, 'tmpdir', 'twisted', 'runner', 'portmap' + ext)
-        self.assertEqual(wanted, path)
+        assert wanted == path
 
         # building twisted.runner.portmap inplace
         cmd.inplace = 1
         path = cmd.get_ext_fullpath('twisted.runner.portmap')
         wanted = os.path.join(curdir, 'twisted', 'runner', 'portmap' + ext)
-        self.assertEqual(wanted, path)
+        assert wanted == path
 
     @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for MacOSX')
+    @pytest.mark.usefixtures('save_env')
     def test_deployment_target_default(self):
         # Issue 9516: Test that, in the absence of the environment variable,
         # an extension module is compiled with the same deployment target as
@@ -461,14 +462,15 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         self._try_compile_deployment_target('==', None)
 
     @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for MacOSX')
+    @pytest.mark.usefixtures('save_env')
     def test_deployment_target_too_low(self):
         # Issue 9516: Test that an extension module is not allowed to be
         # compiled with a deployment target less than that of the interpreter.
-        self.assertRaises(
-            DistutilsPlatformError, self._try_compile_deployment_target, '>', '10.1'
-        )
+        with pytest.raises(DistutilsPlatformError):
+            self._try_compile_deployment_target('>', '10.1')
 
     @unittest.skipUnless(sys.platform == 'darwin', 'test only relevant for MacOSX')
+    @pytest.mark.usefixtures('save_env')
     def test_deployment_target_higher_ok(self):
         # Issue 9516: Test that an extension module can be compiled with a
         # deployment target higher than that of the interpreter: the ext
@@ -482,10 +484,6 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
             self._try_compile_deployment_target('<', deptarget)
 
     def _try_compile_deployment_target(self, operator, target):
-        orig_environ = os.environ
-        os.environ = orig_environ.copy()
-        self.addCleanup(setattr, os, 'environ', orig_environ)
-
         if target is None:
             if os.environ.get('MACOSX_DEPLOYMENT_TARGET'):
                 del os.environ['MACOSX_DEPLOYMENT_TARGET']
@@ -531,7 +529,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
         deptarget_ext = Extension(
             'deptarget',
             [deptarget_c],
-            extra_compile_args=['-DTARGET=%s' % (target,)],
+            extra_compile_args=['-DTARGET={}'.format(target)],
         )
         dist = Distribution({'name': 'deptarget', 'ext_modules': [deptarget_ext]})
         dist.package_dir = self.tmp_dir
@@ -554,7 +552,7 @@ class BuildExtTestCase(TempdirManager, LoggingSilencer, unittest.TestCase):
             self.fail("Wrong deployment target during compilation")
 
 
-class ParallelBuildExtTestCase(BuildExtTestCase):
+class TestParallelBuildExt(TestBuildExt):
     def build_ext(self, *args, **kwargs):
         build_ext = super().build_ext(*args, **kwargs)
         build_ext.parallel = True

--- a/setuptools/_distutils/tests/test_build_py.py
+++ b/setuptools/_distutils/tests/test_build_py.py
@@ -12,9 +12,8 @@ from unittest.mock import patch
 from distutils.tests import support
 
 
-class BuildPyTestCase(
-    support.TempdirManager, support.LoggingSilencer, unittest.TestCase
-):
+@support.combine_markers
+class TestBuildPy(support.TempdirManager, support.LoggingSilencer):
     def test_package_data(self):
         sources = self.mkdtemp()
         f = open(os.path.join(sources, "__init__.py"), "w")
@@ -41,24 +40,24 @@ class BuildPyTestCase(
         cmd = build_py(dist)
         cmd.compile = 1
         cmd.ensure_finalized()
-        self.assertEqual(cmd.package_data, dist.package_data)
+        assert cmd.package_data == dist.package_data
 
         cmd.run()
 
         # This makes sure the list of outputs includes byte-compiled
         # files for Python modules but not for package data files
         # (there shouldn't *be* byte-code files for those!).
-        self.assertEqual(len(cmd.get_outputs()), 3)
+        assert len(cmd.get_outputs()) == 3
         pkgdest = os.path.join(destination, "pkg")
         files = os.listdir(pkgdest)
         pycache_dir = os.path.join(pkgdest, "__pycache__")
-        self.assertIn("__init__.py", files)
-        self.assertIn("README.txt", files)
+        assert "__init__.py" in files
+        assert "README.txt" in files
         if sys.dont_write_bytecode:
-            self.assertFalse(os.path.exists(pycache_dir))
+            assert not os.path.exists(pycache_dir)
         else:
             pyc_files = os.listdir(pycache_dir)
-            self.assertIn("__init__.%s.pyc" % sys.implementation.cache_tag, pyc_files)
+            assert "__init__.%s.pyc" % sys.implementation.cache_tag in pyc_files
 
     def test_empty_package_dir(self):
         # See bugs #1668596/#1720897
@@ -99,9 +98,9 @@ class BuildPyTestCase(
         cmd.run()
 
         found = os.listdir(cmd.build_lib)
-        self.assertEqual(sorted(found), ['__pycache__', 'boiledeggs.py'])
+        assert sorted(found) == ['__pycache__', 'boiledeggs.py']
         found = os.listdir(os.path.join(cmd.build_lib, '__pycache__'))
-        self.assertEqual(found, ['boiledeggs.%s.pyc' % sys.implementation.cache_tag])
+        assert found == ['boiledeggs.%s.pyc' % sys.implementation.cache_tag]
 
     @unittest.skipIf(sys.dont_write_bytecode, 'byte-compile disabled')
     def test_byte_compile_optimized(self):
@@ -116,10 +115,10 @@ class BuildPyTestCase(
         cmd.run()
 
         found = os.listdir(cmd.build_lib)
-        self.assertEqual(sorted(found), ['__pycache__', 'boiledeggs.py'])
+        assert sorted(found) == ['__pycache__', 'boiledeggs.py']
         found = os.listdir(os.path.join(cmd.build_lib, '__pycache__'))
-        expect = 'boiledeggs.{}.opt-1.pyc'.format(sys.implementation.cache_tag)
-        self.assertEqual(sorted(found), [expect])
+        expect = f'boiledeggs.{sys.implementation.cache_tag}.opt-1.pyc'
+        assert sorted(found) == [expect]
 
     def test_dir_in_package_data(self):
         """
@@ -165,7 +164,7 @@ class BuildPyTestCase(
         finally:
             sys.dont_write_bytecode = old_dont_write_bytecode
 
-        self.assertIn('byte-compiling is disabled', self.logs[0][1] % self.logs[0][2])
+        assert 'byte-compiling is disabled' in self.logs[0][1] % self.logs[0][2]
 
     @patch("distutils.command.build_py.log.warn")
     def test_namespace_package_does_not_warn(self, log_warn):

--- a/setuptools/_distutils/tests/test_build_scripts.py
+++ b/setuptools/_distutils/tests/test_build_scripts.py
@@ -1,7 +1,6 @@
 """Tests for distutils.command.build_scripts."""
 
 import os
-import unittest
 
 from distutils.command.build_scripts import build_scripts
 from distutils.core import Distribution
@@ -10,18 +9,16 @@ from distutils import sysconfig
 from distutils.tests import support
 
 
-class BuildScriptsTestCase(
-    support.TempdirManager, support.LoggingSilencer, unittest.TestCase
-):
+class TestBuildScripts(support.TempdirManager, support.LoggingSilencer):
     def test_default_settings(self):
         cmd = self.get_build_scripts_cmd("/foo/bar", [])
-        self.assertFalse(cmd.force)
-        self.assertIsNone(cmd.build_dir)
+        assert not cmd.force
+        assert cmd.build_dir is None
 
         cmd.finalize_options()
 
-        self.assertTrue(cmd.force)
-        self.assertEqual(cmd.build_dir, "/foo/bar")
+        assert cmd.force
+        assert cmd.build_dir == "/foo/bar"
 
     def test_build(self):
         source = self.mkdtemp()
@@ -36,7 +33,7 @@ class BuildScriptsTestCase(
 
         built = os.listdir(target)
         for name in expected:
-            self.assertIn(name, built)
+            assert name in built
 
     def get_build_scripts_cmd(self, target, scripts):
         import sys
@@ -106,4 +103,4 @@ class BuildScriptsTestCase(
 
         built = os.listdir(target)
         for name in expected:
-            self.assertIn(name, built)
+            assert name in built

--- a/setuptools/_distutils/tests/test_clean.py
+++ b/setuptools/_distutils/tests/test_clean.py
@@ -1,12 +1,11 @@
 """Tests for distutils.command.clean."""
 import os
-import unittest
 
 from distutils.command.clean import clean
 from distutils.tests import support
 
 
-class cleanTestCase(support.TempdirManager, support.LoggingSilencer, unittest.TestCase):
+class TestClean(support.TempdirManager, support.LoggingSilencer):
     def test_simple_run(self):
         pkg_dir, dist = self.create_dist()
         cmd = clean(dist)
@@ -38,7 +37,7 @@ class cleanTestCase(support.TempdirManager, support.LoggingSilencer, unittest.Te
 
         # make sure the files where removed
         for name, path in dirs:
-            self.assertFalse(os.path.exists(path), '%s was not removed' % path)
+            assert not os.path.exists(path), '%s was not removed' % path
 
         # let's run the command again (should spit warnings but succeed)
         cmd.all = 1

--- a/setuptools/_distutils/tests/test_cmd.py
+++ b/setuptools/_distutils/tests/test_cmd.py
@@ -7,6 +7,7 @@ from distutils.cmd import Command
 from distutils.dist import Distribution
 from distutils.errors import DistutilsOptionError
 from distutils import debug
+import pytest
 
 
 class MyCmd(Command):
@@ -14,7 +15,7 @@ class MyCmd(Command):
         pass
 
 
-class CommandTestCase(unittest.TestCase):
+class TestCommand(unittest.TestCase):
     def setUp(self):
         dist = Distribution()
         self.cmd = MyCmd(dist)
@@ -29,36 +30,34 @@ class CommandTestCase(unittest.TestCase):
         cmd.ensure_string_list('yes_string_list')
         cmd.ensure_string_list('yes_string_list2')
 
-        self.assertRaises(
-            DistutilsOptionError, cmd.ensure_string_list, 'not_string_list'
-        )
+        with pytest.raises(DistutilsOptionError):
+            cmd.ensure_string_list('not_string_list')
 
-        self.assertRaises(
-            DistutilsOptionError, cmd.ensure_string_list, 'not_string_list2'
-        )
+        with pytest.raises(DistutilsOptionError):
+            cmd.ensure_string_list('not_string_list2')
 
         cmd.option1 = 'ok,dok'
         cmd.ensure_string_list('option1')
-        self.assertEqual(cmd.option1, ['ok', 'dok'])
+        assert cmd.option1 == ['ok', 'dok']
 
         cmd.option2 = ['xxx', 'www']
         cmd.ensure_string_list('option2')
 
         cmd.option3 = ['ok', 2]
-        self.assertRaises(DistutilsOptionError, cmd.ensure_string_list, 'option3')
+        with pytest.raises(DistutilsOptionError):
+            cmd.ensure_string_list('option3')
 
     def test_make_file(self):
 
         cmd = self.cmd
 
         # making sure it raises when infiles is not a string or a list/tuple
-        self.assertRaises(
-            TypeError, cmd.make_file, infiles=1, outfile='', func='func', args=()
-        )
+        with pytest.raises(TypeError):
+            cmd.make_file(infiles=1, outfile='', func='func', args=())
 
         # making sure execute gets called properly
         def _execute(func, args, exec_msg, level):
-            self.assertEqual(exec_msg, 'generating out from in')
+            assert exec_msg == 'generating out from in'
 
         cmd.force = True
         cmd.execute = _execute
@@ -79,7 +78,7 @@ class CommandTestCase(unittest.TestCase):
         cmd.dump_options()
 
         wanted = ["command options for 'MyCmd':", '  option1 = 1', '  option2 = 1']
-        self.assertEqual(msgs, wanted)
+        assert msgs == wanted
 
     def test_ensure_string(self):
         cmd = self.cmd
@@ -88,37 +87,40 @@ class CommandTestCase(unittest.TestCase):
 
         cmd.option2 = None
         cmd.ensure_string('option2', 'xxx')
-        self.assertTrue(hasattr(cmd, 'option2'))
+        assert hasattr(cmd, 'option2')
 
         cmd.option3 = 1
-        self.assertRaises(DistutilsOptionError, cmd.ensure_string, 'option3')
+        with pytest.raises(DistutilsOptionError):
+            cmd.ensure_string('option3')
 
     def test_ensure_filename(self):
         cmd = self.cmd
         cmd.option1 = __file__
         cmd.ensure_filename('option1')
         cmd.option2 = 'xxx'
-        self.assertRaises(DistutilsOptionError, cmd.ensure_filename, 'option2')
+        with pytest.raises(DistutilsOptionError):
+            cmd.ensure_filename('option2')
 
     def test_ensure_dirname(self):
         cmd = self.cmd
         cmd.option1 = os.path.dirname(__file__) or os.curdir
         cmd.ensure_dirname('option1')
         cmd.option2 = 'xxx'
-        self.assertRaises(DistutilsOptionError, cmd.ensure_dirname, 'option2')
+        with pytest.raises(DistutilsOptionError):
+            cmd.ensure_dirname('option2')
 
     def test_debug_print(self):
         cmd = self.cmd
         with captured_stdout() as stdout:
             cmd.debug_print('xxx')
         stdout.seek(0)
-        self.assertEqual(stdout.read(), '')
+        assert stdout.read() == ''
 
         debug.DEBUG = True
         try:
             with captured_stdout() as stdout:
                 cmd.debug_print('xxx')
             stdout.seek(0)
-            self.assertEqual(stdout.read(), 'xxx\n')
+            assert stdout.read() == 'xxx\n'
         finally:
             debug.DEBUG = False

--- a/setuptools/_distutils/tests/test_config.py
+++ b/setuptools/_distutils/tests/test_config.py
@@ -51,6 +51,7 @@ password:xxx
 """
 
 
+@support.combine_markers
 @pytest.mark.usefixtures('save_env')
 class BasePyPIRCCommandTestCase(
     support.TempdirManager,
@@ -59,7 +60,7 @@ class BasePyPIRCCommandTestCase(
 ):
     def setUp(self):
         """Patches the environment."""
-        super(BasePyPIRCCommandTestCase, self).setUp()
+        super().setUp()
         self.tmp_dir = self.mkdtemp()
         os.environ['HOME'] = self.tmp_dir
         os.environ['USERPROFILE'] = self.tmp_dir
@@ -81,7 +82,7 @@ class BasePyPIRCCommandTestCase(
     def tearDown(self):
         """Removes the patch."""
         set_threshold(self.old_threshold)
-        super(BasePyPIRCCommandTestCase, self).tearDown()
+        super().tearDown()
 
 
 class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
@@ -103,7 +104,7 @@ class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
             ('server', 'server1'),
             ('username', 'me'),
         ]
-        self.assertEqual(config, waited)
+        assert config == waited
 
         # old format
         self.write_file(self.rc, PYPIRC_OLD)
@@ -116,18 +117,18 @@ class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
             ('server', 'server-login'),
             ('username', 'tarek'),
         ]
-        self.assertEqual(config, waited)
+        assert config == waited
 
     def test_server_empty_registration(self):
         cmd = self._cmd(self.dist)
         rc = cmd._get_rc_file()
-        self.assertFalse(os.path.exists(rc))
+        assert not os.path.exists(rc)
         cmd._store_pypirc('tarek', 'xxx')
-        self.assertTrue(os.path.exists(rc))
+        assert os.path.exists(rc)
         f = open(rc)
         try:
             content = f.read()
-            self.assertEqual(content, WANTED)
+            assert content == WANTED
         finally:
             f.close()
 
@@ -146,4 +147,4 @@ class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
             ('server', 'server3'),
             ('username', 'cbiggles'),
         ]
-        self.assertEqual(config, waited)
+        assert config == waited

--- a/setuptools/_distutils/tests/test_config_cmd.py
+++ b/setuptools/_distutils/tests/test_config_cmd.py
@@ -9,6 +9,7 @@ from distutils.tests import support
 from distutils import log
 
 
+@support.combine_markers
 class ConfigTestCase(
     support.LoggingSilencer, support.TempdirManager, unittest.TestCase
 ):
@@ -17,14 +18,14 @@ class ConfigTestCase(
             self._logs.append(line)
 
     def setUp(self):
-        super(ConfigTestCase, self).setUp()
+        super().setUp()
         self._logs = []
         self.old_log = log.info
         log.info = self._info
 
     def tearDown(self):
         log.info = self.old_log
-        super(ConfigTestCase, self).tearDown()
+        super().tearDown()
 
     def test_dump_file(self):
         this_file = os.path.splitext(__file__)[0] + '.py'
@@ -35,7 +36,7 @@ class ConfigTestCase(
             f.close()
 
         dump_file(this_file, 'I am the header')
-        self.assertEqual(len(self._logs), numlines + 1)
+        assert len(self._logs) == numlines + 1
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_search_cpp(self):
@@ -53,10 +54,10 @@ class ConfigTestCase(
 
         # simple pattern searches
         match = cmd.search_cpp(pattern='xxx', body='/* xxx */')
-        self.assertEqual(match, 0)
+        assert match == 0
 
         match = cmd.search_cpp(pattern='_configtest', body='/* xxx */')
-        self.assertEqual(match, 1)
+        assert match == 1
 
     def test_finalize_options(self):
         # finalize_options does a bit of transformation
@@ -68,9 +69,9 @@ class ConfigTestCase(
         cmd.library_dirs = 'three%sfour' % os.pathsep
         cmd.ensure_finalized()
 
-        self.assertEqual(cmd.include_dirs, ['one', 'two'])
-        self.assertEqual(cmd.libraries, ['one'])
-        self.assertEqual(cmd.library_dirs, ['three', 'four'])
+        assert cmd.include_dirs == ['one', 'two']
+        assert cmd.libraries == ['one']
+        assert cmd.library_dirs == ['three', 'four']
 
     def test_clean(self):
         # _clean removes files
@@ -82,11 +83,11 @@ class ConfigTestCase(
         self.write_file(f2, 'xxx')
 
         for f in (f1, f2):
-            self.assertTrue(os.path.exists(f))
+            assert os.path.exists(f)
 
         pkg_dir, dist = self.create_dist()
         cmd = config(dist)
         cmd._clean(f1, f2)
 
         for f in (f1, f2):
-            self.assertFalse(os.path.exists(f))
+            assert not os.path.exists(f)

--- a/setuptools/_distutils/tests/test_core.py
+++ b/setuptools/_distutils/tests/test_core.py
@@ -60,20 +60,18 @@ if __name__ == "__main__":
 
 
 @pytest.mark.usefixtures('save_env')
+@pytest.mark.usefixtures('save_argv')
 class CoreTestCase(unittest.TestCase):
     def setUp(self):
-        super(CoreTestCase, self).setUp()
+        super().setUp()
         self.old_stdout = sys.stdout
         self.cleanup_testfn()
-        self.old_argv = sys.argv, sys.argv[:]
         self.addCleanup(log.set_threshold, log._global_log.threshold)
 
     def tearDown(self):
         sys.stdout = self.old_stdout
         self.cleanup_testfn()
-        sys.argv = self.old_argv[0]
-        sys.argv[:] = self.old_argv[1]
-        super(CoreTestCase, self).tearDown()
+        super().tearDown()
 
     def cleanup_testfn(self):
         path = os_helper.TESTFN
@@ -99,14 +97,14 @@ class CoreTestCase(unittest.TestCase):
         # Make sure run_setup does not clobber sys.argv
         argv_copy = sys.argv.copy()
         distutils.core.run_setup(self.write_setup(setup_does_nothing))
-        self.assertEqual(sys.argv, argv_copy)
+        assert sys.argv == argv_copy
 
     def test_run_setup_defines_subclass(self):
         # Make sure the script can use __file__; if that's missing, the test
         # setup.py script will raise NameError.
         dist = distutils.core.run_setup(self.write_setup(setup_defines_subclass))
         install = dist.get_command_obj('install')
-        self.assertIn('cmd', install.sub_commands)
+        assert 'cmd' in install.sub_commands
 
     def test_run_setup_uses_current_dir(self):
         # This tests that the setup script is run with the current directory
@@ -123,23 +121,23 @@ class CoreTestCase(unittest.TestCase):
         output = sys.stdout.getvalue()
         if output.endswith("\n"):
             output = output[:-1]
-        self.assertEqual(cwd, output)
+        assert cwd == output
 
     def test_run_setup_within_if_main(self):
         dist = distutils.core.run_setup(
             self.write_setup(setup_within_if_main), stop_after="config"
         )
-        self.assertIsInstance(dist, Distribution)
-        self.assertEqual(dist.get_name(), "setup_within_if_main")
+        assert isinstance(dist, Distribution)
+        assert dist.get_name() == "setup_within_if_main"
 
     def test_run_commands(self):
         sys.argv = ['setup.py', 'build']
         dist = distutils.core.run_setup(
             self.write_setup(setup_within_if_main), stop_after="commandline"
         )
-        self.assertNotIn('build', dist.have_run)
+        assert 'build' not in dist.have_run
         distutils.core.run_commands(dist)
-        self.assertIn('build', dist.have_run)
+        assert 'build' in dist.have_run
 
     def test_debug_mode(self):
         # this covers the code called when DEBUG is set
@@ -147,7 +145,7 @@ class CoreTestCase(unittest.TestCase):
         with captured_stdout() as stdout:
             distutils.core.setup(name='bar')
         stdout.seek(0)
-        self.assertEqual(stdout.read(), 'bar\n')
+        assert stdout.read() == 'bar\n'
 
         distutils.core.DEBUG = True
         try:
@@ -157,4 +155,4 @@ class CoreTestCase(unittest.TestCase):
             distutils.core.DEBUG = False
         stdout.seek(0)
         wanted = "options (after parsing config files):\n"
-        self.assertEqual(stdout.readlines()[0], wanted)
+        assert stdout.readlines()[0] == wanted

--- a/setuptools/_distutils/tests/test_cygwinccompiler.py
+++ b/setuptools/_distutils/tests/test_cygwinccompiler.py
@@ -11,11 +11,12 @@ from distutils.cygwinccompiler import (
     get_msvcr,
 )
 from distutils.tests import support
+import pytest
 
 
 class CygwinCCompilerTestCase(support.TempdirManager, unittest.TestCase):
     def setUp(self):
-        super(CygwinCCompilerTestCase, self).setUp()
+        super().setUp()
         self.version = sys.version
         self.python_h = os.path.join(self.mkdtemp(), 'python.h')
         from distutils import sysconfig
@@ -28,7 +29,7 @@ class CygwinCCompilerTestCase(support.TempdirManager, unittest.TestCase):
         from distutils import sysconfig
 
         sysconfig.get_config_h_filename = self.old_get_config_h_filename
-        super(CygwinCCompilerTestCase, self).tearDown()
+        super().tearDown()
 
     def _get_config_h_filename(self):
         return self.python_h
@@ -43,16 +44,16 @@ class CygwinCCompilerTestCase(support.TempdirManager, unittest.TestCase):
         compiler = CygwinCCompiler()
         link_name = "bash"
         linkable_file = compiler.find_library_file(["/usr/lib"], link_name)
-        self.assertIsNotNone(linkable_file)
-        self.assertTrue(os.path.exists(linkable_file))
-        self.assertEquals(linkable_file, "/usr/lib/lib{:s}.dll.a".format(link_name))
+        assert linkable_file is not None
+        assert os.path.exists(linkable_file)
+        assert linkable_file == f"/usr/lib/lib{link_name:s}.dll.a"
 
     @unittest.skipIf(sys.platform != "cygwin", "Not running on Cygwin")
     def test_runtime_library_dir_option(self):
         from distutils.cygwinccompiler import CygwinCCompiler
 
         compiler = CygwinCCompiler()
-        self.assertEqual(compiler.runtime_library_dir_option('/foo'), [])
+        assert compiler.runtime_library_dir_option('/foo') == []
 
     def test_check_config_h(self):
 
@@ -63,21 +64,21 @@ class CygwinCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             '4.0.1 (Apple Computer, Inc. build 5370)]'
         )
 
-        self.assertEqual(check_config_h()[0], CONFIG_H_OK)
+        assert check_config_h()[0] == CONFIG_H_OK
 
         # then it tries to see if it can find "__GNUC__" in pyconfig.h
         sys.version = 'something without the *CC word'
 
         # if the file doesn't exist it returns  CONFIG_H_UNCERTAIN
-        self.assertEqual(check_config_h()[0], CONFIG_H_UNCERTAIN)
+        assert check_config_h()[0] == CONFIG_H_UNCERTAIN
 
         # if it exists but does not contain __GNUC__, it returns CONFIG_H_NOTOK
         self.write_file(self.python_h, 'xxx')
-        self.assertEqual(check_config_h()[0], CONFIG_H_NOTOK)
+        assert check_config_h()[0] == CONFIG_H_NOTOK
 
         # and CONFIG_H_OK if __GNUC__ is found
         self.write_file(self.python_h, 'xxx __GNUC__ xxx')
-        self.assertEqual(check_config_h()[0], CONFIG_H_OK)
+        assert check_config_h()[0] == CONFIG_H_OK
 
     def test_get_msvcr(self):
 
@@ -86,40 +87,41 @@ class CygwinCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             '2.6.1 (r261:67515, Dec  6 2008, 16:42:21) '
             '\n[GCC 4.0.1 (Apple Computer, Inc. build 5370)]'
         )
-        self.assertEqual(get_msvcr(), None)
+        assert get_msvcr() is None
 
         # MSVC 7.0
         sys.version = (
             '2.5.1 (r251:54863, Apr 18 2007, 08:51:08) ' '[MSC v.1300 32 bits (Intel)]'
         )
-        self.assertEqual(get_msvcr(), ['msvcr70'])
+        assert get_msvcr() == ['msvcr70']
 
         # MSVC 7.1
         sys.version = (
             '2.5.1 (r251:54863, Apr 18 2007, 08:51:08) ' '[MSC v.1310 32 bits (Intel)]'
         )
-        self.assertEqual(get_msvcr(), ['msvcr71'])
+        assert get_msvcr() == ['msvcr71']
 
         # VS2005 / MSVC 8.0
         sys.version = (
             '2.5.1 (r251:54863, Apr 18 2007, 08:51:08) ' '[MSC v.1400 32 bits (Intel)]'
         )
-        self.assertEqual(get_msvcr(), ['msvcr80'])
+        assert get_msvcr() == ['msvcr80']
 
         # VS2008 / MSVC 9.0
         sys.version = (
             '2.5.1 (r251:54863, Apr 18 2007, 08:51:08) ' '[MSC v.1500 32 bits (Intel)]'
         )
-        self.assertEqual(get_msvcr(), ['msvcr90'])
+        assert get_msvcr() == ['msvcr90']
 
         sys.version = (
             '3.10.0 (tags/v3.10.0:b494f59, Oct  4 2021, 18:46:30) '
             '[MSC v.1929 32 bit (Intel)]'
         )
-        self.assertEqual(get_msvcr(), ['ucrt', 'vcruntime140'])
+        assert get_msvcr() == ['ucrt', 'vcruntime140']
 
         # unknown
         sys.version = (
             '2.5.1 (r251:54863, Apr 18 2007, 08:51:08) ' '[MSC v.2000 32 bits (Intel)]'
         )
-        self.assertRaises(ValueError, get_msvcr)
+        with pytest.raises(ValueError):
+            get_msvcr()

--- a/setuptools/_distutils/tests/test_dep_util.py
+++ b/setuptools/_distutils/tests/test_dep_util.py
@@ -1,13 +1,13 @@
 """Tests for distutils.dep_util."""
-import unittest
 import os
 
 from distutils.dep_util import newer, newer_pairwise, newer_group
 from distutils.errors import DistutilsFileError
 from distutils.tests import support
+import pytest
 
 
-class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
+class TestDepUtil(support.TempdirManager):
     def test_newer(self):
 
         tmpdir = self.mkdtemp()
@@ -15,17 +15,18 @@ class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
         old_file = os.path.abspath(__file__)
 
         # Raise DistutilsFileError if 'new_file' does not exist.
-        self.assertRaises(DistutilsFileError, newer, new_file, old_file)
+        with pytest.raises(DistutilsFileError):
+            newer(new_file, old_file)
 
         # Return true if 'new_file' exists and is more recently modified than
         # 'old_file', or if 'new_file' exists and 'old_file' doesn't.
         self.write_file(new_file)
-        self.assertTrue(newer(new_file, 'I_dont_exist'))
-        self.assertTrue(newer(new_file, old_file))
+        assert newer(new_file, 'I_dont_exist')
+        assert newer(new_file, old_file)
 
         # Return false if both exist and 'old_file' is the same age or younger
         # than 'new_file'.
-        self.assertFalse(newer(old_file, new_file))
+        assert not newer(old_file, new_file)
 
     def test_newer_pairwise(self):
         tmpdir = self.mkdtemp()
@@ -41,7 +42,7 @@ class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
         self.write_file(two)
         self.write_file(four)
 
-        self.assertEqual(newer_pairwise([one, two], [three, four]), ([one], [three]))
+        assert newer_pairwise([one, two], [three, four]) == ([one], [three])
 
     def test_newer_group(self):
         tmpdir = self.mkdtemp()
@@ -57,13 +58,14 @@ class DepUtilTestCase(support.TempdirManager, unittest.TestCase):
         self.write_file(one)
         self.write_file(two)
         self.write_file(three)
-        self.assertTrue(newer_group([one, two, three], old_file))
-        self.assertFalse(newer_group([one, two, old_file], three))
+        assert newer_group([one, two, three], old_file)
+        assert not newer_group([one, two, old_file], three)
 
         # missing handling
         os.remove(one)
-        self.assertRaises(OSError, newer_group, [one, two, old_file], three)
+        with pytest.raises(OSError):
+            newer_group([one, two, old_file], three)
 
-        self.assertFalse(newer_group([one, two, old_file], three, missing='ignore'))
+        assert not newer_group([one, two, old_file], three, missing='ignore')
 
-        self.assertTrue(newer_group([one, two, old_file], three, missing='newer'))
+        assert newer_group([one, two, old_file], three, missing='newer')

--- a/setuptools/_distutils/tests/test_dir_util.py
+++ b/setuptools/_distutils/tests/test_dir_util.py
@@ -16,6 +16,7 @@ from distutils.dir_util import (
 
 from distutils import log
 from distutils.tests import support
+import pytest
 
 
 class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
@@ -26,7 +27,7 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
             self._logs.append(msg)
 
     def setUp(self):
-        super(DirUtilTestCase, self).setUp()
+        super().setUp()
         self._logs = []
         tmp_dir = self.mkdtemp()
         self.root_target = os.path.join(tmp_dir, 'deep')
@@ -37,23 +38,23 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
 
     def tearDown(self):
         log.info = self.old_log
-        super(DirUtilTestCase, self).tearDown()
+        super().tearDown()
 
     def test_mkpath_remove_tree_verbosity(self):
 
         mkpath(self.target, verbose=0)
         wanted = []
-        self.assertEqual(self._logs, wanted)
+        assert self._logs == wanted
         remove_tree(self.root_target, verbose=0)
 
         mkpath(self.target, verbose=1)
         wanted = ['creating %s' % self.root_target, 'creating %s' % self.target]
-        self.assertEqual(self._logs, wanted)
+        assert self._logs == wanted
         self._logs = []
 
         remove_tree(self.root_target, verbose=1)
         wanted = ["removing '%s' (and everything under it)" % self.root_target]
-        self.assertEqual(self._logs, wanted)
+        assert self._logs == wanted
 
     @unittest.skipIf(
         sys.platform.startswith('win'),
@@ -64,19 +65,19 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
         umask = os.umask(0o002)
         os.umask(umask)
         mkpath(self.target, 0o700)
-        self.assertEqual(stat.S_IMODE(os.stat(self.target).st_mode), 0o700 & ~umask)
+        assert stat.S_IMODE(os.stat(self.target).st_mode) == 0o700 & ~umask
         mkpath(self.target2, 0o555)
-        self.assertEqual(stat.S_IMODE(os.stat(self.target2).st_mode), 0o555 & ~umask)
+        assert stat.S_IMODE(os.stat(self.target2).st_mode) == 0o555 & ~umask
 
     def test_create_tree_verbosity(self):
 
         create_tree(self.root_target, ['one', 'two', 'three'], verbose=0)
-        self.assertEqual(self._logs, [])
+        assert self._logs == []
         remove_tree(self.root_target, verbose=0)
 
         wanted = ['creating %s' % self.root_target]
         create_tree(self.root_target, ['one', 'two', 'three'], verbose=1)
-        self.assertEqual(self._logs, wanted)
+        assert self._logs == wanted
 
         remove_tree(self.root_target, verbose=0)
 
@@ -85,7 +86,7 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
         mkpath(self.target, verbose=0)
 
         copy_tree(self.target, self.target2, verbose=0)
-        self.assertEqual(self._logs, [])
+        assert self._logs == []
 
         remove_tree(self.root_target, verbose=0)
 
@@ -94,9 +95,9 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
         with open(a_file, 'w') as f:
             f.write('some content')
 
-        wanted = ['copying %s -> %s' % (a_file, self.target2)]
+        wanted = ['copying {} -> {}'.format(a_file, self.target2)]
         copy_tree(self.target, self.target2, verbose=1)
-        self.assertEqual(self._logs, wanted)
+        assert self._logs == wanted
 
         remove_tree(self.root_target, verbose=0)
         remove_tree(self.target2, verbose=0)
@@ -111,24 +112,24 @@ class DirUtilTestCase(support.TempdirManager, unittest.TestCase):
                 fh.write('some content')
 
         copy_tree(self.target, self.target2)
-        self.assertEqual(os.listdir(self.target2), ['ok.txt'])
+        assert os.listdir(self.target2) == ['ok.txt']
 
         remove_tree(self.root_target, verbose=0)
         remove_tree(self.target2, verbose=0)
 
     def test_ensure_relative(self):
         if os.sep == '/':
-            self.assertEqual(ensure_relative('/home/foo'), 'home/foo')
-            self.assertEqual(ensure_relative('some/path'), 'some/path')
+            assert ensure_relative('/home/foo') == 'home/foo'
+            assert ensure_relative('some/path') == 'some/path'
         else:  # \\
-            self.assertEqual(ensure_relative('c:\\home\\foo'), 'c:home\\foo')
-            self.assertEqual(ensure_relative('home\\foo'), 'home\\foo')
+            assert ensure_relative('c:\\home\\foo') == 'c:home\\foo'
+            assert ensure_relative('home\\foo') == 'home\\foo'
 
     def test_copy_tree_exception_in_listdir(self):
         """
         An exception in listdir should raise a DistutilsFileError
         """
-        with patch("os.listdir", side_effect=OSError()), self.assertRaises(
+        with patch("os.listdir", side_effect=OSError()), pytest.raises(
             errors.DistutilsFileError
         ):
             src = self.tempdirs[-1]

--- a/setuptools/_distutils/tests/test_extension.py
+++ b/setuptools/_distutils/tests/test_extension.py
@@ -1,14 +1,14 @@
 """Tests for distutils.extension."""
-import unittest
 import os
 import warnings
 
 from distutils.extension import read_setup_file, Extension
 
 from .py38compat import check_warnings
+import pytest
 
 
-class ExtensionTestCase(unittest.TestCase):
+class TestExtension:
     def test_read_setup_file(self):
         # trying to read a Setup file
         # (sample extracted from the PyGame project)
@@ -57,20 +57,23 @@ class ExtensionTestCase(unittest.TestCase):
             'transform',
         ]
 
-        self.assertEqual(names, wanted)
+        assert names == wanted
 
     def test_extension_init(self):
         # the first argument, which is the name, must be a string
-        self.assertRaises(AssertionError, Extension, 1, [])
+        with pytest.raises(AssertionError):
+            Extension(1, [])
         ext = Extension('name', [])
-        self.assertEqual(ext.name, 'name')
+        assert ext.name == 'name'
 
         # the second argument, which is the list of files, must
         # be a list of strings
-        self.assertRaises(AssertionError, Extension, 'name', 'file')
-        self.assertRaises(AssertionError, Extension, 'name', ['file', 1])
+        with pytest.raises(AssertionError):
+            Extension('name', 'file')
+        with pytest.raises(AssertionError):
+            Extension('name', ['file', 1])
         ext = Extension('name', ['file1', 'file2'])
-        self.assertEqual(ext.sources, ['file1', 'file2'])
+        assert ext.sources == ['file1', 'file2']
 
         # others arguments have defaults
         for attr in (
@@ -87,17 +90,15 @@ class ExtensionTestCase(unittest.TestCase):
             'swig_opts',
             'depends',
         ):
-            self.assertEqual(getattr(ext, attr), [])
+            assert getattr(ext, attr) == []
 
-        self.assertEqual(ext.language, None)
-        self.assertEqual(ext.optional, None)
+        assert ext.language is None
+        assert ext.optional is None
 
         # if there are unknown keyword options, warn about them
         with check_warnings() as w:
             warnings.simplefilter('always')
             ext = Extension('name', ['file1', 'file2'], chic=True)
 
-        self.assertEqual(len(w.warnings), 1)
-        self.assertEqual(
-            str(w.warnings[0].message), "Unknown Extension options: 'chic'"
-        )
+        assert len(w.warnings) == 1
+        assert str(w.warnings[0].message) == "Unknown Extension options: 'chic'"

--- a/setuptools/_distutils/tests/test_file_util.py
+++ b/setuptools/_distutils/tests/test_file_util.py
@@ -9,6 +9,7 @@ from distutils import log
 from distutils.tests import support
 from distutils.errors import DistutilsFileError
 from .py38compat import unlink
+import pytest
 
 
 class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
@@ -19,7 +20,7 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
             self._logs.append(msg)
 
     def setUp(self):
-        super(FileUtilTestCase, self).setUp()
+        super().setUp()
         self._logs = []
         self.old_log = log.info
         log.info = self._log
@@ -30,7 +31,7 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
 
     def tearDown(self):
         log.info = self.old_log
-        super(FileUtilTestCase, self).tearDown()
+        super().tearDown()
 
     def test_move_file_verbosity(self):
         f = open(self.source, 'w')
@@ -41,14 +42,14 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
 
         move_file(self.source, self.target, verbose=0)
         wanted = []
-        self.assertEqual(self._logs, wanted)
+        assert self._logs == wanted
 
         # back to original state
         move_file(self.target, self.source, verbose=0)
 
         move_file(self.source, self.target, verbose=1)
-        wanted = ['moving %s -> %s' % (self.source, self.target)]
-        self.assertEqual(self._logs, wanted)
+        wanted = ['moving {} -> {}'.format(self.source, self.target)]
+        assert self._logs == wanted
 
         # back to original state
         move_file(self.target, self.source, verbose=0)
@@ -57,12 +58,12 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
         # now the target is a dir
         os.mkdir(self.target_dir)
         move_file(self.source, self.target_dir, verbose=1)
-        wanted = ['moving %s -> %s' % (self.source, self.target_dir)]
-        self.assertEqual(self._logs, wanted)
+        wanted = ['moving {} -> {}'.format(self.source, self.target_dir)]
+        assert self._logs == wanted
 
     def test_move_file_exception_unpacking_rename(self):
         # see issue 22182
-        with patch("os.rename", side_effect=OSError("wrong", 1)), self.assertRaises(
+        with patch("os.rename", side_effect=OSError("wrong", 1)), pytest.raises(
             DistutilsFileError
         ):
             with open(self.source, 'w') as fobj:
@@ -73,7 +74,7 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
         # see issue 22182
         with patch("os.rename", side_effect=OSError(errno.EXDEV, "wrong")), patch(
             "os.unlink", side_effect=OSError("wrong", 1)
-        ), self.assertRaises(DistutilsFileError):
+        ), pytest.raises(DistutilsFileError):
             with open(self.source, 'w') as fobj:
                 fobj.write('spam eggs')
             move_file(self.source, self.target, verbose=0)
@@ -93,10 +94,10 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
         copy_file(self.source, self.target, link='hard')
         st2 = os.stat(self.source)
         st3 = os.stat(self.target)
-        self.assertTrue(os.path.samestat(st, st2), (st, st2))
-        self.assertTrue(os.path.samestat(st2, st3), (st2, st3))
-        with open(self.source, 'r') as f:
-            self.assertEqual(f.read(), 'some content')
+        assert os.path.samestat(st, st2), (st, st2)
+        assert os.path.samestat(st2, st3), (st2, st3)
+        with open(self.source) as f:
+            assert f.read() == 'some content'
 
     def test_copy_file_hard_link_failure(self):
         # If hard linking fails, copy_file() falls back on copying file
@@ -109,8 +110,8 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
             copy_file(self.source, self.target, link='hard')
         st2 = os.stat(self.source)
         st3 = os.stat(self.target)
-        self.assertTrue(os.path.samestat(st, st2), (st, st2))
-        self.assertFalse(os.path.samestat(st2, st3), (st2, st3))
+        assert os.path.samestat(st, st2), (st, st2)
+        assert not os.path.samestat(st2, st3), (st2, st3)
         for fn in (self.source, self.target):
-            with open(fn, 'r') as f:
-                self.assertEqual(f.read(), 'some content')
+            with open(fn) as f:
+                assert f.read() == 'some content'

--- a/setuptools/_distutils/tests/test_install.py
+++ b/setuptools/_distutils/tests/test_install.py
@@ -26,6 +26,7 @@ def _make_ext_name(modname):
     return modname + sysconfig.get_config_var('EXT_SUFFIX')
 
 
+@support.combine_markers
 @pytest.mark.usefixtures('save_env')
 class InstallTestCase(
     support.TempdirManager,
@@ -55,13 +56,13 @@ class InstallTestCase(
         cmd.home = destination
         cmd.ensure_finalized()
 
-        self.assertEqual(cmd.install_base, destination)
-        self.assertEqual(cmd.install_platbase, destination)
+        assert cmd.install_base == destination
+        assert cmd.install_platbase == destination
 
         def check_path(got, expected):
             got = os.path.normpath(got)
             expected = os.path.normpath(expected)
-            self.assertEqual(got, expected)
+            assert got == expected
 
         impl_name = sys.implementation.name.replace("cpython", "python")
         libdir = os.path.join(destination, "lib", impl_name)
@@ -108,31 +109,31 @@ class InstallTestCase(
         self.addCleanup(cleanup)
 
         for key in ('nt_user', 'posix_user'):
-            self.assertIn(key, INSTALL_SCHEMES)
+            assert key in INSTALL_SCHEMES
 
         dist = Distribution({'name': 'xx'})
         cmd = install(dist)
 
         # making sure the user option is there
         options = [name for name, short, lable in cmd.user_options]
-        self.assertIn('user', options)
+        assert 'user' in options
 
         # setting a value
         cmd.user = 1
 
         # user base and site shouldn't be created yet
-        self.assertFalse(os.path.exists(self.user_base))
-        self.assertFalse(os.path.exists(self.user_site))
+        assert not os.path.exists(self.user_base)
+        assert not os.path.exists(self.user_site)
 
         # let's run finalize
         cmd.ensure_finalized()
 
         # now they should
-        self.assertTrue(os.path.exists(self.user_base))
-        self.assertTrue(os.path.exists(self.user_site))
+        assert os.path.exists(self.user_base)
+        assert os.path.exists(self.user_site)
 
-        self.assertIn('userbase', cmd.config_vars)
-        self.assertIn('usersite', cmd.config_vars)
+        assert 'userbase' in cmd.config_vars
+        assert 'usersite' in cmd.config_vars
 
         actual_headers = os.path.relpath(cmd.install_headers, self.user_base)
         if os.name == 'nt':
@@ -144,9 +145,7 @@ class InstallTestCase(
             include = sysconfig.get_python_inc(0, '')
         expect_headers = os.path.join(include, 'xx')
 
-        self.assertEqual(
-            os.path.normcase(actual_headers), os.path.normcase(expect_headers)
-        )
+        assert os.path.normcase(actual_headers) == os.path.normcase(expect_headers)
 
     def test_handle_extra_path(self):
         dist = Distribution({'name': 'xx', 'extra_path': 'path,dirs'})
@@ -154,27 +153,28 @@ class InstallTestCase(
 
         # two elements
         cmd.handle_extra_path()
-        self.assertEqual(cmd.extra_path, ['path', 'dirs'])
-        self.assertEqual(cmd.extra_dirs, 'dirs')
-        self.assertEqual(cmd.path_file, 'path')
+        assert cmd.extra_path == ['path', 'dirs']
+        assert cmd.extra_dirs == 'dirs'
+        assert cmd.path_file == 'path'
 
         # one element
         cmd.extra_path = ['path']
         cmd.handle_extra_path()
-        self.assertEqual(cmd.extra_path, ['path'])
-        self.assertEqual(cmd.extra_dirs, 'path')
-        self.assertEqual(cmd.path_file, 'path')
+        assert cmd.extra_path == ['path']
+        assert cmd.extra_dirs == 'path'
+        assert cmd.path_file == 'path'
 
         # none
         dist.extra_path = cmd.extra_path = None
         cmd.handle_extra_path()
-        self.assertEqual(cmd.extra_path, None)
-        self.assertEqual(cmd.extra_dirs, '')
-        self.assertEqual(cmd.path_file, None)
+        assert cmd.extra_path is None
+        assert cmd.extra_dirs == ''
+        assert cmd.path_file is None
 
         # three elements (no way !)
         cmd.extra_path = 'path,dirs,again'
-        self.assertRaises(DistutilsOptionError, cmd.handle_extra_path)
+        with pytest.raises(DistutilsOptionError):
+            cmd.handle_extra_path()
 
     def test_finalize_options(self):
         dist = Distribution({'name': 'xx'})
@@ -184,18 +184,21 @@ class InstallTestCase(
         # install-base/install-platbase -- not both
         cmd.prefix = 'prefix'
         cmd.install_base = 'base'
-        self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+        with pytest.raises(DistutilsOptionError):
+            cmd.finalize_options()
 
         # must supply either home or prefix/exec-prefix -- not both
         cmd.install_base = None
         cmd.home = 'home'
-        self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+        with pytest.raises(DistutilsOptionError):
+            cmd.finalize_options()
 
         # can't combine user with prefix/exec_prefix/home or
         # install_(plat)base
         cmd.prefix = None
         cmd.user = 'user'
-        self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+        with pytest.raises(DistutilsOptionError):
+            cmd.finalize_options()
 
     def test_record(self):
         install_dir = self.mkdtemp()
@@ -224,7 +227,7 @@ class InstallTestCase(
             'sayhi',
             'UNKNOWN-0.0.0-py%s.%s.egg-info' % sys.version_info[:2],
         ]
-        self.assertEqual(found, expected)
+        assert found == expected
 
     def test_record_extensions(self):
         cmd = test_support.missing_compiler_executable()
@@ -260,7 +263,7 @@ class InstallTestCase(
             _make_ext_name('xx'),
             'UNKNOWN-0.0.0-py%s.%s.egg-info' % sys.version_info[:2],
         ]
-        self.assertEqual(found, expected)
+        assert found == expected
 
     def test_debug_mode(self):
         # this covers the code called when DEBUG is set
@@ -271,4 +274,4 @@ class InstallTestCase(
                 self.test_record()
         finally:
             install_module.DEBUG = False
-        self.assertGreater(len(self.logs), old_logs_len)
+        assert len(self.logs) > old_logs_len

--- a/setuptools/_distutils/tests/test_install_data.py
+++ b/setuptools/_distutils/tests/test_install_data.py
@@ -1,6 +1,5 @@
 """Tests for distutils.command.install_data."""
 import os
-import unittest
 
 import pytest
 
@@ -9,10 +8,9 @@ from distutils.tests import support
 
 
 @pytest.mark.usefixtures('save_env')
-class InstallDataTestCase(
+class TestInstallData(
     support.TempdirManager,
     support.LoggingSilencer,
-    unittest.TestCase,
 ):
     def test_simple_run(self):
         pkg_dir, dist = self.create_dist()
@@ -29,18 +27,18 @@ class InstallDataTestCase(
         self.write_file(two, 'xxx')
 
         cmd.data_files = [one, (inst2, [two])]
-        self.assertEqual(cmd.get_inputs(), [one, (inst2, [two])])
+        assert cmd.get_inputs() == [one, (inst2, [two])]
 
         # let's run the command
         cmd.ensure_finalized()
         cmd.run()
 
         # let's check the result
-        self.assertEqual(len(cmd.get_outputs()), 2)
+        assert len(cmd.get_outputs()) == 2
         rtwo = os.path.split(two)[-1]
-        self.assertTrue(os.path.exists(os.path.join(inst2, rtwo)))
+        assert os.path.exists(os.path.join(inst2, rtwo))
         rone = os.path.split(one)[-1]
-        self.assertTrue(os.path.exists(os.path.join(inst, rone)))
+        assert os.path.exists(os.path.join(inst, rone))
         cmd.outfiles = []
 
         # let's try with warn_dir one
@@ -49,9 +47,9 @@ class InstallDataTestCase(
         cmd.run()
 
         # let's check the result
-        self.assertEqual(len(cmd.get_outputs()), 2)
-        self.assertTrue(os.path.exists(os.path.join(inst2, rtwo)))
-        self.assertTrue(os.path.exists(os.path.join(inst, rone)))
+        assert len(cmd.get_outputs()) == 2
+        assert os.path.exists(os.path.join(inst2, rtwo))
+        assert os.path.exists(os.path.join(inst, rone))
         cmd.outfiles = []
 
         # now using root and empty dir
@@ -64,6 +62,6 @@ class InstallDataTestCase(
         cmd.run()
 
         # let's check the result
-        self.assertEqual(len(cmd.get_outputs()), 4)
-        self.assertTrue(os.path.exists(os.path.join(inst2, rtwo)))
-        self.assertTrue(os.path.exists(os.path.join(inst, rone)))
+        assert len(cmd.get_outputs()) == 4
+        assert os.path.exists(os.path.join(inst2, rtwo))
+        assert os.path.exists(os.path.join(inst, rone))

--- a/setuptools/_distutils/tests/test_install_headers.py
+++ b/setuptools/_distutils/tests/test_install_headers.py
@@ -1,6 +1,5 @@
 """Tests for distutils.command.install_headers."""
 import os
-import unittest
 
 import pytest
 
@@ -9,10 +8,9 @@ from distutils.tests import support
 
 
 @pytest.mark.usefixtures('save_env')
-class InstallHeadersTestCase(
+class TestInstallHeaders(
     support.TempdirManager,
     support.LoggingSilencer,
-    unittest.TestCase,
 ):
     def test_simple_run(self):
         # we have two headers
@@ -25,7 +23,7 @@ class InstallHeadersTestCase(
 
         pkg_dir, dist = self.create_dist(headers=headers)
         cmd = install_headers(dist)
-        self.assertEqual(cmd.get_inputs(), headers)
+        assert cmd.get_inputs() == headers
 
         # let's run the command
         cmd.install_dir = os.path.join(pkg_dir, 'inst')
@@ -33,4 +31,4 @@ class InstallHeadersTestCase(
         cmd.run()
 
         # let's check the results
-        self.assertEqual(len(cmd.get_outputs()), 2)
+        assert len(cmd.get_outputs()) == 2

--- a/setuptools/_distutils/tests/test_install_lib.py
+++ b/setuptools/_distutils/tests/test_install_lib.py
@@ -12,29 +12,31 @@ from distutils.tests import support
 from distutils.errors import DistutilsOptionError
 
 
+@support.combine_markers
 @pytest.mark.usefixtures('save_env')
-class InstallLibTestCase(
+class TestInstallLib(
     support.TempdirManager,
     support.LoggingSilencer,
-    unittest.TestCase,
 ):
     def test_finalize_options(self):
         dist = self.create_dist()[1]
         cmd = install_lib(dist)
 
         cmd.finalize_options()
-        self.assertEqual(cmd.compile, 1)
-        self.assertEqual(cmd.optimize, 0)
+        assert cmd.compile == 1
+        assert cmd.optimize == 0
 
         # optimize must be 0, 1, or 2
         cmd.optimize = 'foo'
-        self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+        with pytest.raises(DistutilsOptionError):
+            cmd.finalize_options()
         cmd.optimize = '4'
-        self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+        with pytest.raises(DistutilsOptionError):
+            cmd.finalize_options()
 
         cmd.optimize = '2'
         cmd.finalize_options()
-        self.assertEqual(cmd.optimize, 2)
+        assert cmd.optimize == 2
 
     @unittest.skipIf(sys.dont_write_bytecode, 'byte-compile disabled')
     def test_byte_compile(self):
@@ -50,8 +52,8 @@ class InstallLibTestCase(
         pyc_opt_file = importlib.util.cache_from_source(
             'foo.py', optimization=cmd.optimize
         )
-        self.assertTrue(os.path.exists(pyc_file))
-        self.assertTrue(os.path.exists(pyc_opt_file))
+        assert os.path.exists(pyc_file)
+        assert os.path.exists(pyc_opt_file)
 
     def test_get_outputs(self):
         project_dir, dist = self.create_dist()
@@ -71,7 +73,7 @@ class InstallLibTestCase(
         # get_outputs should return 4 elements: spam/__init__.py and .pyc,
         # foo.import-tag-abiflags.so / foo.pyd
         outputs = cmd.get_outputs()
-        self.assertEqual(len(outputs), 4, outputs)
+        assert len(outputs) == 4, outputs
 
     def test_get_inputs(self):
         project_dir, dist = self.create_dist()
@@ -91,7 +93,7 @@ class InstallLibTestCase(
         # get_inputs should return 2 elements: spam/__init__.py and
         # foo.import-tag-abiflags.so / foo.pyd
         inputs = cmd.get_inputs()
-        self.assertEqual(len(inputs), 2, inputs)
+        assert len(inputs) == 2, inputs
 
     def test_dont_write_bytecode(self):
         # makes sure byte_compile is not used
@@ -107,4 +109,4 @@ class InstallLibTestCase(
         finally:
             sys.dont_write_bytecode = old_dont_write_bytecode
 
-        self.assertIn('byte-compiling is disabled', self.logs[0][1] % self.logs[0][2])
+        assert 'byte-compiling is disabled' in self.logs[0][1] % self.logs[0][2]

--- a/setuptools/_distutils/tests/test_install_scripts.py
+++ b/setuptools/_distutils/tests/test_install_scripts.py
@@ -1,7 +1,6 @@
 """Tests for distutils.command.install_scripts."""
 
 import os
-import unittest
 
 from distutils.command.install_scripts import install_scripts
 from distutils.core import Distribution
@@ -9,9 +8,7 @@ from distutils.core import Distribution
 from distutils.tests import support
 
 
-class InstallScriptsTestCase(
-    support.TempdirManager, support.LoggingSilencer, unittest.TestCase
-):
+class TestInstallScripts(support.TempdirManager, support.LoggingSilencer):
     def test_default_settings(self):
         dist = Distribution()
         dist.command_obj["build"] = support.DummyCommand(build_scripts="/foo/bar")
@@ -21,17 +18,17 @@ class InstallScriptsTestCase(
             skip_build=1,
         )
         cmd = install_scripts(dist)
-        self.assertFalse(cmd.force)
-        self.assertFalse(cmd.skip_build)
-        self.assertIsNone(cmd.build_dir)
-        self.assertIsNone(cmd.install_dir)
+        assert not cmd.force
+        assert not cmd.skip_build
+        assert cmd.build_dir is None
+        assert cmd.install_dir is None
 
         cmd.finalize_options()
 
-        self.assertTrue(cmd.force)
-        self.assertTrue(cmd.skip_build)
-        self.assertEqual(cmd.build_dir, "/foo/bar")
-        self.assertEqual(cmd.install_dir, "/splat/funk")
+        assert cmd.force
+        assert cmd.skip_build
+        assert cmd.build_dir == "/foo/bar"
+        assert cmd.install_dir == "/splat/funk"
 
     def test_installation(self):
         source = self.mkdtemp()
@@ -75,4 +72,4 @@ class InstallScriptsTestCase(
 
         installed = os.listdir(target)
         for name in expected:
-            self.assertIn(name, installed)
+            assert name in installed

--- a/setuptools/_distutils/tests/test_log.py
+++ b/setuptools/_distutils/tests/test_log.py
@@ -34,20 +34,18 @@ class TestLog(unittest.TestCase):
                     log.set_threshold(old_threshold)
 
                 stdout.seek(0)
-                self.assertEqual(
-                    stdout.read().rstrip(),
+                assert stdout.read().rstrip() == (
                     'Dεbug\tM?ss?ge'
                     if errors == 'replace'
                     else 'Dεbug\tMssge'
                     if errors == 'ignore'
-                    else 'Dεbug\tM\\u0117ss\\xe3ge',
+                    else 'Dεbug\tM\\u0117ss\\xe3ge'
                 )
                 stderr.seek(0)
-                self.assertEqual(
-                    stderr.read().rstrip(),
+                assert stderr.read().rstrip() == (
                     'Fαtal\t?rr?r'
                     if errors == 'replace'
                     else 'Fαtal\trrr'
                     if errors == 'ignore'
-                    else 'Fαtal\t\\xc8rr\\u014dr',
+                    else 'Fαtal\t\\xc8rr\\u014dr'
                 )

--- a/setuptools/_distutils/tests/test_msvccompiler.py
+++ b/setuptools/_distutils/tests/test_msvccompiler.py
@@ -14,7 +14,7 @@ from distutils import _msvccompiler
 needs_winreg = pytest.mark.skipif('not hasattr(_msvccompiler, "winreg")')
 
 
-class msvccompilerTestCase(support.TempdirManager, unittest.TestCase):
+class Testmsvccompiler(support.TempdirManager):
     def test_no_compiler(self):
         # makes sure query_vcvarsall raises
         # a DistutilsPlatformError if the compiler
@@ -25,11 +25,10 @@ class msvccompilerTestCase(support.TempdirManager, unittest.TestCase):
         old_find_vcvarsall = _msvccompiler._find_vcvarsall
         _msvccompiler._find_vcvarsall = _find_vcvarsall
         try:
-            self.assertRaises(
-                DistutilsPlatformError,
-                _msvccompiler._get_vc_env,
-                'wont find this version',
-            )
+            with pytest.raises(DistutilsPlatformError):
+                _msvccompiler._get_vc_env(
+                    'wont find this version',
+                )
         finally:
             _msvccompiler._find_vcvarsall = old_find_vcvarsall
 
@@ -43,8 +42,8 @@ class msvccompilerTestCase(support.TempdirManager, unittest.TestCase):
         os.environ[test_var] = test_value
         try:
             env = _msvccompiler._get_vc_env('x86')
-            self.assertIn(test_var.lower(), env)
-            self.assertEqual(test_value, env[test_var.lower()])
+            assert test_var.lower() in env
+            assert test_value == env[test_var.lower()]
         finally:
             os.environ.pop(test_var)
             if old_distutils_use_sdk:
@@ -56,8 +55,8 @@ class msvccompilerTestCase(support.TempdirManager, unittest.TestCase):
         # and mark it skipped if we do not.
         version, path = _msvccompiler._find_vc2017()
         if version:
-            self.assertGreaterEqual(version, 15)
-            self.assertTrue(os.path.isdir(path))
+            assert version >= 15
+            assert os.path.isdir(path)
         else:
             raise unittest.SkipTest("VS 2017 is not installed")
 
@@ -67,8 +66,8 @@ class msvccompilerTestCase(support.TempdirManager, unittest.TestCase):
         # and mark it skipped if we do not.
         version, path = _msvccompiler._find_vc2015()
         if version:
-            self.assertGreaterEqual(version, 14)
-            self.assertTrue(os.path.isdir(path))
+            assert version >= 14
+            assert os.path.isdir(path)
         else:
             raise unittest.SkipTest("VS 2015 is not installed")
 
@@ -86,7 +85,7 @@ class CheckThread(threading.Thread):
         return not self.exc_info
 
 
-class TestSpawn(unittest.TestCase):
+class TestSpawn:
     def test_concurrent_safe(self):
         """
         Concurrent calls to spawn should have consistent results.

--- a/setuptools/_distutils/tests/test_sdist.py
+++ b/setuptools/_distutils/tests/test_sdist.py
@@ -49,7 +49,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
     def setUp(self):
         # PyPIRCCommandTestCase creates a temp dir already
         # and put it in self.tmp_dir
-        super(SDistTestCase, self).setUp()
+        super().setUp()
         # setting up an environment
         self.old_path = os.getcwd()
         os.mkdir(join(self.tmp_dir, 'somecode'))
@@ -63,7 +63,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
     def tearDown(self):
         # back to normal
         os.chdir(self.old_path)
-        super(SDistTestCase, self).tearDown()
+        super().tearDown()
 
     def get_cmd(self, metadata=None):
         """Returns a cmd"""
@@ -113,7 +113,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         # now let's check what we have
         dist_folder = join(self.tmp_dir, 'dist')
         files = os.listdir(dist_folder)
-        self.assertEqual(files, ['fake-1.0.zip'])
+        assert files == ['fake-1.0.zip']
 
         zip_file = zipfile.ZipFile(join(dist_folder, 'fake-1.0.zip'))
         try:
@@ -130,7 +130,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             'somecode/',
             'somecode/__init__.py',
         ]
-        self.assertEqual(sorted(content), ['fake-1.0/' + x for x in expected])
+        assert sorted(content) == ['fake-1.0/' + x for x in expected]
 
     @pytest.mark.usefixtures('needs_zlib')
     @unittest.skipIf(find_executable('tar') is None, "The tar command is not found")
@@ -148,7 +148,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         dist_folder = join(self.tmp_dir, 'dist')
         result = os.listdir(dist_folder)
         result.sort()
-        self.assertEqual(result, ['fake-1.0.tar', 'fake-1.0.tar.gz'])
+        assert result == ['fake-1.0.tar', 'fake-1.0.tar.gz']
 
         os.remove(join(dist_folder, 'fake-1.0.tar'))
         os.remove(join(dist_folder, 'fake-1.0.tar.gz'))
@@ -161,7 +161,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
 
         result = os.listdir(dist_folder)
         result.sort()
-        self.assertEqual(result, ['fake-1.0.tar', 'fake-1.0.tar.gz'])
+        assert result == ['fake-1.0.tar', 'fake-1.0.tar.gz']
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_add_defaults(self):
@@ -215,7 +215,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         # now let's check what we have
         dist_folder = join(self.tmp_dir, 'dist')
         files = os.listdir(dist_folder)
-        self.assertEqual(files, ['fake-1.0.zip'])
+        assert files == ['fake-1.0.zip']
 
         zip_file = zipfile.ZipFile(join(dist_folder, 'fake-1.0.zip'))
         try:
@@ -243,7 +243,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             'somecode/doc.dat',
             'somecode/doc.txt',
         ]
-        self.assertEqual(sorted(content), ['fake-1.0/' + x for x in expected])
+        assert sorted(content) == ['fake-1.0/' + x for x in expected]
 
         # checking the MANIFEST
         f = open(join(self.tmp_dir, 'MANIFEST'))
@@ -251,7 +251,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             manifest = f.read()
         finally:
             f.close()
-        self.assertEqual(manifest, MANIFEST % {'sep': os.sep})
+        assert manifest == MANIFEST % {'sep': os.sep}
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_metadata_check_option(self):
@@ -265,7 +265,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         warnings = [
             msg for msg in self.get_logs(WARN) if msg.startswith('warning: check:')
         ]
-        self.assertEqual(len(warnings), 1)
+        assert len(warnings) == 1
 
         # trying with a complete set of metadata
         self.clear_logs()
@@ -276,7 +276,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         warnings = [
             msg for msg in self.get_logs(WARN) if msg.startswith('warning: check:')
         ]
-        self.assertEqual(len(warnings), 0)
+        assert len(warnings) == 0
 
     def test_check_metadata_deprecated(self):
         # makes sure make_metadata is deprecated
@@ -284,7 +284,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         with check_warnings() as w:
             warnings.simplefilter("always")
             cmd.check_metadata()
-            self.assertEqual(len(w.warnings), 1)
+            assert len(w.warnings) == 1
 
     def test_show_formats(self):
         with captured_stdout() as stdout:
@@ -297,27 +297,29 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             for line in stdout.getvalue().split('\n')
             if line.strip().startswith('--formats=')
         ]
-        self.assertEqual(len(output), num_formats)
+        assert len(output) == num_formats
 
     def test_finalize_options(self):
         dist, cmd = self.get_cmd()
         cmd.finalize_options()
 
         # default options set by finalize
-        self.assertEqual(cmd.manifest, 'MANIFEST')
-        self.assertEqual(cmd.template, 'MANIFEST.in')
-        self.assertEqual(cmd.dist_dir, 'dist')
+        assert cmd.manifest == 'MANIFEST'
+        assert cmd.template == 'MANIFEST.in'
+        assert cmd.dist_dir == 'dist'
 
         # formats has to be a string splitable on (' ', ',') or
         # a stringlist
         cmd.formats = 1
-        self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+        with pytest.raises(DistutilsOptionError):
+            cmd.finalize_options()
         cmd.formats = ['zip']
         cmd.finalize_options()
 
         # formats has to be known
         cmd.formats = 'supazipa'
-        self.assertRaises(DistutilsOptionError, cmd.finalize_options)
+        with pytest.raises(DistutilsOptionError):
+            cmd.finalize_options()
 
     # the following tests make sure there is a nice error message instead
     # of a traceback when parsing an invalid manifest template
@@ -330,7 +332,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         cmd.filelist = FileList()
         cmd.read_template()
         warnings = self.get_logs(WARN)
-        self.assertEqual(len(warnings), 1)
+        assert len(warnings) == 1
 
     def test_invalid_template_unknown_command(self):
         self._check_template('taunt knights *')
@@ -365,7 +367,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         finally:
             f.close()
 
-        self.assertEqual(len(manifest), 5)
+        assert len(manifest) == 5
 
         # adding a file
         self.write_file((self.tmp_dir, 'somecode', 'doc2.txt'), '#')
@@ -386,8 +388,8 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             f.close()
 
         # do we have the new file in MANIFEST ?
-        self.assertEqual(len(manifest2), 6)
-        self.assertIn('doc2.txt', manifest2[-1])
+        assert len(manifest2) == 6
+        assert 'doc2.txt' in manifest2[-1]
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_manifest_marker(self):
@@ -404,7 +406,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         finally:
             f.close()
 
-        self.assertEqual(manifest[0], '# file GENERATED by distutils, do NOT edit')
+        assert manifest[0] == '# file GENERATED by distutils, do NOT edit'
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_manifest_comments(self):
@@ -423,7 +425,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         self.write_file((self.tmp_dir, 'bad.py'), "# don't pick me!")
         self.write_file((self.tmp_dir, '#bad.py'), "# don't pick me!")
         cmd.run()
-        self.assertEqual(cmd.filelist.files, ['good.py'])
+        assert cmd.filelist.files == ['good.py']
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_manual_manifest(self):
@@ -437,7 +439,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             'This project maintains its MANIFEST file itself.',
         )
         cmd.run()
-        self.assertEqual(cmd.filelist.files, ['README.manual'])
+        assert cmd.filelist.files == ['README.manual']
 
         f = open(cmd.manifest)
         try:
@@ -447,7 +449,7 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         finally:
             f.close()
 
-        self.assertEqual(manifest, ['README.manual'])
+        assert manifest == ['README.manual']
 
         archive_name = join(self.tmp_dir, 'dist', 'fake-1.0.tar.gz')
         archive = tarfile.open(archive_name)
@@ -455,10 +457,11 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
             filenames = [tarinfo.name for tarinfo in archive]
         finally:
             archive.close()
-        self.assertEqual(
-            sorted(filenames),
-            ['fake-1.0', 'fake-1.0/PKG-INFO', 'fake-1.0/README.manual'],
-        )
+        assert sorted(filenames) == [
+            'fake-1.0',
+            'fake-1.0/PKG-INFO',
+            'fake-1.0/README.manual',
+        ]
 
     @pytest.mark.usefixtures('needs_zlib')
     @require_unix_id
@@ -481,8 +484,8 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         archive = tarfile.open(archive_name)
         try:
             for member in archive.getmembers():
-                self.assertEqual(member.uid, 0)
-                self.assertEqual(member.gid, 0)
+                assert member.uid == 0
+                assert member.gid == 0
         finally:
             archive.close()
 
@@ -503,6 +506,6 @@ class SDistTestCase(BasePyPIRCCommandTestCase):
         # rights (see #7408)
         try:
             for member in archive.getmembers():
-                self.assertEqual(member.uid, os.getuid())
+                assert member.uid == os.getuid()
         finally:
             archive.close()

--- a/setuptools/_distutils/tests/test_sysconfig.py
+++ b/setuptools/_distutils/tests/test_sysconfig.py
@@ -22,14 +22,14 @@ from .py38compat import TESTFN
 @pytest.mark.usefixtures('save_env')
 class SysconfigTestCase(unittest.TestCase):
     def setUp(self):
-        super(SysconfigTestCase, self).setUp()
+        super().setUp()
         self.makefile = None
 
     def tearDown(self):
         if self.makefile is not None:
             os.unlink(self.makefile)
         self.cleanup_testfn()
-        super(SysconfigTestCase, self).tearDown()
+        super().tearDown()
 
     def cleanup_testfn(self):
         if os.path.isfile(TESTFN):
@@ -39,7 +39,7 @@ class SysconfigTestCase(unittest.TestCase):
 
     def test_get_config_h_filename(self):
         config_h = sysconfig.get_config_h_filename()
-        self.assertTrue(os.path.isfile(config_h), config_h)
+        assert os.path.isfile(config_h), config_h
 
     @unittest.skipIf(
         sys.platform == 'win32', 'Makefile only exists on Unix like systems'
@@ -49,37 +49,35 @@ class SysconfigTestCase(unittest.TestCase):
     )
     def test_get_makefile_filename(self):
         makefile = sysconfig.get_makefile_filename()
-        self.assertTrue(os.path.isfile(makefile), makefile)
+        assert os.path.isfile(makefile), makefile
 
     def test_get_python_lib(self):
         # XXX doesn't work on Linux when Python was never installed before
         # self.assertTrue(os.path.isdir(lib_dir), lib_dir)
         # test for pythonxx.lib?
-        self.assertNotEqual(
-            sysconfig.get_python_lib(), sysconfig.get_python_lib(prefix=TESTFN)
-        )
+        assert sysconfig.get_python_lib() != sysconfig.get_python_lib(prefix=TESTFN)
 
     def test_get_config_vars(self):
         cvars = sysconfig.get_config_vars()
-        self.assertIsInstance(cvars, dict)
-        self.assertTrue(cvars)
+        assert isinstance(cvars, dict)
+        assert cvars
 
     @unittest.skip('sysconfig.IS_PYPY')
     def test_srcdir(self):
         # See Issues #15322, #15364.
         srcdir = sysconfig.get_config_var('srcdir')
 
-        self.assertTrue(os.path.isabs(srcdir), srcdir)
-        self.assertTrue(os.path.isdir(srcdir), srcdir)
+        assert os.path.isabs(srcdir), srcdir
+        assert os.path.isdir(srcdir), srcdir
 
         if sysconfig.python_build:
             # The python executable has not been installed so srcdir
             # should be a full source checkout.
             Python_h = os.path.join(srcdir, 'Include', 'Python.h')
-            self.assertTrue(os.path.exists(Python_h), Python_h)
-            self.assertTrue(sysconfig._is_python_source_dir(srcdir))
+            assert os.path.exists(Python_h), Python_h
+            assert sysconfig._is_python_source_dir(srcdir)
         elif os.name == 'posix':
-            self.assertEqual(os.path.dirname(sysconfig.get_makefile_filename()), srcdir)
+            assert os.path.dirname(sysconfig.get_makefile_filename()) == srcdir
 
     def test_srcdir_independent_of_cwd(self):
         # srcdir should be independent of the current working directory
@@ -91,7 +89,7 @@ class SysconfigTestCase(unittest.TestCase):
             srcdir2 = sysconfig.get_config_var('srcdir')
         finally:
             os.chdir(cwd)
-        self.assertEqual(srcdir, srcdir2)
+        assert srcdir == srcdir2
 
     def customize_compiler(self):
         # make sure AR gets caught
@@ -146,27 +144,23 @@ class SysconfigTestCase(unittest.TestCase):
         os.environ['RANLIB'] = 'env_ranlib'
 
         comp = self.customize_compiler()
-        self.assertEqual(comp.exes['archiver'], 'env_ar --env-arflags')
-        self.assertEqual(comp.exes['preprocessor'], 'env_cpp --env-cppflags')
-        self.assertEqual(
-            comp.exes['compiler'], 'env_cc --sc-cflags --env-cflags --env-cppflags'
+        assert comp.exes['archiver'] == 'env_ar --env-arflags'
+        assert comp.exes['preprocessor'] == 'env_cpp --env-cppflags'
+        assert comp.exes['compiler'] == 'env_cc --sc-cflags --env-cflags --env-cppflags'
+        assert comp.exes['compiler_so'] == (
+            'env_cc --sc-cflags ' '--env-cflags ' '--env-cppflags --sc-ccshared'
         )
-        self.assertEqual(
-            comp.exes['compiler_so'],
-            ('env_cc --sc-cflags ' '--env-cflags ' '--env-cppflags --sc-ccshared'),
+        assert comp.exes['compiler_cxx'] == 'env_cxx --env-cxx-flags'
+        assert comp.exes['linker_exe'] == 'env_cc'
+        assert comp.exes['linker_so'] == (
+            'env_ldshared --env-ldflags --env-cflags' ' --env-cppflags'
         )
-        self.assertEqual(comp.exes['compiler_cxx'], 'env_cxx --env-cxx-flags')
-        self.assertEqual(comp.exes['linker_exe'], 'env_cc')
-        self.assertEqual(
-            comp.exes['linker_so'],
-            ('env_ldshared --env-ldflags --env-cflags' ' --env-cppflags'),
-        )
-        self.assertEqual(comp.shared_lib_extension, 'sc_shutil_suffix')
+        assert comp.shared_lib_extension == 'sc_shutil_suffix'
 
         if sys.platform == "darwin":
-            self.assertEqual(comp.exes['ranlib'], 'env_ranlib')
+            assert comp.exes['ranlib'] == 'env_ranlib'
         else:
-            self.assertTrue('ranlib' not in comp.exes)
+            assert 'ranlib' not in comp.exes
 
         del os.environ['AR']
         del os.environ['CC']
@@ -180,15 +174,15 @@ class SysconfigTestCase(unittest.TestCase):
         del os.environ['RANLIB']
 
         comp = self.customize_compiler()
-        self.assertEqual(comp.exes['archiver'], 'sc_ar --sc-arflags')
-        self.assertEqual(comp.exes['preprocessor'], 'sc_cc -E')
-        self.assertEqual(comp.exes['compiler'], 'sc_cc --sc-cflags')
-        self.assertEqual(comp.exes['compiler_so'], 'sc_cc --sc-cflags --sc-ccshared')
-        self.assertEqual(comp.exes['compiler_cxx'], 'sc_cxx')
-        self.assertEqual(comp.exes['linker_exe'], 'sc_cc')
-        self.assertEqual(comp.exes['linker_so'], 'sc_ldshared')
-        self.assertEqual(comp.shared_lib_extension, 'sc_shutil_suffix')
-        self.assertTrue('ranlib' not in comp.exes)
+        assert comp.exes['archiver'] == 'sc_ar --sc-arflags'
+        assert comp.exes['preprocessor'] == 'sc_cc -E'
+        assert comp.exes['compiler'] == 'sc_cc --sc-cflags'
+        assert comp.exes['compiler_so'] == 'sc_cc --sc-cflags --sc-ccshared'
+        assert comp.exes['compiler_cxx'] == 'sc_cxx'
+        assert comp.exes['linker_exe'] == 'sc_cc'
+        assert comp.exes['linker_so'] == 'sc_ldshared'
+        assert comp.shared_lib_extension == 'sc_shutil_suffix'
+        assert 'ranlib' not in comp.exes
 
     def test_parse_makefile_base(self):
         self.makefile = TESTFN
@@ -199,9 +193,7 @@ class SysconfigTestCase(unittest.TestCase):
         finally:
             fd.close()
         d = sysconfig.parse_makefile(self.makefile)
-        self.assertEqual(
-            d, {'CONFIG_ARGS': "'--arg1=optarg1' 'ENV=LIB'", 'OTHER': 'foo'}
-        )
+        assert d == {'CONFIG_ARGS': "'--arg1=optarg1' 'ENV=LIB'", 'OTHER': 'foo'}
 
     def test_parse_makefile_literal_dollar(self):
         self.makefile = TESTFN
@@ -212,20 +204,16 @@ class SysconfigTestCase(unittest.TestCase):
         finally:
             fd.close()
         d = sysconfig.parse_makefile(self.makefile)
-        self.assertEqual(
-            d, {'CONFIG_ARGS': r"'--arg1=optarg1' 'ENV=\$LIB'", 'OTHER': 'foo'}
-        )
+        assert d == {'CONFIG_ARGS': r"'--arg1=optarg1' 'ENV=\$LIB'", 'OTHER': 'foo'}
 
     def test_sysconfig_module(self):
         import sysconfig as global_sysconfig
 
-        self.assertEqual(
-            global_sysconfig.get_config_var('CFLAGS'),
-            sysconfig.get_config_var('CFLAGS'),
+        assert global_sysconfig.get_config_var('CFLAGS') == sysconfig.get_config_var(
+            'CFLAGS'
         )
-        self.assertEqual(
-            global_sysconfig.get_config_var('LDFLAGS'),
-            sysconfig.get_config_var('LDFLAGS'),
+        assert global_sysconfig.get_config_var('LDFLAGS') == sysconfig.get_config_var(
+            'LDFLAGS'
         )
 
     @unittest.skipIf(
@@ -250,20 +238,18 @@ class SysconfigTestCase(unittest.TestCase):
 
         if sysconfig.get_config_var('CUSTOMIZED_OSX_COMPILER'):
             self.skipTest('compiler flags customized')
-        self.assertEqual(
-            global_sysconfig.get_config_var('LDSHARED'),
-            sysconfig.get_config_var('LDSHARED'),
+        assert global_sysconfig.get_config_var('LDSHARED') == sysconfig.get_config_var(
+            'LDSHARED'
         )
-        self.assertEqual(
-            global_sysconfig.get_config_var('CC'), sysconfig.get_config_var('CC')
-        )
+        assert global_sysconfig.get_config_var('CC') == sysconfig.get_config_var('CC')
 
     @unittest.skipIf(
         sysconfig.get_config_var('EXT_SUFFIX') is None,
         'EXT_SUFFIX required for this test',
     )
     def test_SO_deprecation(self):
-        self.assertWarns(DeprecationWarning, sysconfig.get_config_var, 'SO')
+        with pytest.warns(DeprecationWarning):
+            sysconfig.get_config_var('SO')
 
     def test_customize_compiler_before_get_config_vars(self):
         # Issue #21923: test that a Distribution compiler
@@ -288,25 +274,25 @@ class SysconfigTestCase(unittest.TestCase):
             universal_newlines=True,
         )
         outs, errs = p.communicate()
-        self.assertEqual(0, p.returncode, "Subprocess failed: " + outs)
+        assert 0 == p.returncode, "Subprocess failed: " + outs
 
     def test_parse_config_h(self):
         config_h = sysconfig.get_config_h_filename()
         input = {}
         with open(config_h, encoding="utf-8") as f:
             result = sysconfig.parse_config_h(f, g=input)
-        self.assertTrue(input is result)
+        assert input is result
         with open(config_h, encoding="utf-8") as f:
             result = sysconfig.parse_config_h(f)
-        self.assertTrue(isinstance(result, dict))
+        assert isinstance(result, dict)
 
     @unittest.skipUnless(sys.platform == 'win32', 'Testing windows pyd suffix')
     @unittest.skipUnless(
         sys.implementation.name == 'cpython', 'Need cpython for this test'
     )
     def test_win_ext_suffix(self):
-        self.assertTrue(sysconfig.get_config_var("EXT_SUFFIX").endswith(".pyd"))
-        self.assertNotEqual(sysconfig.get_config_var("EXT_SUFFIX"), ".pyd")
+        assert sysconfig.get_config_var("EXT_SUFFIX").endswith(".pyd")
+        assert sysconfig.get_config_var("EXT_SUFFIX") != ".pyd"
 
     @unittest.skipUnless(sys.platform == 'win32', 'Testing Windows build layout')
     @unittest.skipUnless(

--- a/setuptools/_distutils/tests/test_text_file.py
+++ b/setuptools/_distutils/tests/test_text_file.py
@@ -1,6 +1,5 @@
 """Tests for distutils.text_file."""
 import os
-import unittest
 from distutils.text_file import TextFile
 from distutils.tests import support
 
@@ -12,7 +11,7 @@ line 3 \\
 """
 
 
-class TextFileTestCase(support.TempdirManager, unittest.TestCase):
+class TestTextFile(support.TempdirManager):
     def test_class(self):
         # old tests moved from text_file.__main__
         # so they are really called by the buildbots
@@ -51,7 +50,7 @@ class TextFileTestCase(support.TempdirManager, unittest.TestCase):
 
         def test_input(count, description, file, expected_result):
             result = file.readlines()
-            self.assertEqual(result, expected_result)
+            assert result == expected_result
 
         tmpdir = self.mkdtemp()
         filename = os.path.join(tmpdir, "test.txt")

--- a/setuptools/_distutils/tests/test_unixccompiler.py
+++ b/setuptools/_distutils/tests/test_unixccompiler.py
@@ -12,6 +12,7 @@ from distutils.unixccompiler import UnixCCompiler
 from distutils.util import _clear_cached_macosx_ver
 
 from . import support
+import pytest
 
 
 class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
@@ -74,7 +75,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
 
         def do_darwin_test(syscfg_macosx_ver, env_macosx_ver, expected_flag):
             env = os.environ
-            msg = "macOS version = (sysconfig=%r, env=%r)" % (
+            msg = "macOS version = (sysconfig={!r}, env={!r})".format(
                 syscfg_macosx_ver,
                 env_macosx_ver,
             )
@@ -93,10 +94,10 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
 
             # Run the test
             if expected_flag is not None:
-                self.assertEqual(self.cc.rpath_foo(), expected_flag, msg=msg)
+                assert self.cc.rpath_foo() == expected_flag, msg
             else:
-                with self.assertRaisesRegex(
-                    DistutilsPlatformError, darwin_ver_var + r' mismatch', msg=msg
+                with pytest.raises(
+                    DistutilsPlatformError, match=darwin_ver_var + r' mismatch'
                 ):
                     self.cc.rpath_foo()
 
@@ -128,19 +129,19 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             return 'xxx'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), ['+s', '-L/foo'])
+        assert self.cc.rpath_foo() == ['+s', '-L/foo']
 
         def gcv(v):
             return 'gcc'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), ['-Wl,+s', '-L/foo'])
+        assert self.cc.rpath_foo() == ['-Wl,+s', '-L/foo']
 
         def gcv(v):
             return 'g++'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), ['-Wl,+s', '-L/foo'])
+        assert self.cc.rpath_foo() == ['-Wl,+s', '-L/foo']
 
         sysconfig.get_config_var = old_gcv
 
@@ -154,7 +155,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
                 return 'yes'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
+        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
 
         def gcv(v):
             if v == 'CC':
@@ -163,7 +164,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
                 return 'yes'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
+        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
 
         # GCC non-GNULD
         sys.platform = 'bar'
@@ -175,7 +176,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
                 return 'no'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
+        assert self.cc.rpath_foo() == '-Wl,-R/foo'
 
         # GCC GNULD with fully qualified configuration prefix
         # see #7617
@@ -188,7 +189,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
                 return 'yes'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
+        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
 
         # non-GCC GNULD
         sys.platform = 'bar'
@@ -200,7 +201,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
                 return 'yes'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-Wl,--enable-new-dtags,-R/foo')
+        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
 
         # non-GCC non-GNULD
         sys.platform = 'bar'
@@ -212,7 +213,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
                 return 'no'
 
         sysconfig.get_config_var = gcv
-        self.assertEqual(self.cc.rpath_foo(), '-Wl,-R/foo')
+        assert self.cc.rpath_foo() == '-Wl,-R/foo'
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_cc_overrides_ldshared(self):
@@ -234,7 +235,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             env['CC'] = 'my_cc'
             del env['LDSHARED']
             sysconfig.customize_compiler(self.cc)
-        self.assertEqual(self.cc.linker_so[0], 'my_cc')
+        assert self.cc.linker_so[0] == 'my_cc'
 
     @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
     def test_cc_overrides_ldshared_for_cxx_correctly(self):
@@ -270,7 +271,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             env['CXX'] = 'my_cxx'
             del env['LDSHARED']
             sysconfig.customize_compiler(self.cc)
-            self.assertEqual(self.cc.linker_so[0:2], ['ccache', 'my_cc'])
+            assert self.cc.linker_so[0:2] == ['ccache', 'my_cc']
             self.cc.link(None, [], 'a.out', target_lang='c++')
             call_args = mock_spawn.call_args[0][0]
             expected = ['my_cxx', '-bundle', '-undefined', 'dynamic_lookup']
@@ -297,7 +298,7 @@ class UnixCCompilerTestCase(support.TempdirManager, unittest.TestCase):
             env['CC'] = 'my_cc'
             env['LDSHARED'] = 'my_ld -bundle -dynamic'
             sysconfig.customize_compiler(self.cc)
-        self.assertEqual(self.cc.linker_so[0], 'my_ld')
+        assert self.cc.linker_so[0] == 'my_ld'
 
     def test_has_function(self):
         # Issue https://github.com/pypa/distutils/issues/64:

--- a/setuptools/_distutils/tests/test_version.py
+++ b/setuptools/_distutils/tests/test_version.py
@@ -15,12 +15,12 @@ class VersionTestCase(unittest.TestCase):
 
     def test_prerelease(self):
         version = StrictVersion('1.2.3a1')
-        self.assertEqual(version.version, (1, 2, 3))
-        self.assertEqual(version.prerelease, ('a', 1))
-        self.assertEqual(str(version), '1.2.3a1')
+        assert version.version == (1, 2, 3)
+        assert version.prerelease == ('a', 1)
+        assert str(version) == '1.2.3a1'
 
         version = StrictVersion('1.2.0')
-        self.assertEqual(str(version), '1.2')
+        assert str(version) == '1.2'
 
     def test_cmp_strict(self):
         versions = (
@@ -51,19 +51,17 @@ class VersionTestCase(unittest.TestCase):
                     raise AssertionError(
                         ("cmp(%s, %s) " "shouldn't raise ValueError") % (v1, v2)
                     )
-            self.assertEqual(
-                res, wanted, 'cmp(%s, %s) should be %s, got %s' % (v1, v2, wanted, res)
+            assert res == wanted, 'cmp({}, {}) should be {}, got {}'.format(
+                v1, v2, wanted, res
             )
             res = StrictVersion(v1)._cmp(v2)
-            self.assertEqual(
-                res, wanted, 'cmp(%s, %s) should be %s, got %s' % (v1, v2, wanted, res)
+            assert res == wanted, 'cmp({}, {}) should be {}, got {}'.format(
+                v1, v2, wanted, res
             )
             res = StrictVersion(v1)._cmp(object())
-            self.assertIs(
-                res,
-                NotImplemented,
-                'cmp(%s, %s) should be NotImplemented, got %s' % (v1, v2, res),
-            )
+            assert (
+                res is NotImplemented
+            ), 'cmp({}, {}) should be NotImplemented, got {}'.format(v1, v2, res)
 
     def test_cmp(self):
         versions = (
@@ -79,16 +77,14 @@ class VersionTestCase(unittest.TestCase):
 
         for v1, v2, wanted in versions:
             res = LooseVersion(v1)._cmp(LooseVersion(v2))
-            self.assertEqual(
-                res, wanted, 'cmp(%s, %s) should be %s, got %s' % (v1, v2, wanted, res)
+            assert res == wanted, 'cmp({}, {}) should be {}, got {}'.format(
+                v1, v2, wanted, res
             )
             res = LooseVersion(v1)._cmp(v2)
-            self.assertEqual(
-                res, wanted, 'cmp(%s, %s) should be %s, got %s' % (v1, v2, wanted, res)
+            assert res == wanted, 'cmp({}, {}) should be {}, got {}'.format(
+                v1, v2, wanted, res
             )
             res = LooseVersion(v1)._cmp(object())
-            self.assertIs(
-                res,
-                NotImplemented,
-                'cmp(%s, %s) should be NotImplemented, got %s' % (v1, v2, res),
-            )
+            assert (
+                res is NotImplemented
+            ), 'cmp({}, {}) should be NotImplemented, got {}'.format(v1, v2, res)

--- a/setuptools/_distutils/text_file.py
+++ b/setuptools/_distutils/text_file.py
@@ -5,7 +5,6 @@ that (optionally) takes care of stripping comments, ignoring blank
 lines, and joining lines with backslashes."""
 
 import sys
-import io
 
 
 class TextFile:
@@ -116,7 +115,7 @@ class TextFile:
         """Open a new file named 'filename'.  This overrides both the
         'filename' and 'file' arguments to the constructor."""
         self.filename = filename
-        self.file = io.open(self.filename, 'r', errors=self.errors)
+        self.file = open(self.filename, errors=self.errors)
         self.current_line = 0
 
     def close(self):

--- a/setuptools/_distutils/util.py
+++ b/setuptools/_distutils/util.py
@@ -334,7 +334,7 @@ def execute(func, args, msg=None, verbose=0, dry_run=0):
     print.
     """
     if msg is None:
-        msg = "%s%r" % (func.__name__, args)
+        msg = "{}{!r}".format(func.__name__, args)
         if msg[-2:] == ',)':  # correct for singleton tuple
             msg = msg[0:-2] + ')'
 
@@ -356,7 +356,7 @@ def strtobool(val):
     elif val in ('n', 'no', 'f', 'false', 'off', '0'):
         return 0
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError("invalid truth value {!r}".format(val))
 
 
 def byte_compile(  # noqa: C901

--- a/setuptools/_distutils/version.py
+++ b/setuptools/_distutils/version.py
@@ -60,7 +60,7 @@ class Version:
         )
 
     def __repr__(self):
-        return "%s ('%s')" % (self.__class__.__name__, str(self))
+        return "{} ('{}')".format(self.__class__.__name__, str(self))
 
     def __eq__(self, other):
         c = self._cmp(other)


### PR DESCRIPTION
- Run pyupgrade --py37-plus
- In DummyCommand, simplify setting of kwargs.
- Implement TempdirManager setup and teardown as a pytest fixture.
- Implement LoggingSilencer setup and teardown as a pytest fixture. Required building a fixture combiner.
- Ran unittest2pytest
- ⚫ Fade to black.
- 👹 Feed the hobgoblins (delint).
- Convert many tests to pytest native
- Remove compatibility shims for Setuptools.
- Replace save/restore of argv and cwd as pytest fixtures.
- Move setup/teardown from BuildExtTestCase into a fixture.
- Add tests capturing failure. Ref pypa/distutils#164.
- Use itertools.product to compute the product of two generators. Fixes pypa/distutils#164.
- Extract 'roots' variable.
- Add test compatibility on Windows.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
