### PR TITLE
Improve `editable_wheel` debugging tips.

### DIFF
--- a/changelog.d/3822.misc.1.rst
+++ b/changelog.d/3822.misc.1.rst
@@ -1,0 +1,3 @@
+Added debugging tips for "editable mode" and update related docs.
+Instead of using a custom exception to display the help message to the user,
+``setuptools`` will now use a warning and re-raise the original exception.

--- a/changelog.d/3822.misc.2.rst
+++ b/changelog.d/3822.misc.2.rst
@@ -1,0 +1,5 @@
+Added clarification about ``editable_wheel`` and ``dist_info`` CLI commands:
+they should not be called directly with ``python setup.py ...`` instead they
+are intended for internal use of ``setuptools`` (effectively as "private" commands).
+Users are recommended to user build backend APIs (:pep:`517` and :pep:`660`)
+in ``setuptools.build_meta``.

--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -192,16 +192,12 @@ works (still within the context of :pep:`660`).
    Users are encouraged to try out the new editable installation techniques
    and make the necessary adaptations.
 
-If the ``compat`` mode does not work for you, you can also disable the
-:pep:`editable install <660>` hooks in ``setuptools`` by setting an environment
-variable:
-
-.. code-block::
-
-   SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-
-This *may* cause the installer (e.g. ``pip``) to effectively run the "legacy"
-installation command: ``python setup.py develop`` [#installer]_.
+.. note::
+   Newer versions of ``pip`` no longer run the fallback command
+   ``python setup.py develop`` when the ``pyproject.toml`` file is present.
+   This means that setting the environment variable
+   ``SETUPTOOLS_ENABLE_FEATURES="legacy-editable"``
+   will have no effect when installing a package with ``pip``.
 
 
 How editable installations work
@@ -250,11 +246,6 @@ More information is available on the text of :pep:`PEP 660 <660#what-to-put-in-t
    can be used to prevent such kinds of situations (checkout `this blog post
    <https://blog.ganssle.io/articles/2019/08/test-as-installed.html>`_ for more
    insights).
