### PR TITLE
Make `pkg_resources` warning more visible

### DIFF
--- a/docs/pkg_resources.rst
+++ b/docs/pkg_resources.rst
@@ -10,12 +10,13 @@ eggs, support for merging packages that have separately-distributed modules or
 subpackages, and APIs for managing Python's current "working set" of active
 packages.
 
-Use of ``pkg_resources`` is discouraged in favor of
-`importlib.resources <https://docs.python.org/3/library/importlib.html#module-importlib.resources>`_,
-`importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_,
-and their backports (:pypi:`importlib_resources`,
-:pypi:`importlib_metadata`).
-Please consider using those libraries instead of pkg_resources.
+.. attention::
+   Use of ``pkg_resources`` is discouraged in favor of
+   `importlib.resources <https://docs.python.org/3/library/importlib.html#module-importlib.resources>`_,
+   `importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_,
+   and their backports (:pypi:`importlib_resources`,
+   :pypi:`importlib_metadata`).
+   Please consider using those libraries instead of pkg_resources.
 
 
 --------


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Change paragraph about `pkg_resources` replacement to admonition, to make it more visible.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
