### PR TITLE
Make clib build reproducible by sorting sources

### DIFF
--- a/changelog.d/3678.change.rst
+++ b/changelog.d/3678.change.rst
@@ -1,1 +1,1 @@
-Make clib builds reproducible by sorting sources -- by :user:`danigm`
+Improve clib builds reproducibility by sorting sources -- by :user:`danigm`

--- a/changelog.d/3678.change.rst
+++ b/changelog.d/3678.change.rst
@@ -1,0 +1,1 @@
+Make clib builds reproducible by sorting sources -- by :user:`danigm`

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -28,7 +28,7 @@ class build_clib(orig.build_clib):
                     "in 'libraries' option (library '%s'), "
                     "'sources' must be present and must be "
                     "a list of source filenames" % lib_name)
-            sources = list(sources)
+            sources = sorted(list(sources))
 
             log.info("building '%s' library", lib_name)
 

--- a/setuptools/tests/test_build_clib.py
+++ b/setuptools/tests/test_build_clib.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 import pytest
 
+import random
 from distutils.errors import DistutilsSetupError
 from setuptools.command.build_clib import build_clib
 from setuptools.dist import Distribution
@@ -56,3 +57,30 @@ class TestBuildCLib:
         cmd.build_libraries(libs)
         assert cmd.compiler.compile.call_count == 1
         assert cmd.compiler.create_static_lib.call_count == 1
+
+    @mock.patch(
+        'setuptools.command.build_clib.newer_pairwise_group')
+    def test_build_libraries_reproducible(self, mock_newer):
+        dist = Distribution()
+        cmd = build_clib(dist)
+
+        # with that out of the way, let's see if the crude dependency
+        # system works
+        cmd.compiler = mock.MagicMock(spec=cmd.compiler)
+        mock_newer.return_value = ([], [])
+
+        original_sources = ['a-example.c', 'example.c']
+        sources = original_sources
+
+        obj_deps = {'': ('global.h',), 'example.c': ('example.h',)}
+        libs = [('example', {'sources': sources, 'obj_deps': obj_deps})]
+
+        cmd.build_libraries(libs)
+        computed_call_args = mock_newer.call_args[0]
+
+        while sources == original_sources:
+            sources = random.sample(original_sources, len(original_sources))
+        libs = [('example', {'sources': sources, 'obj_deps': obj_deps})]
+
+        cmd.build_libraries(libs)
+        assert computed_call_args == mock_newer.call_args[0]


### PR DESCRIPTION
## Summary of changes

Sort sources in `build_clib` command.

Closes https://github.com/pypa/setuptools/issues/3678

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].

