### PR TITLE
Add htmlcov to FlatLayoutModuleFinder.DEFAULT_EXCLUDE

### DIFF
--- a/changelog.d/3594.change.rst
+++ b/changelog.d/3594.change.rst
@@ -1,0 +1,1 @@
+Added ``htmlcov`` to FlatLayoutModuleFinder.DEFAULT_EXCLUDE -- by :user:`demianbrecht`

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -273,6 +273,7 @@ class FlatLayoutModuleFinder(ModuleFinder):
         "benchmarks",
         "exercise",
         "exercises",
+        "htmlcov",
         # ---- Hidden files/Private modules ----
         "[._]*",
     )


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Added `htmlcov` to `FlatLayoutModuleFinder.DEFAULT_EXCLUDE`.

<!-- Summary goes here -->

Closes #3594 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
