### PR TITLE
Merge with pypa/distutils@6852b20

### DIFF
--- a/changelog.d/3617.misc.rst
+++ b/changelog.d/3617.misc.rst
@@ -1,0 +1,1 @@
+Merge with pypa/distutils@6852b20 including fix for pypa/distutils#181.

--- a/setuptools/_distutils/dist.py
+++ b/setuptools/_distutils/dist.py
@@ -334,7 +334,7 @@ Common commands: (see '--help-commands' for more)
         - a file named by an environment variable
         """
         check_environ()
-        files = [str(path) for path in self._gen_paths() if path.is_file()]
+        files = [str(path) for path in self._gen_paths() if os.path.isfile(path)]
 
         if DEBUG:
             self.announce("using config files: %s" % ', '.join(files))

--- a/setuptools/_distutils/sysconfig.py
+++ b/setuptools/_distutils/sysconfig.py
@@ -13,6 +13,7 @@ import os
 import re
 import sys
 import sysconfig
+import pathlib
 
 from .errors import DistutilsPlatformError
 from . import py39compat
@@ -40,14 +41,13 @@ else:
         project_base = os.getcwd()
 
 
-# python_build: (Boolean) if true, we're either building Python or
-# building an extension with an un-installed Python, so we use
-# different (hard-wired) directories.
 def _is_python_source_dir(d):
-    for fn in ("Setup", "Setup.local"):
-        if os.path.isfile(os.path.join(d, "Modules", fn)):
-            return True
-    return False
+    """
+    Return True if the target directory appears to point to an
+    un-installed Python.
+    """
+    modules = pathlib.Path(d).joinpath('Modules')
+    return any(modules.joinpath(fn).is_file() for fn in ('Setup', 'Setup.local'))
 
 
 _sys_home = getattr(sys, '_home', None)

--- a/setuptools/_distutils/tests/py37compat.py
+++ b/setuptools/_distutils/tests/py37compat.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import platform
+
+
+def subprocess_args_compat(*args):
+    return list(map(os.fspath, args))
+
+
+def subprocess_args_passthrough(*args):
+    return list(args)
+
+
+subprocess_args = (
+    subprocess_args_compat
+    if platform.system() == "Windows" and sys.version_info < (3, 8)
+    else subprocess_args_passthrough
+)

--- a/setuptools/_distutils/tests/py38compat.py
+++ b/setuptools/_distutils/tests/py38compat.py
@@ -18,27 +18,19 @@ except (ModuleNotFoundError, ImportError):
 
 try:
     from test.support.os_helper import (
-        change_cwd,
         rmtree,
         EnvironmentVarGuard,
-        TESTFN,
         unlink,
         skip_unless_symlink,
         temp_dir,
-        create_empty_file,
-        temp_cwd,
     )
 except (ModuleNotFoundError, ImportError):
     from test.support import (
-        change_cwd,
         rmtree,
         EnvironmentVarGuard,
-        TESTFN,
         unlink,
         skip_unless_symlink,
         temp_dir,
-        create_empty_file,
-        temp_cwd,
     )
 
 

--- a/setuptools/_distutils/tests/test_archive_util.py
+++ b/setuptools/_distutils/tests/test_archive_util.py
@@ -9,6 +9,7 @@ import operator
 import pathlib
 
 import pytest
+import path
 
 from distutils import archive_util
 from distutils.archive_util import (
@@ -23,7 +24,6 @@ from distutils.tests import support
 from test.support import patch
 from .unix_compat import require_unix_id, require_uid_0, grp, pwd, UID_0_SUPPORT
 
-from .py38compat import change_cwd
 from .py38compat import check_warnings
 
 
@@ -95,7 +95,7 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         base_name = os.path.join(tmpdir2, target_name)
 
         # working with relative paths to avoid tar warnings
-        with change_cwd(tmpdir):
+        with path.Path(tmpdir):
             make_tarball(splitdrive(base_name)[1], 'dist', **kwargs)
 
         # check if the compressed tarball was created
@@ -227,7 +227,7 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         # creating something to tar
         tmpdir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
-        with change_cwd(tmpdir):
+        with path.Path(tmpdir):
             make_zipfile(base_name, 'dist')
 
         # check if the compressed tarball was created
@@ -253,7 +253,7 @@ class ArchiveUtilTestCase(support.TempdirManager, support.LoggingSilencer):
         # create something to tar and compress
         tmpdir = self._create_files()
         base_name = os.path.join(self.mkdtemp(), 'archive')
-        with change_cwd(tmpdir):
+        with path.Path(tmpdir):
             make_zipfile(base_name, 'dist')
 
         tarball = base_name + '.zip'

--- a/setuptools/_distutils/tests/test_build_ext.py
+++ b/setuptools/_distutils/tests/test_build_ext.py
@@ -8,6 +8,10 @@ import platform
 import tempfile
 import importlib
 import shutil
+import re
+
+import path
+import pytest
 
 from distutils.core import Distribution
 from distutils.command.build_ext import build_ext
@@ -27,10 +31,7 @@ from distutils.errors import (
 )
 
 from test import support
-from . import py38compat as os_helper
 from . import py38compat as import_helper
-import pytest
-import re
 
 
 @pytest.fixture()
@@ -47,7 +48,7 @@ def user_site_dir(request):
     # bpo-30132: On Windows, a .pdb file may be created in the current
     # working directory. Create a temporary working directory to cleanup
     # everything at the end of the test.
-    with os_helper.change_cwd(self.tmp_dir):
+    with path.Path(self.tmp_dir):
         yield
 
     site.USER_BASE = orig_user_base

--- a/setuptools/_distutils/tests/test_filelist.py
+++ b/setuptools/_distutils/tests/test_filelist.py
@@ -8,10 +8,12 @@ from distutils.filelist import glob_to_re, translate_pattern, FileList
 from distutils import filelist
 
 from test.support import captured_stdout
-from distutils.tests import support
 
-from . import py38compat as os_helper
 import pytest
+import jaraco.path
+
+from distutils.tests import support
+from . import py38compat as os_helper
 
 
 MANIFEST_IN = """\
