### PR TITLE
Consistently use unittest.mock in tests

### DIFF
--- a/changelog.d/3638.misc.rst
+++ b/changelog.d/3638.misc.rst
@@ -1,0 +1,1 @@
+Drop a test dependency on the ``mock`` package, always use :external+python:py:mod:`unittest.mock` -- by :user:`hroncok`

--- a/pkg_resources/tests/test_markers.py
+++ b/pkg_resources/tests/test_markers.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from pkg_resources import evaluate_marker
 

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -9,10 +9,7 @@ import stat
 import distutils.dist
 import distutils.command.install_egg_info
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 from pkg_resources import (
     DistInfoDistribution, Distribution, EggInfoDistribution,

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,6 @@ testing =
 	pytest-perf
 
 	# local
-	mock
 	flake8-2020
 	virtualenv>=13.0.0
 	wheel

--- a/setuptools/tests/test_bdist_deprecations.py
+++ b/setuptools/tests/test_bdist_deprecations.py
@@ -1,7 +1,7 @@
 """develop tests
 """
-import mock
 import sys
+from unittest import mock
 
 import pytest
 

--- a/setuptools/tests/test_build_clib.py
+++ b/setuptools/tests/test_build_clib.py
@@ -1,6 +1,7 @@
+from unittest import mock
+
 import pytest
 
-import mock
 from distutils.errors import DistutilsSetupError
 from setuptools.command.build_clib import build_clib
 from setuptools.dist import Distribution

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -12,7 +12,6 @@ import itertools
 import distutils.errors
 import io
 import zipfile
-import mock
 import time
 import re
 import subprocess
@@ -20,6 +19,7 @@ import pathlib
 import warnings
 from collections import namedtuple
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from jaraco import path

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -5,8 +5,8 @@ import platform
 import urllib.request
 import urllib.error
 import http.client
+from unittest import mock
 
-import mock
 import pytest
 
 import setuptools.package_index

--- a/setuptools/tests/test_register.py
+++ b/setuptools/tests/test_register.py
@@ -2,10 +2,7 @@ from setuptools.command.register import register
 from setuptools.dist import Distribution
 from setuptools.errors import RemovedCommandError
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import pytest
 

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -2,10 +2,7 @@ from setuptools.command.upload import upload
 from setuptools.dist import Distribution
 from setuptools.errors import RemovedCommandError
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import pytest
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Consistently use unittest.mock in tests

 - Some tests used unittest.mock from the standard library
 - Some tests used mock from PyPI
 - Some tests tried to import unittest.mock with a fallback to mock (the import never fails on Python 3.7+, older Pythons are not supported)

### Pull Request Checklist
- [ ] Changes have tests -- changes **are** tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
