### PR TITLE
PEP 660: Add transitional `compat` editable install mode

### DIFF
--- a/changelog.d/3265.change.rst
+++ b/changelog.d/3265.change.rst
@@ -2,7 +2,7 @@ Added implementation for *editable install* hooks (PEP 660) - **beta** stage.
 
 - The user will be able select between two distinct behaviors:
 
-  - *lax*, which prioritises the ability of the users of changing the
+  - *lenient*, which prioritises the ability of the users of changing the
     distributed packages (e.g. adding new files or removing old ones)
 
   - *strict*, which will try to replicate as much as possible the behavior of

--- a/changelog.d/3484.change.rst
+++ b/changelog.d/3484.change.rst
@@ -1,0 +1,6 @@
+Added *transient* ``compat`` mode to editable installs.
+This more will be temporarily available (to facilitate the transition period)
+for those that want to emulate the behavior of the ``develop`` command
+(in terms of what is added to ``sys.path``).
+This mode is provided "as is", with limited support, and will be removed in
+future versions of ``setuptools``.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -255,20 +255,13 @@ class _ConfigSettingsTranslator:
         >>> list(fn(None))
         []
         >>> list(fn({"editable-mode": "strict"}))
-        ['--strict']
-        >>> list(fn({"editable-mode": "other"}))
-        Traceback (most recent call last):
-           ...
-        ValueError: Invalid value for `editable-mode`: 'other'. Try: 'strict'.
+        ['--mode', 'strict']
         """
         cfg = config_settings or {}
-        if "editable-mode" not in cfg and "editable_mode" not in cfg:
-            return
         mode = cfg.get("editable-mode") or cfg.get("editable_mode")
-        if mode != "strict":
-            msg = f"Invalid value for `editable-mode`: {mode!r}. Try: 'strict'."
-            raise ValueError(msg)
-        yield "--strict"
+        if not mode:
+            return
+        yield from ["--mode", str(mode)]
 
     def _arbitrary_args(self, config_settings: _ConfigSettings) -> Iterator[str]:
         """

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -58,9 +58,9 @@ _logger = logging.getLogger(__name__)
 class _EditableMode(Enum):
     """
     Possible editable installation modes:
-    a) `lenient` (new files automatically added to the package - DEFAULT)
-    b) `strict` (requires a new installation when files are added/removed)
-    c) `compat` (attempts to emulate `python setup.py develop` - DEPRECATED)
+    `lenient` (new files automatically added to the package - DEFAULT);
+    `strict` (requires a new installation when files are added/removed); or
+    `compat` (attempts to emulate `python setup.py develop` - DEPRECATED).
     """
 
     STRICT = "strict"

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -33,10 +33,10 @@ from typing import (
     Optional,
     Tuple,
     TypeVar,
-    Union
+    Union,
 )
 
-from setuptools import Command, errors, namespaces
+from setuptools import Command, SetuptoolsDeprecationWarning, errors, namespaces
 from setuptools.discovery import find_package_path
 from setuptools.dist import Distribution
 
