### PR TITLE
pyproject_config.rst: Remove beta tag for (optional) dependencies

### DIFF
--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -192,8 +192,8 @@ Key                        Directive           Notes
 ``classifiers``            ``file``            Multi-line text with one classifier per line
 ``entry-points``           ``file``            INI format following :doc:`PyPUG:specifications/entry-points`
                                                (``console_scripts`` and ``gui_scripts`` can be included)
-``dependencies``           ``file``            ``requirements.txt`` format (``#`` comments and blank lines excluded) **BETA**
-``optional-dependencies``  ``file``            ``requirements.txt`` format per group (``#`` comments and blank lines excluded) **BETA**
+``dependencies``           ``file``            ``requirements.txt`` format (``#`` comments and blank lines excluded)
+``optional-dependencies``  ``file``            ``requirements.txt`` format per group (``#`` comments and blank lines excluded)
 ========================== =================== =================================================================================================
 
 Supporting ``file`` for dependencies is meant for a convenience for packaging


### PR DESCRIPTION
Remove the beta tag for dependencies and optional dependencies in the [Configuring setuptools using pyproject.toml files](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata) documentation.