### PR TITLE
Adequate venv fixtures to the latest change in virtualenv for Python 3.12

### DIFF
--- a/changelog.d/3915.misc.rst
+++ b/changelog.d/3915.misc.rst
@@ -1,0 +1,1 @@
+Adequate tests to the latest changes in ``virtualenv`` for Python 3.12.

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -105,6 +105,8 @@ def venv(tmp_path, setuptools_wheel):
     """Virtual env with the version of setuptools under test installed"""
     env = environment.VirtualEnv()
     env.root = path.Path(tmp_path / 'venv')
+    env.create_opts = ['--no-setuptools', '--wheel=bundle']
+    # TODO: Use `--no-wheel` when setuptools implements its own bdist_wheel
     env.req = str(setuptools_wheel)
     # In some environments (eg. downstream distro packaging),
     # where tox isn't used to run tests and PYTHONPATH is set to point to
@@ -125,7 +127,7 @@ def venv_without_setuptools(tmp_path):
     """Virtual env without any version of setuptools installed"""
     env = environment.VirtualEnv()
     env.root = path.Path(tmp_path / 'venv_without_setuptools')
-    env.create_opts = ['--no-setuptools']
+    env.create_opts = ['--no-setuptools', '--no-wheel']
     env.ensure_env()
     return env
 

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -174,8 +174,8 @@ def _check_test_command_install_requirements(venv, tmpdir):
 
 
 def test_test_command_install_requirements(venv, tmpdir, tmpdir_cwd):
-    # Ensure pip/wheel packages are installed.
-    venv.run(["python", "-c", "__import__('pkg_resources').require(['pip', 'wheel'])"])
+    # Ensure pip is installed.
+    venv.run(["python", "-c", "import pip"])
     # disable index URL so bits and bobs aren't requested from PyPI
     with contexts.environment(PYTHONPATH=None, PIP_NO_INDEX="1"):
         _check_test_command_install_requirements(venv, tmpdir)

--- a/setuptools/version.py
+++ b/setuptools/version.py
@@ -1,6 +1,6 @@
 from ._importlib import metadata
 
 try:
-    __version__ = metadata.version('setuptools')
+    __version__ = metadata.version('setuptools') or '0.dev0+unknown'
 except Exception:
-    __version__ = 'unknown'
+    __version__ = '0.dev0+unknown'


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Since version v20.23.0, `virtualenv` will no longer include `wheel` and `setuptools` in the created folders.

Some tests in the setuptools test suite assume that these packages are always present. So we need to adequate these tests.

**EDIT**: Apparently we are also having problems with `__version__`. It seems that the code path triggered in the "unhappy path" that results in `__version__ = "unknown"`.
Since `unknown` is not a valid PEP 440, it causes problem. I changed this fallback to be PEP 440-compliant.
This problem might be related to the race conditions between `importlib.metadata` (used by pytest and plugins) and `egg_info` (that writes `setuptools.egg-info/PKG-INFO`).

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`changelog.d/`].
  _(See [documentation][PR docs] for details)_


[`changelog.d/`]: https://github.com/pypa/setuptools/tree/master/changelog.d
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
