### PR TITLE
docs: Add a note about historical `wheel` use in `requires`

### DIFF
--- a/changelog.d/3859.doc.rst
+++ b/changelog.d/3859.doc.rst
@@ -1,0 +1,2 @@
+Added a note about historical presence of ``wheel``
+in ``build-system.requires``, in ``pyproject.toml``.

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -63,7 +63,7 @@ library will be used to actually do the packaging.
    not recommended. The backend automatically adds ``wheel`` dependency
    when it is required, and listing it explicitly causes it to be
    unnecessarily required for source distribution builds.
-   You should only include ``wheel`` in `requires` if you need to explicitly
+   You should only include ``wheel`` in ``requires`` if you need to explicitly
    access it during build time (e.g. if your project needs a ``setup.py``
    script that imports ``wheel``).
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -56,6 +56,17 @@ containing a ``build-system`` section similar to the example below:
 This section declares what are your build system dependencies, and which
 library will be used to actually do the packaging.
 
+.. note::
+
+   Historically this documentation has unnecessarily listed ``wheel``
+   in the ``requires`` list, and many projects still do that. This is
+   not recommended. The backend automatically adds ``wheel`` dependency
+   when it is required, and listing it explicitly causes it to be
+   unnecessarily required for source distribution builds.
+   You should only include ``wheel`` in `requires` if you need to explicitly
+   access it during build time (e.g. if your project needs a ``setup.py``
+   script that imports ``wheel``).
+
 In addition to specifying a build system, you also will need to add
 some package information such as metadata, contents, dependencies, etc.
 This can be done in the same ``pyproject.toml`` [#beta]_ file,


### PR DESCRIPTION
## Summary of changes

Add a note explaining that the `wheel` requirement that used to be historically used in documentation was incorrect.  This also explains why it can frequently be found in existing projects, and what problems it causes.  I find myself repeatedly explaining it, so I think having a single official source would be better.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
