### PR TITLE
Upload accurate coverage flags from unit tests job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           flags: >-  # Mark which lines are covered by which envs
             CI-GHA,
-            Type-units,
+            ${{ github.job }},
             OS-${{
               runner.os
             }},

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
+        id: python-install
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}${{ matrix.dev }}
@@ -67,8 +68,17 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           flags: >-  # Mark which lines are covered by which envs
-            ${{ runner.os }},
-            ${{ matrix.python }}
+            CI-GHA,
+            Type-units,
+            OS-${{
+              runner.os
+            }},
+            VM-${{
+              matrix.platform
+            }},
+            Py-${{
+              steps.python-install.outputs.python-version
+            }}
 
   check:  # This job does nothing and is only used for the branch protection
     if: always()


### PR DESCRIPTION
## Summary of changes

This ensures that the actual job env details are included as Codecov flags. It uses the exact Python patch version instead of the job matrix definition factors which may not be compatible with the acceptable flag syntax sometimes (like `~3.11.0-0` wouldn't be).

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
