### PR TITLE
Fix non-ASCII homoglyph of `v`

### DIFF
--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -69,7 +69,7 @@ Please have a look on the following section if you are looking for a different b
 
        sudo apt install python3-venv
 
-   Alternatively, you can also try installing :pypi:`virtualenᴠ`.
+   Alternatively, you can also try installing :pypi:`virtualenv`.
    More information is available on the Python Packaging User Guide on
    :doc:`PyPUG:guides/installing-using-pip-and-virtual-environments`.
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The last character of `virtualenᴠ` is not an ASCII `v`, but the Unicode homglyph "Latin Letter Small Capital V" (U+1D20) `ᴠ`:
```python
>>> 'ᴠ'.encode("unicode_escape")
b'\\u1d20'
>>> 
>>> 'v'.encode("unicode_escape")
b'v'
>>> 
```

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
