### PR TITLE
Account for file directive with single string (instead of list) in `tool.setuptools.dynamic` (`pyproject.toml`)

### DIFF
--- a/changelog.d/3782.misc.rst
+++ b/changelog.d/3782.misc.rst
@@ -1,0 +1,2 @@
+Fixed problem with ``file`` directive in ``tool.setuptools.dynamic``
+(``pyproject.toml``) when value is a simple string instead of list.

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -11,7 +11,6 @@ from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Mapping, Set, Union
 
 from setuptools.errors import FileError, OptionError
-from setuptools.extern.more_itertools import always_iterable
 
 from . import expand as _expand
 from ._apply_pyprojecttoml import apply as _apply
@@ -310,6 +309,8 @@ class _ConfigExpander:
     def _expand_directive(
         self, specifier: str, directive, package_dir: Mapping[str, str]
     ):
+        from setuptools.extern.more_itertools import always_iterable  # type: ignore
+
         with _ignore_errors(self.ignore_option_errors):
             root_dir = self.root_dir
             if "file" in directive:

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -11,6 +11,7 @@ from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, Optional, Mapping, Set, Union
 
 from setuptools.errors import FileError, OptionError
+from setuptools.extern.more_itertools import always_iterable
 
 from . import expand as _expand
 from ._apply_pyprojecttoml import apply as _apply
@@ -312,8 +313,9 @@ class _ConfigExpander:
         with _ignore_errors(self.ignore_option_errors):
             root_dir = self.root_dir
             if "file" in directive:
-                self._referenced_files.update(directive["file"])
-                return _expand.read_files(directive["file"], root_dir)
+                files = always_iterable(directive["file"])
+                self._referenced_files.update(files)
+                return _expand.read_files(files, root_dir)
             if "attr" in directive:
                 return _expand.read_attr(directive["attr"], package_dir, root_dir)
             raise ValueError(f"invalid `{specifier}`: {directive!r}")

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -314,9 +314,8 @@ class _ConfigExpander:
         with _ignore_errors(self.ignore_option_errors):
             root_dir = self.root_dir
             if "file" in directive:
-                files = always_iterable(directive["file"])
-                self._referenced_files.update(files)
-                return _expand.read_files(files, root_dir)
+                self._referenced_files.update(always_iterable(directive["file"]))
+                return _expand.read_files(directive["file"], root_dir)
             if "attr" in directive:
                 return _expand.read_attr(directive["attr"], package_dir, root_dir)
             raise ValueError(f"invalid `{specifier}`: {directive!r}")

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -546,10 +546,14 @@ class TestSdistTest:
         with quiet():
             cmd.run()
 
-        assert 'src/VERSION.txt' in cmd.filelist.files
+        assert (
+            'src/VERSION.txt' in cmd.filelist.files
+            or 'src\\VERSION.txt' in cmd.filelist.files
+        )
         assert 'USAGE.rst' in cmd.filelist.files
         assert 'DOWHATYOUWANT' in cmd.filelist.files
         assert '/' not in cmd.filelist.files
+        assert '\\' not in cmd.filelist.files
 
     def test_pyproject_toml_in_sdist(self, tmpdir):
         """

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -502,7 +502,7 @@ class TestSdistTest:
         "setup.cfg - long_description and version": """
             [metadata]
             name = testing
-            version = file: VERSION.txt
+            version = file: src/VERSION.txt
             license_files = DOWHATYOUWANT
             long_description = file: README.rst, USAGE.rst
             """,
@@ -513,7 +513,16 @@ class TestSdistTest:
             license = {file = "DOWHATYOUWANT"}
             dynamic = ["version"]
             [tool.setuptools.dynamic]
-            version = {file = ["VERSION.txt"]}
+            version = {file = ["src/VERSION.txt"]}
+            """,
+        "pyproject.toml - directive with str instead of list": """
+            [project]
+            name = "testing"
+            readme = "USAGE.rst"
+            license = {file = "DOWHATYOUWANT"}
+            dynamic = ["version"]
+            [tool.setuptools.dynamic]
+            version = {file = "src/VERSION.txt"}
             """
     }
 
@@ -521,7 +530,8 @@ class TestSdistTest:
     def test_add_files_referenced_by_config_directives(self, tmp_path, config):
         config_file, _, _ = config.partition(" - ")
         config_text = self._EXAMPLE_DIRECTIVES[config]
-        (tmp_path / 'VERSION.txt').write_text("0.42", encoding="utf-8")
+        (tmp_path / 'src').mkdir()
+        (tmp_path / 'src/VERSION.txt').write_text("0.42", encoding="utf-8")
         (tmp_path / 'README.rst').write_text("hello world!", encoding="utf-8")
         (tmp_path / 'USAGE.rst').write_text("hello world!", encoding="utf-8")
         (tmp_path / 'DOWHATYOUWANT').write_text("hello world!", encoding="utf-8")
@@ -536,9 +546,10 @@ class TestSdistTest:
         with quiet():
             cmd.run()
 
-        assert 'VERSION.txt' in cmd.filelist.files
+        assert 'src/VERSION.txt' in cmd.filelist.files
         assert 'USAGE.rst' in cmd.filelist.files
         assert 'DOWHATYOUWANT' in cmd.filelist.files
+        assert '/' not in cmd.filelist.files
 
     def test_pyproject_toml_in_sdist(self, tmpdir):
         """


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Transform simple strings into lists before passing it on to other functions.

Closes #3781

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
