### PR TITLE
Reduce usage of `pkg_resources`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -40,7 +40,7 @@ filterwarnings=
 	ignore:The Windows bytes API has been deprecated:DeprecationWarning
 
 	# https://github.com/pypa/setuptools/issues/2823
-	ignore:setuptools.installer is deprecated.
+	ignore:setuptools.installer and fetch_build_eggs are deprecated.
 
 	# https://github.com/pypa/setuptools/issues/917
 	ignore:setup.py install is deprecated.

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -1,3 +1,7 @@
+"""
+Helpers for normalization as expected in wheel/sdist/module file names
+and core metadata
+"""
 import re
 import warnings
 from inspect import cleandoc
@@ -71,6 +75,7 @@ def best_effort_version(version: str) -> str:
     >>> best_effort_version("ubuntu lts")
     'ubuntu.lts'
     """
+    # See pkg_resources.safe_version
     try:
         return safe_version(version)
     except packaging.version.InvalidVersion:
@@ -87,4 +92,26 @@ def best_effort_version(version: str) -> str:
         """
         warnings.warn(cleandoc(msg), SetuptoolsDeprecationWarning)
         v = version.replace(' ', '.')
-        return safe_name(v).strip("_")
+        return safe_name(v)
+
+
+def filename_component(value: str) -> str:
+    """Normalize each component of a filename (e.g. distribution/version part of wheel)
+    Note: ``value`` needs to be already normalized.
+    >>> filename_component("my-pkg")
+    'my_pkg'
+    """
+    return value.replace("-", "_").strip("_")
+
+
+def safer_name(value: str) -> str:
+    """Like ``safe_name`` but can be used as filename component for wheel"""
+    # See bdist_wheel.safer_name
+    return filename_component(safe_name(value))
+
+
+def safer_best_effort_version(value: str) -> str:
+    """Like ``best_effort_version`` but can be used as filename component for wheel"""
+    # See bdist_wheel.safer_verion
+    # TODO: Replace with only safe_version in the future (no need for best effort)
+    return filename_component(best_effort_version(value))

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -1,6 +1,4 @@
-import os
 import re
-import sys
 import warnings
 from inspect import cleandoc
 from pathlib import Path
@@ -15,13 +13,6 @@ _Path = Union[str, Path]
 # https://packaging.python.org/en/latest/specifications/core-metadata/#name
 _VALID_NAME = re.compile(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.I)
 _UNSAFE_NAME_CHARS = re.compile(r"[^A-Z0-9.]+", re.I)
