### PR TITLE
Merge with pypa/distutils@22b9bcf

### DIFF
--- a/changelog.d/3553.change.rst
+++ b/changelog.d/3553.change.rst
@@ -1,0 +1,1 @@
+Sync with pypa/distutils@22b9bcf, including fixed cross-compiling support and removing deprecation warning per pypa/distutils#169.

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,7 +60,7 @@ filterwarnings=
 	ignore:Setuptools is replacing distutils
 
 	# suppress warnings in deprecated msvc compilers
-	ignore:msvc9?compiler is deprecated
+	ignore:(bcpp|msvc9?)compiler is deprecated
 
 	ignore:Support for .* in .pyproject.toml. is still .beta.
 	ignore::setuptools.command.editable_wheel.InformationOnly

--- a/setuptools/_distutils/_msvccompiler.py
+++ b/setuptools/_distutils/_msvccompiler.py
@@ -318,37 +318,15 @@ class MSVCCompiler(CCompiler):
 
     # -- Worker methods ------------------------------------------------
 
-    def object_filenames(self, source_filenames, strip_dir=0, output_dir=''):
-        ext_map = {
-            **{ext: self.obj_extension for ext in self.src_extensions},
+    @property
+    def out_extensions(self):
+        return {
+            **super().out_extensions,
             **{
                 ext: self.res_extension
                 for ext in self._rc_extensions + self._mc_extensions
             },
         }
-
-        output_dir = output_dir or ''
-
-        def make_out_path(p):
-            base, ext = os.path.splitext(p)
-            if strip_dir:
-                base = os.path.basename(base)
-            else:
-                _, base = os.path.splitdrive(base)
-                if base.startswith((os.path.sep, os.path.altsep)):
-                    base = base[1:]
-            try:
-                # XXX: This may produce absurdly long paths. We should check
-                # the length of the result and trim base until we fit within
-                # 260 characters.
-                return os.path.join(output_dir, base + ext_map[ext])
-            except LookupError:
-                # Better to raise an exception instead of silently continuing
-                # and later complain about sources and targets having
-                # different lengths
-                raise CompileError(f"Don't know how to compile {p}")
-
-        return list(map(make_out_path, source_filenames))
 
     def compile(  # noqa: C901
         self,

--- a/setuptools/_distutils/bcppcompiler.py
+++ b/setuptools/_distutils/bcppcompiler.py
@@ -13,6 +13,8 @@ for the Borland C++ compiler.
 
 
 import os
+import warnings
+
 from distutils.errors import (
     DistutilsExecError,
     CompileError,
@@ -24,6 +26,14 @@ from distutils.ccompiler import CCompiler, gen_preprocess_options
 from distutils.file_util import write_file
 from distutils.dep_util import newer
 from distutils import log
+
+
+warnings.warn(
+    "bcppcompiler is deprecated and slated to be removed "
+    "in the future. Please discontinue use or file an issue "
+    "with pypa/distutils describing your use case.",
+    DeprecationWarning,
+)
 
 
 class BCPPCompiler(CCompiler):

--- a/setuptools/_distutils/sysconfig.py
+++ b/setuptools/_distutils/sysconfig.py
@@ -164,10 +164,19 @@ def _get_python_inc_from_config(plat_specific, spec_prefix):
     the host
     platform Python installation, while the current Python
     executable is from the build platform installation.
+
+    >>> monkeypatch = getfixture('monkeypatch')
+    >>> gpifc = _get_python_inc_from_config
+    >>> monkeypatch.setitem(gpifc.__globals__, 'get_config_var', str.lower)
+    >>> gpifc(False, '/usr/bin/')
+    >>> gpifc(False, '')
+    >>> gpifc(False, None)
+    'includepy'
+    >>> gpifc(True, None)
+    'confincludepy'
     """
-    if not spec_prefix:
-        return
-    return get_config_var('CONF' * plat_specific + 'INCLUDEPY')
+    if spec_prefix is None:
+        return get_config_var('CONF' * plat_specific + 'INCLUDEPY')
 
 
 def _get_python_inc_posix_prefix(prefix):


### PR DESCRIPTION
- Suppress warnings in deprecated msvc compilers
- Fix, again, finding headers during cross compiling
- Rename _mangle_base to _make_relative and add documentation about its purpose. Ref pypa/distutils#169.
- In _make_relative, remove deprecation warning. Ref pypa/distutils#169.
- Extract method for _make_out_path.
- In _msvccompiler, only override _make_out_path
- In _msvccompiler, re-use _make_relative.
- Extract property for mapping src extensions to out extensions.
- Extract property for out_extensions in _msvccompiler
- Deprecate bcppcompiler. Support for Borland C++ compiler was dropped for compiling Python in python/cpython#66782 (2014) and the borlandc.org web site no longer references a compiler. Best I can tell, this compiler hasn't been released for 22 years. Surely no one is using it.
- Remove _msvccompiler._make_out_path.
- In cygwincompiler, re-use object_filenames from ccompiler.
- Add unit tests capturing the expectation

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
