### PR TITLE
Update pyproject_config.rst

### DIFF
--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -111,7 +111,7 @@ Key                       Value Type (TOML)           Notes
 
 .. note::
    The `TOML value types`_ ``array`` and ``table/inline-table`` are roughly
-   equivalent to the Python's :obj:`dict` and :obj:`list` data types.
+   equivalent to the Python's :obj:`list` and :obj:`dict` data types, respectively.
 
 Please note that some of these configurations are deprecated or at least
 discouraged, but they are made available to ensure portability.


### PR DESCRIPTION
The sequence of TOML datatypes and Python datatypes are reversed, which is a bit confusing.

I suggest to align the sequence, so that array and table aligns with list and dict

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
