### PR TITLE
Hotfix add htmlcov to flat layout package finder.default exclude

### DIFF
--- a/changelog.d/3594.change.rst
+++ b/changelog.d/3594.change.rst
@@ -1,1 +1,0 @@
-Added ``htmlcov`` to FlatLayoutPackageFinder.DEFAULT_EXCLUDE -- by :user:`yukihiko-shinoda`

--- a/changelog.d/3594.change.rst
+++ b/changelog.d/3594.change.rst
@@ -1,0 +1,1 @@
+Added ``htmlcov`` to FlatLayoutPackageFinder.DEFAULT_EXCLUDE -- by :user:`yukihiko-shinoda`

--- a/changelog.d/3836.misc.rst
+++ b/changelog.d/3836.misc.rst
@@ -1,0 +1,9 @@
+Fixed interaction between ``setuptools``' package auto-discovery and
+auto-generated ``htmlcov`` files.
+
+Previously, the ``htmlcov`` name was ignored when searching for single-file
+modules, however the correct behaviour is to ignore it when searching for
+packages (since it is supposed to be a directory, see `coverage config`_)
+-- by :user:`yukihiko-shinoda`.
+
+.. _coverage config: https://coverage.readthedocs.io/en/stable/config.html#html-directory

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -234,6 +234,7 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
         "benchmarks",
         "exercise",
         "exercises",
+        "htmlcov",  # Coverage.py
         # ---- Hidden directories/Private packages ----
         "[._]*",
     )
@@ -273,7 +274,7 @@ class FlatLayoutModuleFinder(ModuleFinder):
         "benchmarks",
         "exercise",
         "exercises",
-        "htmlcov",
+        "htmlcov",  # Coverage.py
         # ---- Hidden files/Private modules ----
         "[._]*",
     )

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -274,7 +274,6 @@ class FlatLayoutModuleFinder(ModuleFinder):
         "benchmarks",
         "exercise",
         "exercises",
