### PR TITLE
Fix layout detection for projects with no packages.

### DIFF
--- a/changelog.d/3624.change.rst
+++ b/changelog.d/3624.change.rst
@@ -1,0 +1,1 @@
+Fixed editable install for multi-module/no-package ``src``-layout projects.

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -551,13 +551,18 @@ def _simple_layout(
     False
     >>> _simple_layout(['a', 'a.b'], {"": "src", "a.b": "_ab"}, "/tmp/myproj")
     False
+    >>> # Special cases, no packages yet:
+    >>> _simple_layout([], {"": "src"}, "/tmp/myproj")
+    True
+    >>> _simple_layout([], {"a": "_a", "": "src"}, "/tmp/myproj")
+    False
     """
     layout = {
         pkg: find_package_path(pkg, package_dir, project_dir)
         for pkg in packages
     }
     if not layout:
-        return False
+        return set(package_dir) in ({}, {""})
     parent = os.path.commonpath([_parent_path(k, v) for k, v in layout.items()])
     return all(
         _normalize_path(Path(parent, *key.split('.'))) == _normalize_path(value)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Modify the logic deciding if the package has a simple layout to support projects composed only by top-level modules (no packages).

Closes #3624

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
