### PR TITLE
Merge with pypa/distutils@b65aa40

### DIFF
--- a/changelog.d/3496.misc.rst
+++ b/changelog.d/3496.misc.rst
@@ -1,0 +1,1 @@
+Update to pypa/distutils@b65aa40 including more robust support for library/include dir handling in msvccompiler (pypa/distutils#153) and test suite improvements.

--- a/setuptools/_distutils/_msvccompiler.py
+++ b/setuptools/_distutils/_msvccompiler.py
@@ -222,6 +222,7 @@ class MSVCCompiler(CCompiler):
         super().__init__(verbose, dry_run, force)
         # target platform (.plat_name is consistent with 'bdist')
         self.plat_name = None
+        self.initialized = False
 
     @classmethod
     def _configure(cls, vc_env):
@@ -236,9 +237,8 @@ class MSVCCompiler(CCompiler):
         return [dir.rstrip(os.sep) for dir in val.split(os.pathsep) if dir]
 
     def initialize(self, plat_name=None):
-        def _repeat_call_error(plat_name=None):
-            raise AssertionError("repeat initialize not allowed")
-        self.initialize = _repeat_call_error
+        # multi-init means we would need to check platform same each time...
+        assert not self.initialized, "don't init multiple times"
         if plat_name is None:
             plat_name = get_platform()
         # sanity check for platforms to prevent obscure errors later.
@@ -313,6 +313,8 @@ class MSVCCompiler(CCompiler):
             (CCompiler.SHARED_LIBRARY, False): self.ldflags_static,
             (CCompiler.SHARED_LIBRARY, True): self.ldflags_static_debug,
         }
+
+        self.initialized = True
 
     # -- Worker methods ------------------------------------------------
 

--- a/setuptools/_distutils/_msvccompiler.py
+++ b/setuptools/_distutils/_msvccompiler.py
@@ -17,7 +17,7 @@ import os
 import subprocess
 import contextlib
 import warnings
-import unittest.mock
+import unittest.mock as mock
 
 with contextlib.suppress(ImportError):
     import winreg
@@ -222,11 +222,23 @@ class MSVCCompiler(CCompiler):
         super().__init__(verbose, dry_run, force)
         # target platform (.plat_name is consistent with 'bdist')
         self.plat_name = None
-        self.initialized = False
+
+    @classmethod
+    def _configure(cls, vc_env):
+        """
+        Set class-level include/lib dirs.
+        """
+        cls.include_dirs = cls._parse_path(vc_env.get('include', ''))
+        cls.library_dirs = cls._parse_path(vc_env.get('lib', ''))
+
+    @staticmethod
+    def _parse_path(val):
+        return [dir.rstrip(os.sep) for dir in val.split(os.pathsep) if dir]
 
     def initialize(self, plat_name=None):
-        # multi-init means we would need to check platform same each time...
-        assert not self.initialized, "don't init multiple times"
+        def _repeat_call_error(plat_name=None):
+            raise AssertionError("repeat initialize not allowed")
+        self.initialize = _repeat_call_error
         if plat_name is None:
             plat_name = get_platform()
         # sanity check for platforms to prevent obscure errors later.
@@ -243,6 +255,7 @@ class MSVCCompiler(CCompiler):
             raise DistutilsPlatformError(
                 "Unable to find a compatible " "Visual Studio installation."
             )
+        self._configure(vc_env)
 
         self._paths = vc_env.get('path', '')
         paths = self._paths.split(os.pathsep)
@@ -252,14 +265,6 @@ class MSVCCompiler(CCompiler):
         self.rc = _find_exe("rc.exe", paths)  # resource compiler
         self.mc = _find_exe("mc.exe", paths)  # message compiler
         self.mt = _find_exe("mt.exe", paths)  # message compiler
-
-        for dir in vc_env.get('include', '').split(os.pathsep):
-            if dir:
-                self.add_include_dir(dir.rstrip(os.sep))
-
-        for dir in vc_env.get('lib', '').split(os.pathsep):
-            if dir:
-                self.add_library_dir(dir.rstrip(os.sep))
 
         self.preprocess_options = None
         # bpo-38597: Always compile with dynamic linking
@@ -308,8 +313,6 @@ class MSVCCompiler(CCompiler):
             (CCompiler.SHARED_LIBRARY, False): self.ldflags_static,
             (CCompiler.SHARED_LIBRARY, True): self.ldflags_static_debug,
         }
-
-        self.initialized = True
 
     # -- Worker methods ------------------------------------------------
 
@@ -554,7 +557,7 @@ class MSVCCompiler(CCompiler):
         else:
             return
         warnings.warn("Fallback spawn triggered. Please update distutils monkeypatch.")
-        with unittest.mock.patch.dict('os.environ', env):
+        with mock.patch.dict('os.environ', env):
             bag.value = super().spawn(cmd)
 
     # -- Miscellaneous methods -----------------------------------------

--- a/setuptools/_distutils/archive_util.py
+++ b/setuptools/_distutils/archive_util.py
@@ -121,7 +121,7 @@ def make_tarball(
 
     # compression using `compress`
     if compress == 'compress':
-        warn("'compress' will be deprecated.", PendingDeprecationWarning)
+        warn("'compress' is deprecated.", DeprecationWarning)
         # the option varies depending on the platform
         compressed_name = archive_name + compress_ext[compress]
         if sys.platform == 'win32':

--- a/setuptools/_distutils/ccompiler.py
+++ b/setuptools/_distutils/ccompiler.py
@@ -91,6 +91,16 @@ class CCompiler:
     }
     language_order = ["c++", "objc", "c"]
 
+    include_dirs = []
+    """
+    include dirs specific to this compiler class
+    """
+
+    library_dirs = []
+    """
+    library dirs specific to this compiler class
+    """
+
     def __init__(self, verbose=0, dry_run=0, force=0):
         self.dry_run = dry_run
         self.force = force
@@ -324,24 +334,7 @@ class CCompiler:
 
     def _setup_compile(self, outdir, macros, incdirs, sources, depends, extra):
         """Process arguments and decide which source files to compile."""
-        if outdir is None:
-            outdir = self.output_dir
-        elif not isinstance(outdir, str):
-            raise TypeError("'output_dir' must be a string or None")
-
-        if macros is None:
-            macros = self.macros
-        elif isinstance(macros, list):
-            macros = macros + (self.macros or [])
-        else:
-            raise TypeError("'macros' (if supplied) must be a list of tuples")
-
-        if incdirs is None:
-            incdirs = self.include_dirs
-        elif isinstance(incdirs, (list, tuple)):
-            incdirs = list(incdirs) + (self.include_dirs or [])
-        else:
-            raise TypeError("'include_dirs' (if supplied) must be a list of strings")
+        outdir, macros, incdirs = self._fix_compile_args(outdir, macros, incdirs)
 
         if extra is None:
             extra = []
@@ -400,6 +393,9 @@ class CCompiler:
         else:
             raise TypeError("'include_dirs' (if supplied) must be a list of strings")
 
+        # add include dirs for class
+        include_dirs += self.__class__.include_dirs
+
         return output_dir, macros, include_dirs
 
     def _prep_compile(self, sources, output_dir, depends=None):
@@ -455,6 +451,9 @@ class CCompiler:
             library_dirs = list(library_dirs) + (self.library_dirs or [])
         else:
             raise TypeError("'library_dirs' (if supplied) must be a list of strings")
+
+        # add library dirs for class
+        library_dirs += self.__class__.library_dirs
 
         if runtime_library_dirs is None:
             runtime_library_dirs = self.runtime_library_dirs

--- a/setuptools/_distutils/command/check.py
+++ b/setuptools/_distutils/command/check.py
@@ -2,17 +2,18 @@
 
 Implements the Distutils 'check' command.
 """
+import contextlib
+
 from distutils.core import Command
 from distutils.errors import DistutilsSetupError
 
-try:
-    # docutils is installed
-    from docutils.utils import Reporter
-    from docutils.parsers.rst import Parser
-    from docutils import frontend
-    from docutils import nodes
+with contextlib.suppress(ImportError):
+    import docutils.utils
+    import docutils.parsers.rst
+    import docutils.frontend
+    import docutils.nodes
 
-    class SilentReporter(Reporter):
+    class SilentReporter(docutils.utils.Reporter):
         def __init__(
             self,
             source,
@@ -30,15 +31,9 @@ try:
 
         def system_message(self, level, message, *children, **kwargs):
             self.messages.append((level, message, children, kwargs))
-            return nodes.system_message(
+            return docutils.nodes.system_message(
                 message, level=level, type=self.levels[level], *children, **kwargs
             )
-
-    HAS_DOCUTILS = True
-except Exception:
-    # Catch all exceptions because exceptions besides ImportError probably
-    # indicate that docutils is not ported to Py3k.
-    HAS_DOCUTILS = False
 
 
 class check(Command):
@@ -81,8 +76,11 @@ class check(Command):
         if self.metadata:
             self.check_metadata()
         if self.restructuredtext:
-            if HAS_DOCUTILS:
-                self.check_restructuredtext()
+            if 'docutils' in globals():
+                try:
+                    self.check_restructuredtext()
+                except TypeError as exc:
+                    raise DistutilsSetupError(str(exc))
             elif self.strict:
                 raise DistutilsSetupError('The docutils package is needed.')
 
@@ -124,8 +122,10 @@ class check(Command):
         """Returns warnings when the provided data doesn't compile."""
         # the include and csv_table directives need this to be a path
         source_path = self.distribution.script_name or 'setup.py'
