### PR TITLE
Merge pypa/distutils@3e9d47e with fix for distutils.log.

### DIFF
--- a/changelog.d/3693.bugfix.rst
+++ b/changelog.d/3693.bugfix.rst
@@ -1,0 +1,1 @@
+Merge pypa/distutils@3e9d47e with compatibility fix for distutils.log.Log.

--- a/setuptools/_distutils/log.py
+++ b/setuptools/_distutils/log.py
@@ -5,6 +5,7 @@ Retained for compatibility and should not be used.
 """
 
 import logging
+import warnings
 
 from ._log import log as _global_log
 
@@ -36,3 +37,21 @@ def set_verbosity(v):
         set_threshold(logging.INFO)
     elif v >= 2:
         set_threshold(logging.DEBUG)
+
+
+class Log(logging.Logger):
+    """distutils.log.Log is deprecated, please use an alternative from `logging`."""
+
+    def __init__(self, threshold=WARN):
+        warnings.warn(Log.__doc__)  # avoid DeprecationWarning to ensure warn is shown
+        super().__init__(__name__, level=threshold)
+
+    @property
+    def threshold(self):
+        return self.level
+
+    @threshold.setter
+    def threshold(self, level):
+        self.setLevel(level)
+
+    warn = logging.Logger.warning


### PR DESCRIPTION
Fixes #3693.

- Add distutils.log.Log back for compatibility
- Ignore deprecation warning in tests

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
