### PR TITLE
_deprecated_config_handler(): Use warn stacklevel for better feedback

### DIFF
--- a/changelog.d/change.rst
+++ b/changelog.d/change.rst
@@ -1,0 +1,2 @@
+Add a `stacklevel` parameter to `warnings.warn()` to provide more information to the user.
+-- by :user:`cclauss`

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -513,7 +513,7 @@ class ConfigHandler(Generic[Target]):
 
         @wraps(func)
         def config_handler(*args, **kwargs):
-            warnings.warn(msg, warning_class)
+            warnings.warn(msg, warning_class, stacklevel=2)
             return func(*args, **kwargs)
 
         return config_handler


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Add a `stacklevel` parameter to `warnings.warn()` to provide more information to the user.

[flake8-bugbear rule](https://github.com/PyCQA/flake8-bugbear#list-of-warnings) `B028`: No explicit stacklevel argument found. The warn method from the warnings module uses a stacklevel of 1 by default. This will only show a stack trace for the line on which the warn method is called. It is therefore recommended to use a stacklevel of 2 or greater to provide more information to the user.

Why: I get the following error message but it is unclear which of my dependencies is causing this problem.
```
Warning: /home/admin/.local/share/virtualenvs/application-Xi26YQ0u/lib/python3.9/site-packages/setuptools/config/setupcfg.py:516:
SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.
warnings.warn(msg, warning_class)
```

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