-        parser = Parser()
-        settings = frontend.OptionParser(components=(Parser,)).get_default_values()
+        parser = docutils.parsers.rst.Parser()
+        settings = docutils.frontend.OptionParser(
+            components=(docutils.parsers.rst.Parser,)
+        ).get_default_values()
         settings.tab_width = 4
         settings.pep_references = None
         settings.rfc_references = None
@@ -139,7 +139,7 @@ class check(Command):
             error_handler=settings.error_encoding_error_handler,
         )
 
-        document = nodes.document(settings, reporter, source=source_path)
+        document = docutils.nodes.document(settings, reporter, source=source_path)
         document.note_source(source_path, -1)
         try:
             parser.parse(data, document)

--- a/setuptools/_distutils/command/register.py
+++ b/setuptools/_distutils/command/register.py
@@ -66,9 +66,9 @@ class register(PyPIRCCommand):
     def check_metadata(self):
         """Deprecated API."""
         warn(
-            "distutils.command.register.check_metadata is deprecated, \
-              use the check command instead",
-            PendingDeprecationWarning,
+            "distutils.command.register.check_metadata is deprecated; "
+            "use the check command instead",
+            DeprecationWarning,
         )
         check = self.distribution.get_command_obj('check')
         check.ensure_finalized()

--- a/setuptools/_distutils/tests/py38compat.py
+++ b/setuptools/_distutils/tests/py38compat.py
@@ -42,5 +42,17 @@ except (ModuleNotFoundError, ImportError):
     )
 
 
+try:
+    from test.support.import_helper import (
+        DirsOnSysPath,
+        CleanImport,
+    )
+except (ModuleNotFoundError, ImportError):
+    from test.support import (
+        DirsOnSysPath,
+        CleanImport,
+    )
+
+
 if sys.version_info < (3, 9):
     requires_zlib = lambda: test.support.requires_zlib

--- a/setuptools/_distutils/tests/support.py
+++ b/setuptools/_distutils/tests/support.py
@@ -3,7 +3,6 @@ import os
 import sys
 import shutil
 import tempfile
-import unittest
 import sysconfig
 import itertools
 
@@ -31,9 +30,8 @@ class LoggingSilencer:
 
 @pytest.mark.usefixtures('distutils_managed_tempdir')
 class TempdirManager:
-    """Mix-in class that handles temporary directories for test cases.
-
-    This is intended to be used with unittest.TestCase.
+    """
+    Mix-in class that handles temporary directories for test cases.
     """
 
     def mkdtemp(self):
@@ -99,29 +97,12 @@ def copy_xxmodule_c(directory):
     If the source file can be found, it will be copied to *directory*.  If not,
     the test will be skipped.  Errors during copy are not caught.
     """
-    filename = _get_xxmodule_path()
-    if filename is None:
-        raise unittest.SkipTest(
-            'cannot find xxmodule.c (test must run in ' 'the python build dir)'
-        )
-    shutil.copy(filename, directory)
+    shutil.copy(_get_xxmodule_path(), os.path.join(directory, 'xxmodule.c'))
 
 
 def _get_xxmodule_path():
-    srcdir = sysconfig.get_config_var('srcdir')
-    candidates = [
-        # use installed copy if available
-        os.path.join(os.path.dirname(__file__), 'xxmodule.c'),
-        # otherwise try using copy from build directory
-        os.path.join(srcdir, 'Modules', 'xxmodule.c'),
-        # srcdir mysteriously can be $srcdir/Lib/distutils/tests when
-        # this file is run from its parent directory, so walk up the
-        # tree to find the real srcdir
-        os.path.join(srcdir, '..', '..', '..', 'Modules', 'xxmodule.c'),
-    ]
-    for path in candidates:
-        if os.path.exists(path):
-            return path
+    source_name = 'xxmodule.c' if sys.version_info > (3, 9) else 'xxmodule-3.8.c'
+    return os.path.join(os.path.dirname(__file__), source_name)
 
 
 def fixup_build_ext(cmd):

--- a/setuptools/_distutils/tests/test_archive_util.py
+++ b/setuptools/_distutils/tests/test_archive_util.py
@@ -1,10 +1,12 @@
 """Tests for distutils.archive_util."""
-import unittest
 import os
 import sys
 import tarfile
 from os.path import splitdrive
 import warnings
+import functools
+import operator
+import pathlib
 
 import pytest
 
@@ -16,31 +18,13 @@ from distutils.archive_util import (
     make_archive,
     ARCHIVE_FORMATS,
 )
-from distutils.spawn import find_executable, spawn
+from distutils.spawn import spawn
 from distutils.tests import support
 from test.support import patch
 from .unix_compat import require_unix_id, require_uid_0, grp, pwd, UID_0_SUPPORT
 
 from .py38compat import change_cwd
 from .py38compat import check_warnings
-
-
-try:
-    import zipfile
-
-    ZIP_SUPPORT = True
-except ImportError:
-    ZIP_SUPPORT = find_executable('zip')
-
-try:
-    import bz2
-except ImportError:
-    bz2 = None
-
-try:
-    import lzma
-except ImportError:
-    lzma = None
 
 
 def can_fs_encode(filename):
@@ -54,6 +38,14 @@ def can_fs_encode(filename):
     except UnicodeEncodeError:
         return False
     return True
+
+
+def all_equal(values):
+    return functools.reduce(operator.eq, values)
+
+
+def same_drive(*paths):
+    return all_equal(pathlib.Path(path).drive for path in paths)
 
 
 class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
@@ -70,28 +62,24 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         tmpdir = self._create_files()
         self._make_tarball(tmpdir, 'archive', '.tar.gz', compress='gzip')
 
-    @unittest.skipUnless(bz2, 'Need bz2 support to run')
     def test_make_tarball_bzip2(self):
+        pytest.importorskip('bz2')
         tmpdir = self._create_files()
         self._make_tarball(tmpdir, 'archive', '.tar.bz2', compress='bzip2')
 
-    @unittest.skipUnless(lzma, 'Need lzma support to run')
     def test_make_tarball_xz(self):
+        pytest.importorskip('lzma')
         tmpdir = self._create_files()
         self._make_tarball(tmpdir, 'archive', '.tar.xz', compress='xz')
 
-    @unittest.skipUnless(
-        can_fs_encode('årchiv'), 'File system cannot handle this filename'
-    )
+    @pytest.mark.skipif("not can_fs_encode('årchiv')")
     def test_make_tarball_latin1(self):
         """
         Mirror test_make_tarball, except filename contains latin characters.
         """
         self.test_make_tarball('årchiv')  # note this isn't a real word
 
