### PR TITLE
Disable cygwin for now

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,8 @@ testing =
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"
 	pytest-enabler >= 1.3
-	pytest-ruff
+	# workaround for pypa/setuptools#3921
+	pytest-ruff; sys_platform != "cygwin"
 
 	# local
 	flake8-2020


### PR DESCRIPTION
Workaround for #3921.

CC @lazka : Would you be willing to look into what it will take to make a rust compiler available in the test_cygwin?