### PR TITLE
Prevent optional extensions from crashing editable builds

### DIFF
--- a/changelog.d/3515.misc.rst
+++ b/changelog.d/3515.misc.rst
@@ -1,0 +1,2 @@
+Fixed "inline" file copying for editable installations and
+optional extensions.

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -104,7 +104,8 @@ class build_ext(_build_ext):
             # Always copy, even if source is older than destination, to ensure
             # that the right extensions for the current Python/platform are
             # used.
-            self.copy_file(regular_file, inplace_file, level=self.verbose)
+            if os.path.exists(regular_file) or not ext.optional:
+                self.copy_file(regular_file, inplace_file, level=self.verbose)
 
             if ext._needs_stub:
                 inplace_stub = self._get_equivalent_stub(ext, inplace_file)

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -9,9 +9,12 @@ from jaraco import path
 from setuptools.command.build_ext import build_ext, get_abi3_suffix
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
+from setuptools.errors import CompileError
 
 from . import environment
 from .textwrap import DALS
+
+import pytest
 
 
 IS_PYPY = '__pypy__' in sys.builtin_module_names
@@ -30,26 +33,6 @@ class TestBuildExt:
         res = cmd.get_ext_filename('foo')
         wanted = orig.build_ext.get_ext_filename(cmd, 'foo')
         assert res == wanted
-
-    def test_optional_inplace(self, tmpdir_cwd, capsys):
-        # If optional extensions fail to build, setuptools should show the error
-        # in the logs but not fail to build
-        files = {
-            "eggs.c": "#include missingheader.h\n",
-            ".build": {"lib": {}, "tmp": {}},
-        }
-        path.build(files)
-        extension = Extension('spam.eggs', ['eggs.c'], optional=True)
-        dist = Distribution(dict(ext_modules=[extension]))
-        dist.script_name = 'setup.py'
-        cmd = build_ext(dist)
-        vars(cmd).update(build_lib=".build/lib", build_temp=".build/tmp", inplace=True)
-        cmd.ensure_finalized()
-        cmd.run()
-        logs = capsys.readouterr()
-        messages = (logs.out + logs.err)
-        assert 'build_ext: building extension "spam.eggs" failed' in messages
-        # No exception should be raised
 
     def test_abi3_filename(self):
         """
@@ -195,6 +178,39 @@ class TestBuildExt:
         assert example_stub.startswith(f"{build_lib}/mypkg/__pycache__/ext1")
         assert example_stub.endswith(".pyc")
 
+
+class TestBuildExtInplace:
+    def get_build_ext_cmd(self, optional: bool, **opts):
+        files = {
+            "eggs.c": "#include missingheader.h\n",
+            ".build": {"lib": {}, "tmp": {}},
+        }
+        path.build(files)
+        extension = Extension('spam.eggs', ['eggs.c'], optional=optional)
+        dist = Distribution(dict(ext_modules=[extension]))
+        dist.script_name = 'setup.py'
+        cmd = build_ext(dist)
+        vars(cmd).update(build_lib=".build/lib", build_temp=".build/tmp", **opts)
+        cmd.ensure_finalized()
+        return cmd
+
+    def test_optional(self, tmpdir_cwd, capsys):
+        """
+        If optional extensions fail to build, setuptools should show the error
+        in the logs but not fail to build
+        """
+        cmd = self.get_build_ext_cmd(optional=True, inplace=True)
+        cmd.run()
+        logs = capsys.readouterr()
+        messages = (logs.out + logs.err)
+        assert 'build_ext: building extension "spam.eggs" failed' in messages
+        # No compile error exception should be raised
+
+    def test_non_optional(self, tmpdir_cwd):
+        # Non-optional extensions should raise an exception
+        cmd = self.get_build_ext_cmd(optional=False, inplace=True)
+        with pytest.raises(CompileError):
+            cmd.run()
 
 def test_build_ext_config_handling(tmpdir_cwd):
     files = {

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -212,6 +212,7 @@ class TestBuildExtInplace:
         with pytest.raises(CompileError):
             cmd.run()
 
+
 def test_build_ext_config_handling(tmpdir_cwd):
     files = {
         'setup.py': DALS(


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Don't try to copy the files of an optional extension if its build has failed.

Closes #3510

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
