### PR TITLE
Avoid modification of `install_requires` and `extra_requires` that deviates from core metadata

### DIFF
--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -1,0 +1,96 @@
+"""Helper code used to generate ``requires.txt`` files in the egg-info directory.
+
+The ``requires.txt`` file has an specific format:
+    - Environment markers need to be part of the section headers and
+      should not be part of the requirement spec itself.
+
+See https://setuptools.pypa.io/en/latest/deprecated/python_eggs.html#requires-txt
+"""
+from collections import defaultdict
+from itertools import filterfalse
+from typing import Dict, List, Tuple, Mapping, TypeVar
+
+from .. import _reqs
+from ..extern.packaging.requirements import Requirement
+
+
+# dict can work as an ordered set
+_T = TypeVar("_T")
+_Ordered = Dict[_T, None]
+_ordered = dict
+_StrOrIter = _reqs._StrOrIter
+
+
+def _prepare(
+    install_requires: _StrOrIter, extras_require: Mapping[str, _StrOrIter]
+) -> Tuple[List[str], Dict[str, List[str]]]:
+    """Given values for ``install_requires`` and ``extras_require``
+    create modified versions in a way that can be written in ``requires.txt``
+    """
+    extras = _convert_extras_requirements(extras_require)
+    return _move_install_requirements_markers(install_requires, extras)
+
+
+def _convert_extras_requirements(
+    extras_require: _StrOrIter,
+) -> Mapping[str, _Ordered[Requirement]]:
+    """
+    Convert requirements in `extras_require` of the form
+    `"extra": ["barbazquux; {marker}"]` to
+    `"extra:{marker}": ["barbazquux"]`.
+    """
+    output: Mapping[str, _Ordered[Requirement]] = defaultdict(dict)
+    for section, v in extras_require.items():
+        # Do not strip empty sections.
+        output[section]
+        for r in _reqs.parse(v):
+            output[section + _suffix_for(r)].setdefault(r)
+
+    return output
+
+
+def _move_install_requirements_markers(
+    install_requires: _StrOrIter, extras_require: Mapping[str, _Ordered[Requirement]]
+) -> Tuple[List[str], Dict[str, List[str]]]:
+    """
+    The ``requires.txt`` file has an specific format:
+        - Environment markers need to be part of the section headers and
+          should not be part of the requirement spec itself.
+
+    Move requirements in ``install_requires`` that are using environment
+    markers ``extras_require``.
+    """
+
+    # divide the install_requires into two sets, simple ones still
+    # handled by install_requires and more complex ones handled by extras_require.
+
+    inst_reqs = list(_reqs.parse(install_requires))
+    simple_reqs = filter(_no_marker, inst_reqs)
+    complex_reqs = filterfalse(_no_marker, inst_reqs)
+    simple_install_requires = list(map(str, simple_reqs))
+
+    for r in complex_reqs:
+        extras_require[':' + str(r.marker)].setdefault(r)
+
+    expanded_extras = dict(
+        # list(dict.fromkeys(...))  ensures a list of unique strings
+        (k, list(dict.fromkeys(str(r) for r in map(_clean_req, v))))
+        for k, v in extras_require.items()
+    )
+
+    return simple_install_requires, expanded_extras
+
+
+def _suffix_for(req):
+    """Return the 'extras_require' suffix for a given requirement."""
+    return ':' + str(req.marker) if req.marker else ''
+
+
+def _clean_req(req):
+    """Given a Requirement, remove environment markers and return it"""
+    req.marker = None
+    return req
+
+
+def _no_marker(req):
+    return not req.marker

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -12,12 +12,12 @@ import functools
 import os
 import re
 import sys
-import io
 import time
 import collections
 
 from .._importlib import metadata
 from .. import _entry_points, _normalization
+from . import _requirestxt
 
 from setuptools import Command
 from setuptools.command.sdist import sdist
@@ -28,7 +28,6 @@ import setuptools.unicode_utils as unicode_utils
 from setuptools.glob import glob
 
 from setuptools.extern import packaging
-from setuptools.extern.jaraco.text import yield_lines
 from ..warnings import SetuptoolsDeprecationWarning
 
 
