### PR TITLE
tests: Add extraction_filter for tarfile

### DIFF
--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -697,6 +697,7 @@ class TestSetupRequires:
                 foobar_1_dir = os.path.join(temp_dir, 'foo.bar-0.1')
                 os.mkdir(foobar_1_dir)
                 with tarfile.open(foobar_1_archive) as tf:
+                    tf.extraction_filter = (lambda member, path: member)
                     tf.extractall(foobar_1_dir)
                 sys.path.insert(1, foobar_1_dir)
 


### PR DESCRIPTION
Python 3.12, and earlier via security backports now issue an DeprecationWarning when calling tarfile.extractall without an extraction filter set. Since the only place we've called extractall is literally right after we've created the archive, use a fully trusted filter. This can be replaced with a filter argument to extractall in future.