@@ -303,44 +305,35 @@ class TestFileList(support.LoggingSilencer):
 
 class TestFindAll:
     @os_helper.skip_unless_symlink
-    def test_missing_symlink(self):
-        with os_helper.temp_cwd():
-            os.symlink('foo', 'bar')
-            assert filelist.findall() == []
+    def test_missing_symlink(self, temp_cwd):
+        os.symlink('foo', 'bar')
+        assert filelist.findall() == []
 
-    def test_basic_discovery(self):
+    def test_basic_discovery(self, temp_cwd):
         """
         When findall is called with no parameters or with
         '.' as the parameter, the dot should be omitted from
         the results.
         """
-        with os_helper.temp_cwd():
-            os.mkdir('foo')
-            file1 = os.path.join('foo', 'file1.txt')
-            os_helper.create_empty_file(file1)
-            os.mkdir('bar')
-            file2 = os.path.join('bar', 'file2.txt')
-            os_helper.create_empty_file(file2)
-            expected = [file2, file1]
-            assert sorted(filelist.findall()) == expected
+        jaraco.path.build({'foo': {'file1.txt': ''}, 'bar': {'file2.txt': ''}})
+        file1 = os.path.join('foo', 'file1.txt')
+        file2 = os.path.join('bar', 'file2.txt')
+        expected = [file2, file1]
+        assert sorted(filelist.findall()) == expected
 
-    def test_non_local_discovery(self):
+    def test_non_local_discovery(self, tmp_path):
         """
         When findall is called with another path, the full
         path name should be returned.
         """
-        with os_helper.temp_dir() as temp_dir:
-            file1 = os.path.join(temp_dir, 'file1.txt')
-            os_helper.create_empty_file(file1)
-            expected = [file1]
-            assert filelist.findall(temp_dir) == expected
+        filename = tmp_path / 'file1.txt'
+        filename.write_text('')
+        expected = [str(filename)]
+        assert filelist.findall(tmp_path) == expected
 
     @os_helper.skip_unless_symlink
