### PR TITLE
Fix version syntax in test_nowarn_accidental_env_marker_misconfig

### DIFF
--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -746,12 +746,12 @@ class TestOptions:
             "[options.extras_require]\nfoo = bar;baz\nboo = xxx;yyy",
             "[options.extras_require]\nfoo =\n    bar;python_version<'3'\n",
             "[options.extras_require]\nfoo = bar;baz\nboo = xxx;yyy\n",
-            "[options.extras_require]\nfoo =\n    bar\n    python_version<'3'\n",
+            "[options.extras_require]\nfoo =\n    bar\n    python_version<3\n",
             "[options]\ninstall_requires =\n    bar;python_version<'3'",
             "[options]\ninstall_requires = bar;baz\nboo = xxx;yyy",
             "[options]\ninstall_requires =\n    bar;python_version<'3'\n",
             "[options]\ninstall_requires = bar;baz\nboo = xxx;yyy\n",
-            "[options]\ninstall_requires =\n    bar\n    python_version<'3'\n",
+            "[options]\ninstall_requires =\n    bar\n    python_version<3\n",
         ],
     )
     def test_nowarn_accidental_env_marker_misconfig(self, config, tmpdir, recwarn):


### PR DESCRIPTION
## Summary of changes

Fix the two "marker"-alike cases (for package `python_version`) for test_nowarn_accidental_env_marker_misconfig to use `<3` rather than `<'3'`.  The latter maps to the version `'3'` which is not a valid version and therefore causes an error with packaging-22.0+.

See the discussion at
https://github.com/pypa/setuptools/commit/506e7e7e1cac6a5d534184d35a20a73e9dd58045#r97577660

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
