### PR TITLE
docs: Remove repeated mention of LDFLAGS environment variable

### DIFF
--- a/docs/userguide/ext_modules.rst
+++ b/docs/userguide/ext_modules.rst
@@ -76,8 +76,8 @@ compiler and linker options from various sources:
 * the ``sysconfig`` variables ``CC``, ``CXX``, ``CCSHARED``,
   ``LDSHARED``, and ``CFLAGS``,
 * the environment variables ``CC``, ``CPP``,
-  ``CXX``, ``LDSHARED`` and ``LDFLAGS``,
-  ``CFLAGS``, ``CPPFLAGS``, ``LDFLAGS``,
+  ``CXX``, ``LDSHARED`` and ``CFLAGS``,
+  ``CPPFLAGS``, ``LDFLAGS``,
 * the ``Extension`` attributes ``include_dirs``,
   ``library_dirs``, ``extra_compile_args``, ``extra_link_args``,
   ``runtime_library_dirs``.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The first instance of `LDFLAGS` is removed instead of the second to match the ordering style of the preceding environment variables (`CC`, `CPP`, `CXX`, `LDSHARED`). This repeat was introduced in PR https://github.com/pypa/setuptools/pull/3368 in what seems like a very easy to make copy and paste typo.

### Pull Request Checklist
- [N/A] Changes have tests
- [N/A] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_ (Skipping this as I don't think you want typo corrections in the CHANGELOG, but I can add if desired.)


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