-
-
-def path(filename: _Path) -> str:
-    """Normalize a file/dir name for comparison purposes."""
-    # See pkg_resources.normalize_path
-    file = os.path.abspath(filename) if sys.platform == 'cygwin' else filename
-    return os.path.normcase(os.path.realpath(os.path.normpath(file)))
 
 
 def safe_identifier(name: str) -> str:

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -1,0 +1,99 @@
+import os
+import re
+import sys
+import warnings
+from inspect import cleandoc
+from pathlib import Path
+from typing import Union
+
+from setuptools.extern import packaging
+
+from ._deprecation_warning import SetuptoolsDeprecationWarning
+
+_Path = Union[str, Path]
+
+# https://packaging.python.org/en/latest/specifications/core-metadata/#name
+_VALID_NAME = re.compile(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.I)
+_UNSAFE_NAME_CHARS = re.compile(r"[^A-Z0-9.]+", re.I)
+
+
+def path(filename: _Path) -> str:
+    """Normalize a file/dir name for comparison purposes."""
+    # See pkg_resources.normalize_path
+    file = os.path.abspath(filename) if sys.platform == 'cygwin' else filename
+    return os.path.normcase(os.path.realpath(os.path.normpath(file)))
+
+
+def safe_identifier(name: str) -> str:
+    """Make a string safe to be used as Python identifier.
+    >>> safe_identifier("12abc")
+    '_12abc'
+    >>> safe_identifier("__editable__.myns.pkg-78.9.3_local")
+    '__editable___myns_pkg_78_9_3_local'
+    """
+    safe = re.sub(r'\W|^(?=\d)', '_', name)
+    assert safe.isidentifier()
+    return safe
+
+
+def safe_name(component: str) -> str:
+    """Escape a component used as a project name according to Core Metadata.
+    >>> safe_name("hello world")
+    'hello-world'
+    >>> safe_name("hello?world")
+    'hello-world'
+    """
+    # See pkg_resources.safe_name
+    return _UNSAFE_NAME_CHARS.sub("-", component)
+
+
+def safe_version(version: str) -> str:
+    """Convert an arbitrary string into a valid version string.
+    >>> safe_version("1988 12 25")
+    '1988.12.25'
+    >>> safe_version("v0.2.1")
+    '0.2.1'
+    >>> safe_version("v0.2?beta")
+    '0.2b0'
+    >>> safe_version("v0.2 beta")
+    '0.2b0'
+    >>> safe_version("ubuntu lts")
+    Traceback (most recent call last):
+    ...
+    setuptools.extern.packaging.version.InvalidVersion: Invalid version: 'ubuntu.lts'
+    """
+    v = version.replace(' ', '.')
+    try:
+        return str(packaging.version.Version(v))
+    except packaging.version.InvalidVersion:
+        attempt = _UNSAFE_NAME_CHARS.sub("-", v)
+        return str(packaging.version.Version(attempt))
+
+
+def best_effort_version(version: str) -> str:
+    """Convert an arbitrary string into a version-like string.
+    >>> best_effort_version("v0.2 beta")
+    '0.2b0'
+
+    >>> import warnings
+    >>> warnings.simplefilter("ignore", category=SetuptoolsDeprecationWarning)
+    >>> best_effort_version("ubuntu lts")
+    'ubuntu.lts'
+    """
+    try:
+        return safe_version(version)
+    except packaging.version.InvalidVersion:
+        msg = f"""Invalid version: {version!r}.
+        !!\n\n
+        ###################
+        # Invalid version #
+        ###################
+        {version!r} is not valid according to PEP 440.\n
+        Please make sure specify a valid version for your package.
+        Also note that future releases of setuptools may halt the build process
+        if an invalid version is given.
+        \n\n!!
+        """
+        warnings.warn(cleandoc(msg), SetuptoolsDeprecationWarning)
+        v = version.replace(' ', '.')
+        return safe_name(v).strip("_")

--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from typing import Union
 
 _Path = Union[str, os.PathLike]
@@ -26,4 +27,11 @@ def same_path(p1: _Path, p2: _Path) -> bool:
     >>> same_path("a", "a/b")
     False
     """
-    return os.path.normpath(p1) == os.path.normpath(p2)
+    return normpath(p1) == normpath(p2)
+
+
+def normpath(filename: _Path) -> str:
+    """Normalize a file/dir name for comparison purposes."""
+    # See pkg_resources.normalize_path for notes about cygwin
+    file = os.path.abspath(filename) if sys.platform == 'cygwin' else filename
+    return os.path.normcase(os.path.realpath(os.path.normpath(file)))

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -1,9 +1,13 @@
+from typing import Callable, Iterable, Iterator, TypeVar, Union, overload
+
 import setuptools.extern.jaraco.text as text
+from setuptools.extern.packaging.requirements import Requirement
 
-from pkg_resources import Requirement
+_T = TypeVar("_T")
+_StrOrIter = Union[str, Iterable[str]]
 
 
-def parse_strings(strs):
+def parse_strings(strs: _StrOrIter) -> Iterator[str]:
     """
     Yield requirement strings for each specification in `strs`.
 
@@ -12,8 +16,18 @@ def parse_strings(strs):
     return text.join_continuation(map(text.drop_comment, text.yield_lines(strs)))
 
 
-def parse(strs):
+@overload
+def parse(strs: _StrOrIter) -> Iterator[Requirement]:
+    ...
+
+
+@overload
+def parse(strs: _StrOrIter, parser: Callable[[str], _T]) -> Iterator[_T]:
+    ...
+
+
+def parse(strs, parser=Requirement):
     """
-    Deprecated drop-in replacement for pkg_resources.parse_requirements.
+    Replacement for ``pkg_resources.parse_requirements`` that uses ``packaging``.
     """