-    @unittest.skipUnless(
-        can_fs_encode('のアーカイブ'), 'File system cannot handle this filename'
-    )
+    @pytest.mark.skipif("not can_fs_encode('のアーカイブ')")
     def test_make_tarball_extended(self):
         """
         Mirror test_make_tarball, except filename contains extended
@@ -101,10 +89,8 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
 
     def _make_tarball(self, tmpdir, target_name, suffix, **kwargs):
         tmpdir2 = self.mkdtemp()
-        unittest.skipUnless(
-            splitdrive(tmpdir)[0] == splitdrive(tmpdir2)[0],
-            "source and target should be on same drive",
-        )
+        if same_drive(tmpdir, tmpdir2):
+            pytest.skip("source and target should be on same drive")
 
         base_name = os.path.join(tmpdir2, target_name)
 
@@ -149,10 +135,7 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         return tmpdir
 
     @pytest.mark.usefixtures('needs_zlib')
-    @unittest.skipUnless(
-        find_executable('tar') and find_executable('gzip'),
-        'Need the tar and gzip commands to run',
-    )
+    @pytest.mark.skipif("not (find_executable('tar') and find_executable('gzip'))")
     def test_tarfile_vs_tar(self):
         tmpdir = self._create_files()
         tmpdir2 = self.mkdtemp()
@@ -207,14 +190,12 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         tarball = base_name + '.tar'
         assert os.path.exists(tarball)
 
-    @unittest.skipUnless(
-        find_executable('compress'), 'The compress program is required'
-    )
+    @pytest.mark.skipif("not find_executable('compress')")
     def test_compress_deprecated(self):
         tmpdir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
 
-        # using compress and testing the PendingDeprecationWarning
+        # using compress and testing the DeprecationWarning
         old_dir = os.getcwd()
         os.chdir(tmpdir)
         try:
@@ -241,8 +222,8 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         assert len(w.warnings) == 1
 
     @pytest.mark.usefixtures('needs_zlib')
-    @unittest.skipUnless(ZIP_SUPPORT, 'Need zip support to run')
     def test_make_zipfile(self):
+        zipfile = pytest.importorskip('zipfile')
         # creating something to tar
         tmpdir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
@@ -255,8 +236,8 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         with zipfile.ZipFile(tarball) as zf:
             assert sorted(zf.namelist()) == self._zip_created_files
 
-    @unittest.skipUnless(ZIP_SUPPORT, 'Need zip support to run')
     def test_make_zipfile_no_zlib(self):
+        zipfile = pytest.importorskip('zipfile')
         patch(self, archive_util.zipfile, 'zlib', None)  # force zlib ImportError
 
         called = []
@@ -327,8 +308,8 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         assert os.path.basename(res) == 'archive.tar.gz'
         assert self._tarinfo(res) == self._created_files
 
-    @unittest.skipUnless(bz2, 'Need bz2 support to run')
     def test_make_archive_bztar(self):
+        pytest.importorskip('bz2')
         base_dir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
         res = make_archive(base_name, 'bztar', base_dir, 'dist')
@@ -336,8 +317,8 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         assert os.path.basename(res) == 'archive.tar.bz2'
         assert self._tarinfo(res) == self._created_files
 
-    @unittest.skipUnless(lzma, 'Need xz support to run')
     def test_make_archive_xztar(self):
+        pytest.importorskip('lzma')
         base_dir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
         res = make_archive(base_name, 'xztar', base_dir, 'dist')

--- a/setuptools/_distutils/tests/test_bdist_wininst.py
+++ b/setuptools/_distutils/tests/test_bdist_wininst.py
@@ -1,7 +1,5 @@
 """Tests for distutils.command.bdist_wininst."""
-import sys
-import platform
-import unittest
+import pytest
 
 from .py38compat import check_warnings
 
@@ -9,14 +7,8 @@ from distutils.command.bdist_wininst import bdist_wininst
 from distutils.tests import support
 
 
-@unittest.skipIf(
-    sys.platform == 'win32' and platform.machine() == 'ARM64',
-    'bdist_wininst is not supported in this install',
-)
-@unittest.skipIf(
-    getattr(bdist_wininst, '_unsupported', False),
-    'bdist_wininst is not supported in this install',
-)
+@pytest.mark.skipif("platform.machine() == 'ARM64'")
+@pytest.mark.skipif("bdist_wininst._unsupported")
 class TestBuildWinInst(support.TempdirManager, support.LoggingSilencer):
     def test_get_exe_bytes(self):
 

--- a/setuptools/_distutils/tests/test_build.py
+++ b/setuptools/_distutils/tests/test_build.py
@@ -1,5 +1,4 @@
 """Tests for distutils.command.build."""
-import unittest
 import os
 import sys
 
@@ -8,7 +7,7 @@ from distutils.tests import support
 from sysconfig import get_platform
 
 
-class BuildTestCase(support.TempdirManager, support.LoggingSilencer, unittest.TestCase):
+class TestBuild(support.TempdirManager, support.LoggingSilencer):
     def test_finalize_options(self):
         pkg_dir, dist = self.create_dist()
         cmd = build(dist)

--- a/setuptools/_distutils/tests/test_build_clib.py
+++ b/setuptools/_distutils/tests/test_build_clib.py
@@ -1,14 +1,13 @@
 """Tests for distutils.command.build_clib."""
-import unittest
 import os
-import sys
 
 from test.support import missing_compiler_executable
+
+import pytest
 
 from distutils.command.build_clib import build_clib
 from distutils.errors import DistutilsSetupError
 from distutils.tests import support
-import pytest
 
 
 class TestBuildCLib(support.TempdirManager, support.LoggingSilencer):
@@ -111,7 +110,7 @@ class TestBuildCLib(support.TempdirManager, support.LoggingSilencer):
         with pytest.raises(DistutilsSetupError):
             cmd.finalize_options()
 
-    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
+    @pytest.mark.skipif('platform.system() == "Windows"')
     def test_run(self):
         pkg_dir, dist = self.create_dist()
         cmd = build_clib(dist)

--- a/setuptools/_distutils/tests/test_build_py.py
+++ b/setuptools/_distutils/tests/test_build_py.py
@@ -2,12 +2,13 @@
 
 import os
 import sys
-import unittest
+import unittest.mock as mock
+
+import pytest
 
 from distutils.command.build_py import build_py
 from distutils.core import Distribution
 from distutils.errors import DistutilsFileError
-from unittest.mock import patch
 
 from distutils.tests import support
 
@@ -86,7 +87,7 @@ class TestBuildPy(support.TempdirManager, support.LoggingSilencer):
         except DistutilsFileError:
             self.fail("failed package_data test when package_dir is ''")
 
-    @unittest.skipIf(sys.dont_write_bytecode, 'byte-compile disabled')
+    @pytest.mark.skipif('sys.dont_write_bytecode')
     def test_byte_compile(self):
         project_dir, dist = self.create_dist(py_modules=['boiledeggs'])
         os.chdir(project_dir)
@@ -102,7 +103,7 @@ class TestBuildPy(support.TempdirManager, support.LoggingSilencer):
         found = os.listdir(os.path.join(cmd.build_lib, '__pycache__'))
         assert found == ['boiledeggs.%s.pyc' % sys.implementation.cache_tag]
 
-    @unittest.skipIf(sys.dont_write_bytecode, 'byte-compile disabled')
+    @pytest.mark.skipif('sys.dont_write_bytecode')
     def test_byte_compile_optimized(self):
         project_dir, dist = self.create_dist(py_modules=['boiledeggs'])
         os.chdir(project_dir)
@@ -166,7 +167,7 @@ class TestBuildPy(support.TempdirManager, support.LoggingSilencer):
 
         assert 'byte-compiling is disabled' in self.logs[0][1] % self.logs[0][2]
 
-    @patch("distutils.command.build_py.log.warn")
+    @mock.patch("distutils.command.build_py.log.warn")
     def test_namespace_package_does_not_warn(self, log_warn):
         """
         Originally distutils implementation did not account for PEP 420

--- a/setuptools/_distutils/tests/test_ccompiler.py
+++ b/setuptools/_distutils/tests/test_ccompiler.py
@@ -1,0 +1,55 @@
+import os
+import sys
+import platform
+import textwrap
+import sysconfig
+
+import pytest
+
+from distutils import ccompiler
+
+
+def _make_strs(paths):
+    """
+    Convert paths to strings for legacy compatibility.
+    """
+    if sys.version_info > (3, 8) and platform.system() != "Windows":
+        return paths
+    return list(map(os.fspath, paths))
+
+
+@pytest.fixture
+def c_file(tmp_path):
+    c_file = tmp_path / 'foo.c'
+    gen_headers = ('Python.h',)
+    is_windows = platform.system() == "Windows"
+    plat_headers = ('windows.h',) * is_windows
+    all_headers = gen_headers + plat_headers
+    headers = '\n'.join(f'#include <{header}>\n' for header in all_headers)
+    payload = (
+        textwrap.dedent(
+            """
+        #headers
+        void PyInit_foo(void) {}
+        """
+        )
+        .lstrip()
+        .replace('#headers', headers)
+    )
+    c_file.write_text(payload)
+    return c_file
+
+
+def test_set_include_dirs(c_file):
+    """
+    Extensions should build even if set_include_dirs is invoked.
+    In particular, compiler-specific paths should not be overridden.
+    """
+    compiler = ccompiler.new_compiler()
+    python = sysconfig.get_paths()['include']
+    compiler.set_include_dirs([python])
+    compiler.compile(_make_strs([c_file]))
+
+    # do it again, setting include dirs after any initialization
+    compiler.set_include_dirs([python])
+    compiler.compile(_make_strs([c_file]))

--- a/setuptools/_distutils/tests/test_check.py
+++ b/setuptools/_distutils/tests/test_check.py
@@ -1,12 +1,12 @@
 """Tests for distutils.command.check."""
 import os
 import textwrap
-import unittest
 
-from distutils.command.check import check, HAS_DOCUTILS
+import pytest
+
+from distutils.command.check import check
 from distutils.tests import support
 from distutils.errors import DistutilsSetupError
-import pytest
 
 try:
     import pygments
@@ -102,8 +102,8 @@ class TestCheck(support.LoggingSilencer, support.TempdirManager):
             cmd = self._run(metadata)
             assert cmd._warnings == 0
 
-    @unittest.skipUnless(HAS_DOCUTILS, "won't test without docutils")
     def test_check_document(self):
+        pytest.importorskip('docutils')
         pkg_info, dist = self.create_dist()
         cmd = check(dist)
 
@@ -117,8 +117,8 @@ class TestCheck(support.LoggingSilencer, support.TempdirManager):
         msgs = cmd._check_rst_data(rest)
         assert len(msgs) == 0
 
-    @unittest.skipUnless(HAS_DOCUTILS, "won't test without docutils")
     def test_check_restructuredtext(self):
+        pytest.importorskip('docutils')
         # let's see if it detects broken rest in long_description
         broken_rest = 'title\n===\n\ntest'
         pkg_info, dist = self.create_dist(long_description=broken_rest)
@@ -148,8 +148,8 @@ class TestCheck(support.LoggingSilencer, support.TempdirManager):
         cmd = self._run(metadata, cwd=HERE, strict=1, restructuredtext=1)
         assert cmd._warnings == 0
 
-    @unittest.skipUnless(HAS_DOCUTILS, "won't test without docutils")
     def test_check_restructuredtext_with_syntax_highlight(self):
+        pytest.importorskip('docutils')
         # Don't fail if there is a `code` or `code-block` directive
 
         example_rst_docs = []

--- a/setuptools/_distutils/tests/test_cmd.py
+++ b/setuptools/_distutils/tests/test_cmd.py
@@ -1,5 +1,4 @@
 """Tests for distutils.cmd."""
-import unittest
 import os
 from test.support import captured_stdout
 
@@ -15,14 +14,13 @@ class MyCmd(Command):
         pass
 
 
-class TestCommand(unittest.TestCase):
-    def setUp(self):
-        dist = Distribution()
-        self.cmd = MyCmd(dist)
+@pytest.fixture
+def cmd(request):
+    return MyCmd(Distribution())
 
-    def test_ensure_string_list(self):
 
