### PR TITLE
Removing error prone undefined late binding for Darwin builds

### DIFF
--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -36,7 +36,7 @@ def _customize_compiler_for_shlib(compiler):
         try:
             # XXX Help!  I don't have any idea whether these are right...
             _CONFIG_VARS['LDSHARED'] = (
-                "gcc -Wl,-x -dynamiclib -undefined dynamic_lookup")
+                "gcc -Wl,-x -dynamiclib")
             _CONFIG_VARS['CCSHARED'] = " -dynamiclib"
             _CONFIG_VARS['SO'] = ".dylib"
             customize_compiler(compiler)


### PR DESCRIPTION
This flag causes the linker to succeed and insert dlsym for undefined values which will cause numerious run time issues that are compile time issues with ext modules

## Summary of changes

Do not request darwin (macOS) linker to ignore undefined symbols

Closes <!-- issue number here -->

### Pull Request Checklist
- [NA] Changes have tests - Existing tests pass
- [NA] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
