### PR TITLE
docs: remove include_package_data and package_data interaction note

### DIFF
--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -233,14 +233,6 @@ we specify that ``data1.rst`` from ``mypkg1`` alone should be captured as well.
     ``package_name.egg-info/SOURCES.txt`` file, so make sure that this is removed if
     the ``setup.py`` ``package_data`` list is updated before calling ``setup.py``.
 
-.. note::
-   If using the ``include_package_data`` argument, files specified by
-   ``package_data`` will *not* be automatically added to the manifest unless
-   they are listed in the |MANIFEST.in|_ file or by a plugin like
-   :pypi:`setuptools-scm` or :pypi:`setuptools-svn`.
-
-.. https://docs.python.org/3/distutils/setupscript.html#installing-package-data
-
 exclude_package_data
 ====================
 


### PR DESCRIPTION
this was true in < [58.3.0](https://github.com/abravalheri/experiment-setuptools-package-data#previous-results-setuptools5830) but is no longer the case in [60.6.0+](https://github.com/abravalheri/experiment-setuptools-package-data#results-for-setuptools6060)

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
