### PR TITLE
Cache supported tags for wheels.

### DIFF
--- a/changelog.d/3804.change.rst
+++ b/changelog.d/3804.change.rst
@@ -1,0 +1,1 @@
+Cache supported tags for wheels.

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -609,20 +609,13 @@ def test_wheel_no_dist_dir():
 
 def test_wheel_is_compatible(monkeypatch):
     def sys_tags():
-        for t in parse_tag('cp36-cp36m-manylinux1_x86_64'):
-            yield t
-    monkeypatch.setattr('setuptools.wheel.sys_tags', sys_tags)
-    # Clear the supported tags cache, otherwise the sys_tags monkeypatch
-    # has no effect.
-    setuptools.wheel._supported_tags.cache_clear()
-    try:
-        assert Wheel(
-            'onnxruntime-0.1.2-cp36-cp36m-manylinux1_x86_64.whl'
-        ).is_compatible()
-    finally:
-        # Clear the cache again, otherwise the sys_tags monkeypatch
-        # is still in effect for the rest of the tests.
-        setuptools.wheel._supported_tags.cache_clear()
+        return {
+            (t.interpreter, t.abi, t.platform)
+            for t in parse_tag('cp36-cp36m-manylinux1_x86_64')
+        }
+    monkeypatch.setattr('setuptools.wheel._get_supported_tags', sys_tags)
+    assert Wheel(
+        'onnxruntime-0.1.2-cp36-cp36m-manylinux1_x86_64.whl').is_compatible()
 
 
 def test_wheel_mode():

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -612,6 +612,7 @@ def test_wheel_is_compatible(monkeypatch):
         for t in parse_tag('cp36-cp36m-manylinux1_x86_64'):
             yield t
     monkeypatch.setattr('setuptools.wheel.sys_tags', sys_tags)
+    monkeypatch.setattr('setuptools.wheel._supported_tags', None)
     assert Wheel(
         'onnxruntime-0.1.2-cp36-cp36m-manylinux1_x86_64.whl').is_compatible()
 

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -612,9 +612,17 @@ def test_wheel_is_compatible(monkeypatch):
         for t in parse_tag('cp36-cp36m-manylinux1_x86_64'):
             yield t
     monkeypatch.setattr('setuptools.wheel.sys_tags', sys_tags)
-    monkeypatch.setattr('setuptools.wheel._supported_tags', None)
-    assert Wheel(
-        'onnxruntime-0.1.2-cp36-cp36m-manylinux1_x86_64.whl').is_compatible()
+    # Clear the supported tags cache, otherwise the sys_tags monkeypatch
+    # has no effect.
+    setuptools.wheel._supported_tags.cache_clear()
+    try:
+        assert Wheel(
+            'onnxruntime-0.1.2-cp36-cp36m-manylinux1_x86_64.whl'
+        ).is_compatible()
+    finally:
+        # Clear the cache again, otherwise the sys_tags monkeypatch
+        # is still in effect for the rest of the tests.
+        setuptools.wheel._supported_tags.cache_clear()
 
 
 def test_wheel_mode():

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -34,7 +34,7 @@ def _get_supported_tags():
     # We calculate the supported tags only once, otherwise calling
     # this method on thousands of wheels takes seconds instead of
     # milliseconds.
-    return set((t.interpreter, t.abi, t.platform) for t in sys_tags())
+    return {(t.interpreter, t.abi, t.platform) for t in sys_tags()}
 
 
 def unpack(src_dir, dst_dir):
@@ -92,8 +92,7 @@ class Wheel:
 
     def is_compatible(self):
         '''Is the wheel compatible with the current platform?'''
-        _supported_tags = _get_supported_tags()
-        return next((True for t in self.tags() if t in _supported_tags), False)
+        return next((True for t in self.tags() if t in _get_supported_tags()), False)
 
     def egg_name(self):
         return _egg_basename(


### PR DESCRIPTION
## Summary of changes

In `wheel.py:Wheel.is_compatible` we called `sys_tags` each time to get the list of supported tags. Now we call this once, and cache the result in a simple variable. This drastically speeds up checking the compatibility of hundreds of wheels.

Closes #3804

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
