### PR TITLE
Prevent errors in editable install when plugins include `.egg_info/SOURCES.txt`

### DIFF
--- a/changelog.d/3503.misc.rst
+++ b/changelog.d/3503.misc.rst
@@ -1,0 +1,6 @@
+Added filter to ignore external ``.egg-info`` files in manifest.
+
+Some plugins (e.g. ``pbr``) might rely on the fact that the ``.egg-info``
+directory is produced inside the project dir, which may not be the case
+in editable installs (the ``.egg-info`` directory is produced inside the
+metadata directory given by the build frontend via PEP 660 hooks).

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -11,7 +11,7 @@ import itertools
 import stat
 import warnings
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Tuple
+from typing import Dict, Iterable, Iterator, List, Optional, Tuple
 
 from setuptools._deprecation_warning import SetuptoolsDeprecationWarning
 from setuptools.extern.more_itertools import unique_everseen
@@ -175,15 +175,17 @@ class build_py(orig.build_py):
             getattr(self, 'existing_egg_info_dir', None)
             and Path(self.existing_egg_info_dir, "SOURCES.txt").exists()
         ):
-            manifest = Path(self.existing_egg_info_dir, "SOURCES.txt")
+            egg_info_dir = self.existing_egg_info_dir
+            manifest = Path(egg_info_dir, "SOURCES.txt")
             files = manifest.read_text(encoding="utf-8").splitlines()
         else:
             self.run_command('egg_info')
             ei_cmd = self.get_finalized_command('egg_info')
+            egg_info_dir = ei_cmd.egg_info
             files = ei_cmd.filelist.files
 
         check = _IncludePackageDataAbuse()
-        for path in files:
+        for path in _filter_absolute_egg_info(files, egg_info_dir):
             d, f = os.path.split(assert_relative(path))
             prev = None
             oldf = f
@@ -346,3 +348,15 @@ class _IncludePackageDataAbuse:
             msg = textwrap.dedent(self.MESSAGE).format(importable=importable)
             warnings.warn(msg, SetuptoolsDeprecationWarning, stacklevel=2)
             self._already_warned.add(importable)
+
+
+def _filter_absolute_egg_info(files: Iterable[str], egg_info: str) -> Iterator[str]:
+    """
+    ``build_meta`` may try to create egg_info outside of the project directory,
+    and this can be problematic for certain plugins (reported in issue #3500).
+    This function should filter this case of invalid files out.
+    """
+    egg_info_name = Path(egg_info).name
+    for file in files:
+        if not (egg_info_name in file and os.path.isabs(file)):
+            yield file


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

In #3500, it seems that `pbr` is automatically trying to add `.egg_info/SOURCES.txt` into the default list of data files.
However `editable_wheel` uses a `.egg_info` directory that is external to the project root, which may cause errors with the `pbr` approach.

## Summary of changes

- Filter external `.egg-info` files when analysing manifest in `build_py`.

Closes #3500

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
