### PR TITLE
Editable finder: Avoid recursion when missing module has the same name as parent

### DIFF
--- a/changelog.d/3551.misc.rst
+++ b/changelog.d/3551.misc.rst
@@ -1,0 +1,2 @@
+Avoided circular imports in meta path finder for editable installs when a
+missing module has the same name as parent.

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -684,9 +684,13 @@ def _is_nested(pkg: str, pkg_path: str, parent: str, parent_path: str) -> bool:
     False
     >>> _is_nested("a.b", "path/a/b", "c", "path/c")
     False
+    >>> _is_nested("a.a", "path/a/a", "a", "path/a")
+    True
+    >>> _is_nested("b.a", "path/b/a", "a", "path/a")
+    False
     """
     norm_pkg_path = _normalize_path(pkg_path)
-    rest = pkg.replace(parent, "").strip(".").split(".")
+    rest = pkg.replace(parent, "", 1).strip(".").split(".")
     return (
         pkg.startswith(parent)
         and norm_pkg_path == _normalize_path(Path(parent_path, *rest))

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -755,7 +755,7 @@ class _EditableFinder:  # MetaPathFinder
     def find_spec(cls, fullname, path=None, target=None):
         for pkg, pkg_path in reversed(list(MAPPING.items())):
             if fullname.startswith(pkg):
-                rest = fullname.replace(pkg, "").strip(".").split(".")
+                rest = fullname.replace(pkg, "", 1).strip(".").split(".")
                 return cls._find_spec(fullname, Path(pkg_path, *rest))
 
         return None

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -495,6 +495,7 @@ class TestFinderTemplate:
             assert three.x == 3
 
     def test_no_recursion(self, tmp_path):
+        # See issue #3550
         files = {
             "pkg": {
                 "__init__.py": "from . import pkg",
@@ -511,7 +512,7 @@ class TestFinderTemplate:
             sys.modules.pop("pkg", None)
 
             self.install_finder(template)
-            with pytest.raises(ModuleNotFoundError, match="No module named 'pkg.pkg'"):
+            with pytest.raises(ImportError, match="pkg"):
                 import_module("pkg")
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Ensure that the finder will not result in circular imports when a missing module coincidentally has the same name as its parent module.

Closes #3550.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
