### PR TITLE
Make the `check` job a central gate in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,9 @@ jobs:
     if: always()
 
     needs:
+    - integration-test
     - test
+    - test_cygwin
 
     runs-on: ubuntu-latest
 
@@ -82,6 +84,23 @@ jobs:
     - name: Decide whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
+        allowed-skips: >-
+          ${{
+            (
+              (
+                github.event_name == 'pull_request' ||
+                (
+                  github.event_name == 'push' &&
+                  github.ref == format(
+                    'refs/heads/{0}',
+                    github.event.repository.default_branch
+                  )
+                )
+              )
+            )
+            && 'integration-test'
+            || ''
+          }}
         jobs: ${{ toJSON(needs) }}
 
   test_cygwin:
@@ -143,8 +162,6 @@ jobs:
   release:
     needs:
     - check
-    - test_cygwin
-    - integration-test
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 75

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,23 +84,7 @@ jobs:
     - name: Decide whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: >-
-          ${{
-            (
-              (
-                github.event_name == 'pull_request' ||
-                (
-                  github.event_name == 'push' &&
-                  github.ref == format(
-                    'refs/heads/{0}',
-                    github.event.repository.default_branch
-                  )
-                )
-              )
-            )
-            && 'integration-test'
-            || ''
-          }}
+        allowed-skips: integration-test
         jobs: ${{ toJSON(needs) }}
 
   test_cygwin:


### PR DESCRIPTION
## Summary of changes

I noticed that the way the `check` job is integrated is not what's recommended. It should serve as a single status that can tell people whether all the required tests have passed or not.
So in this patch, I improve the dependency graph to do just that, while preserving the expectation that the integration tests must be allowed to be skipped.

https://github.com/marketplace/actions/alls-green#why