-
-.. [#installer]
-   For this workaround to work, the installer tool needs to support legacy
-   editable installations. (Future versions of ``pip``, for example, may drop
-   support for this feature).
 
 .. [#criteria]
    ``setuptools`` strives to find a balance between allowing the user to see

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -19,8 +19,12 @@ from setuptools._deprecation_warning import SetuptoolsDeprecationWarning
 
 
 class dist_info(Command):
+    """
+    This command is private and reserved for internal use of setuptools,
+    clients should use the ``setuptools.build_meta`` APIs.
+    """
 
-    description = 'create a .dist-info directory'
+    description = "DO NOT CALL DIRECTLY, INTERNAL ONLY: create .dist-info directory"
 
     user_options = [
         ('egg-base=', 'e', "directory containing .egg-info directories"

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -140,18 +140,9 @@ class editable_wheel(Command):
             self._create_wheel_file(bdist_wheel)
         except Exception as ex:
             traceback.print_exc()
-            msg = """
-            Support for editable installs via PEP 660 was recently introduced
-            in `setuptools`. If you are seeing this error, please report to:
-
-            https://github.com/pypa/setuptools/issues
-
-            Meanwhile you can try the legacy behavior by setting an
-            environment variable and trying to install again:
-
-            SETUPTOOLS_ENABLE_FEATURES="legacy-editable"
-            """
-            raise errors.InternalError(cleandoc(msg)) from ex
+            project = self.distribution.name or self.distribution.get_name()
+            _DebuggingInfo.add_help(ex, project)
+            raise
 
     def _ensure_dist_info(self):
         if self.dist_info_dir is None:
@@ -842,3 +833,37 @@ class InformationOnly(UserWarning):
 
 class LinksNotSupported(errors.FileError):
     """File system does not seem to support either symlinks or hard links."""
+
+
+class _DebuggingInfo(InformationOnly):
+    @classmethod
+    def add_help(cls, ex: Exception, project: str):
+        msg = f"""An error happened while installing {project!r} in editable mode.
+
+        ************************************************************************
+        The following steps are recommended to help debugging this problem:
+
+        - Try to install the project normally, without using the editable mode.
+          Does the error still persists?
+          (If it does, try fixing the problem before attempting the editable mode).
+        - If you are using binary extensions, make sure you have all OS-level
+          dependencies installed (e.g. compilers, toolchains, binary libraries, ...).
+        - Try the latest version of setuptools (maybe the error was already fixed).
+        - If you (or your project dependencies) are using any setuptools extension
+          or customization, make sure they support the editable mode.
+
+        After following the steps above, if you think this is related to how setuptools
+        handles editable installations, please submit a reproducible example
+        (see https://stackoverflow.com/help/minimal-reproducible-example) to:
+
+            https://github.com/pypa/setuptools/issues
+
+        More information about editable installs can be found in the docs:
+
+            https://setuptools.pypa.io/en/latest/userguide/development_mode.html
+        ************************************************************************
+        """
+        if hasattr(ex, "add_note"):
+            ex.add_note(msg)
+        else:  # PEP 678 fallback
+            warnings.warn(msg, cls, stacklevel=3)

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -138,10 +138,10 @@ class editable_wheel(Command):
             bdist_wheel.write_wheelfile(self.dist_info_dir)
 
             self._create_wheel_file(bdist_wheel)
-        except Exception as ex:
+        except Exception:
             traceback.print_exc()
             project = self.distribution.name or self.distribution.get_name()
-            _DebuggingInfo.add_help(ex, project)
+            _DebuggingTips.warn(project)
             raise
 
     def _ensure_dist_info(self):
@@ -835,9 +835,9 @@ class LinksNotSupported(errors.FileError):
     """File system does not seem to support either symlinks or hard links."""
 
 
-class _DebuggingInfo(InformationOnly):
+class _DebuggingTips(InformationOnly):
     @classmethod
-    def add_help(cls, ex: Exception, project: str):
+    def warn(cls, project: str):
         msg = f"""An error happened while installing {project!r} in editable mode.
 
         ************************************************************************
@@ -863,7 +863,5 @@ class _DebuggingInfo(InformationOnly):
             https://setuptools.pypa.io/en/latest/userguide/development_mode.html
         ************************************************************************
         """
-        if hasattr(ex, "add_note"):
-            ex.add_note(msg)
-        else:  # PEP 678 fallback
-            warnings.warn(msg, cls, stacklevel=3)
+        # We cannot use `add_notes` since pip hides PEP 678 notes
+        warnings.warn(msg, cls, stacklevel=2)

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -853,8 +853,9 @@ class _DebuggingTips(InformationOnly):
         - If you (or your project dependencies) are using any setuptools extension
           or customization, make sure they support the editable mode.
 
-        After following the steps above, if you think this is related to how setuptools
-        handles editable installations, please submit a reproducible example
+        After following the steps above, if the problem still persist and
+        you think this is related to how setuptools handles editable installations,
+        please submit a reproducible example
         (see https://stackoverflow.com/help/minimal-reproducible-example) to:
 
             https://github.com/pypa/setuptools/issues

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -104,10 +104,11 @@ Options like `package-data`, `include/exclude-package-data` or
 
 class editable_wheel(Command):
     """Build 'editable' wheel for development.
-    (This command is reserved for internal use of setuptools).
+    This command is private and reserved for internal use of setuptools,
+    clients should use the ``setuptools.build_meta`` APIs.
     """
 
-    description = "create a PEP 660 'editable' wheel"
+    description = "DO NOT CALL DIRECTLY, INTERNAL ONLY: create PEP 660 editable wheel"
 
     user_options = [
         ("dist-dir=", "d", "directory to put final built distributions in"),

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -21,6 +21,7 @@ from . import contexts, namespaces
 
 from setuptools._importlib import resources as importlib_resources
 from setuptools.command.editable_wheel import (
+    _DebuggingTips,
     _LinkTree,
     _find_virtual_namespaces,
     _find_namespaces,
@@ -953,6 +954,24 @@ class TestCustomBuildExt:
         assert len(files) == 1
         name = files[0].name
         assert any(name.endswith(ext) for ext in EXTENSION_SUFFIXES)
+
+
+def test_debugging_tips(tmpdir_cwd, monkeypatch):
+    """Make sure to display useful debugging tips to the user."""
+    jaraco.path.build({"module.py": "x = 42"})
+    dist = Distribution()
+    dist.script_name = "setup.py"
+    dist.set_defaults()
+    cmd = editable_wheel(dist)
+    cmd.ensure_finalized()
+
+    SimulatedErr = type("SimulatedErr", (Exception,), {})
+    simulated_failure = Mock(side_effect=SimulatedErr())
+    monkeypatch.setattr(cmd, "get_finalized_command", simulated_failure)
+
+    expected_msg = "following steps are recommended to help debugging"
+    with pytest.raises(SimulatedErr), pytest.warns(_DebuggingTips, match=expected_msg):
+        cmd.run()
 
 
 def install_project(name, venv, tmp_path, files, *opts):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

`pip` no longer fallback to `setup.py develop` which makes setting `SETUPTOOLS_ENABLE_FEATURES="legacy-editable"` useless.

Moreover it is been a while that the PEP 660 implementation landed, so the main problems are already known.

I think it is time to allow the build errors to propagate (instead of having a "catch all" approach), but instead provide up-to-date debugging advice.

## Summary of changes

- Don't catch all the errors inside `editable_wheel`. Instead provide advice on how to debug it.
- Test code path with the advice.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
