### PR TITLE
Merge with pypa/distutils@274758f1c02048

### DIFF
--- a/changelog.d/3482.misc.rst
+++ b/changelog.d/3482.misc.rst
@@ -1,0 +1,1 @@
+Sync with pypa/distutils@274758f1c02048d295efdbc13d2f88d9923547f8, restoring compatibility shim in bdist.format_commands.


### PR DESCRIPTION
- Revert "Remove compatibility shims for Setuptools."
- Mark use of format_commands.append as deprecated. Ref anxuae/setuptools-cythonize#8.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
