### PR TITLE
Remove msvc hack for Numpy < 1.11.2

### DIFF
--- a/changelog.d/3741.breaking.rst
+++ b/changelog.d/3741.breaking.rst
@@ -1,0 +1,2 @@
+Removed patching of ``distutils._msvccompiler.gen_lib_options``
+for compatibility with Numpy < 1.11.2 -- by :user:`mgorny`

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -157,9 +157,3 @@ def patch_for_msvc_specialized_compiler():
         patch_func(*msvc14('_get_vc_env'))
     except ImportError:
         pass
-
-    try:
-        # Patch distutils._msvccompiler.gen_lib_options for Numpy
-        patch_func(*msvc14('gen_lib_options'))
-    except ImportError:
-        pass

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -15,16 +15,12 @@ import json
 from io import open
 from os import listdir, pathsep
 from os.path import join, isfile, isdir, dirname
-import sys
 import contextlib
 import platform
 import itertools
 import subprocess
 import distutils.errors
-from setuptools.extern.packaging.version import LegacyVersion
 from setuptools.extern.more_itertools import unique_everseen
-
-from .monkey import get_unpatched
 
 if platform.system() == 'Windows':
     import winreg
@@ -215,19 +211,6 @@ def msvc14_get_vc_env(plat_spec):
     except distutils.errors.DistutilsPlatformError as exc:
         _augment_exception(exc, 14.0)
         raise
-
-
-def msvc14_gen_lib_options(*args, **kwargs):
-    """
-    Patched "distutils._msvccompiler.gen_lib_options" for fix
-    compatibility between "numpy.distutils" and "distutils._msvccompiler"
-    (for Numpy < 1.11.2)
-    """
-    if "numpy.distutils" in sys.modules:
-        import numpy as np
-        if LegacyVersion(np.__version__) < LegacyVersion('1.11.2'):
-            return np.distutils.ccompiler.gen_lib_options(*args, **kwargs)
-    return get_unpatched(msvc14_gen_lib_options)(*args, **kwargs)
 
 
 def _augment_exception(exc, version, arch=''):


### PR DESCRIPTION
## Summary of changes

Remove the msvc hack that was applied if numpy.distutils were loaded prior to Numpy 1.11.2.  These versions date back to June 2016 and no longer build with Python 3.7.  At the same time, the hack relies on packaging.version.LegacyVersion that is removed in packaging 22.0.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
