### PR TITLE
Fix dependency syntax error in test_dist_info

### DIFF
--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -142,7 +142,8 @@ class TestWheelCompatibility:
     version = {version}
 
     [options]
-    install_requires = foo>=12; sys_platform != "linux"
+    install_requires =
+        foo>=12; sys_platform != "linux"
 
     [options.extras_require]
     test = pytest


### PR DESCRIPTION
## Summary of changes

Fix the install_requires used in test_dist_info to use the dangling syntax, in order to correctly handle markers.  This fixes syntax error when parsed by packaging-22.0+, as well as setuptools warning:

```
UserWarning: One of the parsed requirements in `install_requires` looks like a valid environment marker: \'sys_platform != "linux"\'
Make sure that the config is correct and check https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#opt-2
  warnings.warn(msg, UserWarning)\n'
```

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
