### PR TITLE
Avoid duplication in warning text

### DIFF
--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -2337,8 +2337,8 @@ class EasyInstallDeprecationWarning(SetuptoolsDeprecationWarning):
     _SUMMARY = "easy_install command is deprecated."
     _DETAILS = """
     Please avoid running ``setup.py`` and ``easy_install``.
-    Instead, use pypa/build, pypa/installer, pypa/build or
-    other standards-based tools.
+    Instead, use pypa/build, pypa/installer or other
+    standards-based tools.
     """
     _SEE_URL = "https://github.com/pypa/setuptools/issues/917"
     # _DUE_DATE not defined yet

--- a/setuptools/command/install.py
+++ b/setuptools/command/install.py
@@ -34,8 +34,8 @@ class install(orig.install):
             "setup.py install is deprecated.",
             """
             Please avoid running ``setup.py`` directly.
-            Instead, use pypa/build, pypa/installer, pypa/build or
-            other standards-based tools.
+            Instead, use pypa/build, pypa/installer or other
+            standards-based tools.
             """,
             see_url="https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html",
             # TODO: Document how to bootstrap setuptools without install


### PR DESCRIPTION
`pypa/build` is mentioned twice in one sentence.

@abravalheri from #3849