@@ -692,31 +691,9 @@ def warn_depends_obsolete(cmd, basename, filename):
     """
 
 
-def _write_requirements(stream, reqs):
-    lines = yield_lines(reqs or ())
-
-    def append_cr(line):
-        return line + '\n'
-
-    lines = map(append_cr, lines)
-    stream.writelines(lines)
-
-
-def write_requirements(cmd, basename, filename):
-    dist = cmd.distribution
-    data = io.StringIO()
-    _write_requirements(data, dist.install_requires)
-    extras_require = dist.extras_require or {}
-    for extra in sorted(extras_require):
-        data.write('\n[{extra}]\n'.format(**vars()))
-        _write_requirements(data, extras_require[extra])
-    cmd.write_or_delete_file("requirements", filename, data.getvalue())
-
-
-def write_setup_requirements(cmd, basename, filename):
-    data = io.StringIO()
-    _write_requirements(data, cmd.distribution.setup_requires)
-    cmd.write_or_delete_file("setup-requirements", filename, data.getvalue())
+# Export API used in entry_points
+write_requirements = _requirestxt.write_requirements
+write_setup_requirements = _requirestxt.write_setup_requirements
 
 
 def write_toplevel_names(cmd, basename, filename):

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -216,7 +216,7 @@ def _dependencies(dist: "Distribution", val: list, _root_dir):
 
 
 def _optional_dependencies(dist: "Distribution", val: dict, _root_dir):
-    existing = getattr(dist, "extras_require", {})
+    existing = getattr(dist, "extras_require", None) or {}
     _set_config(dist, "extras_require", {**existing, **val})
 
 
@@ -383,8 +383,8 @@ _PREVIOUSLY_DEFINED = {
     "entry-points": _get_previous_entrypoints,
     "scripts": _get_previous_scripts,
     "gui-scripts": _get_previous_gui_scripts,
-    "dependencies": _some_attrgetter("_orig_install_requires", "install_requires"),
-    "optional-dependencies": _some_attrgetter("_orig_extras_require", "extras_require"),
+    "dependencies": _attrgetter("install_requires"),
+    "optional-dependencies": _attrgetter("extras_require"),
 }
 
 

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -388,12 +388,12 @@ class TestPresetField:
         dist = makedist(tmp_path, install_requires=install_req)
         dist = pyprojecttoml.apply_configuration(dist, pyproject)
         assert "foo" in dist.extras_require
-        assert ':python_version < "3.7"' in dist.extras_require
         egg_info = dist.get_command_obj("egg_info")
         write_requirements(egg_info, tmp_path, tmp_path / "requires.txt")
         reqs = (tmp_path / "requires.txt").read_text(encoding="utf-8")
         assert "importlib-resources" in reqs
         assert "bar" in reqs
+        assert ':python_version < "3.7"' in reqs
 
     @pytest.mark.parametrize(
         "field,group", [("scripts", "console_scripts"), ("gui-scripts", "gui_scripts")]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Extract the logic for writing `requires.txt` from the ``egg_info`` module into ``_requirestxt.py``.
- Extract `egg_info`-specific processing of requirements from `dist.py` to `_requitestxt.py`.
- Avoid direct modifications of `install_requires` and `extra_requires`.
  Instead only process them on demand, when the `requires.txt` file is needed for creating `.egg-info` directories.

This ensures `dist.install_requires` and `dist.extra_requires` remains compatible with core metadata and allow future changes to generate `Requires-Dist` in METADATA files (which are not compatible with `requires.txt`).

---

This is part of a series of PRs:

- #3903
- #3904
- #3905
- #3906
- #3907
- #3908

The motivation for this series of PRs is the following:

- Logic for generating `.egg-info` and `.dist-info` directories is intertwined and implicit
  (See #1386).
- Setuptools uses `pypa/wheel` API which is not stable yet and is very likely to change in the future.
- `pypa/wheel` maintainers previously described that the long term vision is to transfer `bdist_wheel`
  directly to `setuptools` (See [pypa/wheel#262](https://github.com/pypa/wheel/issues/262#issuecomment-640471412), [pypa/wheel#472](https://github.com/pypa/wheel/pull/472#issuecomment-1306186724), [pypa/wheel#472](https://github.com/pypa/wheel/pull/472#issuecomment-1328129928)).

---

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
