### PR TITLE
Add a test for maintainers w/ international emails

### DIFF
--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -136,6 +136,19 @@ spam-gui = "spam:main_gui"
 tomatoes = "spam:main_tomatoes"
 """
 
+PEP621_INTERNATIONAL_EMAIL_EXAMPLE = """\
+[project]
+name = "spam"
+version = "2020.0.0"
+authors = [
+  {email = "hi@pradyunsg.me"},
+  {name = "Tzu-Ping Chung"}
+]
+maintainers = [
+  {name = "Степан Бандера", email = "криївка@оун-упа.укр"},
+]
+"""
+
 PEP621_EXAMPLE_SCRIPT = """
 def main_cli(): pass
 def main_gui(): pass
@@ -143,9 +156,13 @@ def main_tomatoes(): pass
 """
 
 
-def _pep621_example_project(tmp_path, readme="README.rst"):
+def _pep621_example_project(
+        tmp_path,
+        readme="README.rst",
+        pyproject_text=PEP621_EXAMPLE,
+):
     pyproject = tmp_path / "pyproject.toml"
-    text = PEP621_EXAMPLE
+    text = pyproject_text
     replacements = {'readme = "README.rst"': f'readme = "{readme}"'}
     for orig, subst in replacements.items():
         text = text.replace(orig, subst)
@@ -191,19 +208,43 @@ def test_no_explicit_content_type_for_missing_extension(tmp_path):
     assert dist.metadata.long_description_content_type is None
 
 
-def test_utf8_maintainer_in_metadata(tmp_path):  # issue-3663
-    pyproject = _pep621_example_project(tmp_path, "README")
-    dist = pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
-    expected = (
-        'Brett Cannon <brett@python.org>, "John X. Ãørçeč" <john@utf8.org>, '
-        'Γαμα קּ 東 <gama@utf8.org>'
+@pytest.mark.parametrize(
+    ('pyproject_text', 'expected_maintainers_meta_value'),
+    (
+        pytest.param(
+            PEP621_EXAMPLE,
+            (
+                'Brett Cannon <brett@python.org>, "John X. Ãørçeč" <john@utf8.org>, '
+                'Γαμα קּ 東 <gama@utf8.org>'
+            ),
+            id='non-international-emails',
+        ),
+        pytest.param(
+            PEP621_INTERNATIONAL_EMAIL_EXAMPLE,
+            'Степан Бандера <криївка@оун-упа.укр>',
+            marks=pytest.mark.xfail(
+                reason="CPython's `email.headerregistry.Address` only supports "
+                'RFC 5322, as of Nov 10, 2022 and latest Python 3.11.0',
+                strict=True,
+            ),
+            id='international-email',
+        ),
+    ),
+)
+def test_utf8_maintainer_in_metadata(  # issue-3663
+        expected_maintainers_meta_value,
+        pyproject_text, tmp_path,
+):
+    pyproject = _pep621_example_project(
+        tmp_path, "README", pyproject_text=pyproject_text,
     )
-    assert dist.metadata.maintainer_email == expected
+    dist = pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
+    assert dist.metadata.maintainer_email == expected_maintainers_meta_value
     pkg_file = tmp_path / "PKG-FILE"
     with open(pkg_file, "w", encoding="utf-8") as fh:
         dist.metadata.write_pkg_file(fh)
     content = pkg_file.read_text(encoding="utf-8")
-    assert f"Maintainer-email: {expected}" in content
+    assert f"Maintainer-email: {expected_maintainers_meta_value}" in content
 
 
 # TODO: After PEP 639 is accepted, we have to move the license-files


### PR DESCRIPTION
## Summary of changes

This is a follow-up for PR #3666.

The current `email.headerregistry.Address` implementation only allows RFC 5322 but the world is slowly moving towards supporting the international emails too. This patch adds a test case that is currently expected to fail but hopefully should pass once the support for RFC 6532 is implemented in the standard library.

Refs:
* https://datatracker.ietf.org/doc/html/rfc6532
* https://en.wikipedia.org/wiki/International_email

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
