### PR TITLE
Highlight in docs: 'attr' directive needs MANIFEST.in config / SCM plugin

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -166,6 +166,12 @@ Special directives:
       The ``file:`` directive is sandboxed and won't reach anything outside the
       project directory (i.e. the directory containing ``setup.cfg``/``pyproject.toml``).
 
+  .. attention::
+      When using the ``file:`` directive, please make sure that all necessary
+      files are included in the ``sdist``. You can do that via ``MANIFEST.in``
+      or using plugins such as ``setuptools-scm``.
+      Please have a look on :doc:`/userguide/miscellaneous` for more information.
+
 
 Metadata
 --------

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -210,6 +210,13 @@ Also note that the file format for specifying dependencies resembles a ``require
 however please keep in mind that all non-comment lines must conform with :pep:`508`
 (``pip``-specify syntaxes, e.g. ``-c/-r/-e`` flags, are not supported).
 
+
+.. attention::
+   When using the ``file`` directive, please make sure that all necessary
+   files are included in the ``sdist``. You can do that via ``MANIFEST.in``
+   or using plugins such as ``setuptools-scm``.
+   Please have a look on :doc:`/userguide/miscellaneous` for more information.
+
 ----
 
 .. rubric:: Notes


### PR DESCRIPTION
## Summary of changes

Motivated by https://github.com/pypa/setuptools/issues/1951#issuecomment-1302465693

- Highlight in docs: 'attr' directive needs MANIFEST.in config / SCM plugin to work properly

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
