### PR TITLE
Docs: Link directly to PEPs

### DIFF
--- a/docs/artwork.rst
+++ b/docs/artwork.rst
@@ -65,7 +65,7 @@ Inspiration
 This design was inspired by :user:`cajhne`'s `original proposal`_ and the
 ancient symbol of the ouroboros_.
 It features a snake moving in a circular trajectory not only as a reference to
-the Python programming language but also to the `wheel package format`_ as one
+the Python programming language but also to the :pep:`wheel package format <427>` as one
 of the distribution formats supported by setuptools.
 The shape of the snake also resembles a cog, which together with the hammer is
 a nod to the two words that compose the name of the project.
@@ -115,5 +115,4 @@ https://github.com/pypa/setuptools or https://setuptools.pypa.io.
 .. _setuptools repository: https://github.com/pypa/setuptools
 .. _install the correct fonts: https://wiki.inkscape.org/wiki/Installing_fonts
 .. _original proposal: https://github.com/pypa/setuptools/issues/2227#issuecomment-653628344
-.. _wheel package format: https://www.python.org/dev/peps/pep-0427/
 .. _ouroboros: https://en.wikipedia.org/wiki/Ouroboros

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -16,7 +16,7 @@ overhaul. Because ``setup.py`` scripts allow for arbitrary execution, it
 is difficult to provide a reliable user experience across environments
 and history.
 
-`PEP 517 <https://www.python.org/dev/peps/pep-0517/>`_ came to
+:pep:`517` came to
 the rescue and specified a new standard for packaging and distributing Python
 modules. Under PEP 517:
 

--- a/docs/deprecated/easy_install.rst
+++ b/docs/deprecated/easy_install.rst
@@ -989,9 +989,7 @@ The following section lists only the easiest and most relevant approaches [1]_.
 
 `Use "virtualenv"`_
 
-.. [1] There are older ways to achieve custom installation using various ``easy_install`` and ``setup.py install`` options, combined with ``PYTHONPATH`` and/or ``PYTHONUSERBASE`` alterations, but all of these are effectively deprecated by the User scheme brought in by `PEP-370`_.
-
-.. _PEP-370: http://www.python.org/dev/peps/pep-0370/
+.. [1] There are older ways to achieve custom installation using various ``easy_install`` and ``setup.py install`` options, combined with ``PYTHONPATH`` and/or ``PYTHONUSERBASE`` alterations, but all of these are effectively deprecated by the User scheme brought in by :pep:`370`.
 
 
 Use the "--user" option

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -508,7 +508,7 @@ available to your interpreter.
 Legacy Namespace Packages
 =========================
 The fact you can create namespace packages so effortlessly above is credited
-to `PEP 420 <https://www.python.org/dev/peps/pep-0420/>`_. It used to be more
+to :pep:`420`. It used to be more
 cumbersome to accomplish the same result. Historically, there were two methods
 to create namespace packages. One is the ``pkg_resources`` style supported by
 ``setuptools`` and the other one being ``pkgutils`` style offered by


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Use the Sphinx `:pep:` role to link to PEPs in docs:

https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-pep

This means they'll link directly to their new home at https://peps.python.org/ rather than going via redirect at the old https://www.python.org/dev/peps/

And update the non-docs links to the new home.


### Pull Request Checklist
- [n/a] Changes have tests
- [n/a?] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request

Is a changelog needed for this?