-        cmd = self.cmd
+class TestCommand:
+    def test_ensure_string_list(self, cmd):
         cmd.not_string_list = ['one', 2, 'three']
         cmd.yes_string_list = ['one', 'two', 'three']
         cmd.not_string_list2 = object()
@@ -47,10 +45,7 @@ class TestCommand(unittest.TestCase):
         with pytest.raises(DistutilsOptionError):
             cmd.ensure_string_list('option3')
 
-    def test_make_file(self):
-
-        cmd = self.cmd
-
+    def test_make_file(self, cmd):
         # making sure it raises when infiles is not a string or a list/tuple
         with pytest.raises(TypeError):
             cmd.make_file(infiles=1, outfile='', func='func', args=())
@@ -63,14 +58,13 @@ class TestCommand(unittest.TestCase):
         cmd.execute = _execute
         cmd.make_file(infiles='in', outfile='out', func='func', args=())
 
-    def test_dump_options(self):
+    def test_dump_options(self, cmd):
 
         msgs = []
 
         def _announce(msg, level):
             msgs.append(msg)
 
-        cmd = self.cmd
         cmd.announce = _announce
         cmd.option1 = 1
         cmd.option2 = 1
@@ -80,8 +74,7 @@ class TestCommand(unittest.TestCase):
         wanted = ["command options for 'MyCmd':", '  option1 = 1', '  option2 = 1']
         assert msgs == wanted
 
-    def test_ensure_string(self):
-        cmd = self.cmd
+    def test_ensure_string(self, cmd):
         cmd.option1 = 'ok'
         cmd.ensure_string('option1')
 
@@ -93,24 +86,21 @@ class TestCommand(unittest.TestCase):
         with pytest.raises(DistutilsOptionError):
             cmd.ensure_string('option3')
 
-    def test_ensure_filename(self):
-        cmd = self.cmd
+    def test_ensure_filename(self, cmd):
         cmd.option1 = __file__
         cmd.ensure_filename('option1')
         cmd.option2 = 'xxx'
         with pytest.raises(DistutilsOptionError):
             cmd.ensure_filename('option2')
 
-    def test_ensure_dirname(self):
-        cmd = self.cmd
+    def test_ensure_dirname(self, cmd):
         cmd.option1 = os.path.dirname(__file__) or os.curdir
         cmd.ensure_dirname('option1')
         cmd.option2 = 'xxx'
         with pytest.raises(DistutilsOptionError):
             cmd.ensure_dirname('option2')
 
-    def test_debug_print(self):
-        cmd = self.cmd
+    def test_debug_print(self, cmd):
         with captured_stdout() as stdout:
             cmd.debug_print('xxx')
         stdout.seek(0)

--- a/setuptools/_distutils/tests/test_config.py
+++ b/setuptools/_distutils/tests/test_config.py
@@ -1,13 +1,7 @@
 """Tests for distutils.pypirc.pypirc."""
 import os
-import unittest
 
 import pytest
-
-from distutils.core import PyPIRCCommand
-from distutils.core import Distribution
-from distutils.log import set_threshold
-from distutils.log import WARN
 
 from distutils.tests import support
 
@@ -52,37 +46,13 @@ password:xxx
 
 
 @support.combine_markers
-@pytest.mark.usefixtures('save_env')
+@pytest.mark.usefixtures('threshold_warn')
+@pytest.mark.usefixtures('pypirc')
 class BasePyPIRCCommandTestCase(
     support.TempdirManager,
     support.LoggingSilencer,
-    unittest.TestCase,
 ):
-    def setUp(self):
-        """Patches the environment."""
-        super().setUp()
-        self.tmp_dir = self.mkdtemp()
-        os.environ['HOME'] = self.tmp_dir
-        os.environ['USERPROFILE'] = self.tmp_dir
-        self.rc = os.path.join(self.tmp_dir, '.pypirc')
-        self.dist = Distribution()
-
-        class command(PyPIRCCommand):
-            def __init__(self, dist):
-                super().__init__(dist)
-
-            def initialize_options(self):
-                pass
-
-            finalize_options = initialize_options
-
-        self._cmd = command
-        self.old_threshold = set_threshold(WARN)
-
-    def tearDown(self):
-        """Removes the patch."""
-        set_threshold(self.old_threshold)
-        super().tearDown()
+    pass
 
 
 class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):

--- a/setuptools/_distutils/tests/test_config_cmd.py
+++ b/setuptools/_distutils/tests/test_config_cmd.py
@@ -1,31 +1,27 @@
 """Tests for distutils.command.config."""
-import unittest
 import os
 import sys
 from test.support import missing_compiler_executable
+
+import pytest
 
 from distutils.command.config import dump_file, config
 from distutils.tests import support
 from distutils import log
 
 
+@pytest.fixture(autouse=True)
+def info_log(request, monkeypatch):
+    self = request.instance
+    self._logs = []
+    monkeypatch.setattr(log, 'info', self._info)
+
+
 @support.combine_markers
-class ConfigTestCase(
-    support.LoggingSilencer, support.TempdirManager, unittest.TestCase
-):
+class TestConfig(support.LoggingSilencer, support.TempdirManager):
     def _info(self, msg, *args):
         for line in msg.splitlines():
             self._logs.append(line)
-
-    def setUp(self):
-        super().setUp()
-        self._logs = []
-        self.old_log = log.info
-        log.info = self._info
-
-    def tearDown(self):
-        log.info = self.old_log
-        super().tearDown()
 
     def test_dump_file(self):
         this_file = os.path.splitext(__file__)[0] + '.py'
