### PR TITLE
Implemented right file name in the stack frame of `setup.py` being `exec`uted.

### DIFF
--- a/changelog.d/3577.change.rst
+++ b/changelog.d/3577.change.rst
@@ -1,0 +1,1 @@
+Implemented providing the right file name in the stack frame of ``setup.py`` being ``exec``-uted.


### PR DESCRIPTION
## Summary of changes

This PR provides a better traceback when examining stack while building wheels, i.e. from `setuptools` plugins. Instead of `<string>` it now prints the actual filename of `setup.py`, and if the `setup.py` is virtual, it prints where its source can be found in the form of an inline string.

Now some opinion: I think it may make sense to eliminate `exec` of the virtual `setup.py` file and call the `setup` function directly.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_
