### PR TITLE
fix documentation for dynamic build dependencies

### DIFF
--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -143,11 +143,11 @@ the ``_custom_build/backend.py`` file, as shown in the following example:
     build_sdist = _orig.build_sdist
 
 
-    def get_requires_for_build_wheel(self, config_settings=None):
+    def get_requires_for_build_wheel(config_settings=None):
         return _orig.get_requires_for_build_wheel(config_settings) + [...]
 
 
-    def get_requires_for_build_sdist(self, config_settings=None):
+    def get_requires_for_build_sdist(config_settings=None):
         return _orig.get_requires_for_build_sdist(config_settings) + [...]
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

I followed the documentation on dynamic build dependencies, which is apparently incorrect. See https://github.com/maxbachmann/RapidFuzz/issues/303. This fixes the passage in the documentation.


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
