### PR TITLE
fixes spelling mod->module

### DIFF
--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -86,7 +86,7 @@ exactly to the directory structure, you also need to configure ``package_dir``:
         setup(
             # ...
             package_dir = {
-                "mypkg": "lib",  # mypkg.module corresponds to lib/mod.py
+                "mypkg": "lib",  # mypkg.module corresponds to lib/module.py
                 "mypkg.subpkg1": "lib1",  # mypkg.subpkg1.module1 corresponds to lib1/module1.py
                 "mypkg.subpkg2": "lib2"   # mypkg.subpkg2.module2 corresponds to lib2/module2.py
                 # ...


### PR DESCRIPTION
## Summary of changes

This PR adjusts inconsistent wording in the package discovery documentation. See the referenced issue 


Closes #3954

### Pull Request Checklist
- [x] Changes have tests (not applicable)
- [x] News fragment added in [`changelog.d/`]. (not applicable due to small change as specified [here](https://github.com/pypa/setuptools/pull/3931#issuecomment-1555905966))
  
