### PR TITLE
Fix typo in docs/userguide/extension.rst

### DIFF
--- a/docs/userguide/extension.rst
+++ b/docs/userguide/extension.rst
@@ -44,7 +44,7 @@ different aspect of the build. In ``setuptools``, however, these command
 objects are just a design abstraction that encapsulate logic and help to
 organise the code.
 
-You can overwrite exiting commands (or add new ones) by defining entry
+You can overwrite existing commands (or add new ones) by defining entry
 points in the ``distutils.commands`` group.  For example, if you wanted to add
 a ``foo`` command, you might add something like this to your project:
 


### PR DESCRIPTION
## Summary of changes

This PR fixes a typo in `docs/userguide/extension.rst` that actually changes the meaning of this paragraph in an important way. Had me wondering a bit about this part's meaning when reading the docs :)
