### PR TITLE
ENH: Remove egg-info directory if created during sdist

### DIFF
--- a/changelog.d/3578.change.rst
+++ b/changelog.d/3578.change.rst
@@ -1,0 +1,1 @@
+Remove ``.egg-info`` directories created by ``sdist`` builds -- py :user:`effigies`

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -560,6 +560,30 @@ class TestSdistTest:
         manifest = cmd.filelist.files
         assert '.myfile~' in manifest
 
+    @pytest.mark.parametrize("existing_egg", (True, False))
+    def test_egg_info_cleanup(self, tmpdir, existing_egg):
+        """
+        Test that sdist does not add or remove a .egg-info directory from the
+        source tree
+        """
+        dist = Distribution(SETUP_ATTRS)
+        dist.script_name = 'setup.py'
+        cmd = sdist(dist)
+        cmd.ensure_finalized()
+
+        ei_cmd = cmd.get_finalized_command('egg_info')
+
+        if existing_egg:
+            with quiet():
+                cmd.run_command('egg_info')
+
+        assert os.path.isdir(ei_cmd.egg_info) == existing_egg
+
+        with quiet():
+            cmd.run()
+
+        assert os.path.isdir(ei_cmd.egg_info) == existing_egg
+
 
 def test_default_revctrl():
     """

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -364,6 +364,7 @@ class TestSdistTest:
 
         # Create manifest
         with quiet():
+            cmd.run_command('egg_info')
             cmd.run()
 
         # Add UTF-8 filename to manifest
@@ -395,6 +396,7 @@ class TestSdistTest:
 
         # Create manifest
         with quiet():
+            cmd.run_command('egg_info')
             cmd.run()
 
         # Add Latin-1 filename to manifest


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

If sdist creates a `.egg-info` directory, remove it after copying it to the build directory. If a `.egg-info` directory is already found, warn that the build may differ from a build from a clean source tree.

Closes #3573. 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
