### PR TITLE
Get rid of trailing spaces, mainly in docs

### DIFF
--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -48,8 +48,8 @@ files, a ``pyproject.toml`` file and a ``setup.cfg`` file::
         pyproject.toml
         setup.cfg
         meowpkg/
-		    __init__.py
-			module.py
+            __init__.py
+            module.py
 
 The ``pyproject.toml`` file specifies the build system (i.e. what is
 being used to package your scripts and install from source). To use it with
@@ -161,7 +161,7 @@ requirements.
    and :pypi:`setuptools-svn`), or by correctly setting up :ref:`MANIFEST.in
    <manifest>`.
 
-   The generated ``.tar.gz`` and ``.whl`` files are compressed archives that 
+   The generated ``.tar.gz`` and ``.whl`` files are compressed archives that
    can be inspected as follows:
    On POSIX systems, this can be done with ``tar -tf dist/*.tar.gz``
    and ``unzip -l dist/*.whl``.

--- a/docs/deprecated/distutils/commandref.rst
+++ b/docs/deprecated/distutils/commandref.rst
@@ -101,5 +101,3 @@ anything except backslash or colon.
 .. % \subsection{\protect\command{bdist}}
 .. % \subsection{\protect\command{bdist\_dumb}}
 .. % \subsection{\protect\command{bdist\_rpm}}
-
-

--- a/docs/deprecated/distutils/configfile.rst
+++ b/docs/deprecated/distutils/configfile.rst
@@ -142,4 +142,3 @@ split across multiple lines for readability.
 
 .. [#] This ideal probably won't be achieved until auto-configuration is fully
    supported by the Distutils.
-

--- a/docs/deprecated/distutils/extending.rst
+++ b/docs/deprecated/distutils/extending.rst
@@ -94,5 +94,3 @@ to add ``(command, filename)`` pairs to ``self.distribution.dist_files`` so that
 :command:`upload` can upload it to PyPI.  The *filename* in the pair contains no
 path information, only the name of the file itself.  In dry-run mode, pairs
 should still be added to represent what would have been created.
-
-

--- a/docs/deprecated/zip_safe.rst
+++ b/docs/deprecated/zip_safe.rst
@@ -62,7 +62,7 @@ Currently, popular Python package installers (such as :pypi:`pip`) and package
 indexes (such as PyPI_) consider that distribution packages are always
 installed as a directory.
 It is however still possible to load packages from zip files added to
-:obj:`sys.path`, thanks to the :mod:`zipimport` module 
+:obj:`sys.path`, thanks to the :mod:`zipimport` module
 and the :mod:`importlib` machinery provided by Python standard library.
 
 When working with modules loaded from a zip file, it is important to keep in

--- a/docs/userguide/entry_point.rst
+++ b/docs/userguide/entry_point.rst
@@ -89,7 +89,7 @@ configuration:
 .. tab:: setup.py
 
     .. code-block:: python
-    
+
         from setuptools import setup
 
         setup(

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -165,7 +165,7 @@ to specify to properly package your project.
   :doc:`setup.cfg <declarative_config>`, and keep the ``setup.py`` minimal
   with only the dynamic parts (or even omit it completely if applicable).
 
-  See `Why you shouldn't invoke setup.py directly`_ for more background.  
+  See `Why you shouldn't invoke setup.py directly`_ for more background.
 
 .. _Why you shouldn't invoke setup.py directly: https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html
 

--- a/launcher.c
+++ b/launcher.c
@@ -180,7 +180,7 @@ void pass_control_to_child(DWORD control_type) {
 }
 
 BOOL control_handler(DWORD control_type) {
-    /* 
+    /*
      * distribute-issue207
      * control event handler callback function
      */
@@ -209,7 +209,7 @@ int create_and_wait_for_subprocess(char* command) {
     if (!CreateProcessA(NULL, commandline, NULL, NULL, TRUE, 0, NULL, NULL, &s_info, &p_info)) {
         fprintf(stderr, "failed to create process.\n");
         return 0;
-    }   
+    }
     child_pid = p_info.dwProcessId;
     // wait for Python to exit
     WaitForSingleObject(p_info.hProcess, INFINITE);
@@ -229,7 +229,7 @@ char* join_executable_and_args(char *executable, char **args, int argc)
      */
     int len,counter;
     char* cmdline;
-    
+
     len=strlen(executable)+2;
     for (counter=1; counter<argc; counter++) {
         len+=strlen(args[counter])+1;
@@ -333,4 +333,3 @@ int WINAPI WinMain(HINSTANCE hI, HINSTANCE hP, LPSTR lpCmd, int nShow) {
 int main(int argc, char** argv) {
     return run(argc, argv, GUI);
 }
-


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Remove trailing spaces at end of line, and empty lines at end of file.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
