### PR TITLE
Remove extraneous question mark in section heading

### DIFF
--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -200,8 +200,8 @@ This *may* cause the installer (e.g. ``pip``) to effectively run the "legacy"
 installation command: ``python setup.py develop`` [#installer]_.
 
 
-How editable installations work?
---------------------------------
+How editable installations work
+-------------------------------
 
 *Advanced topic*
 


### PR DESCRIPTION
The heading "How editable installations work?" either contains a typo (the question mark should be omitted), or else the heading as written is ungrammatical because it is missing a word ("How **do** editable installations work?").

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Other headings in this section are not written as questions, so this commit removes the question mark, based on the assumption that the question mark is extraneous.

### Pull Request Checklist
- <s>[ ] Changes have tests.</s> Not relevant.
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_

This is such a small typo that it does not seem to warrant a changelog.d file.