### PR TITLE
Make __file__ an absolute path in setuptools.build_meta

### DIFF
--- a/changelog.d/3795.change.rst
+++ b/changelog.d/3795.change.rst
@@ -1,0 +1,2 @@
+Ensured that ``__file__`` is an absolute path when executing ``setup.py`` as
+part of ``setuptools.build_meta``.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -326,7 +326,7 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
     def run_setup(self, setup_script='setup.py'):
         # Note that we can reuse our build directory between calls
         # Correctness comes first, then optimization later
-        __file__ = setup_script
+        __file__ = os.path.abspath(setup_script)
         __name__ = '__main__'
 
         with _open_setup_script(__file__) as f:

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -194,6 +194,22 @@ defns = [
             print('hello')
         """)
     },
+    {  # setup.py that relies on __file__ being an absolute path
+        'setup.py': DALS("""
+            import os
+            assert os.path.isabs(__file__)
+            __import__('setuptools').setup(
+                name='foo',
+                version='0.0.0',
+                py_modules=['hello'],
+                setup_requires=['six'],
+            )
+            """),
+        'hello.py': DALS("""
+            def run():
+                print('hello')
+            """),
+    },
 ]
 
 


### PR DESCRIPTION
## Summary of changes

This is a difference between pip's legacy wheel build (or direct invocations of setup.py) and the PEP 517 build.

While setup.py scripts that rely on this are fragile, it was quite painful to debug! Since Python 3.4, `__file__` is usually an absolute path, so this change might result in fewer surprises.