### PR TITLE
docs: Fix wrong syntax usage on CHANGES.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,7 +67,7 @@ Breaking Changes
 ^^^^^^^^^^^^^^^^
 * #3421: Drop setuptools' support for installing an entrypoint extra requirements at load time:
   - the functionality has been broken since v60.8.0.
-  - the mechanism to do so is deprecated (`fetch_build_eggs`).
+  - the mechanism to do so is deprecated (``fetch_build_eggs``).
   - that use case (e.g. a custom command class entrypoint) is covered by making sure the necessary build requirements are declared.
 
 Documentation changes


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix wrong syntax usage on `CHANGES.rst`.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
