### PR TITLE
Docs: Fix link to importlib.resources in the docs

### DIFF
--- a/docs/pkg_resources.rst
+++ b/docs/pkg_resources.rst
@@ -12,7 +12,7 @@ packages.
 
 .. attention::
    Use of ``pkg_resources`` is deprecated in favor of
-   `importlib.resources <https://docs.python.org/3/library/importlib.html#module-importlib.resources>`_,
+   `importlib.resources <https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources>`_,
    `importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_,
    and their backports (:pypi:`importlib_resources`,
    :pypi:`importlib_metadata`).

--- a/docs/pkg_resources.rst
+++ b/docs/pkg_resources.rst
@@ -12,10 +12,8 @@ packages.
 
 .. attention::
    Use of ``pkg_resources`` is deprecated in favor of
-   `importlib.resources <https://docs.python.org/3/library/importlib.resources.html#module-importlib.resources>`_,
-   `importlib.metadata <https://docs.python.org/3/library/importlib.metadata.html>`_,
-   and their backports (:pypi:`importlib_resources`,
-   :pypi:`importlib_metadata`).
+   :mod:`importlib.resources`, :mod:`importlib.metadata`
+   and their backports (:pypi:`importlib_resources`, :pypi:`importlib_metadata`).
    Users should refrain from new usage of ``pkg_resources`` and
    should work to port to importlib-based solutions.
 


### PR DESCRIPTION
Just fixed a link so it takes you to the correct page, not the `importlib` docs homepage.