### PR TITLE
Merge with distutils@8c3c3d29

### DIFF
--- a/changelog.d/3809.change.rst
+++ b/changelog.d/3809.change.rst
@@ -1,0 +1,1 @@
+Merge with distutils@8c3c3d29, including fix for ``sysconfig.get_python_inc()`` (pypa/distutils#178), fix for segfault on MinGW (pypa/distutils#196), and better ``has_function`` support (pypa/distutils#195).

--- a/setuptools/_distutils/_collections.py
+++ b/setuptools/_distutils/_collections.py
@@ -185,7 +185,7 @@ class RangeMap(dict):
         return (sorted_keys[RangeMap.first_item], sorted_keys[RangeMap.last_item])
 
     # some special values for the RangeMap
-    undefined_value = type(str('RangeValueUndefined'), (), {})()
+    undefined_value = type('RangeValueUndefined', (), {})()
 
     class Item(int):
         "RangeMap Item"

--- a/setuptools/_distutils/_msvccompiler.py
+++ b/setuptools/_distutils/_msvccompiler.py
@@ -339,7 +339,6 @@ class MSVCCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         if not self.initialized:
             self.initialize()
         compile_info = self._setup_compile(
@@ -413,8 +412,7 @@ class MSVCCompiler(CCompiler):
             args = [self.cc] + compile_opts + pp_opts
             if add_cpp_opts:
                 args.append('/EHsc')
-            args.append(input_opt)
-            args.append("/Fo" + obj)
+            args.extend((input_opt, "/Fo" + obj))
             args.extend(extra_postargs)
 
             try:
@@ -427,7 +425,6 @@ class MSVCCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         if not self.initialized:
             self.initialize()
         objects, output_dir = self._fix_object_args(objects, output_dir)
@@ -461,7 +458,6 @@ class MSVCCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         if not self.initialized:
             self.initialize()
         objects, output_dir = self._fix_object_args(objects, output_dir)

--- a/setuptools/_distutils/bcppcompiler.py
+++ b/setuptools/_distutils/bcppcompiler.py
@@ -64,7 +64,6 @@ class BCPPCompiler(CCompiler):
     exe_extension = '.exe'
 
     def __init__(self, verbose=0, dry_run=0, force=0):
-
         super().__init__(verbose, dry_run, force)
 
         # These executables are assumed to all be in the path.
@@ -98,7 +97,6 @@ class BCPPCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         macros, objects, extra_postargs, pp_opts, build = self._setup_compile(
             output_dir, macros, include_dirs, sources, depends, extra_postargs
         )
@@ -167,7 +165,6 @@ class BCPPCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         (objects, output_dir) = self._fix_object_args(objects, output_dir)
         output_filename = self.library_filename(output_libname, output_dir=output_dir)
 
@@ -200,7 +197,6 @@ class BCPPCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         # XXX this ignores 'build_temp'!  should follow the lead of
         # msvccompiler.py
 
@@ -219,7 +215,6 @@ class BCPPCompiler(CCompiler):
             output_filename = os.path.join(output_dir, output_filename)
 
         if self._need_link(objects, output_filename):
-
             # Figure out linker args based on type of target.
             if target_desc == CCompiler.EXECUTABLE:
                 startup_obj = 'c0w32'
@@ -294,8 +289,7 @@ class BCPPCompiler(CCompiler):
                     ld_args.append(libfile)
 
             # some default libraries
-            ld_args.append('import32')
-            ld_args.append('cw32mt')
+            ld_args.extend(('import32', 'cw32mt'))
 
             # def file for export symbols
             ld_args.extend([',', def_file])
@@ -381,7 +375,6 @@ class BCPPCompiler(CCompiler):
         extra_preargs=None,
         extra_postargs=None,
     ):
-
         (_, macros, include_dirs) = self._fix_compile_args(None, macros, include_dirs)
         pp_opts = gen_preprocess_options(macros, include_dirs)
         pp_args = ['cpp32.exe'] + pp_opts

--- a/setuptools/_distutils/cmd.py
+++ b/setuptools/_distutils/cmd.py
@@ -160,7 +160,7 @@ class Command:
             header = "command options for '%s':" % self.get_command_name()
         self.announce(indent + header, level=logging.INFO)
         indent = indent + "  "
-        for (option, _, _) in self.user_options:
+        for option, _, _ in self.user_options:
             option = option.translate(longopt_xlate)
             if option[-1] == "=":
                 option = option[:-1]
@@ -291,7 +291,7 @@ class Command:
         # Option_pairs: list of (src_option, dst_option) tuples
         src_cmd_obj = self.distribution.get_command_obj(src_cmd)
         src_cmd_obj.ensure_finalized()
-        for (src_option, dst_option) in option_pairs:
+        for src_option, dst_option in option_pairs:
             if getattr(self, dst_option) is None:
                 setattr(self, dst_option, getattr(src_cmd_obj, src_option))
 
@@ -325,7 +325,7 @@ class Command:
         run for the current distribution.  Return a list of command names.
         """
         commands = []
-        for (cmd_name, method) in self.sub_commands:
+        for cmd_name, method in self.sub_commands:
             if method is None or method(self):
                 commands.append(cmd_name)
         return commands

--- a/setuptools/_distutils/command/bdist.py
+++ b/setuptools/_distutils/command/bdist.py
@@ -33,7 +33,6 @@ class ListCompat(dict):
 
 
 class bdist(Command):
-
     description = "create a built (binary) distribution"
 
     user_options = [

--- a/setuptools/_distutils/command/bdist_dumb.py
+++ b/setuptools/_distutils/command/bdist_dumb.py
@@ -14,7 +14,6 @@ from distutils._log import log
 
 
 class bdist_dumb(Command):
-
     description = "create a \"dumb\" built distribution"
 
     user_options = [

--- a/setuptools/_distutils/command/bdist_rpm.py
+++ b/setuptools/_distutils/command/bdist_rpm.py
@@ -21,7 +21,6 @@ from distutils._log import log
 
 
 class bdist_rpm(Command):
-
     description = "create an RPM distribution"
 
     user_options = [
@@ -554,7 +553,7 @@ class bdist_rpm(Command):
             ('postun', 'post_uninstall', None),
         ]
 
-        for (rpm_opt, attr, default) in script_options:
+        for rpm_opt, attr, default in script_options:
             # Insert contents of file referred to, if no file is referred to
             # use 'default' as contents of script
             val = getattr(self, attr)

--- a/setuptools/_distutils/command/build.py
+++ b/setuptools/_distutils/command/build.py
@@ -16,7 +16,6 @@ def show_compilers():
 
 
 class build(Command):
-
     description = "build everything needed to install"
 
     user_options = [

--- a/setuptools/_distutils/command/build_clib.py
+++ b/setuptools/_distutils/command/build_clib.py
@@ -28,7 +28,6 @@ def show_compilers():
 
 
 class build_clib(Command):
-
     description = "build C/C++ libraries used by Python extensions"
 
     user_options = [
@@ -103,7 +102,7 @@ class build_clib(Command):
             self.compiler.set_include_dirs(self.include_dirs)
         if self.define is not None:
             # 'define' option is a list of (name,value) tuples
-            for (name, value) in self.define:
+            for name, value in self.define:
                 self.compiler.define_macro(name, value)
         if self.undef is not None:
             for macro in self.undef:
@@ -155,14 +154,14 @@ class build_clib(Command):
             return None
 
         lib_names = []
-        for (lib_name, build_info) in self.libraries:
+        for lib_name, build_info in self.libraries:
             lib_names.append(lib_name)
         return lib_names
 
     def get_source_files(self):
         self.check_library_list(self.libraries)
         filenames = []
-        for (lib_name, build_info) in self.libraries:
+        for lib_name, build_info in self.libraries:
             sources = build_info.get('sources')
             if sources is None or not isinstance(sources, (list, tuple)):
                 raise DistutilsSetupError(
@@ -175,7 +174,7 @@ class build_clib(Command):
         return filenames
 
     def build_libraries(self, libraries):
-        for (lib_name, build_info) in libraries:
+        for lib_name, build_info in libraries:
             sources = build_info.get('sources')
             if sources is None or not isinstance(sources, (list, tuple)):
                 raise DistutilsSetupError(

--- a/setuptools/_distutils/command/build_ext.py
+++ b/setuptools/_distutils/command/build_ext.py
@@ -39,7 +39,6 @@ def show_compilers():
 
 
 class build_ext(Command):
-
     description = "build C/C++ extensions (compile/link to build directory)"
 
     # XXX thoughts on how to deal with complex command-line options like
@@ -328,7 +327,7 @@ class build_ext(Command):
             self.compiler.set_include_dirs(self.include_dirs)
         if self.define is not None:
             # 'define' option is a list of (name,value) tuples
-            for (name, value) in self.define:
+            for name, value in self.define:
                 self.compiler.define_macro(name, value)
         if self.undef is not None:
             for macro in self.undef:
@@ -721,7 +720,7 @@ class build_ext(Command):
         name = ext.name.split('.')[-1]
         try:
             # Unicode module name support as defined in PEP-489
-            # https://www.python.org/dev/peps/pep-0489/#export-hook-name
+            # https://peps.python.org/pep-0489/#export-hook-name
             name.encode('ascii')
         except UnicodeEncodeError:
             suffix = 'U_' + name.encode('punycode').replace(b'-', b'_').decode('ascii')

--- a/setuptools/_distutils/command/build_py.py
+++ b/setuptools/_distutils/command/build_py.py
@@ -14,7 +14,6 @@ from distutils._log import log
 
 
 class build_py(Command):
-
     description = "\"build\" pure Python modules (copy to build directory)"
 
     user_options = [
@@ -310,7 +309,7 @@ class build_py(Command):
     def get_outputs(self, include_bytecode=1):
         modules = self.find_all_modules()
         outputs = []
-        for (package, module, module_file) in modules:
+        for package, module, module_file in modules:
             package = package.split('.')
             filename = self.get_module_outfile(self.build_lib, package, module)
             outputs.append(filename)
@@ -352,7 +351,7 @@ class build_py(Command):
 
     def build_modules(self):
         modules = self.find_modules()
-        for (package, module, module_file) in modules:
+        for package, module, module_file in modules:
             # Now "build" the module -- ie. copy the source file to
             # self.build_lib (the build directory for Python source).
             # (Actually, it gets copied to the directory for this package
@@ -375,7 +374,7 @@ class build_py(Command):
 
             # Now loop over the modules we found, "building" each one (just
             # copy it to self.build_lib).
-            for (package_, module, module_file) in modules:
+            for package_, module, module_file in modules:
                 assert package == package_
                 self.build_module(module, module_file, package)
 

--- a/setuptools/_distutils/command/build_scripts.py
+++ b/setuptools/_distutils/command/build_scripts.py
@@ -22,7 +22,6 @@ first_line_re = shebang_pattern
 
 
 class build_scripts(Command):
-
     description = "\"build\" scripts (copy and fixup #! line)"
 
     user_options = [

--- a/setuptools/_distutils/command/clean.py
+++ b/setuptools/_distutils/command/clean.py
@@ -11,7 +11,6 @@ from distutils._log import log
 
 
 class clean(Command):
-
     description = "clean up temporary files from 'build' command"
     user_options = [
         ('build-base=', 'b', "base build directory (default: 'build.build-base')"),

--- a/setuptools/_distutils/command/config.py
+++ b/setuptools/_distutils/command/config.py
@@ -21,7 +21,6 @@ LANG_EXT = {"c": ".c", "c++": ".cxx"}
 
 
 class config(Command):
-
     description = "prepare to build"
 
     user_options = [

--- a/setuptools/_distutils/command/install.py
+++ b/setuptools/_distutils/command/install.py
@@ -180,7 +180,6 @@ def _pypy_hack(name):
 
 
 class install(Command):
-
     description = "install everything from build directory"
 
     user_options = [
@@ -609,7 +608,7 @@ class install(Command):
         for attr in attrs:
             val = getattr(self, attr)
             if val is not None:
-                if os.name == 'posix' or os.name == 'nt':
+                if os.name in ('posix', 'nt'):
                     val = os.path.expanduser(val)
                 val = subst_vars(val, self.config_vars)
                 setattr(self, attr, val)

--- a/setuptools/_distutils/command/install_data.py
+++ b/setuptools/_distutils/command/install_data.py
@@ -11,7 +11,6 @@ from ..util import change_root, convert_path
 
 
 class install_data(Command):
-
     description = "install data files"
 
     user_options = [

--- a/setuptools/_distutils/command/install_headers.py
+++ b/setuptools/_distutils/command/install_headers.py
@@ -8,7 +8,6 @@ from ..core import Command
 
 # XXX force is never used
 class install_headers(Command):
-
     description = "install C/C++ header files"
 
     user_options = [

--- a/setuptools/_distutils/command/install_lib.py
+++ b/setuptools/_distutils/command/install_lib.py
@@ -16,7 +16,6 @@ PYTHON_SOURCE_EXTENSION = ".py"
 
 
 class install_lib(Command):
-
     description = "install all Python modules (extensions and pure Python)"
 
     # The byte-compilation options are a tad confusing.  Here are the

--- a/setuptools/_distutils/command/install_scripts.py
+++ b/setuptools/_distutils/command/install_scripts.py
@@ -12,7 +12,6 @@ from stat import ST_MODE
 
 
 class install_scripts(Command):
-
     description = "install scripts (Python or otherwise)"
 
     user_options = [

--- a/setuptools/_distutils/command/register.py
+++ b/setuptools/_distutils/command/register.py
@@ -17,7 +17,6 @@ from distutils._log import log
 
 
 class register(PyPIRCCommand):
-
     description = "register the distribution with the Python package index"
     user_options = PyPIRCCommand.user_options + [
         ('list-classifiers', None, 'list the valid Trove classifiers'),

--- a/setuptools/_distutils/command/sdist.py
+++ b/setuptools/_distutils/command/sdist.py
@@ -33,7 +33,6 @@ def show_formats():
 
 
 class sdist(Command):
-
     description = "create a source distribution (tarball, zip file, etc.)"
 
     def checking_metadata(self):
@@ -235,7 +234,7 @@ class sdist(Command):
         """Add all the default files to self.filelist:
           - README or README.txt
           - setup.py
-          - test/test*.py
+          - tests/test*.py and test/test*.py
           - all pure Python modules mentioned in setup script
           - all files pointed by package_data (build_py)
           - all files defined in data_files.
@@ -293,7 +292,7 @@ class sdist(Command):
                     self.warn("standard file '%s' not found" % fn)
 
     def _add_defaults_optional(self):
-        optional = ['test/test*.py', 'setup.cfg']
+        optional = ['tests/test*.py', 'test/test*.py', 'setup.cfg']
         for pattern in optional:
             files = filter(os.path.isfile, glob(pattern))
             self.filelist.extend(files)

--- a/setuptools/_distutils/command/upload.py
+++ b/setuptools/_distutils/command/upload.py
@@ -27,7 +27,6 @@ _FILE_CONTENT_DIGESTS = {
 
 
 class upload(PyPIRCCommand):
-
     description = "upload binary package to PyPI"
 
     user_options = PyPIRCCommand.user_options + [

--- a/setuptools/_distutils/core.py
+++ b/setuptools/_distutils/core.py
@@ -132,7 +132,7 @@ def setup(**attrs):  # noqa: C901
     # our Distribution (see below).
     klass = attrs.get('distclass')
     if klass:
-        del attrs['distclass']
+        attrs.pop('distclass')
     else:
         klass = Distribution
 

--- a/setuptools/_distutils/cygwinccompiler.py
+++ b/setuptools/_distutils/cygwinccompiler.py
@@ -43,7 +43,7 @@ _msvcr_lookup = RangeMap.left(
         # VS2013 / MSVC 12.0
         1800: ['msvcr120'],
         # VS2015 / MSVC 14.0
-        1900: ['ucrt', 'vcruntime140'],
+        1900: ['vcruntime140'],
         2000: RangeMap.undefined_value,
     },
 )
@@ -84,7 +84,6 @@ class CygwinCCompiler(UnixCCompiler):
     exe_extension = ".exe"
 
     def __init__(self, verbose=0, dry_run=0, force=0):
-
         super().__init__(verbose, dry_run, force)
 
         status, details = check_config_h()
@@ -118,7 +117,7 @@ class CygwinCCompiler(UnixCCompiler):
 
     @property
     def gcc_version(self):
-        # Older numpy dependend on this existing to check for ancient
+        # Older numpy depended on this existing to check for ancient
         # gcc versions. This doesn't make much sense with clang etc so
         # just hardcode to something recent.
         # https://github.com/numpy/numpy/pull/20333
@@ -133,7 +132,7 @@ class CygwinCCompiler(UnixCCompiler):
 
     def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
         """Compiles the source by spawning GCC and windres if needed."""
-        if ext == '.rc' or ext == '.res':
+        if ext in ('.rc', '.res'):
             # gcc needs '.res' and '.rc' compiled to object files !!!
             try:
                 self.spawn(["windres", "-i", src, "-o", obj])
@@ -269,7 +268,6 @@ class Mingw32CCompiler(CygwinCCompiler):
     compiler_type = 'mingw32'
 
     def __init__(self, verbose=0, dry_run=0, force=0):
-
         super().__init__(verbose, dry_run, force)
 
         shared_option = "-shared"

--- a/setuptools/_distutils/dir_util.py
+++ b/setuptools/_distutils/dir_util.py
@@ -227,7 +227,7 @@ def remove_tree(directory, verbose=1, dry_run=0):
             # remove dir from cache if it's already there
             abspath = os.path.abspath(cmd[1])
             if abspath in _path_created:
-                del _path_created[abspath]
+                _path_created.pop(abspath)
         except OSError as exc:
             log.warning("error removing %s: %s", directory, exc)
 

--- a/setuptools/_distutils/dist.py
+++ b/setuptools/_distutils/dist.py
@@ -237,9 +237,9 @@ Common commands: (see '--help-commands' for more)
             options = attrs.get('options')
             if options is not None:
                 del attrs['options']
-                for (command, cmd_options) in options.items():
+                for command, cmd_options in options.items():
                     opt_dict = self.get_option_dict(command)
-                    for (opt, val) in cmd_options.items():
+                    for opt, val in cmd_options.items():
                         opt_dict[opt] = ("setup script", val)
 
             if 'licence' in attrs:
@@ -253,7 +253,7 @@ Common commands: (see '--help-commands' for more)
 
             # Now work on the rest of the attributes.  Any attribute that's
             # not already defined is invalid!
-            for (key, val) in attrs.items():
+            for key, val in attrs.items():
                 if hasattr(self.metadata, "set_" + key):
                     getattr(self.metadata, "set_" + key)(val)
                 elif hasattr(self.metadata, key):
@@ -414,7 +414,7 @@ Common commands: (see '--help-commands' for more)
         # to set Distribution options.
 
         if 'global' in self.command_options:
-            for (opt, (src, val)) in self.command_options['global'].items():
+            for opt, (src, val) in self.command_options['global'].items():
                 alias = self.negative_opt.get(opt)
                 try:
                     if alias:
@@ -585,7 +585,7 @@ Common commands: (see '--help-commands' for more)
             cmd_class.help_options, list
         ):
             help_option_found = 0
-            for (help_option, short, desc, func) in cmd_class.help_options:
+            for help_option, short, desc, func in cmd_class.help_options:
                 if hasattr(opts, parser.get_attr_name(help_option)):
                     help_option_found = 1
                     if callable(func):
@@ -603,7 +603,7 @@ Common commands: (see '--help-commands' for more)
         # Put the options from the command-line into their official
         # holding pen, the 'command_options' dictionary.
         opt_dict = self.get_option_dict(command)
-        for (name, value) in vars(opts).items():
+        for name, value in vars(opts).items():
             opt_dict[name] = ("command line", value)
 
         return args
@@ -696,11 +696,11 @@ Common commands: (see '--help-commands' for more)
         for option in self.display_options:
             is_display_option[option[0]] = 1
 
-        for (opt, val) in option_order:
+        for opt, val in option_order:
             if val and is_display_option.get(opt):
                 opt = translate_longopt(opt)
                 value = getattr(self.metadata, "get_" + opt)()
-                if opt in ['keywords', 'platforms']:
+                if opt in ('keywords', 'platforms'):
                     print(','.join(value))
                 elif opt in ('classifiers', 'provides', 'requires', 'obsoletes'):
                     print('\n'.join(value))
@@ -887,7 +887,7 @@ Common commands: (see '--help-commands' for more)
 
         if DEBUG:
             self.announce("  setting options for '%s' command:" % command_name)
-        for (option, (source, value)) in option_dict.items():
+        for option, (source, value) in option_dict.items():
             if DEBUG:
                 self.announce("    {} = {} (from {})".format(option, value, source))
             try:

--- a/setuptools/_distutils/fancy_getopt.py
+++ b/setuptools/_distutils/fancy_getopt.py
@@ -113,7 +113,7 @@ class FancyGetopt:
 
     def _check_alias_dict(self, aliases, what):
         assert isinstance(aliases, dict)
-        for (alias, opt) in aliases.items():
+        for alias, opt in aliases.items():
             if alias not in self.option_index:
                 raise DistutilsGetoptError(
                     ("invalid %s '%s': " "option '%s' not defined")

--- a/setuptools/_distutils/file_util.py
+++ b/setuptools/_distutils/file_util.py
@@ -176,7 +176,6 @@ def copy_file(  # noqa: C901
 
 # XXX I suspect this is Unix-specific -- need porting help!
 def move_file(src, dst, verbose=1, dry_run=0):  # noqa: C901
-
     """Move a file 'src' to 'dst'.  If 'dst' is a directory, the file will
     be moved into it with the same name; otherwise, 'src' is just renamed
     to 'dst'.  Return the new full name of the file.

--- a/setuptools/_distutils/msvc9compiler.py
+++ b/setuptools/_distutils/msvc9compiler.py
@@ -391,7 +391,7 @@ class MSVCCompiler(CCompiler):
             # to cross compile, you use 'x86_amd64'.
             # On AMD64, 'vcvars32.bat amd64' is a native build env; to cross
             # compile use 'x86' (ie, it runs the x86 compiler directly)
-            if plat_name == get_platform() or plat_name == 'win32':
+            if plat_name in (get_platform(), 'win32'):
                 # native build or cross-compile to win32
                 plat_spec = PLAT_TO_VCVARS[plat_name]
             else:
@@ -499,7 +499,6 @@ class MSVCCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         if not self.initialized:
             self.initialize()
         compile_info = self._setup_compile(
@@ -586,7 +585,6 @@ class MSVCCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)
@@ -619,7 +617,6 @@ class MSVCCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)

--- a/setuptools/_distutils/msvccompiler.py
+++ b/setuptools/_distutils/msvccompiler.py
@@ -389,7 +389,6 @@ class MSVCCompiler(CCompiler):
         extra_postargs=None,
         depends=None,
     ):
-
         if not self.initialized:
             self.initialize()
         compile_info = self._setup_compile(
@@ -476,7 +475,6 @@ class MSVCCompiler(CCompiler):
     def create_static_lib(
         self, objects, output_libname, output_dir=None, debug=0, target_lang=None
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)
@@ -509,7 +507,6 @@ class MSVCCompiler(CCompiler):
         build_temp=None,
         target_lang=None,
     ):
-
         if not self.initialized:
             self.initialize()
         (objects, output_dir) = self._fix_object_args(objects, output_dir)

--- a/setuptools/_distutils/sysconfig.py
+++ b/setuptools/_distutils/sysconfig.py
@@ -130,12 +130,20 @@ def get_python_inc(plat_specific=0, prefix=None):
     return getter(resolved_prefix, prefix, plat_specific)
 
 
+@pass_none
+def _extant(path):
+    """
+    Replace path with None if it doesn't exist.
+    """
+    return path if os.path.exists(path) else None
+
+
 def _get_python_inc_posix(prefix, spec_prefix, plat_specific):
     if IS_PYPY and sys.version_info < (3, 8):
         return os.path.join(prefix, 'include')
     return (
         _get_python_inc_posix_python(plat_specific)
-        or _get_python_inc_from_config(plat_specific, spec_prefix)
+        or _extant(_get_python_inc_from_config(plat_specific, spec_prefix))
         or _get_python_inc_posix_prefix(prefix)
     )
 
@@ -474,7 +482,6 @@ def parse_makefile(fn, g=None):  # noqa: C901
                         del notdone[name]
 
                         if name.startswith('PY_') and name[3:] in renamed_variables:
-
                             name = name[3:]
                             if name not in done:
                                 done[name] = value

--- a/setuptools/_distutils/tests/test_archive_util.py
+++ b/setuptools/_distutils/tests/test_archive_util.py
@@ -289,7 +289,7 @@ class ArchiveUtilTestCase(support.TempdirManager):
                 pass
             assert os.getcwd() == current_dir
         finally:
-            del ARCHIVE_FORMATS['xxx']
+            ARCHIVE_FORMATS.pop('xxx')
 
     def test_make_archive_tar(self):
         base_dir = self._create_files()

--- a/setuptools/_distutils/tests/test_bdist_dumb.py
+++ b/setuptools/_distutils/tests/test_bdist_dumb.py
@@ -29,7 +29,6 @@ class TestBuildDumb(
 ):
     @pytest.mark.usefixtures('needs_zlib')
     def test_simple_built(self):
-
         # let's create a simple package
         tmp_dir = self.mkdtemp()
         pkg_dir = os.path.join(tmp_dir, 'foo')

--- a/setuptools/_distutils/tests/test_build_clib.py
+++ b/setuptools/_distutils/tests/test_build_clib.py
@@ -71,7 +71,6 @@ class TestBuildCLib(support.TempdirManager):
         assert cmd.get_source_files() == ['a', 'b', 'c', 'd']
 
     def test_build_libraries(self):
-
         pkg_dir, dist = self.create_dist()
         cmd = build_clib(dist)
 

--- a/setuptools/_distutils/tests/test_build_ext.py
+++ b/setuptools/_distutils/tests/test_build_ext.py
@@ -158,7 +158,7 @@ class TestBuildExt(TempdirManager):
         cmd = self.build_ext(dist)
 
         # making sure the user option is there
-        options = [name for name, short, lable in cmd.user_options]
+        options = [name for name, short, label in cmd.user_options]
         assert 'user' in options
 
         # setting a value
@@ -180,7 +180,6 @@ class TestBuildExt(TempdirManager):
         assert incl in cmd.include_dirs
 
     def test_optional_extension(self):
-
         # this extension will fail, but let's ignore this failure
         # with the optional argument.
         modules = [Extension('foo', ['xxx'], optional=False)]

--- a/setuptools/_distutils/tests/test_ccompiler.py
+++ b/setuptools/_distutils/tests/test_ccompiler.py
@@ -53,3 +53,40 @@ def test_set_include_dirs(c_file):
     # do it again, setting include dirs after any initialization
     compiler.set_include_dirs([python])
     compiler.compile(_make_strs([c_file]))
+
+
+def test_has_function_prototype():
+    # Issue https://github.com/pypa/setuptools/issues/3648
+    # Test prototype-generating behavior.
+
+    compiler = ccompiler.new_compiler()
+
+    # Every C implementation should have these.
+    assert compiler.has_function('abort')
+    assert compiler.has_function('exit')
+    with pytest.deprecated_call(match='includes is deprecated'):
+        # abort() is a valid expression with the <stdlib.h> prototype.
+        assert compiler.has_function('abort', includes=['<stdlib.h>'])
+    with pytest.deprecated_call(match='includes is deprecated'):
+        # But exit() is not valid with the actual prototype in scope.
+        assert not compiler.has_function('exit', includes=['<stdlib.h>'])
+    # And setuptools_does_not_exist is not declared or defined at all.
+    assert not compiler.has_function('setuptools_does_not_exist')
+    with pytest.deprecated_call(match='includes is deprecated'):
+        assert not compiler.has_function(
+            'setuptools_does_not_exist', includes=['<stdio.h>']
+        )
+
+
+def test_include_dirs_after_multiple_compile_calls(c_file):
+    """
+    Calling compile multiple times should not change the include dirs
+    (regression test for setuptools issue #3591).
+    """
+    compiler = ccompiler.new_compiler()
+    python = sysconfig.get_paths()['include']
+    compiler.set_include_dirs([python])
+    compiler.compile(_make_strs([c_file]))
+    assert compiler.include_dirs == [python]
+    compiler.compile(_make_strs([c_file]))
+    assert compiler.include_dirs == [python]

--- a/setuptools/_distutils/tests/test_check.py
+++ b/setuptools/_distutils/tests/test_check.py
@@ -152,8 +152,7 @@ class TestCheck(support.TempdirManager):
         pytest.importorskip('docutils')
         # Don't fail if there is a `code` or `code-block` directive
 
-        example_rst_docs = []
-        example_rst_docs.append(
+        example_rst_docs = [
             textwrap.dedent(
                 """\
             Here's some code:
@@ -163,9 +162,7 @@ class TestCheck(support.TempdirManager):
                 def foo():
                     pass
             """
-            )
-        )
-        example_rst_docs.append(
+            ),
             textwrap.dedent(
                 """\
             Here's some code:
@@ -175,8 +172,8 @@ class TestCheck(support.TempdirManager):
                 def foo():
                     pass
             """
-            )
-        )
+            ),
+        ]
 
         for rest_with_code in example_rst_docs:
             pkg_info, dist = self.create_dist(long_description=rest_with_code)

--- a/setuptools/_distutils/tests/test_cmd.py
+++ b/setuptools/_distutils/tests/test_cmd.py
@@ -58,7 +58,6 @@ class TestCommand:
         cmd.make_file(infiles='in', outfile='out', func='func', args=())
 
     def test_dump_options(self, cmd):
-
         msgs = []
 
         def _announce(msg, level):

--- a/setuptools/_distutils/tests/test_cygwinccompiler.py
+++ b/setuptools/_distutils/tests/test_cygwinccompiler.py
@@ -47,7 +47,6 @@ class TestCygwinCCompiler(support.TempdirManager):
         assert compiler.runtime_library_dir_option('/foo') == []
 
     def test_check_config_h(self):
-
         # check_config_h looks for "GCC" in sys.version first
         # returns CONFIG_H_OK if found
         sys.version = (
@@ -72,7 +71,6 @@ class TestCygwinCCompiler(support.TempdirManager):
         assert check_config_h()[0] == CONFIG_H_OK
 
     def test_get_msvcr(self):
-
         # none
         sys.version = (
             '2.6.1 (r261:67515, Dec  6 2008, 16:42:21) '
@@ -108,7 +106,7 @@ class TestCygwinCCompiler(support.TempdirManager):
             '3.10.0 (tags/v3.10.0:b494f59, Oct  4 2021, 18:46:30) '
             '[MSC v.1929 32 bit (Intel)]'
         )
-        assert get_msvcr() == ['ucrt', 'vcruntime140']
+        assert get_msvcr() == ['vcruntime140']
 
         # unknown
         sys.version = (

--- a/setuptools/_distutils/tests/test_dep_util.py
+++ b/setuptools/_distutils/tests/test_dep_util.py
@@ -9,7 +9,6 @@ import pytest
 
 class TestDepUtil(support.TempdirManager):
     def test_newer(self):
-
         tmpdir = self.mkdtemp()
         new_file = os.path.join(tmpdir, 'new')
         old_file = os.path.abspath(__file__)

--- a/setuptools/_distutils/tests/test_dir_util.py
+++ b/setuptools/_distutils/tests/test_dir_util.py
@@ -51,7 +51,6 @@ class TestDirUtil(support.TempdirManager):
         assert stat.S_IMODE(os.stat(self.target2).st_mode) == 0o555 & ~umask
 
     def test_create_tree_verbosity(self, caplog):
-
         create_tree(self.root_target, ['one', 'two', 'three'], verbose=0)
         assert caplog.messages == []
         remove_tree(self.root_target, verbose=0)
@@ -63,7 +62,6 @@ class TestDirUtil(support.TempdirManager):
         remove_tree(self.root_target, verbose=0)
 
     def test_copy_tree_verbosity(self, caplog):
-
         mkpath(self.target, verbose=0)
 
         copy_tree(self.target, self.target2, verbose=0)

--- a/setuptools/_distutils/tests/test_dist.py
+++ b/setuptools/_distutils/tests/test_dist.py
@@ -142,7 +142,7 @@ class TestDistributionBehavior(support.TempdirManager):
             result_dict.keys()
         )
 
-        for (key, value) in d.command_options.get('install').items():
+        for key, value in d.command_options.get('install').items():
             assert value == result_dict[key]
 
         # Test case: In a Virtual Environment

--- a/setuptools/_distutils/tests/test_install.py
+++ b/setuptools/_distutils/tests/test_install.py
@@ -100,7 +100,7 @@ class TestInstall(
         cmd = install(dist)
 
         # making sure the user option is there
-        options = [name for name, short, lable in cmd.user_options]
+        options = [name for name, short, label in cmd.user_options]
         assert 'user' in options
 
         # setting a value

--- a/setuptools/_distutils/tests/test_register.py
+++ b/setuptools/_distutils/tests/test_register.py
@@ -158,7 +158,6 @@ class TestRegister(BasePyPIRCCommandTestCase):
         assert b'xxx' in self.conn.reqs[1].data
 
     def test_password_not_in_file(self):
-
         self.write_file(self.rc, PYPIRC_NOPASSWORD)
         cmd = self._get_cmd()
         cmd._set_config()

--- a/setuptools/_distutils/tests/test_sdist.py
+++ b/setuptools/_distutils/tests/test_sdist.py
@@ -162,7 +162,6 @@ class TestSDist(BasePyPIRCCommandTestCase):
 
     @pytest.mark.usefixtures('needs_zlib')
     def test_add_defaults(self):
-
         # http://bugs.python.org/issue2279
 
         # add_default should also include

--- a/setuptools/_distutils/tests/test_sysconfig.py
+++ b/setuptools/_distutils/tests/test_sysconfig.py
@@ -297,3 +297,22 @@ class TestSysconfig:
             cmd, env={**os.environ, "PYTHONPATH": distutils_path}
         )
         assert out == "True"
+
+    def test_get_python_inc_missing_config_dir(self, monkeypatch):
+        """
+        In portable Python installations, the sysconfig will be broken,
+        pointing to the directories where the installation was built and
+        not where it currently is. In this case, ensure that the missing
+        directory isn't used for get_python_inc.
+
+        See pypa/distutils#178.
+        """
+
+        def override(name):
+            if name == 'INCLUDEPY':
+                return '/does-not-exist'
+            return sysconfig.get_config_var(name)
+
+        monkeypatch.setattr(sysconfig, 'get_config_var', override)
+
+        assert os.path.exists(sysconfig.get_python_inc())

--- a/setuptools/_distutils/tests/test_unixccompiler.py
+++ b/setuptools/_distutils/tests/test_unixccompiler.py
@@ -303,4 +303,4 @@ class TestUnixCCompiler(support.TempdirManager):
         # FileNotFoundError: [Errno 2] No such file or directory: 'a.out'
         self.cc.output_dir = 'scratch'
         os.chdir(self.mkdtemp())
-        self.cc.has_function('abort', includes=['stdlib.h'])
+        self.cc.has_function('abort')

--- a/setuptools/_distutils/tests/test_upload.py
+++ b/setuptools/_distutils/tests/test_upload.py
@@ -77,7 +77,6 @@ class TestUpload(BasePyPIRCCommandTestCase):
         return self.last_open
 
     def test_finalize_options(self):
-
         # new format
         self.write_file(self.rc, PYPIRC)
         dist = Distribution()

--- a/setuptools/_distutils/text_file.py
+++ b/setuptools/_distutils/text_file.py
@@ -180,7 +180,6 @@ class TextFile:
                 line = None
 
             if self.strip_comments and line:
-
                 # Look for the first "#" in the line.  If none, never
                 # mind.  If we find one and it's the first character, or
                 # is not preceded by "\", then it starts a comment --
@@ -255,7 +254,7 @@ class TextFile:
 
             # blank line (whether we rstrip'ed or not)? skip to next line
             # if appropriate
-            if (line == '' or line == '\n') and self.skip_blanks:
+            if line in ('', '\n') and self.skip_blanks:
                 continue
 
             if self.join_lines:

--- a/setuptools/_distutils/unixccompiler.py
+++ b/setuptools/_distutils/unixccompiler.py
@@ -103,7 +103,6 @@ def _linker_params(linker_cmd, compiler_cmd):
 
 
 class UnixCCompiler(CCompiler):
-
     compiler_type = 'unix'
 
     # These are used by CCompiler in two places: the constructor sets

--- a/setuptools/_distutils/util.py
+++ b/setuptools/_distutils/util.py
@@ -228,7 +228,7 @@ def _subst_compat(s):
         import warnings
 
         warnings.warn(
-            "shell/Perl-style substitions are deprecated",
+            "shell/Perl-style substitutions are deprecated",
             DeprecationWarning,
         )
     return repl

--- a/setuptools/_distutils/version.py
+++ b/setuptools/_distutils/version.py
@@ -169,7 +169,6 @@ class StrictVersion(Version):
             self.prerelease = None
 
     def __str__(self):
-
         if self.version[2] == 0:
             vstring = '.'.join(map(str, self.version[0:2]))
         else:


### PR DESCRIPTION
- Add `tests/test*.py` to source distributions
- distutils.ccompiler: Make has_function work with more C99 compilers
- Fix MinGW-w64 segmentation fault
- Apply refurb suggestions
- Apply refurb suggestions
- Apply refurb suggestions
- Apply refurb suggestions
- Apply refurb suggestions
- Update outdated GitHub Actions
- Link directly to PEPs
- Add xfail test capturing missed expectation. Ref pypa/distutils#178.
- In _get_python_inc_posix, only return an extant path from the sysconfig. Fixes pypa/distutils#178.
- ⚫ Fade to black.
- Fix typos found by codespell
- add a pypy CI run
- Revert "Merge pull request #197 from GalaxySnail/fix-mingw-w64"
- Fix MinGW-w64 segmentation fault
- Fixed accumulating include dirs after compile
- Mark test as xfail on Windows. Ref pypa/distutils#195.
- distutils.ccompiler: Remove correct executable file on Windows

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
