### PR TITLE
Improve `pyproject.toml` validation messages

### DIFF
--- a/changelog.d/3487.misc.rst
+++ b/changelog.d/3487.misc.rst
@@ -1,0 +1,2 @@
+Modified ``pyproject.toml`` validation exception handling to
+make relevant debugging information easier to spot.

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -41,10 +41,14 @@ def validate(config: dict, filepath: _Path) -> bool:
     try:
         return validator.validate(config)
     except validator.ValidationError as ex:
-        _logger.error(f"configuration error: {ex.summary}")  # type: ignore
-        _logger.debug(ex.details)  # type: ignore
-        error = ValueError(f"invalid pyproject.toml config: {ex.name}")  # type: ignore
-        raise error from None
+        summary = f"configuration error: {ex.summary}"
+        if ex.name.strip("`") != "project":
+            # Probably it is just a field missing/misnamed, not worthy the verbosity...
+            _logger.debug(summary)
+            _logger.debug(ex.details)
+
+        error = f"invalid pyproject.toml config: {ex.name}."
+        raise ValueError(f"{error}\n{summary}") from None
 
 
 def apply_configuration(


### PR DESCRIPTION
Based on the following discussions:

- https://github.com/pypa/packaging.python.org/pull/1031#issuecomment-1127214128
- https://github.com/pypa/packaging-problems/issues/604

it seems that people are having a hard time finding information about validation error due to the long traceback and debug info.


<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Make the most relevant information to fix a `pyproject.toml` error easier to spot:
  - Add the error summary to the exception message itself (this way it is shown at the bottom of the traceback)
  - Avoid displaying debugging information in the case the whole `project` table is considered invalid (too verbose, and probably the error is just a missing/misnamed field).
  - Modify the tests to reflect the changes listed above.


Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
