### PR TITLE
Catching excption from utime and providing human-readable error description

### DIFF
--- a/changelog.d/3667.change.rst
+++ b/changelog.d/3667.change.rst
@@ -1,0 +1,1 @@
+Added a human-readable error description when ``.egg-info`` directory is not writeable -- by :user:`droodev`

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -295,7 +295,11 @@ class egg_info(InfoCommon, Command):
 
     def run(self):
         self.mkpath(self.egg_info)
-        os.utime(self.egg_info, None)
+        try:
+            os.utime(self.egg_info, None)
+        except OSError as e:
+            msg = f"Cannot update time stamp of directory '{self.egg_info}'"
+            raise distutils.errors.DistutilsFileError(msg) from e
         for ep in metadata.entry_points(group='egg_info.writers'):
             writer = ep.load()
             writer(self, ep.name, os.path.join(self.egg_info, ep.name))

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -7,6 +7,7 @@ import stat
 import time
 from typing import List, Tuple
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from jaraco import path
@@ -157,6 +158,16 @@ class TestEggInfo:
             'top_level.txt',
         ]
         assert sorted(actual) == expected
+
+    def test_handling_utime_error(self, tmpdir_cwd, env):
+        dist = Distribution()
+        ei = egg_info(dist)
+        with mock.patch('os.utime', side_effect=OSError("TEST")),\
+        mock.patch('setuptools.command.egg_info.egg_info.mkpath', return_val=None):
+            import distutils.errors
+            with pytest.raises(distutils.errors.DistutilsFileError, match =
+            r"Cannot update time stamp of directory 'None'"):
+                ei.run()
 
     def test_license_is_a_string(self, tmpdir_cwd, env):
         setup_config = DALS("""


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

An OSError raised by ``utime`` when ``egg-info`` was not writeable was not clear at all---it was only mentioning "Permision denied"; without even specifying the file. So now, when this error occurs, we provide an exception that clearly describes which file causes troubles.

The fact that the original OSError does not have the causing filename set is unclear to me. The OSError class has fields ``filename`` and ``filename2`` that should be populated in such a case but they're not for some reason. 

Closes  #3667

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
