### PR TITLE
Ensure `build_ext` inheriting directly from `distutils` run an in-place build during editable install

### DIFF
--- a/changelog.d/3526.misc.rst
+++ b/changelog.d/3526.misc.rst
@@ -1,0 +1,2 @@
+Fix backward compatibility of editable installs and custom ``build_ext``
+commands inheriting directly from ``distutils``.

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -237,6 +237,8 @@ class editable_wheel(Command):
             cmd = dist.get_command_obj(cmd_name)
             if hasattr(cmd, "editable_mode"):
                 cmd.editable_mode = True
+            elif hasattr(cmd, "inplace"):
+                cmd.inplace = True  # backward compatibility with distutils
 
     def _collect_build_outputs(self) -> Tuple[List[str], Dict[str, str]]:
         files: List[str] = []

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -874,9 +874,8 @@ class TestCustomBuildWheel:
         cmd = editable_wheel(dist)
         cmd.ensure_finalized()
         cmd.run()
-        wheel_file = str(next(Path().glob('dist/*')))
+        wheel_file = str(next(Path().glob('dist/*.whl')))
         assert "editable" in wheel_file
-        assert wheel_file.endswith(".whl")
 
 
 class TestCustomBuildExt:
@@ -900,7 +899,7 @@ class TestCustomBuildExt:
         cmd = editable_wheel(dist)
         cmd.ensure_finalized()
         cmd.run()
-        wheel_file = str(next(Path().glob('dist/*')))
+        wheel_file = str(next(Path().glob('dist/*.whl')))
         assert "editable" in wheel_file
         files = [p for p in Path().glob("module.*") if p.suffix != ".c"]
         assert len(files) == 1

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -887,6 +887,9 @@ class TestCustomBuildExt:
 
         dist.cmdclass["build_ext"] = MyBuildExt
 
+    @pytest.mark.skipif(
+        sys.platform != "linux", reason="compilers may fail without correct setup",
+    )
     def test_distutils_leave_inplace_files(self, tmpdir_cwd):
         jaraco.path.build({"module.c": ""})
         attrs = {


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Set the `inplace` flag during editable installs if the build subcommand has this attribute.

Closes #3522

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
