### PR TITLE
`pkg_resources`: Flip import conditionals around `pkgutil.ImpImporter` and `importlib.machinery.FileFinder`

### DIFF
--- a/changelog.d/3685.change.rst
+++ b/changelog.d/3685.change.rst
@@ -1,0 +1,1 @@
+Fix improper usage of deprecated/removed ``pkgutil`` APIs in Python 3.12+.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2187,7 +2187,8 @@ def resolve_egg_link(path):
     return next(dist_groups, ())
 
 
-register_finder(pkgutil.ImpImporter, find_on_path)
+if hasattr(pkgutil, 'ImpImporter'):
+    register_finder(pkgutil.ImpImporter, find_on_path)
 
 if hasattr(importlib_machinery, 'FileFinder'):
     register_finder(importlib_machinery.FileFinder, find_on_path)
@@ -2344,7 +2345,9 @@ def file_ns_handler(importer, path_item, packageName, module):
         return subpath
 
 
-register_namespace_handler(pkgutil.ImpImporter, file_ns_handler)
+if hasattr(pkgutil, 'ImpImporter'):
+    register_namespace_handler(pkgutil.ImpImporter, file_ns_handler)
+
 register_namespace_handler(zipimport.zipimporter, file_ns_handler)
 
 if hasattr(importlib_machinery, 'FileFinder'):

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2190,8 +2190,7 @@ def resolve_egg_link(path):
 if hasattr(pkgutil, 'ImpImporter'):
     register_finder(pkgutil.ImpImporter, find_on_path)
 
-if hasattr(importlib_machinery, 'FileFinder'):
-    register_finder(importlib_machinery.FileFinder, find_on_path)
+register_finder(importlib_machinery.FileFinder, find_on_path)
 
 _declare_state('dict', _namespace_handlers={})
 _declare_state('dict', _namespace_packages={})
@@ -2349,9 +2348,7 @@ if hasattr(pkgutil, 'ImpImporter'):
     register_namespace_handler(pkgutil.ImpImporter, file_ns_handler)
 
 register_namespace_handler(zipimport.zipimporter, file_ns_handler)
-
-if hasattr(importlib_machinery, 'FileFinder'):
-    register_namespace_handler(importlib_machinery.FileFinder, file_ns_handler)
+register_namespace_handler(importlib_machinery.FileFinder, file_ns_handler)
 
 
 def null_ns_handler(importer, path_item, packageName, module):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->


## Summary of changes

- In Python 3.3+ `importlib.machinery.FileFinder` is always present, therefore we no longer need to keep the conditional
- In Python 3.12+ `pkgutil.ImpImporter` is removed, so we need a conditional to avoid using it directly.

(Potentially) closes #3631

### Notes

- `pkg_resources` uses `pkgutil.get_importer` to find out which importer is responsible for importing an specific file.
  - I don't know if there is a situation in `Python >= 3.7, < 3.12` where this function can return an instance of `pkgutil.ImpImporter`.
  - In the case `pkgutil.get_importer` never returns `pkgutil.ImpImporter`, I believe we could simply remove `pkgutil.ImpImporter` from the namespace handler and finder registries in `pkg_resources` (but don't quote me on that 😅).
- Issue #3631 also indicates that the `find_module` will be removed in 3.12.
  - `pkg_resources` use this function just as a contingency in the case `find_spec` is not defined.
    - This might be particularly important for `zipimporter` in `Python >=3.7, < 3.10`
  - For `Python >= 3.12`, `find_spec` should always be defined, and therefore I believe the code path is not triggered.
- Both `pkg_resources.find_on_path` and `pkg_resources.file_ns_handler` ignore the `importer` argument.
  - If needed we can also play with that.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
