### PR TITLE
🎨📝 Fix in-tree PEP 517 backend wrapper example

### DIFF
--- a/changelog.d/3893.doc.rst
+++ b/changelog.d/3893.doc.rst
@@ -1,0 +1,3 @@
+Improved the documentation example regarding making a thin :pep:`517` in-tree
+backend wrapper of ``setuptools.build_meta`` that is future-proof and supports
+:pep:`660` hook too -- by :user:`webknjaz`.

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -136,24 +136,29 @@ the ``_custom_build/backend.py`` file, as shown in the following example:
 
 .. code-block:: python
 
-    from setuptools import build_meta as _orig
+    from setuptools.build_meta import *
 
-    prepare_metadata_for_build_wheel = _orig.prepare_metadata_for_build_wheel
-    build_wheel = _orig.build_wheel
-    build_sdist = _orig.build_sdist
+    _original_get_requires_for_build_wheel = get_requires_for_build_wheel
+    _original_get_requires_for_build_sdist = get_requires_for_build_sdist
 
 
     def get_requires_for_build_wheel(config_settings=None):
-        return _orig.get_requires_for_build_wheel(config_settings) + [...]
+        return _original_get_requires_for_build_wheel(config_settings) + [...]
 
 
     def get_requires_for_build_sdist(config_settings=None):
-        return _orig.get_requires_for_build_sdist(config_settings) + [...]
+        return _original_get_requires_for_build_sdist(config_settings) + [...]
 
 
-Note that you can override any of the functions specified in :pep:`PEP 517
-<517#build-backend-interface>`, not only the ones responsible for gathering
-requirements.
+.. note::
+
+   You can override any of the functions specified in :pep:`PEP 517
+   <517#build-backend-interface>`, not only the ones responsible for gathering
+   requirements. It is important to ``import *`` so that the hooks that you
+   choose not to reimplement would be inherited from the setuptools' backend
+   automatically. This will also cover hooks that might be added in the future
+   like the ones that :pep:`660` declares.
+
 
 .. important:: Make sure your backend script is included in the :doc:`source
    distribution </userguide/distribution>`, otherwise the build will fail.

--- a/docs/build_meta.rst
+++ b/docs/build_meta.rst
@@ -136,18 +136,16 @@ the ``_custom_build/backend.py`` file, as shown in the following example:
 
 .. code-block:: python
 
+    from setuptools import build_meta as _orig
     from setuptools.build_meta import *
-
-    _original_get_requires_for_build_wheel = get_requires_for_build_wheel
-    _original_get_requires_for_build_sdist = get_requires_for_build_sdist
 
 
     def get_requires_for_build_wheel(config_settings=None):
-        return _original_get_requires_for_build_wheel(config_settings) + [...]
+        return _orig.get_requires_for_build_wheel(config_settings) + [...]
 
 
     def get_requires_for_build_sdist(config_settings=None):
-        return _original_get_requires_for_build_sdist(config_settings) + [...]
+        return _orig.get_requires_for_build_sdist(config_settings) + [...]
 
 
 .. note::


### PR DESCRIPTION
Before this patch, the documentation suggested the package authors to declare a fixed set of hooks inherited from setuptools. But this approach turned out non-future proof. Over time, as `setuptools` added support for editable installs, it introduced new hooks per PEP 660. But if one were to follow the outlined example, they'd end up with an in-tree build backend that does not support editable installs, nor would it re-export any hooks that might be added in future versions of setuptools, implementing any new standards that may emerge over time.

This change demonstrates an approach that would allow the thin wrapper authors to get the new hooks that setuptools may add over time.

Ref: https://github.com/ansible/ansible/pull/79606#discussion_r1080753862

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
