### PR TITLE
Typo in user guide: development mode

### DIFF
--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -5,7 +5,7 @@ When creating a Python project, developers usually want to implement and test
 changes iteratively, before cutting a release and preparing a distribution archive.
 
 In normal circumstances this can be quite cumbersome and require the developers
-to manipulate the ``PATHONPATH`` environment variable or to continuous re-build
+to manipulate the ``PYTHONPATH`` environment variable or to continuous re-build
 and re-install the project.
 
 To facilitate iterative exploration and experimentation, setuptools allows


### PR DESCRIPTION
`PATHONPATH` --> `PYTHONPATH`

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->

## Summary of changes

Fixed a typo

Closes #3507

### Pull Request Checklist
- [x] Changes have tests 
  - N/A ?
- [x] News fragment added in [`changelog.d/`].
  - Seems unnecessary ?



[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
