### PR TITLE
Bypass encoding warnings in execnet

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,8 @@ testing =
 	pytest-perf
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
+	# workaround for pytest-dev/execnet#195
+	execnet @ git+https://github.com/jaraco/execnet@bugfix/195-encodingwarning
 
 testing-integration =
 	pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,8 @@ testing =
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
 	# workaround for pytest-dev/execnet#195
 	execnet @ git+https://github.com/jaraco/execnet@bugfix/195-encodingwarning
+	# workaround for pypa/build#630
+	build[virtualenv] @ git+https://github.com/jaraco/build@bugfix/630-importlib-metadata
 
 testing-integration =
 	pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,10 +73,6 @@ testing =
 	pytest-perf
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
-	# workaround for pytest-dev/execnet#195
-	execnet @ git+https://github.com/jaraco/execnet@bugfix/195-encodingwarning
-	# workaround for pypa/build#630
-	build[virtualenv] @ git+https://github.com/jaraco/build@bugfix/630-importlib-metadata
 
 testing-integration =
 	pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,10 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 [testenv]
 deps =
 	# Ideally all the dependencies should be set as "extras"
+	# workaround for pytest-dev/execnet#195
+	execnet @ git+https://github.com/jaraco/execnet@bugfix/195-encodingwarning
+	# workaround for pypa/build#630
+	build[virtualenv] @ git+https://github.com/jaraco/build@bugfix/630-importlib-metadata
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
 	SETUPTOOLS_ENFORCE_DEPRECATION = 1


### PR DESCRIPTION
Originally, I just pushed this commit to main before I realized it causes failures on Python 3.8 when something attempts to construct a requirement, but creates the wrong syntax:

```
  File "/home/runner/work/setuptools/setuptools/.tox/py/lib/python3.8/site-packages/packaging/requirements.py", line 37, in __init__
    raise InvalidRequirement(str(e)) from e
packaging.requirements.InvalidRequirement: Expected end or semicolon (after URL and whitespace)
    execnet@ git+https://github.com/jaraco/execnet@bugfix/195-encodingwarning; extra == "testing"
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```

The error message is misleading. The problem is that [PEP 508](https://peps.python.org/pep-0508/) specifies `url_req` as

```
url_req       = name wsp* extras? wsp* urlspec wsp+ quoted_marker?
```

Where the urlspec needs to be separated from the quoted marker (the semicolon) with whitespace.