### PR TITLE
Fix towncrier URL

### DIFF
--- a/changelog.d/README.rst
+++ b/changelog.d/README.rst
@@ -90,4 +90,4 @@ File :file:`changelog.d/2355.change.rst`:
    (``tool.towncrier.type``).
 
 .. _Towncrier philosophy:
-   https://towncrier.readthedocs.io/en/actual-freaking-docs/#philosophy
+   https://towncrier.readthedocs.io/en/latest/#philosophy


### PR DESCRIPTION
The link to towncrier philosophy section displays a 404 error. So this patch updates the broken URL to the correct one.

I think no news are necessary but I can add one if you want.