@@ -38,7 +34,7 @@ class ConfigTestCase(
         dump_file(this_file, 'I am the header')
         assert len(self._logs) == numlines + 1
 
-    @unittest.skipIf(sys.platform == 'win32', "can't test on Windows")
+    @pytest.mark.skipif('platform.system() == "Windows"')
     def test_search_cpp(self):
         cmd = missing_compiler_executable(['preprocessor'])
         if cmd is not None:

--- a/setuptools/_distutils/tests/test_core.py
+++ b/setuptools/_distutils/tests/test_core.py
@@ -3,15 +3,12 @@
 import io
 import distutils.core
 import os
-import shutil
 import sys
 from test.support import captured_stdout
 
 import pytest
 
 from . import py38compat as os_helper
-import unittest
-from distutils import log
 from distutils.dist import Distribution
 
 # setup script that uses __file__
@@ -59,27 +56,15 @@ if __name__ == "__main__":
 """
 
 
+@pytest.fixture(autouse=True)
+def save_stdout(monkeypatch):
+    monkeypatch.setattr(sys, 'stdout', sys.stdout)
+
+
 @pytest.mark.usefixtures('save_env')
 @pytest.mark.usefixtures('save_argv')
-class CoreTestCase(unittest.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.old_stdout = sys.stdout
-        self.cleanup_testfn()
-        self.addCleanup(log.set_threshold, log._global_log.threshold)
-
-    def tearDown(self):
-        sys.stdout = self.old_stdout
-        self.cleanup_testfn()
-        super().tearDown()
-
-    def cleanup_testfn(self):
-        path = os_helper.TESTFN
-        if os.path.isfile(path):
-            os.remove(path)
-        elif os.path.isdir(path):
-            shutil.rmtree(path)
-
+@pytest.mark.usefixtures('cleanup_testfn')
+class TestCore:
     def write_setup(self, text, path=os_helper.TESTFN):
         f = open(path, "w")
         try:

--- a/setuptools/_distutils/tests/test_dist.py
+++ b/setuptools/_distutils/tests/test_dist.py
@@ -2,12 +2,10 @@
 import os
 import io
 import sys
-import unittest
 import warnings
 import textwrap
 import functools
-
-from unittest import mock
+import unittest.mock as mock
 
 import pytest
 
@@ -89,9 +87,9 @@ class TestDistributionBehavior(
         assert isinstance(cmd, test_dist)
         assert cmd.sample_option == "sometext"
 
-    @unittest.skipIf(
+    @pytest.mark.skipif(
         'distutils' not in Distribution.parse_config_files.__module__,
-        'Cannot test when virtualenv has monkey-patched Distribution.',
+        reason='Cannot test when virtualenv has monkey-patched Distribution',
     )
     def test_venv_install_options(self, request):
         sys.argv.append("install")

--- a/setuptools/_distutils/tests/test_install_lib.py
+++ b/setuptools/_distutils/tests/test_install_lib.py
@@ -2,7 +2,6 @@
 import sys
 import os
 import importlib.util
-import unittest
 
 import pytest
 
@@ -38,7 +37,7 @@ class TestInstallLib(
         cmd.finalize_options()
         assert cmd.optimize == 2
 
-    @unittest.skipIf(sys.dont_write_bytecode, 'byte-compile disabled')
+    @pytest.mark.skipif('sys.dont_write_bytecode')
     def test_byte_compile(self):
         project_dir, dist = self.create_dist()
         os.chdir(project_dir)

--- a/setuptools/_distutils/tests/test_log.py
+++ b/setuptools/_distutils/tests/test_log.py
@@ -2,50 +2,51 @@
 
 import io
 import sys
-import unittest
 from test.support import swap_attr
+
+import pytest
 
 from distutils import log
 
 
-class TestLog(unittest.TestCase):
-    def test_non_ascii(self):
-        # Issues #8663, #34421: test that non-encodable text is escaped with
-        # backslashreplace error handler and encodable non-ASCII text is
-        # output as is.
-        for errors in (
+class TestLog:
+    @pytest.mark.parametrize(
+        'errors',
+        (
             'strict',
             'backslashreplace',
             'surrogateescape',
             'replace',
             'ignore',
-        ):
-            with self.subTest(errors=errors):
-                stdout = io.TextIOWrapper(io.BytesIO(), encoding='cp437', errors=errors)
-                stderr = io.TextIOWrapper(io.BytesIO(), encoding='cp437', errors=errors)
-                old_threshold = log.set_threshold(log.DEBUG)
-                try:
-                    with swap_attr(sys, 'stdout', stdout), swap_attr(
-                        sys, 'stderr', stderr
-                    ):
-                        log.debug('Dεbug\tMėssãge')
-                        log.fatal('Fαtal\tÈrrōr')
-                finally:
-                    log.set_threshold(old_threshold)
+        ),
+    )
+    def test_non_ascii(self, errors):
+        # Issues #8663, #34421: test that non-encodable text is escaped with
+        # backslashreplace error handler and encodable non-ASCII text is
+        # output as is.
+        stdout = io.TextIOWrapper(io.BytesIO(), encoding='cp437', errors=errors)
+        stderr = io.TextIOWrapper(io.BytesIO(), encoding='cp437', errors=errors)
+        old_threshold = log.set_threshold(log.DEBUG)
+        try:
+            with swap_attr(sys, 'stdout', stdout), swap_attr(sys, 'stderr', stderr):
+                log.debug('Dεbug\tMėssãge')
+                log.fatal('Fαtal\tÈrrōr')
+        finally:
+            log.set_threshold(old_threshold)
 
-                stdout.seek(0)
-                assert stdout.read().rstrip() == (
-                    'Dεbug\tM?ss?ge'
-                    if errors == 'replace'
-                    else 'Dεbug\tMssge'
-                    if errors == 'ignore'
-                    else 'Dεbug\tM\\u0117ss\\xe3ge'
-                )
-                stderr.seek(0)
-                assert stderr.read().rstrip() == (
-                    'Fαtal\t?rr?r'
-                    if errors == 'replace'
-                    else 'Fαtal\trrr'
-                    if errors == 'ignore'
-                    else 'Fαtal\t\\xc8rr\\u014dr'
-                )
+        stdout.seek(0)
+        assert stdout.read().rstrip() == (
+            'Dεbug\tM?ss?ge'
+            if errors == 'replace'
+            else 'Dεbug\tMssge'
+            if errors == 'ignore'
+            else 'Dεbug\tM\\u0117ss\\xe3ge'
+        )
+        stderr.seek(0)
+        assert stderr.read().rstrip() == (
+            'Fαtal\t?rr?r'
+            if errors == 'replace'
+            else 'Fαtal\trrr'
+            if errors == 'ignore'
+            else 'Fαtal\t\\xc8rr\\u014dr'
+        )

--- a/setuptools/_distutils/tests/test_spawn.py
+++ b/setuptools/_distutils/tests/test_spawn.py
@@ -2,7 +2,8 @@
 import os
 import stat
 import sys
-import unittest.mock
+import unittest.mock as mock
+
 from test.support import unix_shell
 
 from . import py38compat as os_helper
@@ -15,7 +16,7 @@ import pytest
 
 
 class TestSpawn(support.TempdirManager, support.LoggingSilencer):
-    @unittest.skipUnless(os.name in ('nt', 'posix'), 'Runs only under posix or nt')
+    @pytest.mark.skipif("os.name not in ('nt', 'posix')")
     def test_spawn(self):
         tmpdir = self.mkdtemp()
 
@@ -78,9 +79,9 @@ class TestSpawn(support.TempdirManager, support.LoggingSilencer):
             # PATH='': no match, except in the current directory
             with os_helper.EnvironmentVarGuard() as env:
                 env['PATH'] = ''
-                with unittest.mock.patch(
+                with mock.patch(
                     'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
-                ), unittest.mock.patch('distutils.spawn.os.defpath', tmp_dir):
+                ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
                     rv = find_executable(program)
                     assert rv is None
 
@@ -92,9 +93,9 @@ class TestSpawn(support.TempdirManager, support.LoggingSilencer):
             # PATH=':': explicitly looks in the current directory
             with os_helper.EnvironmentVarGuard() as env:
                 env['PATH'] = os.pathsep
-                with unittest.mock.patch(
+                with mock.patch(
                     'distutils.spawn.os.confstr', return_value='', create=True
-                ), unittest.mock.patch('distutils.spawn.os.defpath', ''):
+                ), mock.patch('distutils.spawn.os.defpath', ''):
                     rv = find_executable(program)
                     assert rv is None
 
@@ -108,16 +109,16 @@ class TestSpawn(support.TempdirManager, support.LoggingSilencer):
                 env.pop('PATH', None)
 
                 # without confstr
-                with unittest.mock.patch(
+                with mock.patch(
                     'distutils.spawn.os.confstr', side_effect=ValueError, create=True
-                ), unittest.mock.patch('distutils.spawn.os.defpath', tmp_dir):
+                ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
                     rv = find_executable(program)
                     assert rv == filename
 
                 # with confstr
-                with unittest.mock.patch(
+                with mock.patch(
                     'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
-                ), unittest.mock.patch('distutils.spawn.os.defpath', ''):
+                ), mock.patch('distutils.spawn.os.defpath', ''):
                     rv = find_executable(program)
                     assert rv == filename
 

--- a/setuptools/_distutils/tests/test_version.py
+++ b/setuptools/_distutils/tests/test_version.py
@@ -1,18 +1,18 @@
 """Tests for distutils.version."""
-import unittest
+import pytest
+
 import distutils
 from distutils.version import LooseVersion
 from distutils.version import StrictVersion
 
 
-class VersionTestCase(unittest.TestCase):
-    def setUp(self):
-        self.ctx = distutils.version.suppress_known_deprecation()
-        self.ctx.__enter__()
+@pytest.fixture(autouse=True)
+def suppress_deprecation():
+    with distutils.version.suppress_known_deprecation():
+        yield
 
-    def tearDown(self):
-        self.ctx.__exit__(None, None, None)
 
+class TestVersion:
     def test_prerelease(self):
         version = StrictVersion('1.2.3a1')
         assert version.version == (1, 2, 3)

--- a/setuptools/_distutils/tests/unix_compat.py
+++ b/setuptools/_distutils/tests/unix_compat.py
@@ -1,5 +1,4 @@
 import sys
-import unittest
 
 try:
     import grp
@@ -7,9 +6,13 @@ try:
 except ImportError:
     grp = pwd = None
 
+import pytest
+
 
 UNIX_ID_SUPPORT = grp and pwd
 UID_0_SUPPORT = UNIX_ID_SUPPORT and sys.platform != "cygwin"
 
-require_unix_id = unittest.skipUnless(UNIX_ID_SUPPORT, "Requires grp and pwd support")
-require_uid_0 = unittest.skipUnless(UID_0_SUPPORT, "Requires UID 0 support")
+require_unix_id = pytest.mark.skipif(
+    not UNIX_ID_SUPPORT, reason="Requires grp and pwd support"
+)
+require_uid_0 = pytest.mark.skipif(not UID_0_SUPPORT, reason="Requires UID 0 support")

--- a/setuptools/_distutils/tests/xxmodule-3.8.c
+++ b/setuptools/_distutils/tests/xxmodule-3.8.c
@@ -1,0 +1,411 @@
+
+/* Use this file as a template to start implementing a module that
+   also declares object types. All occurrences of 'Xxo' should be changed
+   to something reasonable for your objects. After that, all other
+   occurrences of 'xx' should be changed to something reasonable for your
+   module. If your module is named foo your sourcefile should be named
+   foomodule.c.
+
+   You will probably want to delete all references to 'x_attr' and add
+   your own types of attributes instead.  Maybe you want to name your
+   local variables other than 'self'.  If your object type is needed in
+   other files, you'll have to create a file "foobarobject.h"; see
+   floatobject.h for an example. */
+
+/* Xxo objects */
+
+#include "Python.h"
+
+static PyObject *ErrorObject;
+
+typedef struct {
+    PyObject_HEAD
+    PyObject            *x_attr;        /* Attributes dictionary */
+} XxoObject;
+
+static PyTypeObject Xxo_Type;
+
+#define XxoObject_Check(v)      (Py_TYPE(v) == &Xxo_Type)
+
+static XxoObject *
+newXxoObject(PyObject *arg)
+{
+    XxoObject *self;
+    self = PyObject_New(XxoObject, &Xxo_Type);
+    if (self == NULL)
+        return NULL;
+    self->x_attr = NULL;
+    return self;
+}
+
+/* Xxo methods */
+
+static void
+Xxo_dealloc(XxoObject *self)
+{
+    Py_XDECREF(self->x_attr);
+    PyObject_Del(self);
+}
+
+static PyObject *
+Xxo_demo(XxoObject *self, PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, ":demo"))
+        return NULL;
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyMethodDef Xxo_methods[] = {
+    {"demo",            (PyCFunction)Xxo_demo,  METH_VARARGS,
+        PyDoc_STR("demo() -> None")},
+    {NULL,              NULL}           /* sentinel */
+};
+
+static PyObject *
+Xxo_getattro(XxoObject *self, PyObject *name)
+{
+    if (self->x_attr != NULL) {
+        PyObject *v = PyDict_GetItemWithError(self->x_attr, name);
+        if (v != NULL) {
+            Py_INCREF(v);
+            return v;
+        }
+        else if (PyErr_Occurred()) {
+            return NULL;
+        }
+    }
+    return PyObject_GenericGetAttr((PyObject *)self, name);
+}
+
+static int
+Xxo_setattr(XxoObject *self, const char *name, PyObject *v)
+{
+    if (self->x_attr == NULL) {
+        self->x_attr = PyDict_New();
+        if (self->x_attr == NULL)
+            return -1;
+    }
+    if (v == NULL) {
+        int rv = PyDict_DelItemString(self->x_attr, name);
+        if (rv < 0 && PyErr_ExceptionMatches(PyExc_KeyError))
+            PyErr_SetString(PyExc_AttributeError,
+                "delete non-existing Xxo attribute");
+        return rv;
+    }
+    else
+        return PyDict_SetItemString(self->x_attr, name, v);
+}
+
+static PyTypeObject Xxo_Type = {
+    /* The ob_type field must be initialized in the module init function
+     * to be portable to Windows without using C++. */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "xxmodule.Xxo",             /*tp_name*/
+    sizeof(XxoObject),          /*tp_basicsize*/
+    0,                          /*tp_itemsize*/
+    /* methods */
+    (destructor)Xxo_dealloc,    /*tp_dealloc*/
+    0,                          /*tp_vectorcall_offset*/
+    (getattrfunc)0,             /*tp_getattr*/
+    (setattrfunc)Xxo_setattr,   /*tp_setattr*/
+    0,                          /*tp_as_async*/
+    0,                          /*tp_repr*/
+    0,                          /*tp_as_number*/
+    0,                          /*tp_as_sequence*/
+    0,                          /*tp_as_mapping*/
+    0,                          /*tp_hash*/
+    0,                          /*tp_call*/
+    0,                          /*tp_str*/
+    (getattrofunc)Xxo_getattro, /*tp_getattro*/
+    0,                          /*tp_setattro*/
+    0,                          /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT,         /*tp_flags*/
+    0,                          /*tp_doc*/
+    0,                          /*tp_traverse*/
+    0,                          /*tp_clear*/
+    0,                          /*tp_richcompare*/
+    0,                          /*tp_weaklistoffset*/
+    0,                          /*tp_iter*/
+    0,                          /*tp_iternext*/
+    Xxo_methods,                /*tp_methods*/
+    0,                          /*tp_members*/
+    0,                          /*tp_getset*/
+    0,                          /*tp_base*/
+    0,                          /*tp_dict*/
+    0,                          /*tp_descr_get*/
+    0,                          /*tp_descr_set*/
+    0,                          /*tp_dictoffset*/
+    0,                          /*tp_init*/
+    0,                          /*tp_alloc*/
+    0,                          /*tp_new*/
+    0,                          /*tp_free*/
+    0,                          /*tp_is_gc*/
+};
+/* --------------------------------------------------------------------- */
+
+/* Function of two integers returning integer */
+
+PyDoc_STRVAR(xx_foo_doc,
+"foo(i,j)\n\
+\n\
+Return the sum of i and j.");
+
+static PyObject *
+xx_foo(PyObject *self, PyObject *args)
+{
+    long i, j;
+    long res;
+    if (!PyArg_ParseTuple(args, "ll:foo", &i, &j))
+        return NULL;
+    res = i+j; /* XXX Do something here */
+    return PyLong_FromLong(res);
+}
+
+
+/* Function of no arguments returning new Xxo object */
+
+static PyObject *
+xx_new(PyObject *self, PyObject *args)
+{
+    XxoObject *rv;
+
+    if (!PyArg_ParseTuple(args, ":new"))
+        return NULL;
+    rv = newXxoObject(args);
+    if (rv == NULL)
+        return NULL;
+    return (PyObject *)rv;
+}
+
+/* Example with subtle bug from extensions manual ("Thin Ice"). */
+
+static PyObject *
+xx_bug(PyObject *self, PyObject *args)
+{
+    PyObject *list, *item;
+
+    if (!PyArg_ParseTuple(args, "O:bug", &list))
+        return NULL;
+
+    item = PyList_GetItem(list, 0);
+    /* Py_INCREF(item); */
+    PyList_SetItem(list, 1, PyLong_FromLong(0L));
+    PyObject_Print(item, stdout, 0);
+    printf("\n");
+    /* Py_DECREF(item); */
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+/* Test bad format character */
+
+static PyObject *
+xx_roj(PyObject *self, PyObject *args)
+{
+    PyObject *a;
+    long b;
+    if (!PyArg_ParseTuple(args, "O#:roj", &a, &b))
+        return NULL;
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
+/* ---------- */
+
+static PyTypeObject Str_Type = {
+    /* The ob_type field must be initialized in the module init function
+     * to be portable to Windows without using C++. */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "xxmodule.Str",             /*tp_name*/
+    0,                          /*tp_basicsize*/
+    0,                          /*tp_itemsize*/
+    /* methods */
+    0,                          /*tp_dealloc*/
+    0,                          /*tp_vectorcall_offset*/
+    0,                          /*tp_getattr*/
+    0,                          /*tp_setattr*/
+    0,                          /*tp_as_async*/
+    0,                          /*tp_repr*/
+    0,                          /*tp_as_number*/
+    0,                          /*tp_as_sequence*/
+    0,                          /*tp_as_mapping*/
+    0,                          /*tp_hash*/
+    0,                          /*tp_call*/
+    0,                          /*tp_str*/
+    0,                          /*tp_getattro*/
+    0,                          /*tp_setattro*/
+    0,                          /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    0,                          /*tp_doc*/
+    0,                          /*tp_traverse*/
+    0,                          /*tp_clear*/
+    0,                          /*tp_richcompare*/
+    0,                          /*tp_weaklistoffset*/
+    0,                          /*tp_iter*/
+    0,                          /*tp_iternext*/
+    0,                          /*tp_methods*/
+    0,                          /*tp_members*/
+    0,                          /*tp_getset*/
+    0, /* see PyInit_xx */      /*tp_base*/
+    0,                          /*tp_dict*/
+    0,                          /*tp_descr_get*/
+    0,                          /*tp_descr_set*/
+    0,                          /*tp_dictoffset*/
+    0,                          /*tp_init*/
+    0,                          /*tp_alloc*/
+    0,                          /*tp_new*/
+    0,                          /*tp_free*/
+    0,                          /*tp_is_gc*/
+};
+
+/* ---------- */
+
+static PyObject *
+null_richcompare(PyObject *self, PyObject *other, int op)
+{
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+}
+
+static PyTypeObject Null_Type = {
+    /* The ob_type field must be initialized in the module init function
+     * to be portable to Windows without using C++. */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "xxmodule.Null",            /*tp_name*/
+    0,                          /*tp_basicsize*/
+    0,                          /*tp_itemsize*/
+    /* methods */
+    0,                          /*tp_dealloc*/
+    0,                          /*tp_vectorcall_offset*/
+    0,                          /*tp_getattr*/
+    0,                          /*tp_setattr*/
+    0,                          /*tp_as_async*/
+    0,                          /*tp_repr*/
+    0,                          /*tp_as_number*/
+    0,                          /*tp_as_sequence*/
+    0,                          /*tp_as_mapping*/
+    0,                          /*tp_hash*/
+    0,                          /*tp_call*/
+    0,                          /*tp_str*/
+    0,                          /*tp_getattro*/
+    0,                          /*tp_setattro*/
+    0,                          /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    0,                          /*tp_doc*/
+    0,                          /*tp_traverse*/
+    0,                          /*tp_clear*/
+    null_richcompare,           /*tp_richcompare*/
+    0,                          /*tp_weaklistoffset*/
+    0,                          /*tp_iter*/
+    0,                          /*tp_iternext*/
+    0,                          /*tp_methods*/
+    0,                          /*tp_members*/
+    0,                          /*tp_getset*/
+    0, /* see PyInit_xx */      /*tp_base*/
+    0,                          /*tp_dict*/
+    0,                          /*tp_descr_get*/
+    0,                          /*tp_descr_set*/
+    0,                          /*tp_dictoffset*/
+    0,                          /*tp_init*/
+    0,                          /*tp_alloc*/
+    PyType_GenericNew,          /*tp_new*/
+    0,                          /*tp_free*/
+    0,                          /*tp_is_gc*/
+};
+
+
+/* ---------- */
+
+
+/* List of functions defined in the module */
+
+static PyMethodDef xx_methods[] = {
+    {"roj",             xx_roj,         METH_VARARGS,
+        PyDoc_STR("roj(a,b) -> None")},
+    {"foo",             xx_foo,         METH_VARARGS,
+        xx_foo_doc},
+    {"new",             xx_new,         METH_VARARGS,
+        PyDoc_STR("new() -> new Xx object")},
+    {"bug",             xx_bug,         METH_VARARGS,
+        PyDoc_STR("bug(o) -> None")},
+    {NULL,              NULL}           /* sentinel */
+};
+
+PyDoc_STRVAR(module_doc,
+"This is a template module just for instruction.");
+
+
+static int
+xx_exec(PyObject *m)
+{
+    /* Slot initialization is subject to the rules of initializing globals.
+       C99 requires the initializers to be "address constants".  Function
+       designators like 'PyType_GenericNew', with implicit conversion to
+       a pointer, are valid C99 address constants.
+
+       However, the unary '&' operator applied to a non-static variable
+       like 'PyBaseObject_Type' is not required to produce an address
+       constant.  Compilers may support this (gcc does), MSVC does not.
+
+       Both compilers are strictly standard conforming in this particular
+       behavior.
+    */
+    Null_Type.tp_base = &PyBaseObject_Type;
+    Str_Type.tp_base = &PyUnicode_Type;
+
+    /* Finalize the type object including setting type of the new type
+     * object; doing it here is required for portability, too. */
+    if (PyType_Ready(&Xxo_Type) < 0)
+        goto fail;
+
+    /* Add some symbolic constants to the module */
+    if (ErrorObject == NULL) {
+        ErrorObject = PyErr_NewException("xx.error", NULL, NULL);
+        if (ErrorObject == NULL)
+            goto fail;
+    }
+    Py_INCREF(ErrorObject);
+    PyModule_AddObject(m, "error", ErrorObject);
+
+    /* Add Str */
+    if (PyType_Ready(&Str_Type) < 0)
+        goto fail;
+    PyModule_AddObject(m, "Str", (PyObject *)&Str_Type);
+
+    /* Add Null */
+    if (PyType_Ready(&Null_Type) < 0)
+        goto fail;
+    PyModule_AddObject(m, "Null", (PyObject *)&Null_Type);
+    return 0;
+ fail:
+    Py_XDECREF(m);
+    return -1;
+}
+
+static struct PyModuleDef_Slot xx_slots[] = {
+    {Py_mod_exec, xx_exec},
+    {0, NULL},
+};
+
+static struct PyModuleDef xxmodule = {
+    PyModuleDef_HEAD_INIT,
+    "xx",
+    module_doc,
+    0,
+    xx_methods,
+    xx_slots,
+    NULL,
+    NULL,
+    NULL
+};
+
+/* Export function for the module (*must* be called PyInit_xx) */
+
+PyMODINIT_FUNC
+PyInit_xx(void)
+{
+    return PyModuleDef_Init(&xxmodule);
+}

--- a/setuptools/_distutils/tests/xxmodule.c
+++ b/setuptools/_distutils/tests/xxmodule.c
@@ -1,0 +1,412 @@
+
+/* Use this file as a template to start implementing a module that
+   also declares object types. All occurrences of 'Xxo' should be changed
+   to something reasonable for your objects. After that, all other
+   occurrences of 'xx' should be changed to something reasonable for your
+   module. If your module is named foo your sourcefile should be named
+   foomodule.c.
+
+   You will probably want to delete all references to 'x_attr' and add
+   your own types of attributes instead.  Maybe you want to name your
+   local variables other than 'self'.  If your object type is needed in
+   other files, you'll have to create a file "foobarobject.h"; see
+   floatobject.h for an example. */
+
+/* Xxo objects */
+
+#include "Python.h"
+
+static PyObject *ErrorObject;
+
+typedef struct {
+    PyObject_HEAD
+    PyObject            *x_attr;        /* Attributes dictionary */
+} XxoObject;
+
+static PyTypeObject Xxo_Type;
+
+#define XxoObject_Check(v)      Py_IS_TYPE(v, &Xxo_Type)
+
+static XxoObject *
+newXxoObject(PyObject *arg)
+{
+    XxoObject *self;
+    self = PyObject_New(XxoObject, &Xxo_Type);
+    if (self == NULL)
+        return NULL;
+    self->x_attr = NULL;
+    return self;
+}
+
+/* Xxo methods */
+
+static void
+Xxo_dealloc(XxoObject *self)
+{
+    Py_XDECREF(self->x_attr);
+    PyObject_Free(self);
+}
+
+static PyObject *
+Xxo_demo(XxoObject *self, PyObject *args)
+{
+    if (!PyArg_ParseTuple(args, ":demo"))
+        return NULL;
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+static PyMethodDef Xxo_methods[] = {
+    {"demo",            (PyCFunction)Xxo_demo,  METH_VARARGS,
+        PyDoc_STR("demo() -> None")},
+    {NULL,              NULL}           /* sentinel */
+};
+
+static PyObject *
+Xxo_getattro(XxoObject *self, PyObject *name)
+{
+    if (self->x_attr != NULL) {
+        PyObject *v = PyDict_GetItemWithError(self->x_attr, name);
+        if (v != NULL) {
+            Py_INCREF(v);
+            return v;
+        }
+        else if (PyErr_Occurred()) {
+            return NULL;
+        }
+    }
+    return PyObject_GenericGetAttr((PyObject *)self, name);
+}
+
+static int
+Xxo_setattr(XxoObject *self, const char *name, PyObject *v)
+{
+    if (self->x_attr == NULL) {
+        self->x_attr = PyDict_New();
+        if (self->x_attr == NULL)
+            return -1;
+    }
+    if (v == NULL) {
+        int rv = PyDict_DelItemString(self->x_attr, name);
+        if (rv < 0 && PyErr_ExceptionMatches(PyExc_KeyError))
+            PyErr_SetString(PyExc_AttributeError,
+                "delete non-existing Xxo attribute");
+        return rv;
+    }
+    else
+        return PyDict_SetItemString(self->x_attr, name, v);
+}
+
+static PyTypeObject Xxo_Type = {
+    /* The ob_type field must be initialized in the module init function
+     * to be portable to Windows without using C++. */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "xxmodule.Xxo",             /*tp_name*/
+    sizeof(XxoObject),          /*tp_basicsize*/
+    0,                          /*tp_itemsize*/
+    /* methods */
+    (destructor)Xxo_dealloc,    /*tp_dealloc*/
+    0,                          /*tp_vectorcall_offset*/
+    (getattrfunc)0,             /*tp_getattr*/
+    (setattrfunc)Xxo_setattr,   /*tp_setattr*/
+    0,                          /*tp_as_async*/
+    0,                          /*tp_repr*/
+    0,                          /*tp_as_number*/
+    0,                          /*tp_as_sequence*/
+    0,                          /*tp_as_mapping*/
+    0,                          /*tp_hash*/
+    0,                          /*tp_call*/
+    0,                          /*tp_str*/
+    (getattrofunc)Xxo_getattro, /*tp_getattro*/
+    0,                          /*tp_setattro*/
+    0,                          /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT,         /*tp_flags*/
+    0,                          /*tp_doc*/
+    0,                          /*tp_traverse*/
+    0,                          /*tp_clear*/
+    0,                          /*tp_richcompare*/
+    0,                          /*tp_weaklistoffset*/
+    0,                          /*tp_iter*/
+    0,                          /*tp_iternext*/
+    Xxo_methods,                /*tp_methods*/
+    0,                          /*tp_members*/
+    0,                          /*tp_getset*/
+    0,                          /*tp_base*/
+    0,                          /*tp_dict*/
+    0,                          /*tp_descr_get*/
+    0,                          /*tp_descr_set*/
+    0,                          /*tp_dictoffset*/
+    0,                          /*tp_init*/
+    0,                          /*tp_alloc*/
+    0,                          /*tp_new*/
+    0,                          /*tp_free*/
+    0,                          /*tp_is_gc*/
+};
+/* --------------------------------------------------------------------- */
+
+/* Function of two integers returning integer */
+
+PyDoc_STRVAR(xx_foo_doc,
+"foo(i,j)\n\
+\n\
+Return the sum of i and j.");
+
+static PyObject *
+xx_foo(PyObject *self, PyObject *args)
+{
+    long i, j;
+    long res;
+    if (!PyArg_ParseTuple(args, "ll:foo", &i, &j))
+        return NULL;
+    res = i+j; /* XXX Do something here */
+    return PyLong_FromLong(res);
+}
+
+
+/* Function of no arguments returning new Xxo object */
+
+static PyObject *
+xx_new(PyObject *self, PyObject *args)
+{
+    XxoObject *rv;
+
+    if (!PyArg_ParseTuple(args, ":new"))
+        return NULL;
+    rv = newXxoObject(args);
+    if (rv == NULL)
+        return NULL;
+    return (PyObject *)rv;
+}
+
+/* Example with subtle bug from extensions manual ("Thin Ice"). */
+
+static PyObject *
+xx_bug(PyObject *self, PyObject *args)
+{
+    PyObject *list, *item;
+
+    if (!PyArg_ParseTuple(args, "O:bug", &list))
+        return NULL;
+
+    item = PyList_GetItem(list, 0);
+    /* Py_INCREF(item); */
+    PyList_SetItem(list, 1, PyLong_FromLong(0L));
+    PyObject_Print(item, stdout, 0);
+    printf("\n");
+    /* Py_DECREF(item); */
+
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+/* Test bad format character */
+
+static PyObject *
+xx_roj(PyObject *self, PyObject *args)
+{
+    PyObject *a;
+    long b;
+    if (!PyArg_ParseTuple(args, "O#:roj", &a, &b))
+        return NULL;
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+
+/* ---------- */
+
+static PyTypeObject Str_Type = {
+    /* The ob_type field must be initialized in the module init function
+     * to be portable to Windows without using C++. */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "xxmodule.Str",             /*tp_name*/
+    0,                          /*tp_basicsize*/
+    0,                          /*tp_itemsize*/
+    /* methods */
+    0,                          /*tp_dealloc*/
+    0,                          /*tp_vectorcall_offset*/
+    0,                          /*tp_getattr*/
+    0,                          /*tp_setattr*/
+    0,                          /*tp_as_async*/
+    0,                          /*tp_repr*/
+    0,                          /*tp_as_number*/
+    0,                          /*tp_as_sequence*/
+    0,                          /*tp_as_mapping*/
+    0,                          /*tp_hash*/
+    0,                          /*tp_call*/
+    0,                          /*tp_str*/
+    0,                          /*tp_getattro*/
+    0,                          /*tp_setattro*/
+    0,                          /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    0,                          /*tp_doc*/
+    0,                          /*tp_traverse*/
+    0,                          /*tp_clear*/
+    0,                          /*tp_richcompare*/
+    0,                          /*tp_weaklistoffset*/
+    0,                          /*tp_iter*/
+    0,                          /*tp_iternext*/
+    0,                          /*tp_methods*/
+    0,                          /*tp_members*/
+    0,                          /*tp_getset*/
+    0, /* see PyInit_xx */      /*tp_base*/
+    0,                          /*tp_dict*/
+    0,                          /*tp_descr_get*/
+    0,                          /*tp_descr_set*/
+    0,                          /*tp_dictoffset*/
+    0,                          /*tp_init*/
+    0,                          /*tp_alloc*/
+    0,                          /*tp_new*/
+    0,                          /*tp_free*/
+    0,                          /*tp_is_gc*/
+};
+
+/* ---------- */
+
+static PyObject *
+null_richcompare(PyObject *self, PyObject *other, int op)
+{
+    Py_INCREF(Py_NotImplemented);
+    return Py_NotImplemented;
+}
+
+static PyTypeObject Null_Type = {
+    /* The ob_type field must be initialized in the module init function
+     * to be portable to Windows without using C++. */
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "xxmodule.Null",            /*tp_name*/
+    0,                          /*tp_basicsize*/
+    0,                          /*tp_itemsize*/
+    /* methods */
+    0,                          /*tp_dealloc*/
+    0,                          /*tp_vectorcall_offset*/
+    0,                          /*tp_getattr*/
+    0,                          /*tp_setattr*/
+    0,                          /*tp_as_async*/
+    0,                          /*tp_repr*/
+    0,                          /*tp_as_number*/
+    0,                          /*tp_as_sequence*/
+    0,                          /*tp_as_mapping*/
+    0,                          /*tp_hash*/
+    0,                          /*tp_call*/
+    0,                          /*tp_str*/
+    0,                          /*tp_getattro*/
+    0,                          /*tp_setattro*/
+    0,                          /*tp_as_buffer*/
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /*tp_flags*/
+    0,                          /*tp_doc*/
+    0,                          /*tp_traverse*/
+    0,                          /*tp_clear*/
+    null_richcompare,           /*tp_richcompare*/
+    0,                          /*tp_weaklistoffset*/
+    0,                          /*tp_iter*/
+    0,                          /*tp_iternext*/
+    0,                          /*tp_methods*/
+    0,                          /*tp_members*/
+    0,                          /*tp_getset*/
+    0, /* see PyInit_xx */      /*tp_base*/
+    0,                          /*tp_dict*/
+    0,                          /*tp_descr_get*/
+    0,                          /*tp_descr_set*/
+    0,                          /*tp_dictoffset*/
+    0,                          /*tp_init*/
+    0,                          /*tp_alloc*/
+    PyType_GenericNew,          /*tp_new*/
+    0,                          /*tp_free*/
+    0,                          /*tp_is_gc*/
+};
+
+
+/* ---------- */
+
+
+/* List of functions defined in the module */
+
+static PyMethodDef xx_methods[] = {
+    {"roj",             xx_roj,         METH_VARARGS,
+        PyDoc_STR("roj(a,b) -> None")},
+    {"foo",             xx_foo,         METH_VARARGS,
+        xx_foo_doc},
+    {"new",             xx_new,         METH_VARARGS,
+        PyDoc_STR("new() -> new Xx object")},
+    {"bug",             xx_bug,         METH_VARARGS,
+        PyDoc_STR("bug(o) -> None")},
+    {NULL,              NULL}           /* sentinel */
+};
+
+PyDoc_STRVAR(module_doc,
+"This is a template module just for instruction.");
+
+
+static int
+xx_exec(PyObject *m)
+{
+    /* Slot initialization is subject to the rules of initializing globals.
+       C99 requires the initializers to be "address constants".  Function
+       designators like 'PyType_GenericNew', with implicit conversion to
+       a pointer, are valid C99 address constants.
+
+       However, the unary '&' operator applied to a non-static variable
+       like 'PyBaseObject_Type' is not required to produce an address
+       constant.  Compilers may support this (gcc does), MSVC does not.
+
+       Both compilers are strictly standard conforming in this particular
+       behavior.
+    */
+    Null_Type.tp_base = &PyBaseObject_Type;
+    Str_Type.tp_base = &PyUnicode_Type;
+
+    /* Finalize the type object including setting type of the new type
+     * object; doing it here is required for portability, too. */
+    if (PyType_Ready(&Xxo_Type) < 0) {
+        return -1;
+    }
+
+    /* Add some symbolic constants to the module */
+    if (ErrorObject == NULL) {
+        ErrorObject = PyErr_NewException("xx.error", NULL, NULL);
+        if (ErrorObject == NULL) {
+            return -1;
+        }
+    }
+    int rc = PyModule_AddType(m, (PyTypeObject *)ErrorObject);
+    Py_DECREF(ErrorObject);
+    if (rc < 0) {
+        return -1;
+    }
+
+    /* Add Str and Null types */
+    if (PyModule_AddType(m, &Str_Type) < 0) {
+        return -1;
+    }
+    if (PyModule_AddType(m, &Null_Type) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static struct PyModuleDef_Slot xx_slots[] = {
+    {Py_mod_exec, xx_exec},
+    {0, NULL},
+};
+
+static struct PyModuleDef xxmodule = {
+    PyModuleDef_HEAD_INIT,
+    "xx",
+    module_doc,
+    0,
+    xx_methods,
+    xx_slots,
+    NULL,
+    NULL,
+    NULL
+};
+
+/* Export function for the module (*must* be called PyInit_xx) */
+
+PyMODINIT_FUNC
+PyInit_xx(void)
+{
+    return PyModuleDef_Init(&xxmodule);
+}


### PR DESCRIPTION
- Convert test_cmd to pytest
- Convert BasePyPIRCCommandTestCase to pytest
- Convert RegisterTestCase to pytest
- ⚫ Fade to black.
- Use jaraco.path to generate a tree.
- Port sdist tests to pytest
- Convert TestUpload to pytest
- Convert TestUpload to parametrized test. Remove dependence on unittest for PyPIRC tests.
- Implement HTTP 400 error as a pytest.param to avoid collection error. Ref pytest-dev/pytest#10184.
- Convert core tests to pytest
- ⚫ Fade to black.
- Convert TestVersion to pytest.
- Convert TestConfig to pytest
- Convert TestCygwinCCompiler to pytest
- Convert TestDirUtil to pytest
- Convert TestFileUtil to pytest
- Convert TestSysconfig to pytest
- ⚫ Fade to black.
- 👹 Feed the hobgoblins (delint).
- Remove patching of uname.
- Convert TestUtil to pytest
- Convert TestUnixCCompiler to pytest
- Prefer pytest for skip
- Convert more tests to pytest
- Prefer pytest for skip
- Prefer pytest for skip
- Convert TestBuild to pytest
- Prefer pytest for skip
- Prefer pytest for skip
- Remove unreachable code
- Copy xxmodule.c from Python 3.11 and 3.8, restoring tests for build_ext.
- Exclude Python 3.11 on macOS due to lack of wheels. Ref pypa/distutils#165.
- Mark test as xfail for now. Ref pypa/distutils#166.
- Use pathlib to read the text
- ⚫ Fade to black.
- Convert TestInstall to pytest
- Only xfail on Windows
- Allow overriding toxworkdir with an env var.
- Ensure sys.version is restored in test_cygwinccompiler. Fixes #166.
- Run test_xx in process, utilizing import_helper On Windows, move the extension module to another temporary directory.
- Redirect extension module to a directory that's not deleted on Windows.
- Include cygwin
- Prefer pytest in test_build_py
- Prefer pytest in test_check
- Refactor imports around docutils.
- Replace addCleanup with monkeypatch.
- Enable tests requiring docutils.
- Fix broken tests around docutils.
- Convert PendingDeprecationWarnings to DeprecationWarnings.
- Ignore unactionable warnings in docutils.
- Prefer pytest for skip
- Prefer pytest for skip
- Prefer pytest for skip
- Prefer pytest for skip
- Prefer pytest for skip
- Convert TestLog to pytest.
- Prefer pytest for skip
- Consolidate tests
- Prefer pytest for skip
- Prefer pytest for skip
- Convert unconditional skip to conditional skip. Mark test as xfail because it's failing.
- Prefer pytest for skip
- ⚫ Fade to black.
- Convert unix_compat to pytest skips
- Consistently import unittest.mock.
- Prefer pytest for skip
- Remove unnecessary comment.
- ⚫ Fade to black.
- 👹 Feed the hobgoblins (delint).
- Prefer tabs
- Add pytest-flake8 and pytest-black and pytest-cov to test lint and style and coverage
- 👹 Feed the hobgoblins (delint).
- Add test capturing failed expectation.
- Add compatibility for Python 3.7
- Windows is sensitive even on Python 3.10
- Also test library dirs
- Extract fixture for c_file
- Generate a C file that imports Python.h and something platform specific.
- Ensure Python include directory is configured.
- Extend the test to compile a second time after setting include dirs again.
- Ensure Windows SDK directories are not cleared when caller specifies include/library dirs
- Remove stray colon
- Fixup bad super() call
- Use CCompiler._fix_compile_args to fix args to compile()
- ⚫ Fade to black.
- Allow compiler classes to supply include and library dirs at the class level.
- Disallow repeat calls to .initialize in one place.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
