### PR TITLE
Avoid crashing on `build_py` errors during editable installs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,10 @@ Breaking Changes
   end users. The *strict* editable installation is not able to detect if files
   are added or removed from the project (a new installation is required).
 
+  This implementation might also affect plugins and customizations that assume
+  certain ``build`` subcommands don't run during editable installs or that they
+  always copy files to the temporary build directory.
+
   .. important::
      The *editable* aspect of the *editable install* supported this implementation
      is restricted to the Python modules contained in the distributed package.

--- a/changelog.d/3506.misc.rst
+++ b/changelog.d/3506.misc.rst
@@ -1,0 +1,5 @@
+Suppress errors in custom ``build_py`` implementations when running editable
+installs in favor of a warning indicating what is the most appropriate
+migration path.
+This is a *transitional* measure. Errors might be raised in future versions of
+``setuptools``.

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -20,7 +20,7 @@ class build(_build):
     # copy to avoid sharing the object with parent class
     sub_commands = _build.sub_commands[:]
 
-    def run(self):
+    def get_sub_commands(self):
         subcommands = {cmd[0] for cmd in _build.sub_commands}
         if subcommands - _ORIGINAL_SUBCOMMANDS:
             msg = """
@@ -30,7 +30,7 @@ class build(_build):
             """
             warnings.warn(msg, SetuptoolsDeprecationWarning)
             self.sub_commands = _build.sub_commands
-        super().run()
+        return super().get_sub_commands()
 
 
 class SubCommand(Protocol):

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -37,6 +37,7 @@ from typing import (
 )
 
 from setuptools import Command, SetuptoolsDeprecationWarning, errors, namespaces
+from setuptools.command.build_py import build_py as build_py_cls
 from setuptools.discovery import find_package_path
 from setuptools.dist import Distribution
 
@@ -254,12 +255,54 @@ class editable_wheel(Command):
         self, dist_name: str, unpacked_wheel: _Path, build_lib: _Path, tmp_dir: _Path
     ) -> Tuple[List[str], Dict[str, str]]:
         self._configure_build(dist_name, unpacked_wheel, build_lib, tmp_dir)
-        self.run_command("build")
+        self._run_build_subcommands()
         files, mapping = self._collect_build_outputs()
         self._run_install("headers")
         self._run_install("scripts")
         self._run_install("data")
         return files, mapping
+
+    def _run_build_subcommands(self):
+        """
+        Issue #3501 indicates that some plugins/customizations might rely on:
+
+        1. ``build_py`` not running
+        2. ``build_py`` always copying files to ``build_lib``
+
+        However both these assumptions may be false in editable_wheel.
+        This method implements a temporary workaround to support the ecosystem
+        while the implementations catch up.
+        """
+        # TODO: Once plugins/customisations had the chance to catch up, replace
+        #       `self._run_build_subcommands()` with `self.run_command("build")`.
+        #       Also remove _safely_run, TestCustomBuildPy. Suggested date: Aug/2023.
+        build: Command = self.get_finalized_command("build")
+        for name in build.get_sub_commands():
+            cmd = self.distribution.get_command_obj(name)
+            if name == "build_py" and type(cmd) != build_py_cls:
+                self._safely_run(name)
+            else:
+                self.run_command(name)
+
+    def _safely_run(self, cmd_name: str):
+        try:
+            return self.run_command(cmd_name)
+        except Exception:
+            msg = f"""{traceback.format_exc()}\n
+            If you are seeing this warning it is very likely that a setuptools
+            plugin or customization overrides the `build_py` command, without
+            tacking into consideration how editable installs run build steps
+            starting from v64.0.0.
+
+            Plugin authors and developers relying on custom build steps are encouraged
+            to update their `build_py` implementation considering the information in
+            https://setuptools.pypa.io/en/latest/userguide/extension.html
+            about editable installs.
+
+            For the time being `setuptools` will silence this error and ignore
+            the faulty command, but this behaviour will change in future versions.\n
+            """
+            warnings.warn(msg, SetuptoolsDeprecationWarning, stacklevel=2)
 
     def _create_wheel_file(self, bdist_wheel):
         from wheel.wheelfile import WheelFile

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -290,12 +290,12 @@ class editable_wheel(Command):
         except Exception:
             msg = f"""{traceback.format_exc()}\n
             If you are seeing this warning it is very likely that a setuptools
-            plugin or customization overrides the `build_py` command, without
+            plugin or customization overrides the `{cmd_name}` command, without
             tacking into consideration how editable installs run build steps
             starting from v64.0.0.
 
             Plugin authors and developers relying on custom build steps are encouraged
-            to update their `build_py` implementation considering the information in
+            to update their `{cmd_name}` implementation considering the information in
             https://setuptools.pypa.io/en/latest/userguide/extension.html
             about editable installs.
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

The #3501 issue seems to represent a class of problems with plugins assuming that `build_py` don't run during editable installs (as it was the case with the `develop` command), or that `build_py` will always copy the files for the temporary build folder.

The idea of this PR is to prevent this class of problems from causing disruption in the environment.

## Summary of changes

- When running `build_py` during editable installs, capture errors and use a warning to indicate what is the most appropriate migration path.

Closes #3501

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