-    return map(Requirement, parse_strings(strs))
+    return map(parser, parse_strings(strs))

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -11,7 +11,6 @@ import re
 import textwrap
 import marshal
 
-from pkg_resources import get_build_platform, Distribution
 from setuptools.extension import Library
 from setuptools import Command
 from .._path import ensure_directory
@@ -64,7 +63,7 @@ class bdist_egg(Command):
         ('bdist-dir=', 'b',
          "temporary directory for creating the distribution"),
         ('plat-name=', 'p', "platform name to embed in generated filenames "
-                            "(default: %s)" % get_build_platform()),
+                            "(by default uses `pkg_resources.get_build_platform()`)"),
         ('exclude-source-files', None,
          "remove all .py files from the generated egg"),
         ('keep-temp', 'k',
@@ -98,18 +97,18 @@ class bdist_egg(Command):
             self.bdist_dir = os.path.join(bdist_base, 'egg')
 
         if self.plat_name is None:
+            from pkg_resources import get_build_platform
+
             self.plat_name = get_build_platform()
 
         self.set_undefined_options('bdist', ('dist_dir', 'dist_dir'))
 
         if self.egg_output is None:
-
             # Compute filename of the output egg
-            basename = Distribution(
-                None, None, ei_cmd.egg_name, ei_cmd.egg_version,
-                get_python_version(),
-                self.distribution.has_ext_modules() and self.plat_name
-            ).egg_name()
+            basename = ei_cmd._get_egg_basename(
+                py_version=get_python_version(),
+                platform=self.distribution.has_ext_modules() and self.plat_name,
+            )
 
             self.egg_output = os.path.join(self.dist_dir, basename + '.egg')
 

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -5,9 +5,9 @@ import os
 import glob
 import io
 
-import pkg_resources
 from setuptools.command.easy_install import easy_install
 from setuptools import namespaces
+from setuptools import _normalization
 import setuptools
 
 
@@ -42,6 +42,8 @@ class develop(namespaces.DevelopInstaller, easy_install):
         self.always_copy_from = '.'  # always copy eggs installed in curdir
 
     def finalize_options(self):
+        import pkg_resources
+
         ei = self.get_finalized_command("egg_info")
         if ei.broken_egg_info:
             template = "Please rename %r to %r before using 'develop'"
@@ -61,8 +63,8 @@ class develop(namespaces.DevelopInstaller, easy_install):
         if self.egg_path is None:
             self.egg_path = os.path.abspath(ei.egg_base)
 
-        target = pkg_resources.normalize_path(self.egg_base)
-        egg_path = pkg_resources.normalize_path(
+        target = _normalization.path(self.egg_base)
+        egg_path = _normalization.path(
             os.path.join(self.install_dir, self.egg_path)
         )
         if egg_path != target:
@@ -94,15 +96,15 @@ class develop(namespaces.DevelopInstaller, easy_install):
         path_to_setup = egg_base.replace(os.sep, '/').rstrip('/')
         if path_to_setup != os.curdir:
             path_to_setup = '../' * (path_to_setup.count('/') + 1)
-        resolved = pkg_resources.normalize_path(
+        resolved = _normalization.path(
             os.path.join(install_dir, egg_path, path_to_setup)
         )
-        if resolved != pkg_resources.normalize_path(os.curdir):
+        if resolved != _normalization.path(os.curdir):
             raise DistutilsOptionError(
                 "Can't get a consistent path to setup script from"
                 " installation directory",
                 resolved,
-                pkg_resources.normalize_path(os.curdir),
+                _normalization.path(os.curdir),
             )
         return path_to_setup
 

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -63,17 +63,18 @@ class develop(namespaces.DevelopInstaller, easy_install):
         if self.egg_path is None:
             self.egg_path = os.path.abspath(ei.egg_base)
 
-        egg_path = os.path.join(self.install_dir, self.egg_path)
-        if not _path.same_path(egg_path, self.egg_base):
+        target = _path.normpath(self.egg_base)
+        egg_path = _path.normpath(os.path.join(self.install_dir, self.egg_path))
+        if egg_path != target:
             raise DistutilsOptionError(
                 "--egg-path must be a relative path from the install"
-                f" directory to {self.egg_base}"
+                " directory to " + target
             )
 
         # Make a distribution for the package's source
         self.dist = pkg_resources.Distribution(
-            self.egg_base,
-            pkg_resources.PathMetadata(self.egg_base, os.path.abspath(ei.egg_info)),
+            target,
+            pkg_resources.PathMetadata(target, os.path.abspath(ei.egg_info)),
             project_name=ei.egg_name,
         )
 

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -4,18 +4,16 @@ As defined in the wheel specification
 """
 
 import os
-import re
 import shutil
 import sys
 import warnings
 from contextlib import contextmanager
-from inspect import cleandoc
+from distutils import log
+from distutils.core import Command
 from pathlib import Path
 
-from distutils.core import Command
-from distutils import log
-from setuptools.extern import packaging
-from setuptools._deprecation_warning import SetuptoolsDeprecationWarning
+from .. import _normalization
+from .._deprecation_warning import SetuptoolsDeprecationWarning
 
 
 class dist_info(Command):
@@ -72,8 +70,8 @@ class dist_info(Command):
         egg_info.finalize_options()
         self.egg_info = egg_info
 
-        name = _safe(dist.get_name())
-        version = _version(dist.get_version())
+        name = _normalization.safe_name(dist.get_name()).replace(".", "_")
+        version = _normalization.best_effort_version(dist.get_version())
         self.name = f"{name}-{version}"
         self.dist_info_dir = os.path.join(self.output_dir, f"{self.name}.dist-info")
 
@@ -103,32 +101,6 @@ class dist_info(Command):
         # TODO: if bdist_wheel if merged into setuptools, just add "keep_egg_info" there
         with self._maybe_bkp_dir(egg_info_dir, self.keep_egg_info):
             bdist_wheel.egg2dist(egg_info_dir, self.dist_info_dir)
-
-
-def _safe(component: str) -> str:
-    """Escape a component used to form a wheel name according to PEP 491"""
-    return re.sub(r"[^\w\d.]+", "_", component)
-
-
-def _version(version: str) -> str:
-    """Convert an arbitrary string to a version string."""
-    v = version.replace(' ', '.')
-    try:
-        return str(packaging.version.Version(v)).replace("-", "_")
-    except packaging.version.InvalidVersion:
-        msg = f"""Invalid version: {version!r}.
-        !!\n\n
-        ###################
-        # Invalid version #
-        ###################
-        {version!r} is not valid according to PEP 440.\n
-        Please make sure specify a valid version for your package.
-        Also note that future releases of setuptools may halt the build process
-        if an invalid version is given.
-        \n\n!!
-        """
-        warnings.warn(cleandoc(msg))
-        return _safe(v).strip("_")
 
 
 def _rm(dir_name, **opts):

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -70,8 +70,8 @@ class dist_info(Command):
         egg_info.finalize_options()
         self.egg_info = egg_info
 
-        name = _normalization.safe_name(dist.get_name()).replace(".", "_")
-        version = _normalization.best_effort_version(dist.get_version())
+        name = _normalization.safer_name(dist.get_name())
+        version = _normalization.safer_best_effort_version(dist.get_version())
         self.name = f"{name}-{version}"
         self.dist_info_dir = os.path.join(self.output_dir, f"{self.name}.dist-info")
 

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -12,7 +12,6 @@ Create a wheel that, when installed, will make the source package 'editable'
 
 import logging
 import os
-import re
 import shutil
 import sys
 import traceback
@@ -36,10 +35,10 @@ from typing import (
     Union,
 )
 
-from setuptools import Command, SetuptoolsDeprecationWarning, errors, namespaces
-from setuptools.command.build_py import build_py as build_py_cls
-from setuptools.discovery import find_package_path
-from setuptools.dist import Distribution
+from .. import Command, SetuptoolsDeprecationWarning, errors, namespaces, _normalization
+from ..discovery import find_package_path
+from ..dist import Distribution
+from .build_py import build_py as build_py_cls
 
 if TYPE_CHECKING:
     from wheel.wheelfile import WheelFile  # noqa
@@ -490,7 +489,7 @@ class _TopLevelFinder:
         ))
 
         name = f"__editable__.{self.name}.finder"
-        finder = _make_identifier(name)
+        finder = _normalization.safe_identifier(name)
         content = bytes(_finder_template(name, roots, namespaces_), "utf-8")
         wheel.writestr(f"{finder}.py", content)
 
@@ -569,7 +568,7 @@ def _simple_layout(
         return set(package_dir) in ({}, {""})
     parent = os.path.commonpath([_parent_path(k, v) for k, v in layout.items()])
     return all(
-        _normalize_path(Path(parent, *key.split('.'))) == _normalize_path(value)
+        _normalization.path(Path(parent, *key.split('.'))) == _normalization.path(value)
         for key, value in layout.items()
     )
 
@@ -698,19 +697,12 @@ def _is_nested(pkg: str, pkg_path: str, parent: str, parent_path: str) -> bool:
     >>> _is_nested("b.a", "path/b/a", "a", "path/a")
     False
     """
-    norm_pkg_path = _normalize_path(pkg_path)
+    norm_pkg_path = _normalization.path(pkg_path)
     rest = pkg.replace(parent, "", 1).strip(".").split(".")
     return (
         pkg.startswith(parent)
-        and norm_pkg_path == _normalize_path(Path(parent_path, *rest))
+        and norm_pkg_path == _normalization.path(Path(parent_path, *rest))
     )
-
-
-def _normalize_path(filename: _Path) -> str:
-    """Normalize a file/dir name for comparison purposes"""
-    # See pkg_resources.normalize_path
-    file = os.path.abspath(filename) if sys.platform == 'cygwin' else filename
-    return os.path.normcase(os.path.realpath(os.path.normpath(file)))
 
 
 def _empty_dir(dir_: _P) -> _P:
@@ -718,18 +710,6 @@ def _empty_dir(dir_: _P) -> _P:
     shutil.rmtree(dir_, ignore_errors=True)
     os.makedirs(dir_)
     return dir_
-
-
-def _make_identifier(name: str) -> str:
-    """Make a string safe to be used as Python identifier.
-    >>> _make_identifier("12abc")
-    '_12abc'
-    >>> _make_identifier("__editable__.myns.pkg-78.9.3_local")
-    '__editable___myns_pkg_78_9_3_local'
-    """
-    safe = re.sub(r'\W|^(?=\d)', '_', name)
-    assert safe.isidentifier()
-    return safe
 
 
 class _NamespaceInstaller(namespaces.Installer):

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -35,7 +35,14 @@ from typing import (
     Union,
 )
 
-from .. import Command, SetuptoolsDeprecationWarning, errors, namespaces, _normalization
+from .. import (
+    Command,
+    SetuptoolsDeprecationWarning,
+    _normalization,
+    _path,
+    errors,
+    namespaces,
+)
 from ..discovery import find_package_path
 from ..dist import Distribution
 from .build_py import build_py as build_py_cls
@@ -568,7 +575,7 @@ def _simple_layout(
         return set(package_dir) in ({}, {""})
     parent = os.path.commonpath([_parent_path(k, v) for k, v in layout.items()])
     return all(
-        _normalization.path(Path(parent, *key.split('.'))) == _normalization.path(value)
+        _path.same_path(Path(parent, *key.split('.')), value)
         for key, value in layout.items()
     )
 
@@ -697,11 +704,11 @@ def _is_nested(pkg: str, pkg_path: str, parent: str, parent_path: str) -> bool:
     >>> _is_nested("b.a", "path/b/a", "a", "path/a")
     False
     """
-    norm_pkg_path = _normalization.path(pkg_path)
+    norm_pkg_path = _path.normpath(pkg_path)
     rest = pkg.replace(parent, "", 1).strip(".").split(".")
     return (
         pkg.startswith(parent)
-        and norm_pkg_path == _normalization.path(Path(parent_path, *rest))
+        and norm_pkg_path == _path.normpath(Path(parent_path, *rest))
     )
 
 

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -234,7 +234,7 @@ class egg_info(InfoCommon, Command):
             self.egg_base = (dirs or {}).get('', os.curdir)
 
         self.ensure_dirname('egg_base')
-        self.egg_info = _filename_component(self.egg_name) + '.egg-info'
+        self.egg_info = _normalization.filename_component(self.egg_name) + '.egg-info'
         if self.egg_base != os.curdir:
             self.egg_info = os.path.join(self.egg_base, self.egg_info)
         if '-' in self.egg_name:
@@ -778,16 +778,12 @@ def get_pkg_info_revision():
 
 def _egg_basename(egg_name, egg_version, py_version=PY_MAJOR, platform=None):
     """Compute filename of the output egg. Private API."""
-    name = _filename_component(egg_name)
-    version = _filename_component(egg_version)
+    name = _normalization.filename_component(egg_name)
+    version = _normalization.filename_component(egg_version)
     egg = f"{name}-{version}-py{py_version}"
     if platform:
         egg += f"-{platform}"
     return egg
-
-
-def _filename_component(value):
-    return value.replace("-", "_")
 
 
 class EggInfoDeprecationWarning(SetuptoolsDeprecationWarning):

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -776,11 +776,11 @@ def get_pkg_info_revision():
     return 0
 
 
-def _egg_basename(egg_name, egg_version, py_version=PY_MAJOR, platform=None):
+def _egg_basename(egg_name, egg_version, py_version=None, platform=None):
     """Compute filename of the output egg. Private API."""
     name = _normalization.filename_component(egg_name)
     version = _normalization.filename_component(egg_version)
-    egg = f"{name}-{version}-py{py_version}"
+    egg = f"{name}-{version}-py{py_version or PY_MAJOR}"
     if platform:
         egg += f"-{platform}"
     return egg

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -25,9 +25,6 @@ from setuptools.command.sdist import sdist
 from setuptools.command.sdist import walk_revctrl
 from setuptools.command.setopt import edit_config
 from setuptools.command import bdist_egg
-from pkg_resources import (
-    Requirement, safe_name, parse_version,
-    safe_version, to_filename)
 import setuptools.unicode_utils as unicode_utils
 from setuptools.glob import glob
 
@@ -217,12 +214,12 @@ class egg_info(InfoCommon, Command):
         # repercussions.
         self.egg_name = self.name
         self.egg_version = self.tagged_version()
-        parsed_version = parse_version(self.egg_version)
+        parsed_version = packaging.version.Version(self.egg_version)
 
         try:
             is_version = isinstance(parsed_version, packaging.version.Version)
             spec = "%s==%s" if is_version else "%s===%s"
-            Requirement(spec % (self.egg_name, self.egg_version))
+            packaging.requirements.Requirement(spec % (self.egg_name, self.egg_version))
         except ValueError as e:
             raise distutils.errors.DistutilsOptionError(
                 "Invalid distribution name or version syntax: %s-%s" %
@@ -252,7 +249,7 @@ class egg_info(InfoCommon, Command):
         pd = self.distribution._patched_dist
         if pd is not None and pd.key == self.egg_name.lower():
             pd._version = self.egg_version
-            pd._parsed_version = parse_version(self.egg_version)
+            pd._parsed_version = packaging.version.Version(self.egg_version)
             self.distribution._patched_dist = None
 
     def write_or_delete_file(self, what, filename, data, force=False):

--- a/setuptools/command/install_egg_info.py
+++ b/setuptools/command/install_egg_info.py
@@ -5,7 +5,6 @@ from setuptools import Command
 from setuptools import namespaces
 from setuptools.archive_util import unpack_archive
 from .._path import ensure_directory
-import pkg_resources
 
 
 class install_egg_info(namespaces.Installer, Command):
@@ -24,9 +23,7 @@ class install_egg_info(namespaces.Installer, Command):
         self.set_undefined_options('install_lib',
                                    ('install_dir', 'install_dir'))
         ei_cmd = self.get_finalized_command("egg_info")
-        basename = pkg_resources.Distribution(
-            None, None, ei_cmd.egg_name, ei_cmd.egg_version
-        ).egg_name() + '.egg-info'
+        basename = f"{ei_cmd._get_egg_basename()}.egg-info"
         self.source = ei_cmd.egg_info
         self.target = os.path.join(self.install_dir, basename)
         self.outputs = []

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -4,7 +4,6 @@ from distutils.errors import DistutilsModuleError
 import os
 import sys
 
-from pkg_resources import Distribution, PathMetadata
 from .._path import ensure_directory
 
 
@@ -16,8 +15,6 @@ class install_scripts(orig.install_scripts):
         self.no_ep = False
 
     def run(self):
-        import setuptools.command.easy_install as ei
-
         self.run_command("egg_info")
         if self.distribution.scripts:
             orig.install_scripts.run(self)  # run first to set up self.outfiles
@@ -26,6 +23,12 @@ class install_scripts(orig.install_scripts):
         if self.no_ep:
             # don't install entry point scripts into .egg file!
             return
+        self._install_ep_scripts()
+
+    def _install_ep_scripts(self):
+        # Delay import side-effects
+        from pkg_resources import Distribution, PathMetadata
+        from . import easy_install as ei
 
         ei_cmd = self.get_finalized_command("egg_info")
         dist = Distribution(

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -300,9 +300,19 @@ def check_extras(dist, attr, value):
 
 def _check_extra(extra, reqs):
     name, sep, marker = extra.partition(':')
-    if marker and pkg_resources.invalid_marker(marker):
-        raise DistutilsSetupError("Invalid environment marker: " + marker)
+    try:
+        _check_marker(marker)
+    except packaging.markers.InvalidMarker:
+        msg = f"Invalid environment marker: {marker} ({extra!r})"
+        raise DistutilsSetupError(msg) from None
     list(_reqs.parse(reqs))
+
+
+def _check_marker(marker):
+    if not marker:
+        return
+    m = packaging.markers.Marker(marker)
+    m.evaluate()
 
 
 def assert_bool(dist, attr, value):

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -42,7 +42,6 @@ from setuptools.monkey import get_unpatched
 from setuptools.config import setupcfg, pyprojecttoml
 from setuptools.discovery import ConfigDiscovery
 
-import pkg_resources
 from setuptools.extern.packaging import version
 from . import _reqs
 from . import _entry_points
@@ -888,14 +887,9 @@ class Distribution(_Distribution):
 
     def fetch_build_eggs(self, requires):
         """Resolve pre-setup requirements"""
-        resolved_dists = pkg_resources.working_set.resolve(
-            _reqs.parse(requires),
-            installer=self.fetch_build_egg,
-            replace_conflicting=True,
-        )
-        for dist in resolved_dists:
-            pkg_resources.working_set.add(dist, replace=True)
-        return resolved_dists
+        from setuptools.installer import _fetch_build_eggs
+
+        return _fetch_build_eggs(self, requires)
 
     def finalize_options(self):
         """

--- a/setuptools/version.py
+++ b/setuptools/version.py
@@ -1,6 +1,6 @@
-import pkg_resources
+from ._importlib import metadata
 
 try:
-    __version__ = pkg_resources.get_distribution('setuptools').version
+    __version__ = metadata.version('setuptools')
 except Exception:
     __version__ = 'unknown'

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -15,7 +15,7 @@ import setuptools
 from pkg_resources import parse_version
 from setuptools.extern.packaging.tags import sys_tags
 from setuptools.extern.packaging.utils import canonicalize_name
-from setuptools.command.egg_info import write_requirements
+from setuptools.command.egg_info import write_requirements, _egg_basename
 from setuptools.archive_util import _unpack_zipfile_obj
 
 
@@ -89,10 +89,11 @@ class Wheel:
         return next((True for t in self.tags() if t in supported_tags), False)
 
     def egg_name(self):
-        return pkg_resources.Distribution(
-            project_name=self.project_name, version=self.version,
+        return _egg_basename(
+            self.project_name,
+            self.version,
             platform=(None if self.platform == 'any' else get_platform()),
-        ).egg_name() + '.egg'
+        ) + ".egg"
 
     def get_dist_info(self, zf):
         # find the correct name of the .dist-info dir in the wheel file

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -10,9 +10,8 @@ import contextlib
 
 from distutils.util import get_platform
 
-import pkg_resources
 import setuptools
-from pkg_resources import parse_version
+from setuptools.extern.packaging.version import Version as parse_version
 from setuptools.extern.packaging.tags import sys_tags
 from setuptools.extern.packaging.utils import canonicalize_name
 from setuptools.command.egg_info import write_requirements, _egg_basename
@@ -122,6 +121,8 @@ class Wheel:
 
     @staticmethod
     def _convert_metadata(zf, destination_eggdir, dist_info, egg_info):
+        import pkg_resources
+
         def get_metadata(name):
             with zf.open(posixpath.join(dist_info, name)) as fp:
                 value = fp.read().decode('utf-8')


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

This is an attempt to reduce the usage of `pkg_resources` (and in some places to delay the associated import[^1]).


## Summary of changes

The approaches used are:
- Whenever possible use `packaging` and `importlib.metadata`
- Create suitable replacements in the modules `_normalization`, `_path`
- Centralize the import/usage of `pkg_resources` to as few modules as possible (ideally only the ones that inevitably have to traverse deprecated code paths).
- Delay importing `pkg_resources` in an attempt saving the import cost when the module is not necessary.

---

* 60506348 - Replace `pkg_resources` in `version.py`
* ec238c4a - Extract normalization functions from `editable_wheel` and `dist_info` into `_normalization`
* 3c48e7c1 - Prefer `_normalization` to `pkg_resources` in `develop.py`
* daadc5af - Prefer `_normalization` and importlib_metadata to `pkg_resources` in `dist.py`
* 61ad58b1 - Prefer `_normalization` to `pkg_resources` in `egg_info.py`
* f8f56bce - Prefer `packaging` to `pkg_resources` in `egg_info.py`
* 6f93ec71 - Prefer `packaging` to `pkg_resources` in `dist.py` for markers
* cbd0cb7d - Prefer alternative from `egg_info.py` to `pkg_resources.Distribution.egg_name`
* 1cfd18b4 - Prefer `packaging` instead for `pkg_resources` for version in `wheel.py`
* dd7b8fbc - Modify `_reqs.py` to favour `packaging` over `pkg_resources`
* e5681c0e - Centralize usage of `pkg_resources` from `dist.py` to `installer.py`
* 99b7b645 - Delay imports of `pkg_resources` in `install_scripts.py`
* 5e7b76f7 - Refactor/reorganize: replace `_normalization.path` with `_path.samepath` and `_path.normpath`
* 33f3243c - Fix dist-info naming discrepancy in relation to bdist_wheel
* 3736cbc2 - Revert to using normalized paths in develop to fix test errors

---

I created the following diagram manually (it can be incorrect) to represent the main modules where `pkg_resources` is still used *after the change in the PR*.

The red boxes represent the parts where it is very difficult to replace `pkg_resources` and we might just have to wait the end of the deprecation period to remove...

The yellow boxes represent parts to which I believe we could add explicit deprecations.

```mermaid
graph LR
  pkg_resources -->|delayed| setuptools.wheel.Wheel.install_as_egg:::can_deprec
  pkg_resources -->|delayed| setuptools.command.bdist_egg
  setuptools.command.bdist_egg --> setuptools.command.egg_info

  setuptools.dist.Distribuition.fetch_build_egg --> notoml[`pip install` for packages without pyproject.toml]
  setuptools.installer.fetch_build_egg:::critic --> setuptools.dist.Distribuition.fetch_build_egg
  pkg_resources --> setuptools.sandbox:::can_deprec
  pkg_resources --> setuptools.package_index:::can_deprec
  pkg_resources --> setuptools.installer.fetch_build_egg
  setuptools.sandbox --> setuptools.command.easy_install:::critic
  pkg_resources --> setuptools.command.easy_install
  setuptools.package_index --> setuptools.command.easy_install


  setuptools.dist.Distribuition.fetch_build_egg --> setuptools.command.develop

  pkg_resources --> setuptools.command.develop:::can_deprec
  setuptools.command.easy_install --> setuptools.command.develop
  setuptools.command.easy_install -->|delayed/conditional| setuptools.command.install_scripts


  setuptools.command.install_scripts --> setuptools.command.editable_wheel
  setuptools.command.install_scripts --> wheel.bdist_wheel

  pkg_resources --> wheel.bdist_wheel

  classDef critic fill:#fe0013
  classDef can_deprec fill:#fff386
  classDef is_deprec fill:#90ee90
```

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request

[^1]: The idea behind delaying the import is that ideally only users that touch deprecated code paths should pay the cost of initializing `pkg_resources`.