@@ -62,6 +62,7 @@ class _EditableMode(Enum):
     b) `strict` (requires a new installation when files are added/removed)
     c) `compat` (attempts to replicate `python setup.py develop` - DEPRECATED)
     """
+
     STRICT = "strict"
     LENIENT = "lenient"
     COMPAT = "compat"  # TODO: Remove `compat` after Dec/2022.
@@ -74,6 +75,18 @@ class _EditableMode(Enum):
         _mode = mode.upper()
         if _mode not in _EditableMode.__members__:
             raise errors.OptionError(f"Invalid editable mode: {mode!r}. Try: 'strict'.")
+
+        if _mode == "COMPAT":
+            msg = """
+            The 'compat' editable mode is transitional and will be removed
+            in future versions of `setuptools`.
+            Please adapt your code accordingly to use either the 'strict' or the
+            'lenient' modes.
+
+            For more information, please check:
+            https://setuptools.pypa.io/en/latest/userguide/development_mode.html
+            """
+            warnings.warn(msg, SetuptoolsDeprecationWarning)
 
         return _EditableMode[_mode]
 

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -18,6 +18,7 @@ import sys
 import traceback
 import warnings
 from contextlib import suppress
+from enum import Enum
 from inspect import cleandoc
 from itertools import chain
 from pathlib import Path
@@ -54,34 +55,57 @@ _P = TypeVar("_P", bound=_Path)
 _logger = logging.getLogger(__name__)
 
 
+class _EditableMode(Enum):
+    """
+    Possible editable installation modes:
+    a) `lenient` (new files automatically added to the package - DEFAULT)
+    b) `strict` (requires a new installation when files are added/removed)
+    c) `compat` (attempts to replicate `python setup.py develop` - DEPRECATED)
+    """
+    STRICT = "strict"
+    LENIENT = "lenient"
+    COMPAT = "compat"  # TODO: Remove `compat` after Dec/2022.
+
+    @classmethod
+    def convert(cls, mode: Optional[str]) -> "_EditableMode":
+        if not mode:
+            return _EditableMode.LENIENT  # default
+
+        _mode = mode.upper()
+        if _mode not in _EditableMode.__members__:
+            raise errors.OptionError(f"Invalid editable mode: {mode!r}. Try: 'strict'.")
+
+        return _EditableMode[_mode]
+
+
 _STRICT_WARNING = """
 New or renamed files may not be automatically picked up without a new installation.
 """
 
-_LAX_WARNING = """
+_LENIENT_WARNING = """
 Options like `package-data`, `include/exclude-package-data` or
 `packages.find.exclude/include` may have no effect.
 """
 
 
 class editable_wheel(Command):
-    """Build 'editable' wheel for development"""
+    """Build 'editable' wheel for development.
+    (This command is reserved for internal use of setuptools).
+    """
 
     description = "create a PEP 660 'editable' wheel"
 
     user_options = [
         ("dist-dir=", "d", "directory to put final built distributions in"),
         ("dist-info-dir=", "I", "path to a pre-build .dist-info directory"),
-        ("strict", None, "perform an strict installation"),
+        ("mode=", None, cleandoc(_EditableMode.__doc__ or "")),
     ]
-
-    boolean_options = ["strict"]
 
     def initialize_options(self):
         self.dist_dir = None
         self.dist_info_dir = None
         self.project_dir = None
-        self.strict = False
+        self.mode = None
 
     def finalize_options(self):
         dist = self.distribution
@@ -267,16 +291,18 @@ class editable_wheel(Command):
         """Decides which strategy to use to implement an editable installation."""
         build_name = f"__editable__.{name}-{tag}"
         project_dir = Path(self.project_dir)
+        mode = _EditableMode.convert(self.mode)
 
-        if self.strict or os.getenv("SETUPTOOLS_EDITABLE", None) == "strict":
+        if mode is _EditableMode.STRICT:
             auxiliary_dir = _empty_dir(Path(self.project_dir, "build", build_name))
             return _LinkTree(self.distribution, name, auxiliary_dir, build_lib)
 
         packages = _find_packages(self.distribution)
         has_simple_layout = _simple_layout(packages, self.package_dir, project_dir)
-        if set(self.package_dir) == {""} and has_simple_layout:
+        is_compat_mode = mode is _EditableMode.COMPAT
+        if set(self.package_dir) == {""} and has_simple_layout or is_compat_mode:
             # src-layout(ish) is relatively safe for a simple pth file
-            src_dir = self.package_dir[""]
+            src_dir = self.package_dir.get("", ".")
             return _StaticPth(self.distribution, name, [Path(project_dir, src_dir)])
 
         # Use a MetaPathFinder to avoid adding accidental top-level packages/modules
