### PR TITLE
Handle `setup.py` possibly using `sys.exit`

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -337,7 +337,15 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         with _open_setup_script(__file__) as f:
             code = f.read().replace(r'\r\n', r'\n')
 
-        exec(code, locals())
+        try:
+            exec(code, locals())
+        except SystemExit as e:
+            if e.code:
+                # We pretend under PEP 517 that the implementation
+                # called a subprocess, which failed.
+                from subprocess import CalledProcessError
+                raise CalledProcessError(e.code, "setup.py")
+            # We ignore exit code indicating success
 
     def get_requires_for_build_wheel(self, config_settings=None):
         return self._get_build_requires(config_settings, requirements=['wheel'])

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -341,11 +341,15 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
             exec(code, locals())
         except SystemExit as e:
             if e.code:
-                # We pretend under PEP 517 that the implementation
-                # called a subprocess, which failed.
-                from subprocess import CalledProcessError
-                raise CalledProcessError(e.code, "setup.py")
+                raise
             # We ignore exit code indicating success
+            SetuptoolsDeprecationWarning.emit(
+                "Running `setup.py` directly as CLI tool is deprecated.",
+                "Please avoid using `sys.exit(0)` or similar statements "
+                "that don't fit in the paradigm of a configuration file.",
+                see_url="https://blog.ganssle.io/articles/2021/10/"
+                "setup-py-deprecated.html",
+            )
 
     def get_requires_for_build_wheel(self, config_settings=None):
         return self._get_build_requires(config_settings, requirements=['wheel'])

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -9,7 +9,6 @@ from concurrent import futures
 import re
 from zipfile import ZipFile
 from pathlib import Path
-from subprocess import CalledProcessError
 
 import pytest
 from jaraco import path

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -218,37 +218,6 @@ defns = [
     },
 ]
 
-sys_exit_defns = [
-    {  # simple setup.py script
-        'setup.py': DALS(
-            """
-            __import__('setuptools').setup(
-                name='foo',
-                version='0.0.0',
-                py_modules=['hello'],
-                setup_requires=['six'],
-            )
-            import sys
-            sys.exit(0)
-            """
-        ),
-        'hello.py': DALS(
-            """
-            def run():
-                print('hello')
-            """
-        ),
-    },
-    {  # simple setup.py script
-        'setup.py': DALS(
-            """
-            import sys
-            sys.exit(1)
-            """
-        ),
-    },
-]
-
 
 class TestBuildMetaBackend:
     backend_name = 'setuptools.build_meta'


### PR DESCRIPTION
## Summary of changes

Since `setup.py` is an arbitrary Python script legacy scripts my be complex and may use `sys.exit`.
To adhere to PEP 517 handle `SystemExit` exception by ignoring it with exit code `0` and converting it to `CalledProcessError(exit_code, 'setup.py')` in case of non-zero exit code.

fixes #3973

### Pull Request Checklist
- [X] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_
