### PR TITLE
Fix other problems with editable installs

### DIFF
--- a/changelog.d/3517.misc.1.rst
+++ b/changelog.d/3517.misc.1.rst
@@ -1,0 +1,3 @@
+Fixed ``editable_wheel`` to ensure other commands are finalized before using
+them. This should prevent errors with plugins trying to use different commands
+or reinitializing them.

--- a/changelog.d/3517.misc.2.rst
+++ b/changelog.d/3517.misc.2.rst
@@ -1,0 +1,2 @@
+Augmented filter to prevent transient/temporary source files from being
+considered ``package_data`` or ``data_files``.

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -133,7 +133,8 @@ class editable_wheel(Command):
             self._ensure_dist_info()
 
             # Add missing dist_info files
-            bdist_wheel = self.reinitialize_command("bdist_wheel")
+            self.reinitialize_command("bdist_wheel")
+            bdist_wheel = self.get_finalized_command("bdist_wheel")
             bdist_wheel.write_wheelfile(self.dist_info_dir)
 
             self._create_wheel_file(bdist_wheel)
@@ -156,7 +157,7 @@ class editable_wheel(Command):
         if self.dist_info_dir is None:
             dist_info = self.reinitialize_command("dist_info")
             dist_info.output_dir = self.dist_dir
-            dist_info.finalize_options()
+            dist_info.ensure_finalized()
             dist_info.run()
             self.dist_info_dir = dist_info.dist_info_dir
         else:
@@ -278,7 +279,7 @@ class editable_wheel(Command):
         #       Also remove _safely_run, TestCustomBuildPy. Suggested date: Aug/2023.
         build: Command = self.get_finalized_command("build")
         for name in build.get_sub_commands():
-            cmd = self.distribution.get_command_obj(name)
+            cmd = self.get_finalized_command(name)
             if name == "build_py" and type(cmd) != build_py_cls:
                 self._safely_run(name)
             else:

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -25,6 +25,7 @@ from setuptools.command.editable_wheel import (
     _find_namespaces,
     _find_package_roots,
     _finder_template,
+    editable_wheel,
 )
 from setuptools.dist import Distribution
 
@@ -844,6 +845,36 @@ class TestCustomBuildPy:
         # but installation should be successful
         out = venv.run(["python", "-c", "import mypkg.mod1; print(mypkg.mod1.var)"])
         assert b"42" in out
+
+
+class TestCustomBuildWheel:
+    def install_custom_build_wheel(self, dist):
+        bdist_wheel_cls = dist.get_command_class("bdist_wheel")
+
+        class MyBdistWheel(bdist_wheel_cls):
+            def get_tag(self):
+                # In issue #3513, we can see that some extensions may try to access
+                # the `plat_name` property in bdist_wheel
+                if self.plat_name.startswith("macosx-"):
+                    _ = "macOS platform"
+                return super().get_tag()
+
+        dist.cmdclass["bdist_wheel"] = MyBdistWheel
+
+    def test_access_plat_name(self, tmpdir_cwd):
+        # Even when a custom build step tries to access plat_name the build should
+        # be successful
+        jaraco.path.build({"module.py": "x = 42"})
+        dist = Distribution()
+        dist.script_name = "setup.py"
+        dist.set_defaults()
+        self.install_custom_build_wheel(dist)
+        cmd = editable_wheel(dist)
+        cmd.ensure_finalized()
+        cmd.run()
+        wheel_file = next(Path().glob('dist/*'))
+        assert "editable" in wheel_file
+        assert wheel_file.endswith(".whl")
 
 
 def install_project(name, venv, tmp_path, files, *opts):

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -862,7 +862,7 @@ class TestCustomBuildWheel:
         dist.cmdclass["bdist_wheel"] = MyBdistWheel
 
     def test_access_plat_name(self, tmpdir_cwd):
-        # Even when a custom build step tries to access plat_name the build should
+        # Even when a custom bdist_wheel tries to access plat_name the build should
         # be successful
         jaraco.path.build({"module.py": "x = 42"})
         dist = Distribution()
@@ -872,7 +872,7 @@ class TestCustomBuildWheel:
         cmd = editable_wheel(dist)
         cmd.ensure_finalized()
         cmd.run()
-        wheel_file = next(Path().glob('dist/*'))
+        wheel_file = str(next(Path().glob('dist/*')))
         assert "editable" in wheel_file
         assert wheel_file.endswith(".whl")
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

Motivated by `pyca/cryptography` use case.

## Summary of changes

1. Ensure commands are finalized, to ensure `plat_name` is set.
2. Filter out temporary source files and prevent `setuptools` for attempting to consider them as part of the data_files/package_data list

Closes #3513

### Pull Request Checklist
- [ ] Changes have tests -- partially. I did not manage to find a small reproducer for change 2.
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
