### PR TITLE
The default encoding of Python sources is UTF-8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 extensions = [
     'sphinx.ext.autodoc',

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """upload_docs
 
 Implements a Distutils 'upload_docs' subcommand (upload documentation to

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 __all__ = ['Distribution']
 
 import io

--- a/setuptools/tests/script-with-bom.py
+++ b/setuptools/tests/script-with-bom.py
@@ -1,3 +1,1 @@
-﻿# -*- coding: utf-8 -*-
-
-result = 'passed'
+﻿result = 'passed'

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """sdist tests"""
 
 import contextlib

--- a/setuptools/tests/test_msvc14.py
+++ b/setuptools/tests/test_msvc14.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Tests for msvc support module (msvc14 unit tests).
 """

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """wheel tests
 """
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->
Python 3 assumes the encoding is UTF-8 by default, and so do or should do tools such as text editors when opening Python files.

No need to explicitly set `*- coding: utf-8 -*-`.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_