### PR TITLE
Avoid `pypa/wheel` API in `editable_wheel`

### DIFF
--- a/setuptools/_wheelbuilder.py
+++ b/setuptools/_wheelbuilder.py
@@ -15,7 +15,7 @@ from .discovery import _Filter
 
 _Path = Union[str, Path]
 _Timestamp = Tuple[int, int, int, int, int, int]
-_StrOrIter = Union[str, Iterable[str]]
+_TextOrIter = Union[str, bytes, Iterable[str], Iterable[bytes]]
 
 _HASH_ALG = "sha256"
 _HASH_BUF_SIZE = 65536
@@ -121,7 +121,7 @@ class WheelBuilder:
                     arcname = os.path.join(prefix, arcname)
                 self.add_existing_file(arcname, file)
 
-    def new_file(self, arcname: str, contents: _StrOrIter, permissions: int = 0o664):
+    def new_file(self, arcname: str, contents: _TextOrIter, permissions: int = 0o664):
         """
         Create a new entry in the wheel named ``arcname`` that contains
         the UTF-8 text specified by ``contents``.
@@ -131,10 +131,10 @@ class WheelBuilder:
         zipinfo.compress_type = self._compression
         hashsum = hashlib.new(_HASH_ALG)
         file_size = 0
-        iter_contents = [contents] if isinstance(contents, str) else contents
+        iter_contents = [contents] if isinstance(contents, (str, bytes)) else contents
         with self._zip.open(zipinfo, "w") as fp:
             for part in iter_contents:
-                bpart = bytes(part, "utf-8")
+                bpart = bytes(part, "utf-8") if isinstance(part, str) else part
                 file_size += fp.write(bpart)
                 hashsum.update(bpart)
         hash_digest = urlsafe_b64encode(hashsum.digest()).decode('ascii').rstrip('=')

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -128,9 +128,17 @@ def _any_compat_tag() -> _Tag:
     the same system where it was produced.
     Therefore we can just be pragmatic and pick one of the compatible tags.
     """
-    tag = next(sys_tags())
+    tag = next(_skip_incompatible_tags())
+    # ^-- TODO: replace with `tag = next(sys_tags())` (pypa/python#11789)
     components = (tag.interpreter, tag.abi, tag.platform)
     return cast(_Tag, tuple(map(_normalization.filename_component, components)))
+
+
+def _skip_incompatible_tags():
+    # Temporary workaround for https://github.com/pypa/pip/issues/11789
+    for tag in sys_tags():
+        if all(plat not in tag.platform for plat in ("macosx_12", "macosx_11")):
+            yield tag
 
 
 class editable_wheel(Command):

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -185,7 +185,7 @@ class editable_wheel(Command):
 
     def _ensure_dist_info(self):
         if not Path(self.dist_info_dir, "METADATA").exists():
-            self.distribution.run_command("dist_info")
+            self.run_command("dist_info")
 
     def _install_namespaces(self, installation_dir, pth_prefix):
         # XXX: Only required to support the deprecated namespace practice


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Uses `WheelBuilder` and `_core_metadata` introduced in previous PRs instead of `pypa/wheel`.

(The `pypa/wheel` APIs for building wheel files are likely to change in the future)


---

This is part of a series of PRs:

- #3903
- #3904
- #3905
- #3906
- #3907
- #3908

The motivation for this series of PRs is the following:

- Logic for generating `.egg-info` and `.dist-info` directories is intertwined and implicit
  (See #1386).
- Setuptools uses `pypa/wheel` API which is not stable yet and is very likely to change in the future.
- `pypa/wheel` maintainers previously described that the long term vision is to transfer `bdist_wheel`
  directly to `setuptools` (See [pypa/wheel#262](https://github.com/pypa/wheel/issues/262#issuecomment-640471412), [pypa/wheel#472](https://github.com/pypa/wheel/pull/472#issuecomment-1306186724), [pypa/wheel#472](https://github.com/pypa/wheel/pull/472#issuecomment-1328129928)).

---

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
