### PR TITLE
Update logging.py to patch the distutils.log logger to have the warning attribute

### DIFF
--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -28,7 +28,7 @@ def configure():
         # and then loaded again when patched,
         # implying: id(distutils.log) != id(distutils.dist.log).
         # Make sure the same module object is used everywhere:
-        distutils.dist.log = distutils.log
+        distutils.log = distutils.dist.log
 
 
 def set_threshold(level):


### PR DESCRIPTION
Patch the distutils.log logger to be the rootlogger from distutils.dist.log

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
