### PR TITLE
Skip stdlib distutils tests on Python 3.12

### DIFF
--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -49,6 +49,13 @@ def count_meta_path(venv, env=None):
     return int(popen_text(venv.run)(cmd, env=win_sr(env)))
 
 
+skip_without_stdlib_distutils = pytest.mark.skipif(
+    sys.version_info >= (3, 12),
+    reason='stdlib distutils is removed from Python 3.12+',
+)
+
+
+@skip_without_stdlib_distutils
 def test_distutils_stdlib(venv):
     """
     Ensure stdlib distutils is used when appropriate.
@@ -119,9 +126,9 @@ print("success")
 @pytest.mark.parametrize(
     "distutils_version, imported_module",
     [
-        ("stdlib", "dir_util"),
-        ("stdlib", "file_util"),
-        ("stdlib", "archive_util"),
+        pytest.param("stdlib", "dir_util", marks=skip_without_stdlib_distutils),
+        pytest.param("stdlib", "file_util", marks=skip_without_stdlib_distutils),
+        pytest.param("stdlib", "archive_util", marks=skip_without_stdlib_distutils),
         ("local", "dir_util"),
         ("local", "file_util"),
         ("local", "archive_util"),
@@ -147,7 +154,13 @@ print("success")
 """
 
 
-@pytest.mark.parametrize("distutils_version", "local stdlib".split())
+@pytest.mark.parametrize(
+    "distutils_version",
+    [
+        "local",
+        pytest.param("stdlib", marks=skip_without_stdlib_distutils),
+    ]
+)
 def test_log_module_is_not_duplicated_on_import(distutils_version, tmpdir_cwd, venv):
     env = dict(SETUPTOOLS_USE_DISTUTILS=distutils_version)
     cmd = ['python', '-c', ENSURE_LOG_IMPORT_IS_NOT_DUPLICATED]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This is an imperfect way to make the tests pass on Python 3.12.

Long-term goal is to deprecate the stdlib option,
see https://github.com/pypa/setuptools/issues/3625

### Pull Request Checklist
- [ ] Changes have tests -- the change is in the tests
- [ ] News fragment added in [`changelog.d/`] -- IMHO not news-worthy