@@ -310,7 +336,7 @@ class _StaticPth:
         Editable install will be performed using .pth file to extend `sys.path` with:
         {self.path_entries!r}
         """
-        _logger.warning(msg + _LAX_WARNING)
+        _logger.warning(msg + _LENIENT_WARNING)
         return self
 
     def __exit__(self, _exc_type, _exc_value, _traceback):
@@ -414,7 +440,7 @@ class _TopLevelFinder:
 
     def __enter__(self):
         msg = "Editable install will be performed using a meta path finder.\n"
-        _logger.warning(msg + _LAX_WARNING)
+        _logger.warning(msg + _LENIENT_WARNING)
         return self
 
     def __exit__(self, _exc_type, _exc_value, _traceback):

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -60,7 +60,7 @@ class _EditableMode(Enum):
     Possible editable installation modes:
     a) `lenient` (new files automatically added to the package - DEFAULT)
     b) `strict` (requires a new installation when files are added/removed)
-    c) `compat` (attempts to replicate `python setup.py develop` - DEPRECATED)
+    c) `compat` (attempts to emulate `python setup.py develop` - DEPRECATED)
     """
 
     STRICT = "strict"

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -643,7 +643,7 @@ class TestBuildMetaBackend:
         build_backend = self.get_build_backend()
         assert not Path("build").exists()
 
-        cfg = {"--global-option": "--strict"}
+        cfg = {"--global-option": ["--mode", "strict"]}
         build_backend.prepare_metadata_for_build_editable("_meta", cfg)
         build_backend.build_editable("temp", cfg, "_meta")
 
@@ -651,10 +651,10 @@ class TestBuildMetaBackend:
 
     def test_editable_without_config_settings(self, tmpdir_cwd):
         """
-        Sanity check to ensure tests with --strict are different from the ones
-        without --strict.
+        Sanity check to ensure tests with --mode=strict are different from the ones
+        without --mode.
 
-        --strict should create a local directory with a package tree.
+        --mode=strict should create a local directory with a package tree.
         The directory should not get created otherwise.
         """
         path.build(self._simple_pyproject_example)
@@ -665,7 +665,7 @@ class TestBuildMetaBackend:
 
     @pytest.mark.parametrize(
         "config_settings", [
-            {"--build-option": "--strict"},
+            {"--build-option": ["--mode", "strict"]},
             {"editable-mode": "strict"},
         ]
     )

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -662,17 +662,17 @@ def test_compat_install(tmp_path, venv):
     out = venv.run(["python", "-c", "import mypkg.mod1; print(mypkg.mod1.var)"])
     assert b"42" in out
 
-    expected_path = str(tmp_path).lower().replace(os.sep, "/")
+    expected_path = comparable_path(str(tmp_path))
 
-    # Compatible behaviour will make spurious modules and excluded files importable
+    # Compatible behaviour will make spurious modules and excluded
+    # files importable directly from the original path
     for cmd in (
         "import otherfile; print(otherfile)",
         "import other; print(other)",
         "import mypkg; print(mypkg)",
     ):
-        out = str(venv.run(["python", "-c", cmd]), "utf-8").lower().replace(os.sep, "/")
+        out = comparable_path(str(venv.run(["python", "-c", cmd]), "utf-8"))
         assert expected_path in out
-        # Compatible mode works by adding the project dir to sys.path
 
     # Compatible behaviour will not consider custom mappings
     cmd = """\
@@ -713,3 +713,7 @@ def assert_link_to(file: Path, other: Path):
         other_stat = other.stat()
         assert file_stat[stat.ST_INO] == other_stat[stat.ST_INO]
         assert file_stat[stat.ST_DEV] == other_stat[stat.ST_DEV]
+
+
+def comparable_path(str_with_path: str) -> str:
+    return str_with_path.lower().replace(os.sep, "/").replace("//", "/")


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

*(Another PR related to the PEP 660 implementation, carried out in the feature/pep660 branch)*

## Summary of changes

- Add a temporary `compat` mode that will try (best effort) to emulate the same "static `.pth`" file produced by `python setup.py develop`.
  
  This was originally suggested in https://discuss.python.org/t/help-testing-pep-660-support-in-setuptools/16904

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
