### PR TITLE
Update keywords note on editable installs

### DIFF
--- a/changelog.d/3519.doc.rst
+++ b/changelog.d/3519.doc.rst
@@ -1,0 +1,2 @@
+Changed the note in ``keywords`` documentation regarding editable installations
+to specify which ``setuptools`` version require a minimal ``setup.py`` file or not.

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -20,17 +20,16 @@ tap into special behaviour that requires scripting (such as building C
 extensions).
 
 .. note::
-   When using declarative configs via ``pyproject.toml`` users can still keep a
-   very simple ``setup.py`` just to ensure editable installs are supported, for
-   example::
+   When using declarative configs via ``pyproject.toml``
+   with ``setuptools<64.0.0``, users can still keep a very simple ``setup.py``
+   just to ensure editable installs are supported, for example::
 
        from setuptools import setup
 
        setup()
 
-   Future versions of ``setuptools`` may support editable installs even
-   without ``setup.py``.
-
+   Versions of ``setuptools`` ``>=64.0.0`` do not require this extra minimal
+   ``setup.py`` file.
 
 .. _keyword/name:
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Updates the keywords note about editable installations requiring a minimal `setup.py` file after the release of `64.0.0`

[Link to Keywords docs section with PR docs](https://setuptools--3519.org.readthedocs.build/en/3519/references/keywords.html)

### Pull Request Checklist
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
