### PR TITLE
Add note about global `distutils.cfg`

### DIFF
--- a/docs/deprecated/distutils-legacy.rst
+++ b/docs/deprecated/distutils-legacy.rst
@@ -7,6 +7,15 @@ Since the 60.0.0 release, Setuptools includes a local, vendored copy of distutil
 
     SETUPTOOLS_USE_DISTUTILS=stdlib
 
+.. warning::
+   Please note that this also affects how ``distutils.cfg`` files inside stdlib's ``distutils``
+   package directory are processed.
+   Unless ``SETUPTOOLS_USE_DISTUTILS=stdlib``, they will have no effect on the build process.
+
+   You can still use a global user config file, ``~/.pydistutils.cfg`` (POSIX) or ``%USERPROFILE%/pydistutils.cfg`` (Windows),
+   or use the environment variable :doc:`DIST_EXTRA_CONFIG <deprecated/distutils/configfile>` to point to another
+   supplementary configuration file.
+
 
 Prefer Setuptools
 -----------------


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- With the move to `setuptools/_distutils` people might be confused why their `distutilts/distutils.cfg` does not work.
- This PR adds clarification about that to the docs.

Closes #3681 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
