### PR TITLE
sdist: automatically add metadata `file` referenced files

### DIFF
--- a/changelog.d/3771.change.rst
+++ b/changelog.d/3771.change.rst
@@ -1,0 +1,1 @@
+Added `file:` referenced files auto-inclusion into sdist

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -170,9 +170,9 @@ Special directives:
       project directory (i.e. the directory containing ``setup.cfg``/``pyproject.toml``).
 
   .. attention::
-      When using the ``file:`` directive, please make sure that all necessary
-      files are included in the ``sdist``. You can do that via ``MANIFEST.in``
-      or using plugins such as ``setuptools-scm``.
+      For versions prior to <VERSION>: When using the ``file:`` directive,
+      please make sure that all necessary files are included in the ``sdist``.
+      You can do that via ``MANIFEST.in`` or using plugins such as ``setuptools-scm``.
       Please have a look on :doc:`/userguide/miscellaneous` for more information.
 
 

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -565,6 +565,7 @@ class manifest_maker(sdist):
         if os.path.exists(self.template):
             self.read_template()
         self.add_license_files()
+        self.add_metadata_files()
         self.prune_file_list()
         self.filelist.sort()
         self.filelist.remove_duplicates()
@@ -621,6 +622,10 @@ class manifest_maker(sdist):
             log.info("adding license file '%s'", lf)
             pass
         self.filelist.extend(license_files)
+
+    def add_metadata_files(self):
+        """Add all metadata `file:` referenced files to self.filelist"""
+        sdist.add_metadata_files(self)
 
     def prune_file_list(self):
         build = self.get_finalized_command('build')

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -54,12 +54,13 @@ def validate(config: dict, filepath: _Path) -> bool:
 def apply_configuration(
     dist: "Distribution",
     filepath: _Path,
+    expand=True,
     ignore_option_errors=False,
 ) -> "Distribution":
     """Apply the configuration from a ``pyproject.toml`` file into an existing
     distribution object.
     """
-    config = read_configuration(filepath, True, ignore_option_errors, dist)
+    config = read_configuration(filepath, expand, ignore_option_errors, dist)
     return _apply(dist, config, filepath)
 
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -852,7 +852,9 @@ class Distribution(_Distribution):
             tomlfiles = [standard_project_metadata]
         return filenames, tomlfiles
 
-    def parse_config_files(self, filenames=None, ignore_option_errors=False):
+    def parse_config_files(
+        self, filenames=None, expand_directives=True, ignore_option_errors=False
+    ):
         """Parses configuration files from various levels
         and loads configuration.
         """
@@ -861,10 +863,18 @@ class Distribution(_Distribution):
         self._parse_config_files(filenames=inifiles)
 
         setupcfg.parse_configuration(
-            self, self.command_options, ignore_option_errors=ignore_option_errors
+            self,
+            self.command_options,
+            expand_directives=expand_directives,
+            ignore_option_errors=ignore_option_errors,
         )
         for filename in tomlfiles:
-            pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
+            pyprojecttoml.apply_configuration(
+                self,
+                filename,
+                expand_directives,
+                ignore_option_errors,
+            )
 
         self._finalize_requires()
         self._finalize_license_files()

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -498,6 +498,53 @@ class TestSdistTest:
             filename = filename.decode('latin-1')
             filename not in cmd.filelist.files
 
+    def test_setup_cfg_add_metadata_required_files(self, tmpdir):
+        touch(tmpdir / 'README.rst')
+        touch(tmpdir / 'USAGE.rst')
+
+        with open(tmpdir / 'setup.cfg', 'w') as f:
+            f.writelines("""
+                [metadata]
+                long_description = file: README.rst, USAGE.rst
+                [options]
+                packages = find:
+            """)
+
+        dist = Distribution(SETUP_ATTRS)
+        dist.script_name = 'setup.py'
+
+        cmd = sdist(dist)
+        cmd.ensure_finalized()
+        with quiet():
+            cmd.run()
+
+        assert 'README.rst' in cmd.filelist.files
+        assert 'USAGE.rst' in cmd.filelist.files
+
+    def test_pyproject_toml_add_metadata_required_files(self, tmpdir):
+        touch(tmpdir / 'README.rst')
+        touch(tmpdir / 'USAGE.rst')
+
+        with open(tmpdir / 'pyproject.toml', 'w') as f:
+            f.writelines("""
+                [project]
+                name = 'testing'
+                version = '0.0.1'
+                [tool.setuptools.dynamic]
+                readme = {file = ["README.rst", "USAGE.rst"]}
+            """)
+
+        dist = Distribution(SETUP_ATTRS)
+        dist.script_name = 'setup.py'
+
+        cmd = sdist(dist)
+        cmd.ensure_finalized()
+        with quiet():
+            cmd.run()
+
+        assert 'README.rst' in cmd.filelist.files
+        assert 'USAGE.rst' in cmd.filelist.files
+
     def test_pyproject_toml_in_sdist(self, tmpdir):
         """
         Check if pyproject.toml is included in source distribution if present


### PR DESCRIPTION
## Summary of changes

This is a first approximation to issue https://github.com/pypa/setuptools/issues/2821, where the _lack of automatic inclusion of `file:` referenced files into the source distribution_ was explained. The strategy followed was to read the **unexpanded version** of supported configuration files, in the `egg_info` command (called within `sdist` command), by either:

- Option A) Using [setupcfg.read_configuration](https://github.com/pypa/setuptools/blob/82eee6a998251b33ab3984f39b25c27ca72ba8b0/setuptools/config/setupcfg.py#L40-L65) and [pyprojecttoml.read_configuration](https://github.com/pypa/setuptools/blob/82eee6a998251b33ab3984f39b25c27ca72ba8b0/setuptools/config/pyprojecttoml.py#L66-L142) funcs (https://github.com/pypa/setuptools/commit/4194c2a1994ebca396c4f8291784ade0ce970f68).
- Option B) Using [Distribution.parse_config_files](https://github.com/pypa/setuptools/blob/82eee6a998251b33ab3984f39b25c27ca72ba8b0/setuptools/dist.py#L855-L870) method (https://github.com/pypa/setuptools/commit/abdbe0894236278acc0132db5d2bc91e628b4074).

Finally, all files within `file:` prefixed strings (`setup.cfg` case), of `file` dict keys (`pyproject.toml` case) are added to the list of distribution files.

Closes https://github.com/pypa/setuptools/issues/2821

### Pending questions
- Do folks prefer implementation option A, or option B?
- Do folks prefer to "hide" this feature behind a feature flag?

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d