### PR TITLE
Improve example docs for setup.cfg and pyproject.toml

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -25,10 +25,13 @@ boilerplate code in some cases.
     [metadata]
     name = my_package
     version = attr: my_package.VERSION
+    author = Josiah Carberry
+    author_email = josiah_carberry@brown.edu
     description = My package description
     long_description = file: README.rst, CHANGELOG.rst, LICENSE.rst
     keywords = one, two
-    license = BSD 3-Clause License
+    python_requires = >=3.7
+    license = BSD-3-Clause
     classifiers =
         Framework :: Django
         Programming Language :: Python :: 3

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -42,11 +42,14 @@ The ``project`` table contains metadata fields as described by
 
    [project]
    name = "my_package"
+   authors = [
+       {name = "Josiah Carberry", email = "josiah_carberry@brown.edu"},
+   ]
    description = "My package description"
    readme = "README.rst"
    requires-python = ">=3.7"
    keywords = ["one", "two"]
-   license = {text = "BSD 3-Clause License"}
+   license = {text = "BSD-3-Clause"}
    classifiers = [
        "Framework :: Django",
        "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR improves the example documentation for both `setup.cfg` and `pyproject.toml`.

Changes to both examples:

- Add an author and email, as these are commonly used (an alternative fictional person could be nominated, if a better one exists)
- Use the SPDX short identifier [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html), which aligns with [PEP 639](https://peps.python.org/pep-0639/)

Other:

- With `setup.py` only, add `python_requires` to example, so that it is compatible to `pyproject.toml`