### PR TITLE
Catch an edge case in expand._assert_local()

### DIFF
--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -41,6 +41,7 @@ from typing import (
     Union,
     cast
 )
+from pathlib import Path
 from types import ModuleType
 
 from distutils.errors import DistutilsOptionError
@@ -150,7 +151,9 @@ def _read_file(filepath: Union[bytes, _Path]) -> str:
 
 
 def _assert_local(filepath: _Path, root_dir: str):
-    if not os.path.abspath(filepath).startswith(root_dir):
+    # NOTE: Path.resolve() will raise RuntimeError if an infinite loop is
+    # encountered along the resolution path of root_dir or file_path.
+    if Path(root_dir).resolve() not in Path(filepath).resolve().parents:
         msg = f"Cannot access {filepath!r} (or anything outside {root_dir!r})"
         raise DistutilsOptionError(msg)
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -151,9 +151,7 @@ def _read_file(filepath: Union[bytes, _Path]) -> str:
 
 
 def _assert_local(filepath: _Path, root_dir: str):
-    # NOTE: Path.resolve() will raise RuntimeError if an infinite loop is
-    # encountered along the resolution path of root_dir or file_path.
-    if Path(root_dir).resolve() not in Path(filepath).resolve().parents:
+    if Path(os.path.abspath(root_dir)) not in Path(os.path.abspath(filepath)).parents:
         msg = f"Cannot access {filepath!r} (or anything outside {root_dir!r})"
         raise DistutilsOptionError(msg)
 

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import pytest
 
@@ -45,6 +46,10 @@ def test_read_files(tmp_path, monkeypatch):
     }
     write_files(files, dir_)
 
+    secrets = Path(str(dir_) + "secrets")
+    secrets.mkdir(exist_ok=True)
+    write_files({"secrets.txt": "secret keys"}, secrets)
+
     with monkeypatch.context() as m:
         m.chdir(dir_)
         assert expand.read_files(list(files)) == "a\nb\nc"
@@ -52,6 +57,10 @@ def test_read_files(tmp_path, monkeypatch):
         cannot_access_msg = r"Cannot access '.*\.\..a\.txt'"
         with pytest.raises(DistutilsOptionError, match=cannot_access_msg):
             expand.read_files(["../a.txt"])
+
+        cannot_access_secrets_msg = r"Cannot access '.*secrets\.txt'"
+        with pytest.raises(DistutilsOptionError, match=cannot_access_secrets_msg):
+            expand.read_files(["../dir_secrets/secrets.txt"])
 
     # Make sure the same APIs work outside cwd
     assert expand.read_files(list(files), dir_) == "a\nb\nc"


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Using `str.startswith()` for sandboxing file access has an edge case where someone can access files outside the root directory. For example, consider the case where the root directory is "/home/user/my-package" but some secrets are stored in "/home/user/my-package-secrets". Evaluating a check that "/home/user/my-package-secrets".startswith("/home/user/my-package") will return True, but the statement's intention is that no file outside of "/home/user/my-package" can be accessed.

Using `pathlib.Path.resolve()` and `pathlib.Path.parents` eliminates this edge case.

See https://salvatoresecurity.com/preventing-directory-traversal-vulnerabilities-in-python/ for more details.

### Caveats
1. If there is an infinite loop in the directory structure, `pathlib.Path.resolve()` will raise a `RuntimeError`.
2. `pathlib.Path.resolve()` resolves symlinks, whereas the old code using `os.pathlib.abspath()` did not.


I am not intimately familiar with setuptools and could use some guidance as to whether or not either of these two caveats would cause an issue. My guess would be that the first would not impact users and the second might, but probably won't. If either of the above caveats is an issue, I can provide an alternate implementation using `os.path.abspath()`, though that comes with its own caveats.

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`]. - This PR should not change the way users interact with setuptools, with the possible exception of the caveats above.


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