-    def test_symlink_loop(self):
-        with os_helper.temp_dir() as temp_dir:
-            link = os.path.join(temp_dir, 'link-to-parent')
-            content = os.path.join(temp_dir, 'somefile')
-            os_helper.create_empty_file(content)
-            os.symlink('.', link)
-            files = filelist.findall(temp_dir)
-            assert len(files) == 1
+    def test_symlink_loop(self, tmp_path):
+        tmp_path.joinpath('link-to-parent').symlink_to('.')
+        tmp_path.joinpath('somefile').write_text('')
+        files = filelist.findall(tmp_path)
+        assert len(files) == 1

--- a/setuptools/_distutils/tests/test_spawn.py
+++ b/setuptools/_distutils/tests/test_spawn.py
@@ -6,6 +6,8 @@ import unittest.mock as mock
 
 from test.support import unix_shell
 
+import path
+
 from . import py38compat as os_helper
 
 from distutils.spawn import find_executable
@@ -44,83 +46,82 @@ class TestSpawn(support.TempdirManager, support.LoggingSilencer):
         os.chmod(exe, 0o777)
         spawn([exe])  # should work without any error
 
-    def test_find_executable(self):
-        with os_helper.temp_dir() as tmp_dir:
-            # use TESTFN to get a pseudo-unique filename
-            program_noeext = os_helper.TESTFN
-            # Give the temporary program an ".exe" suffix for all.
-            # It's needed on Windows and not harmful on other platforms.
-            program = program_noeext + ".exe"
+    def test_find_executable(self, tmp_path):
+        program_noeext = 'program'
+        # Give the temporary program an ".exe" suffix for all.
+        # It's needed on Windows and not harmful on other platforms.
+        program = program_noeext + ".exe"
 
-            filename = os.path.join(tmp_dir, program)
-            with open(filename, "wb"):
-                pass
-            os.chmod(filename, stat.S_IXUSR)
+        program_path = tmp_path / program
+        program_path.write_text("")
+        program_path.chmod(stat.S_IXUSR)
+        filename = str(program_path)
+        tmp_dir = path.Path(tmp_path)
 
-            # test path parameter
-            rv = find_executable(program, path=tmp_dir)
+        # test path parameter
+        rv = find_executable(program, path=tmp_dir)
+        assert rv == filename
+
+        if sys.platform == 'win32':
+            # test without ".exe" extension
+            rv = find_executable(program_noeext, path=tmp_dir)
             assert rv == filename
 
