### PR TITLE
Fix logging errors: 'underlying buffer has been detached' (pypa#1631)

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -1195,19 +1195,11 @@ class Distribution(_Distribution):
 
         # Print metadata in UTF-8 no matter the platform
         encoding = sys.stdout.encoding
-        errors = sys.stdout.errors
-        newline = sys.platform != 'win32' and '\n' or None
-        line_buffering = sys.stdout.line_buffering
-
-        sys.stdout = io.TextIOWrapper(
-            sys.stdout.detach(), 'utf-8', errors, newline, line_buffering
-        )
+        sys.stdout.reconfigure(encoding='utf-8')
         try:
             return _Distribution.handle_display_options(self, option_order)
         finally:
-            sys.stdout = io.TextIOWrapper(
-                sys.stdout.detach(), encoding, errors, newline, line_buffering
-            )
+            sys.stdout.reconfigure(encoding=encoding)
 
     def run_command(self, command):
         self.set_defaults()


### PR DESCRIPTION
## Summary of changes

Those changes fix the issue reported in #1631. From a simple test case, the command `bdist_wheel` displayed error messages:
```
Traceback (most recent call last):
  File "C:\dev\Python311\Lib\logging\__init__.py", line 1113, in emit
    stream.write(msg + self.terminator)
ValueError: underlying buffer has been detached
```
Python 3.7 offers a good alternative to change the encoding of the standard output: io.TextIOWrapper.reconfigure (). This alternative solves the error messages.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
