### PR TITLE
Remove test dependency on `pip-run` for Cygwin

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,7 +69,9 @@ testing =
 	ini2toml[lite]>=0.9
 	tomli-w>=1.0.0
 	pytest-timeout
-	pytest-perf
+	pytest-perf; \
+		# workaround for jaraco/inflect#195, pydantic/pydantic-core#773 (see #3986)
+		sys_platform != "cygwin"
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,6 @@ testing =
 	jaraco.path>=3.2.0
 	build[virtualenv]
 	filelock>=3.4.0
-	pip_run>=8.8
 	ini2toml[lite]>=0.9
 	tomli-w>=1.0.0
 	pytest-timeout

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -20,7 +20,7 @@ setup(
 )
 def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     """Make sure the correct verbosity level is set (issue #3038)"""
-    import setuptools  # noqa: Import setuptools to monkeypatch distutils
+    import setuptools  # noqa: F401  # import setuptools to monkeypatch distutils
     import distutils  # <- load distutils after all the patches take place
 
     logger = logging.Logger(__name__)

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,6 @@ toxworkdir={env:TOX_WORK_DIR:.tox}
 [testenv]
 deps =
 	# Ideally all the dependencies should be set as "extras"
-	# workaround for pytest-dev/execnet#195
-	execnet @ git+https://github.com/jaraco/execnet@bugfix/195-encodingwarning
 	# workaround for pypa/build#630
 	build[virtualenv] @ git+https://github.com/jaraco/build@bugfix/630-importlib-metadata
 setenv =


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

In #3976 it was identified that an indirect dependency on `pydantic-core` was causing `pip` to fail when installing `setuptools[testing]`. This is due to the fact that `pydantic-core` uses Rust and does not publish pre-built wheels for all platforms (see pydantic/pydantic-core#773).

The following changes were implemented:

- Remove `pip-run` as dependency of `setuptools[testing]`.

This PR builds on top of #3976 as an attempt to fix the errors in the test suite.

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
