### PR TITLE
Remove inadvertent splatting of the name attribute

### DIFF
--- a/changelog.d/3547.change.rst
+++ b/changelog.d/3547.change.rst
@@ -1,1 +1,1 @@
-Stop `ConfigDiscovery.analyse_name` from splatting the `Distribution.name` attribute -- by :user:`jeamland`
+Stop ``ConfigDiscovery.analyse_name`` from splatting the ``Distribution.name`` attribute -- by :user:`jeamland`

--- a/changelog.d/3547.change.rst
+++ b/changelog.d/3547.change.rst
@@ -1,0 +1,1 @@
+Stop `ConfigDiscovery.analyse_name` from splatting the `Distribution.name` attribute -- by :user:`jeamland`

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -234,8 +234,8 @@ class _ConfigExpander:
 
         # A distribution object is required for discovering the correct package_dir
         dist = self._ensure_dist()
-
-        with _EnsurePackagesDiscovered(dist, self.setuptools_cfg) as ensure_discovered:
+        ctx = _EnsurePackagesDiscovered(dist, self.project_cfg, self.setuptools_cfg)
+        with ctx as ensure_discovered:
             package_dir = ensure_discovered.package_dir
             self._expand_data_files()
             self._expand_cmdclass(package_dir)
@@ -428,8 +428,11 @@ def _ignore_errors(ignore_option_errors: bool):
 
 
 class _EnsurePackagesDiscovered(_expand.EnsurePackagesDiscovered):
-    def __init__(self, distribution: "Distribution", setuptools_cfg: dict):
+    def __init__(
+        self, distribution: "Distribution", project_cfg: dict, setuptools_cfg: dict
+    ):
         super().__init__(distribution)
+        self._project_cfg = project_cfg
         self._setuptools_cfg = setuptools_cfg
 
     def __enter__(self):
@@ -443,8 +446,10 @@ class _EnsurePackagesDiscovered(_expand.EnsurePackagesDiscovered):
 
         dist.set_defaults._ignore_ext_modules()  # pyproject.toml-specific behaviour
 
-        # Set `py_modules` and `packages` in dist to short-circuit auto-discovery,
-        # but avoid overwriting empty lists purposefully set by users.
+        # Set `name`, `py_modules` and `packages` in dist to short-circuit
+        # auto-discovery, but avoid overwriting empty lists purposefully set by users.
+        if dist.metadata.name is None:
+            dist.metadata.name = self._project_cfg.get("name")
         if dist.py_modules is None:
             dist.py_modules = cfg.get("py-modules")
         if dist.packages is None:

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -481,7 +481,6 @@ class ConfigDiscovery:
         )
         if name:
             self.dist.metadata.name = name
-            self.dist.name = name
 
     def _find_name_single_package_or_module(self) -> Optional[str]:
         """Exactly one module or package"""

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -508,6 +508,15 @@ def test_compatible_with_numpy_configuration(tmp_path):
     assert dist.packages is None
 
 
+def test_name_discovery_doesnt_break_cli(tmpdir_cwd):
+    jaraco.path.build({"pkg.py": ""})
+    dist = Distribution({})
+    dist.script_args = ["--name"]
+    dist.set_defaults()
+    dist.parse_command_line()  # <-- no exception should be raised here.
+    assert dist.get_name() == "pkg"
+
+
 def _populate_project_dir(root, files, options):
     # NOTE: Currently pypa/build will refuse to build the project if no
     # `pyproject.toml` or `setup.py` is found. So it is impossible to do


### PR DESCRIPTION
The `name` attribute of a `Distribution` object is used by the command-line processing system and is not intended to hold the name of the distribution itself. Setting it to the name will cause the command-line processing system to have a bad time.

Fixes #3545