### PR TITLE
Merge with distutils@d82d926

### DIFF
--- a/changelog.d/3609.change.rst
+++ b/changelog.d/3609.change.rst
@@ -1,0 +1,1 @@
+Merge with pypa/distutils@d82d926 including support for DIST_EXTRA_CONFIG in pypa/distutils#177.

--- a/docs/deprecated/distutils/configfile.rst
+++ b/docs/deprecated/distutils/configfile.rst
@@ -36,7 +36,8 @@ consequences:
   :file:`setup.py`
 
 * installers can override anything in :file:`setup.cfg` using the command-line
-  options to :file:`setup.py`
+  options to :file:`setup.py` or by pointing :envvar:`DIST_EXTRA_CONFIG`
+  to another configuration file
 
 The basic syntax of the configuration file is simple:
 

--- a/setuptools/_distutils/dist.py
+++ b/setuptools/_distutils/dist.py
@@ -7,6 +7,8 @@ being built/installed/distributed.
 import sys
 import os
 import re
+import pathlib
+import contextlib
 from email import message_from_file
 
 try:
@@ -322,47 +324,40 @@ Common commands: (see '--help-commands' for more)
         should be parsed.  The filenames returned are guaranteed to exist
         (modulo nasty race conditions).
 
-        There are three possible config files: distutils.cfg in the
-        Distutils installation directory (ie. where the top-level
-        Distutils __inst__.py file lives), a file in the user's home
-        directory named .pydistutils.cfg on Unix and pydistutils.cfg
-        on Windows/Mac; and setup.cfg in the current directory.
-
-        The file in the user's home directory can be disabled with the
-        --no-user-cfg option.
+        There are multiple possible config files:
+        - distutils.cfg in the Distutils installation directory (i.e.
+          where the top-level Distutils __inst__.py file lives)
+        - a file in the user's home directory named .pydistutils.cfg
+          on Unix and pydistutils.cfg on Windows/Mac; may be disabled
+          with the ``--no-user-cfg`` option
+        - setup.cfg in the current directory
+        - a file named by an environment variable
         """
-        files = []
         check_environ()
-
-        # Where to look for the system-wide Distutils config file
-        sys_dir = os.path.dirname(sys.modules['distutils'].__file__)
-
-        # Look for the system config file
-        sys_file = os.path.join(sys_dir, "distutils.cfg")
-        if os.path.isfile(sys_file):
-            files.append(sys_file)
-
-        # What to call the per-user config file
-        if os.name == 'posix':
-            user_filename = ".pydistutils.cfg"
-        else:
-            user_filename = "pydistutils.cfg"
-
-        # And look for the user config file
-        if self.want_user_cfg:
-            user_file = os.path.join(os.path.expanduser('~'), user_filename)
-            if os.path.isfile(user_file):
-                files.append(user_file)
-
-        # All platforms support local setup.cfg
-        local_file = "setup.cfg"
-        if os.path.isfile(local_file):
-            files.append(local_file)
+        files = [str(path) for path in self._gen_paths() if path.is_file()]
 
         if DEBUG:
             self.announce("using config files: %s" % ', '.join(files))
 
         return files
+
+    def _gen_paths(self):
+        # The system-wide Distutils config file
+        sys_dir = pathlib.Path(sys.modules['distutils'].__file__).parent
+        yield sys_dir / "distutils.cfg"
+
+        # The per-user config file
+        prefix = '.' * (os.name == 'posix')
+        filename = prefix + 'pydistutils.cfg'
+        if self.want_user_cfg:
+            yield pathlib.Path('~').expanduser() / filename
+
+        # All platforms support local setup.cfg
+        yield pathlib.Path('setup.cfg')
+
+        # Additional config indicated in the environment
+        with contextlib.suppress(TypeError):
+            yield pathlib.Path(os.getenv("DIST_EXTRA_CONFIG"))
 
     def parse_config_files(self, filenames=None):  # noqa: C901
         from configparser import ConfigParser

--- a/setuptools/_distutils/tests/test_util.py
+++ b/setuptools/_distutils/tests/test_util.py
@@ -136,17 +136,16 @@ class TestUtil:
         # XXX platforms to be covered: mac
 
     def test_check_environ(self):
-        util._environ_checked = 0
+        util.check_environ.cache_clear()
         os.environ.pop('HOME', None)
 
         check_environ()
 
         assert os.environ['PLAT'] == get_platform()
-        assert util._environ_checked == 1
 
     @pytest.mark.skipif("os.name != 'posix'")
     def test_check_environ_getpwuid(self):
-        util._environ_checked = 0
+        util.check_environ.cache_clear()
         os.environ.pop('HOME', None)
 
         import pwd
@@ -159,7 +158,7 @@ class TestUtil:
             check_environ()
             assert os.environ['HOME'] == '/home/distutils'
 
-        util._environ_checked = 0
+        util.check_environ.cache_clear()
         os.environ.pop('HOME', None)
 
         # bpo-10496: Catch pwd.getpwuid() error

--- a/setuptools/_distutils/util.py
+++ b/setuptools/_distutils/util.py
@@ -11,6 +11,8 @@ import string
 import subprocess
 import sys
 import sysconfig
+import functools
+
 from distutils.errors import DistutilsPlatformError, DistutilsByteCompileError
 from distutils.dep_util import newer
 from distutils.spawn import spawn
@@ -170,9 +172,7 @@ def change_root(new_root, pathname):
     raise DistutilsPlatformError(f"nothing known about platform '{os.name}'")
 
 
-_environ_checked = 0
-
-
+@functools.lru_cache()
 def check_environ():
     """Ensure that 'os.environ' has all the environment variables we
     guarantee that users can use in config files, command-line options,
@@ -181,10 +181,6 @@ def check_environ():
       PLAT - description of the current platform, including hardware
              and OS (see 'get_platform()')
     """
-    global _environ_checked
-    if _environ_checked:
-        return
-
     if os.name == 'posix' and 'HOME' not in os.environ:
         try:
             import pwd
@@ -197,8 +193,6 @@ def check_environ():
 
     if 'PLAT' not in os.environ:
         os.environ['PLAT'] = get_platform()
-
-    _environ_checked = 1
 
 
 def subst_vars(s, local_vars):


### PR DESCRIPTION
- Revert "Exclude Python 3.11 on macOS due to lack of wheels. Ref pypa/distutils#165."
- Restore metadata tests (not discovered due to class name).
- Add DISTUTILS_EXTRA_CONFIG option for passing setup.cfg overrides during build
- Fix name in test
- Prefer monkeypatch for setting environment variable
- Use tmp_path and jaraco.path.build to build files.
- Use functools.lru_cache to memoize check_environ.
- Use pathlib for generating paths and generate the paths in a separate function, consolidating 'is_file' check.
- Update docs to reference environment variable.
- Rename environment variable to DIST_EXTRA_CONFIG, decoupling it from the name of the implementation.
- Simplify logic in test_custom_pydistutils
- Inline variables used once
- Remove meaningless dot from config files
- Extract a temp_home fixture.
- Re-use temp_home in test_find_config_files_disable
- Extract property for pydistutils.cfg name
- Move property to a module attribute and re-use jaraco.path for simpler tests.
- Use jaraco.path for more tests
- Fix warning in test

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