-            if sys.platform == 'win32':
-                # test without ".exe" extension
-                rv = find_executable(program_noeext, path=tmp_dir)
+        # test find in the current directory
+        with tmp_dir:
+            rv = find_executable(program)
+            assert rv == program
+
+        # test non-existent program
+        dont_exist_program = "dontexist_" + program
+        rv = find_executable(dont_exist_program, path=tmp_dir)
+        assert rv is None
+
+        # PATH='': no match, except in the current directory
+        with os_helper.EnvironmentVarGuard() as env:
+            env['PATH'] = ''
+            with mock.patch(
+                'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
+            ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
+                rv = find_executable(program)
+                assert rv is None
+
+                # look in current directory
+                with tmp_dir:
+                    rv = find_executable(program)
+                    assert rv == program
+
+        # PATH=':': explicitly looks in the current directory
+        with os_helper.EnvironmentVarGuard() as env:
+            env['PATH'] = os.pathsep
+            with mock.patch(
+                'distutils.spawn.os.confstr', return_value='', create=True
+            ), mock.patch('distutils.spawn.os.defpath', ''):
+                rv = find_executable(program)
+                assert rv is None
+
+                # look in current directory
+                with tmp_dir:
+                    rv = find_executable(program)
+                    assert rv == program
+
+        # missing PATH: test os.confstr("CS_PATH") and os.defpath
+        with os_helper.EnvironmentVarGuard() as env:
+            env.pop('PATH', None)
+
+            # without confstr
+            with mock.patch(
+                'distutils.spawn.os.confstr', side_effect=ValueError, create=True
+            ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
+                rv = find_executable(program)
                 assert rv == filename
 
-            # test find in the current directory
-            with os_helper.change_cwd(tmp_dir):
+            # with confstr
+            with mock.patch(
+                'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
+            ), mock.patch('distutils.spawn.os.defpath', ''):
                 rv = find_executable(program)
-                assert rv == program
-
-            # test non-existent program
-            dont_exist_program = "dontexist_" + program
-            rv = find_executable(dont_exist_program, path=tmp_dir)
-            assert rv is None
-
-            # PATH='': no match, except in the current directory
-            with os_helper.EnvironmentVarGuard() as env:
-                env['PATH'] = ''
-                with mock.patch(
-                    'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
-                ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
-                    rv = find_executable(program)
-                    assert rv is None
-
-                    # look in current directory
-                    with os_helper.change_cwd(tmp_dir):
-                        rv = find_executable(program)
-                        assert rv == program
-
-            # PATH=':': explicitly looks in the current directory
-            with os_helper.EnvironmentVarGuard() as env:
-                env['PATH'] = os.pathsep
-                with mock.patch(
-                    'distutils.spawn.os.confstr', return_value='', create=True
-                ), mock.patch('distutils.spawn.os.defpath', ''):
-                    rv = find_executable(program)
-                    assert rv is None
-
-                    # look in current directory
-                    with os_helper.change_cwd(tmp_dir):
-                        rv = find_executable(program)
-                        assert rv == program
-
-            # missing PATH: test os.confstr("CS_PATH") and os.defpath
-            with os_helper.EnvironmentVarGuard() as env:
-                env.pop('PATH', None)
-
-                # without confstr
-                with mock.patch(
-                    'distutils.spawn.os.confstr', side_effect=ValueError, create=True
-                ), mock.patch('distutils.spawn.os.defpath', tmp_dir):
-                    rv = find_executable(program)
-                    assert rv == filename
-
-                # with confstr
-                with mock.patch(
-                    'distutils.spawn.os.confstr', return_value=tmp_dir, create=True
-                ), mock.patch('distutils.spawn.os.defpath', ''):
-                    rv = find_executable(program)
-                    assert rv == filename
+                assert rv == filename
 
     def test_spawn_missing_exe(self):
         with pytest.raises(DistutilsExecError) as ctx:


### PR DESCRIPTION
- Use path.Path for changing the cwd temporarily.
- Remove needless assert renderings. Any decent test runner will provide this detail.
- Remove reference to duplicate issue.
- Refactor _is_python_source_dir using pathlib.
- Use 'samefile' to check for same file, because they may not be the same path. Fixes #180.
- Split test into two tests.
- Use pathlib
- Remove special case for TestCore.write_setup.
- Replace TESTFN with temp_file fixture.
- Remove 'cleanup_testfn', unused.
- Remove distracting comments
- In test_sysconfig, prefer fixtures to TESTFN.
- Remove cleanup_testfn, no longer used.
- Replace TESTFN with fixture.
- Remove empty logic branch.
- Use path.Path for changing the cwd temporarily.
- Remove reliance on TESTFN in test_dist
- Remove TESTFN from py38compat, no longer needed.
- xfail srcdir_simple on Windows
- Remove reliance on os_helper in test_build_ext
- Remove reliance on change_cwd
- Add compatibility shim for subprocess on Python 3.7 on Windows
- Extract _save_cwd for saving the current working directory.
- Prefer a temp_cwd fixture to reduce indentation.
- Remove reliance on create_empty_file
- Add test for PermissionError. Ref pypa/distutils#181.
- Use os.path.isfile for checking if path.is_file, suppresses exceptions. Fixes pypa/distutils#181.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
