### PR TITLE
Update failing test due to latest versions of `pip_run`

### DIFF
--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -341,7 +341,7 @@ def test_editable_with_prefix(tmp_path, sample_project, editable_opts):
     site_packages.mkdir(parents=True)
 
     # install workaround
-    pip_run.launch.inject_sitecustomize(str(site_packages))
+    pip_run.launch.inject_sitecustomize(site_packages)
 
     env = dict(os.environ, PYTHONPATH=str(site_packages))
     cmd = [


### PR DESCRIPTION
It seems that the latest version of `pip_run` can no longer handle `str` objects in `inject_sitecustomize` (see
`https://github.com/jaraco/pip-run/commit/30c62a0eadd5af422709e75993ff19a39fe69733`).

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
- Avoid converting argument of `pip_run.launch.inject_sitecustomize` into `str`

Examples of previously failing tests: https://github.com/pypa/setuptools/actions/runs/3855567261/jobs/6570754102

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
