### PR TITLE
Remove execnet workaround

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 [testenv]
 deps =
 	# Ideally all the dependencies should be set as "extras"
-	# workaround for pytest-dev/execnet#195
-	execnet @ git+https://github.com/jaraco/execnet@bugfix/195-encodingwarning
 	# workaround for pypa/build#630
 	build[virtualenv] @ git+https://github.com/jaraco/build@bugfix/630-importlib-metadata
 setenv =


### PR DESCRIPTION
The fix was just included in a release, and the branch this was installing from has been deleted, so it was causing CI failures.