### PR TITLE
Avoid undocumented `pypa/wheel` API in `dist_info`

### DIFF
--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -75,7 +75,7 @@ class dist_info(Command):
         project_dir = dist.src_root or os.curdir
         self.output_dir = Path(self.output_dir or project_dir)
 
-        egg_info = self.reinitialize_command("egg_info")
+        egg_info = self.reinitialize_command("egg_info", reinit_subcommands=True)
         egg_info.egg_base = str(self.output_dir)
         self._sync_tag_details(egg_info)
         egg_info.finalize_options()
@@ -110,7 +110,9 @@ class dist_info(Command):
         # If in the future we don't want to use egg_info, we have to create the files:
         # METADATA, entry-points.txt
         shutil.copytree(egg_info_dir, dist_info_dir, ignore=lambda _, __: _IGNORE)
-        shutil.copy2(egg_info_dir / "PKG-INFO", dist_info_dir / "METADATA")
+        metadata_file = dist_info_dir / "METADATA"
+        shutil.copy2(egg_info_dir / "PKG-INFO", metadata_file)
+        log.debug(f"creating {str(os.path.abspath(metadata_file))!r}")
         if self.distribution.dependency_links:
             shutil.copy2(egg_info_dir / "dependency_links.txt", dist_info_dir)
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Avoid `pypa/wheel` API in `dist_info`

- Instead of using `bdist_wheel` to convert `egg-info` directory into `dist-info`, just do the conversion directly.
  This relies on the fact that `PKG-INFO` and `METADATA` files are compatible after the last PRs.

This is done because there is an understanding that `pypa/wheel` is not meant to be used public yet and will change in the future.

---

This is part of a series of PRs:

- #3903
- #3904
- #3905
- #3906
- #3907
- #3908

The motivation for this series of PRs is the following:

- Logic for generating `.egg-info` and `.dist-info` directories is intertwined and implicit
  (See #1386).
- Setuptools uses `pypa/wheel` API which is not stable yet and is very likely to change in the future.
- `pypa/wheel` maintainers previously described that the long term vision is to transfer `bdist_wheel`
  directly to `setuptools` (See [pypa/wheel#262](https://github.com/pypa/wheel/issues/262#issuecomment-640471412), [pypa/wheel#472](https://github.com/pypa/wheel/pull/472#issuecomment-1306186724), [pypa/wheel#472](https://github.com/pypa/wheel/pull/472#issuecomment-1328129928)).

---

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
