### PR TITLE
Fix spacing (mixed spaces and tabs) in build_meta.rst

### DIFF
--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -49,7 +49,7 @@ files, a ``pyproject.toml`` file and a ``setup.cfg`` file::
         setup.cfg
         meowpkg/
 		    __init__.py
-			module.py
+		    module.py
 
 The ``pyproject.toml`` file specifies the build system (i.e. what is
 being used to package your scripts and install from source). To use it with

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -48,8 +48,8 @@ files, a ``pyproject.toml`` file and a ``setup.cfg`` file::
         pyproject.toml
         setup.cfg
         meowpkg/
-		    __init__.py
-		    module.py
+            __init__.py
+            module.py
 
 The ``pyproject.toml`` file specifies the build system (i.e. what is
 being used to package your scripts and install from source). To use it with


### PR DESCRIPTION

Right now tabs and spaces are mixed:
<img width="865" alt="image" src="https://user-images.githubusercontent.com/6897215/203130851-c4049184-073c-4614-850e-7fa7d0cb1b5d.png">

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
