### PR TITLE
Replace condition to patch `distutils.dist.log`

### DIFF
--- a/changelog.d/3709.misc.rst
+++ b/changelog.d/3709.misc.rst
@@ -1,0 +1,2 @@
+Fix condition to patch ``distutils.dist.log`` to only apply when using
+``distutils`` from the stdlib.

--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -1,4 +1,5 @@
 import sys
+import inspect
 import logging
 import distutils.log
 from . import monkey
@@ -22,7 +23,7 @@ def configure():
     handlers = err_handler, out_handler
     logging.basicConfig(
         format="{message}", style='{', handlers=handlers, level=logging.DEBUG)
-    if hasattr(distutils.log, 'Log'):
+    if inspect.ismodule(distutils.dist.log):
         monkey.patch_func(set_threshold, distutils.log, 'set_threshold')
         # For some reason `distutils.log` module is getting cached in `distutils.dist`
         # and then loaded again when patched,

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -42,7 +42,7 @@ def test_patching_does_not_cause_problems():
     # Ensure `dist.log` is only patched if necessary
 
     import setuptools.logging
-    from distutils import dist  # <- load distutils after all the patches take place
+    from distutils import dist
 
     setuptools.logging.configure()
 

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -1,4 +1,6 @@
+import inspect
 import logging
+import os
 
 import pytest
 
@@ -34,3 +36,18 @@ def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     log_level = logger.getEffectiveLevel()
     log_level_name = logging.getLevelName(log_level)
     assert log_level_name == expected_level
+
+
+def test_patching_does_not_cause_problems():
+    # Ensure `dist.log` is only patched if necessary
+
+    import setuptools.logging
+    from distutils import dist  # <- load distutils after all the patches take place
+
+    setuptools.logging.configure()
+
+    if os.getenv("SETUPTOOLS_USE_DISTUTILS", "local").lower() == "local":
+        # Modern logging infra, no problematic patching.
+        assert isinstance(dist.log, logging.Logger)
+    else:
+        assert inspect.ismodule(dist.log)


### PR DESCRIPTION
As `distutils.log.Log` was backfilled for compatibility we no longer can use this as a condition.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Replace protection condition.

Closes #3707 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
