### PR TITLE
DOC: fix section for python_requires in setup.cfg

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -30,7 +30,6 @@ boilerplate code in some cases.
     description = My package description
     long_description = file: README.rst, CHANGELOG.rst, LICENSE.rst
     keywords = one, two
-    python_requires = >=3.7
     license = BSD-3-Clause
     classifiers =
         Framework :: Django
@@ -40,6 +39,7 @@ boilerplate code in some cases.
     zip_safe = False
     include_package_data = True
     packages = find:
+    python_requires = >=3.7
     install_requires =
         requests
         importlib-metadata; python_version<"3.8"


### PR DESCRIPTION
This fixes an error that I had submitted in #3712 to move `python_requires` to the `[options]` section in the `setup.cfg` example.