### PR TITLE
Make `pkg_resources` more forgiving of non-compliant versions

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -112,6 +112,9 @@ _namespace_handlers = None
 _namespace_packages = None
 
 
+_PEP440_FALLBACK = re.compile(r"^v?(?P<safe>(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*)", re.I)
+
+
 class PEP440Warning(RuntimeWarning):
     """
     Used when there is an issue with a version or specifier not complying with
@@ -1389,6 +1392,38 @@ def safe_version(version):
         return re.sub('[^A-Za-z0-9.]+', '-', version)
 
 
+def _forgiving_version(version):
+    """Fallback when ``safe_version`` is not safe enough
+    >>> parse_version(_forgiving_version('0.23ubuntu1'))
+    <Version('0.23.dev0+sanitized.ubuntu1')>
+    >>> parse_version(_forgiving_version('0.23-'))
+    <Version('0.23.dev0+sanitized')>
+    >>> parse_version(_forgiving_version('0.-_'))
+    <Version('0.dev0+sanitized')>
+    >>> parse_version(_forgiving_version('42.+?1'))
+    <Version('42.dev0+sanitized.1')>
+    >>> parse_version(_forgiving_version('hello world'))
+    <Version('0.dev0+sanitized.hello.world')>
+    """
+    version = version.replace(' ', '.')
+    match = _PEP440_FALLBACK.search(version)
+    if match:
+        safe = match["safe"]
+        rest = version[len(safe):]
+    else:
+        safe = "0"
+        rest = version
+    local = f"sanitized.{_safe_segment(rest)}".strip(".")
+    return f"{safe}.dev0+{local}"
+
+
+def _safe_segment(segment):
+    """Convert an arbitrary string into a safe segment"""
+    segment = re.sub('[^A-Za-z0-9.]+', '-', segment)
+    segment = re.sub('-[^A-Za-z0-9]+', '-', segment)
+    return re.sub(r'\.[^A-Za-z0-9]+', '.', segment).strip(".-")
+
+
 def safe_extra(extra):
     """Convert an arbitrary string to a standard 'extra' name
 
@@ -2637,7 +2672,7 @@ class Distribution:
     @property
     def hashcmp(self):
         return (
-            self.parsed_version,
+            self._forgiving_parsed_version,
             self.precedence,
             self.key,
             self.location,
@@ -2694,6 +2729,32 @@ class Distribution:
                 raise packaging.version.InvalidVersion(f"{str(ex)} {info}") from None
 
         return self._parsed_version
+
+    @property
+    def _forgiving_parsed_version(self):
+        try:
+            return self.parsed_version
+        except packaging.version.InvalidVersion as ex:
+            self._parsed_version = parse_version(_forgiving_version(self.version))
+
+            notes = "\n".join(getattr(ex, "__notes__", []))  # PEP 678
+            msg = f"""!!\n\n
+            *************************************************************************
+            Invalid Version: {str(ex)}\n{notes}
+
+            This is a long overdue deprecation.
+            For the time being, `pkg_resources` will use `{self._parsed_version}`
+            as a replacement to avoid breaking existing environments,
+            but no future compatibility is guaranteed.
+
+            If you maintain package {self.project_name} you should implement
+            the relevant changes to adequate the project to PEP 440 immediately.
+            *************************************************************************
+            \n\n!!
+            """
+            warnings.warn(msg, DeprecationWarning)
+
+            return self._parsed_version
 
     @property
     def version(self):

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2740,7 +2740,7 @@ class Distribution:
             notes = "\n".join(getattr(ex, "__notes__", []))  # PEP 678
             msg = f"""!!\n\n
             *************************************************************************
-            Invalid Version: {str(ex)}\n{notes}
+            {str(ex)}\n{notes}
 
             This is a long overdue deprecation.
             For the time being, `pkg_resources` will use `{self._parsed_version}`


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->

In `#3772` we learned that some users have been finding trouble to install packages that follow PEP 440 if another package that does not follow PEP 440 is already installed. This is caused by `pkg_resources` automatically "activating" an environment with all the installed distributions and trying to sort them when `setup.py install` or `setup.py develop` is invoked[^1].

[^1]: So far those were the circumstances I could identify, but there might be others.

<!-- Remove sections if not applicable -->

## Summary of changes

- When calculating the `hashcmp` string in `pkg_resources`, use a fallback sanitized version in the case of parsing errors.

## Tests

I tested this is working based on the reproducer provided in a [commend in #3772](https://github.com/pypa/setuptools/issues/3772#issuecomment-1429496548):

```bash
> docker run --rm -e DEBIAN_FRONTEND=noninteractive -it ubuntu:bionic@sha256:4a45212e9518f35983a976eead0de5eecc555a2f047134e9dd2cfc589076a00d bash

apt update && apt install -q -y virtualenv python3-distro-info python3-distutils

mkdir -p /tmp/mypkg
cd /tmp/mypkg
echo "aaa=1" > mymod.py
cat <<EOF > setup.py
from setuptools import setup
setup(
    name="mypkg",
    version='1.0',
    py_modules=['mymod']
)
EOF

virtualenv --system-site-packages /tmp/.venv1
/tmp/.venv1/bin/python -m pip install -U 'pip==23.0.1' 'setuptools==67.4.0'
/tmp/.venv1/bin/python -m pip install -e .
# ...
# File "/tmp/.venv1/lib/python3.8/site-packages/pkg_resources/__init__.py", line 2694, in parsed_version
#   raise packaging.version.InvalidVersion(f"{str(ex)} {info}") from None
# pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '0.23ubuntu1' (package: distro-info)


virtualenv --system-site-packages /tmp/.venv2
/tmp/.venv2/bin/python -m pip install -U 'pip==23.0.1' 'setuptools @ https://github.com/abravalheri/setuptools/archive/refs/heads/issue-3772.zip'
/tmp/.venv2/bin/python -m pip -v install -e .
# Successfully installed mypkg-1.0
```

## Problems with this approach:

`pip` will not display the deprecation warning unless setting `PYTHONWARNINGS=once` and using the verbose flag (`pip -v`).

## Alternatives

A workaround already exists (the users just need to add `--use-pep517` to the `pip install` command).

`pip` 23.1 is supposed to use PEP 517 by default (no need for `--use-pep517` flag), so I think most of the users will no longer face this error after the update.

(Specially now that we are avoid importing `pkg_resources` unless absolutely necessary).

Is it worthy to add such workaround to the codebase?

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
