### PR TITLE
Correct docs on how to use the `legacy-editable` mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,7 +143,7 @@ Changes
   ``sdist``. This allows plugins and customization scripts to automatically
   add required source files in the source distribution.
 * #3414: Users can *temporarily* specify an environment variable
-  ``SETUPTOOLS_ENABLE_FEATURE=legacy-editable`` as a escape hatch for the
+  ``SETUPTOOLS_ENABLE_FEATURES=legacy-editable`` as a escape hatch for the
   :pep:`660` behavior. This setting is **transitional** and may be removed in the
   future.
 * #3484: Added *transient* ``compat`` mode to editable installs.

--- a/changelog.d/3538.doc.rst
+++ b/changelog.d/3538.doc.rst
@@ -1,0 +1,1 @@
+Corrected documentation on how to use the `legacy-editable` mode.

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -194,7 +194,7 @@ variable:
 
 .. code-block::
 
-   SETUPTOOLS_USE_FEATURE="legacy-editable"
+   SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
 
 This *may* cause the installer (e.g. ``pip``) to effectively run the "legacy"
 installation command: ``python setup.py develop`` [#installer]_.


### PR DESCRIPTION
## Summary of changes

PR #3414 added support for disabling the new PEP660 editable install hooks. However the documentation and changelog mentions didn't match the implementation.

Before:
- The implementation used: `SETUPTOOLS_ENABLE_FEATURES`
- The changelog said to use: `SETUPTOOLS_ENABLE_FEATURE` (notice the missing "S")
- The docs said to use: `SETUPTOOLS_USE_FEATURE`

This caused confusion in #3535, since the testcase there used the form mentioned in the changelog, which doesn't do anything.

Now, the changelog and docs both say to use `SETUPTOOLS_ENABLE_FEATURES`.

### Pull Request Checklist
- [ ] ~Changes have tests~
- [x] News fragment added in [`changelog.d/`].
