### PR TITLE
Remove python2 cases

### DIFF
--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -118,7 +118,7 @@ class test(Command):
         return list(self._test_args())
 
     def _test_args(self):
-        if not self.test_suite and sys.version_info >= (2, 7):
+        if not self.test_suite:
             yield 'discover'
         if self.verbose:
             yield '--verbose'

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -71,8 +71,6 @@ def patch_all():
         distutils.filelist.findall = setuptools.findall
 
     needs_warehouse = (
-        sys.version_info < (2, 7, 13)
-        or
         (3, 4) < sys.version_info < (3, 4, 6)
         or
         (3, 5) < sys.version_info <= (3, 5, 3)


### PR DESCRIPTION
## Summary of changes

setuptools does not support python2 anymore.
This PR removes two cases where the code checks if python release is version 2.

### Pull Request Checklist
I runned `tox` and get one error before and after this patch.

I don't think news are useful because it does not affect end-users.