-        "htmlcov",  # Coverage.py
         # ---- Hidden files/Private modules ----
         "[._]*",
     )

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -217,6 +217,7 @@ class TestFlatLayoutPackageFinder:
         ),
         "tool-specific": (
             [
+                "htmlcov/index.html",
                 "pkg/__init__.py",
                 "tasks/__init__.py",
                 "tasks/subpackage/__init__.py",


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Added htmlcov to FlatLayoutPackageFinder.DEFAULT_EXCLUDE.

Closes https://github.com/pypa/setuptools/issues/3594

#3715 still remains issue:

<details>
  <summary>The command: `pip install --editable` still fails:</summary>

```console
# pip install -e .
Obtaining file:///workspace
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [16 lines of output]
      /tmp/pip-build-env-fyn78agv/overlay/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
        warnings.warn(msg, _BetaConfiguration)
      error: Multiple top-level packages discovered in a flat-layout: ['htmlcov', 'examplepackage'].
      
      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.
      
      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:
      
      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names
      
      To find more information, look for "package discovery" on setuptools docs.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

</details>

Integrated test succeed by using this branch:

```toml
[build-system]
requires = ["setuptools@git+https://github.com/yukihiko-shinoda/setuptools.git@hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE"]
build-backend = "setuptools.build_meta"
```

<details>
  <summary>The command: `pip install --editable` is fixed:</summary>

```console
# pip install -e . --verbose
Using pip 23.0.1 from /usr/local/lib/python3.11/site-packages/pip (python 3.11)
Obtaining file:///workspace
  Running command pip subprocess to install build dependencies
  Collecting setuptools@ git+https://github.com/yukihiko-shinoda/setuptools.git@hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE
    Cloning https://github.com/yukihiko-shinoda/setuptools.git (to revision hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE) to /tmp/pip-install-p2og1wji/setuptools_20e1fd3a7e9740408f23b3e39e39728a
    Running command git clone --filter=blob:none --quiet https://github.com/yukihiko-shinoda/setuptools.git /tmp/pip-install-p2og1wji/setuptools_20e1fd3a7e9740408f23b3e39e39728a
    Running command git checkout -b hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE --track origin/hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE
    Switched to a new branch 'hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE'
    Branch 'hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE' set up to track remote branch 'hotfix-add-htmlcov-to-FlatLayoutPackageFinder.DEFAULT_EXCLUDE' from 'origin'.
    Resolved https://github.com/yukihiko-shinoda/setuptools.git to commit 9182fef90589676c3f361d65d457ea97d4b9510f
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'done'
    Installing backend dependencies: started
    Installing backend dependencies: finished with status 'done'
    Preparing metadata (pyproject.toml): started
    Preparing metadata (pyproject.toml): finished with status 'done'
  Building wheels for collected packages: setuptools
    Building wheel for setuptools (pyproject.toml): started
    Building wheel for setuptools (pyproject.toml): finished with status 'done'
    Created wheel for setuptools: filename=setuptools-67.4.0.post20230223-py3-none-any.whl size=1088479 sha256=ae98e1ca4bd02cabc0d3794fd4674265f901a3565c13445c1a67a7ff05b17f0f
    Stored in directory: /tmp/pip-ephem-wheel-cache-d19brlch/wheels/87/2c/5d/b1b0e64626e12f658fc5d950e2f7ea981092d18a9cca625b98
  Successfully built setuptools
  Installing collected packages: setuptools
  Successfully installed setuptools-67.4.0.post20230223
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  Installing build dependencies ... done
  Running command Checking if build backend supports build_editable
  Checking if build backend supports build_editable ... done
  Running command Getting requirements to build editable
  /tmp/pip-build-env-wlh43ph8/overlay/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
    warnings.warn(msg, _BetaConfiguration)
  running egg_info
  writing examplepackage.egg-info/PKG-INFO
  writing dependency_links to examplepackage.egg-info/dependency_links.txt
  writing requirements to examplepackage.egg-info/requires.txt
  writing top-level names to examplepackage.egg-info/top_level.txt
  reading manifest file 'examplepackage.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  adding license file 'LICENSE'
  writing manifest file 'examplepackage.egg-info/SOURCES.txt'
  Getting requirements to build editable ... done
  Running command pip subprocess to install backend dependencies
  Collecting wheel
    Using cached wheel-0.38.4-py3-none-any.whl (36 kB)
  Installing collected packages: wheel
  Successfully installed wheel-0.38.4
  WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
  Installing backend dependencies ... done
  Running command Preparing editable metadata (pyproject.toml)
  /tmp/pip-build-env-wlh43ph8/overlay/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
    warnings.warn(msg, _BetaConfiguration)
  running dist_info
  creating /tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info
  writing /tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info/PKG-INFO
  writing dependency_links to /tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info/dependency_links.txt
  writing requirements to /tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info/requires.txt
  writing top-level names to /tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info/top_level.txt
  writing manifest file '/tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info/SOURCES.txt'
  reading manifest file '/tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  adding license file 'LICENSE'
  writing manifest file '/tmp/pip-modern-metadata-0zjedxyb/examplepackage.egg-info/SOURCES.txt'
  creating '/tmp/pip-modern-metadata-0zjedxyb/examplepackage-0.1.0.dist-info'
  Preparing editable metadata (pyproject.toml) ... done
Building wheels for collected packages: examplepackage
  Running command Building editable for examplepackage (pyproject.toml)
  /tmp/pip-build-env-wlh43ph8/overlay/lib/python3.11/site-packages/setuptools/config/pyprojecttoml.py:108: _BetaConfiguration: Support for `[tool.setuptools]` in `pyproject.toml` is still *beta*.
    warnings.warn(msg, _BetaConfiguration)
  running editable_wheel
  creating /tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info
  writing /tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info/PKG-INFO
  writing dependency_links to /tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info/dependency_links.txt
  writing requirements to /tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info/requires.txt
  writing top-level names to /tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info/top_level.txt
  writing manifest file '/tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info/SOURCES.txt'
  reading manifest file '/tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  adding license file 'LICENSE'
  writing manifest file '/tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage.egg-info/SOURCES.txt'
  creating '/tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage-0.1.0.dist-info'
  creating /tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage-0.1.0.dist-info/WHEEL
  running build_py
  running egg_info
  creating /tmp/tmp61v2pjih.build-temp/examplepackage.egg-info
  writing /tmp/tmp61v2pjih.build-temp/examplepackage.egg-info/PKG-INFO
  writing dependency_links to /tmp/tmp61v2pjih.build-temp/examplepackage.egg-info/dependency_links.txt
  writing requirements to /tmp/tmp61v2pjih.build-temp/examplepackage.egg-info/requires.txt
  writing top-level names to /tmp/tmp61v2pjih.build-temp/examplepackage.egg-info/top_level.txt
  writing manifest file '/tmp/tmp61v2pjih.build-temp/examplepackage.egg-info/SOURCES.txt'
  reading manifest file '/tmp/tmp61v2pjih.build-temp/examplepackage.egg-info/SOURCES.txt'
  reading manifest template 'MANIFEST.in'
  adding license file 'LICENSE'
  writing manifest file '/tmp/tmp61v2pjih.build-temp/examplepackage.egg-info/SOURCES.txt'
  Editable install will be performed using a meta path finder.

  Options like `package-data`, `include/exclude-package-data` or
  `packages.find.exclude/include` may have no effect.

  adding '__editable___examplepackage_0_1_0_finder.py'
  adding '__editable__.examplepackage-0.1.0.pth'
  creating '/tmp/pip-wheel-lo8mljie/.tmp-rirdxxj6/examplepackage-0.1.0-0.editable-py3-none-any.whl' and adding '/tmp/tmpgs9yglkeexamplepackage-0.1.0-0.editable-py3-none-any.whl' to it
  adding 'examplepackage-0.1.0.dist-info/LICENSE'
  adding 'examplepackage-0.1.0.dist-info/METADATA'
  adding 'examplepackage-0.1.0.dist-info/WHEEL'
  adding 'examplepackage-0.1.0.dist-info/top_level.txt'
  adding 'examplepackage-0.1.0.dist-info/RECORD'
  /tmp/pip-build-env-wlh43ph8/overlay/lib/python3.11/site-packages/setuptools/command/editable_wheel.py:508: InformationOnly:

          Please be careful with folders in your working directory with the same
          name as your package as they may take precedence during imports.

    warnings.warn(msg, InformationOnly)
  Building editable for examplepackage (pyproject.toml) ... done
  Created wheel for examplepackage: filename=examplepackage-0.1.0-0.editable-py3-none-any.whl size=4487 sha256=1fbe74bbb68d1aef17bb0bb4ff5f0fd338c0ec0c6431173918023e5d88069873
  Stored in directory: /tmp/pip-ephem-wheel-cache-vvnbmyp4/wheels/e2/2c/68/4c4a53c0aec7bc75cfaa7bb42a2542d1390caa1e3199ccef70
Successfully built examplepackage
Installing collected packages: examplepackage
Successfully installed examplepackage-0.1.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
root@b450ea04586e:/workspace# pip list
Package          Version   Editable project location
---------------- --------- -------------------------
certifi          2022.12.7
distlib          0.3.6
filelock         3.9.0
examplepackage   0.1.0     /workspace
pip              23.0.1
pipenv           2023.2.18
platformdirs     3.0.0
setuptools       67.3.3
virtualenv       20.19.0
virtualenv-clone 0.5.7
wheel            0.38.4
root@b450ea04586e:/workspace# 
```

</details>

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
