### PR TITLE
Fixed accumulating include dirs after compile

### DIFF
--- a/changelog.d/3591.change.rst
+++ b/changelog.d/3591.change.rst
@@ -1,0 +1,2 @@
+Fixed gradually increasing length of include dirs after each ``compile`` call, which could lead to compile errors under
+Windows (command line too long).

--- a/setuptools/_distutils/ccompiler.py
+++ b/setuptools/_distutils/ccompiler.py
@@ -388,7 +388,7 @@ class CCompiler:
             raise TypeError("'macros' (if supplied) must be a list of tuples")
 
         if include_dirs is None:
-            include_dirs = self.include_dirs
+            include_dirs = list(self.include_dirs)
         elif isinstance(include_dirs, (list, tuple)):
             include_dirs = list(include_dirs) + (self.include_dirs or [])
         else:

--- a/setuptools/_distutils/tests/test_ccompiler.py
+++ b/setuptools/_distutils/tests/test_ccompiler.py
@@ -53,3 +53,17 @@ def test_set_include_dirs(c_file):
     # do it again, setting include dirs after any initialization
     compiler.set_include_dirs([python])
     compiler.compile(_make_strs([c_file]))
+
+
+def test_include_dirs_after_multiple_compile_calls(c_file):
+    """
+    Calling compile multiple times should not change the include dirs
+    (regression test for #3591).
+    """
+    compiler = ccompiler.new_compiler()
+    python = sysconfig.get_paths()['include']
+    compiler.set_include_dirs([python])
+    compiler.compile(_make_strs([c_file]))
+    assert compiler.include_dirs == [python]
+    compiler.compile(_make_strs([c_file]))
+    assert compiler.include_dirs == [python]


### PR DESCRIPTION
## Summary of changes
- makes a copy of include dir list to avoid increasing the list in subsequent calls of compile
- fix had been proposed by @mdavidsaver in #3591

It could also make sense to merge this back into upstream `distutils`. The bug itself does not happen there (this was introduced only here in [this commit](https://github.com/pypa/setuptools/commit/9f9a3e57643cb49796c1b08b5b5afb2826ecd7f6)), but it may also be problematic if the internal include dir list is returned in this case (and may be modified unintentionally by the caller). Or maybe not, as `distutils` is deprecated anyway...

Closes #3591

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_

[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
