### PR TITLE
Improve warnings in editable install

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes
 
 Documentation changes
 ^^^^^^^^^^^^^^^^^^^^^
-* #3554: Changed requires to requests in the pyproject.toml example in the :ref:`Dependency management section of the Quickstart guide <userguide/quickstart:dependency-management>` -- by :user:`mfbutner`
+* #3554: Changed requires to requests in the pyproject.toml example in the :doc:`Dependency management section of the Quickstart guide <userguide/quickstart>` -- by :user:`mfbutner`
 
 Misc
 ^^^^
@@ -44,7 +44,7 @@ Changes
 
 Documentation changes
 ^^^^^^^^^^^^^^^^^^^^^
-* #3538: Corrected documentation on how to use the `legacy-editable` mode.
+* #3538: Corrected documentation on how to use the ``legacy-editable`` mode.
 
 
 v65.0.2

--- a/changelog.d/3569.misc.rst
+++ b/changelog.d/3569.misc.rst
@@ -1,0 +1,2 @@
+Improved information about conflicting entries in the current working directory
+and editable install (in documentation and as an informational warning).

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -247,7 +247,7 @@ More information is available on the text of :pep:`PEP 660 <660#what-to-put-in-t
 .. [#cwd]
    Techniques like the :ref:`src-layout` or tooling-specific options like
    `tox's changedir <https://tox.wiki/en/stable/config.html#conf-changedir>`_
-   can be used to prevent such kinds of situations (chekout `this blog post
+   can be used to prevent such kinds of situations (checkout `this blog post
    <https://blog.ganssle.io/articles/2019/08/test-as-installed.html>`_ for more
    insights).
 

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -155,6 +155,10 @@ Limitations
   projects structured using :ref:`flat-layout` is still **experimental**.
   If you experience problems, you can try converting your package structure
   to the :ref:`src-layout`.
+- File system entries in the current working directory
+  whose names coincidentally match installed packages
+  may take precedence in :doc:`Python's import system <python:reference/import>`.
+  Users are encouraged to avoid such scenarios [#cwd]_.
 
 .. attention::
    Editable installs are **not a perfect replacement for regular installs**
@@ -239,6 +243,13 @@ More information is available on the text of :pep:`PEP 660 <660#what-to-put-in-t
    You *may* be able to use *strict* editable installations with namespace
    packages created with ``pkgutil`` or ``pkg_namespaces``, however this is not
    officially supported.
+
+.. [#cwd]
+   Techniques like the :ref:`src-layout` or tooling-specific options like
+   `tox's changedir <https://tox.wiki/en/stable/config.html#conf-changedir>`_
+   can be used to prevent such kinds of situations (chekout `this blog post
+   <https://blog.ganssle.io/articles/2019/08/test-as-installed.html>`_ for more
+   insights).
 
 .. [#installer]
    For this workaround to work, the installer tool needs to support legacy

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -437,9 +437,10 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
             info_dir = self._get_dist_info_dir(metadata_directory)
             opts = ["--dist-info-dir", info_dir] if info_dir else []
             cmd = ["editable_wheel", *opts, *self._editable_args(config_settings)]
-            return self._build_with_temp_dir(
-                cmd, ".whl", wheel_directory, config_settings
-            )
+            with suppress_known_deprecation():
+                return self._build_with_temp_dir(
+                    cmd, ".whl", wheel_directory, config_settings
+                )
 
         def get_requires_for_build_editable(self, config_settings=None):
             return self.get_requires_for_build_wheel(config_settings)

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -393,7 +393,7 @@ class _StaticPth:
     def __enter__(self):
         msg = f"""
         Editable install will be performed using .pth file to extend `sys.path` with:
-        {self.path_entries!r}
+        {list(map(os.fspath, self.path_entries))!r}
         """
         _logger.warning(msg + _LENIENT_WARNING)
         return self
@@ -503,7 +503,11 @@ class _TopLevelFinder:
         return self
 
     def __exit__(self, _exc_type, _exc_value, _traceback):
-        ...
+        msg = """\n
+        Please be careful with folders in your working directory with the same
+        name as your package as they may take precedence during imports.
+        """
+        warnings.warn(msg, InformationOnly)
 
 
 def _can_symlink_files(base_dir: Path) -> bool:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

This was initially motivated by #3557.

## Summary of changes

- Added warning about CWD interfering with editable installs
- Listed CWD entries overshadowing installation, as a limitation in the editable installation docs.
- Fixed existing RST syntax on changelog.
- Fixed warning about `install` command during editable install.


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
