### PR TITLE
Make _EditableFinder case-sensitive on case-insensitive filesystems (for certain editable installations)

### DIFF
--- a/newsfragments/3995.bugfix.rst
+++ b/newsfragments/3995.bugfix.rst
@@ -1,0 +1,1 @@
+Made imports in editable installs case-sensitive on case-insensitive filesystems -- by :user:`aganders3`

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -772,7 +772,8 @@ class _EditableFinder:  # MetaPathFinder
         init = candidate_path / "__init__.py"
         candidates = (candidate_path.with_suffix(x) for x in module_suffixes())
         for candidate in chain([init], candidates):
-            if candidate.is_file() and _check_case(candidate, len(rest)):
+            last_n = len(rest) + len(candidate.parts) - len(candidate_path.parts)
+            if candidate.is_file() and _check_case(candidate, last_n):
                 return spec_from_file_location(fullname, candidate)
 
 
@@ -801,17 +802,17 @@ class _EditableNamespaceFinder:  # PathEntryFinder
         return None
 
 
-def _check_case(path, n):
+def _check_case(path, last_n):
     '''Verify the last `n` parts of the path have correct case.'''
     return (
         (not sys.flags.ignore_environment and "PYTHONCASEOK" in os.environ)
         or (
             # check the case of the name by listing its parent directory
             path.as_posix() in (p.as_posix() for p in path.parent.iterdir())
-            # check the case of the next n parent directories the same way
+            # check the case of the next n - 1 components the same way
             and all(
                 part.as_posix() in (p.as_posix() for p in part.parent.iterdir())
-                for part in list(path.parents)[:n]
+                for part in list(path.parents)[:last_n - 1]
             )
         )
     )

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -810,8 +810,8 @@ def _check_case(path, n):
             path.as_posix() in (p.as_posix() for p in path.parent.iterdir())
             # check the case of the next n parent directories the same way
             and all(
-                p1.as_posix() in (p.as_posix() for p in p2.iterdir())
-                for p1, p2 in list(zip(path.parents, path.parents[1:]))[:n]
+                part.as_posix() in (p.as_posix() for p in part.parent.iterdir())
+                for part in list(path.parents)[:n]
             )
         )
     )

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -756,22 +756,6 @@ NAMESPACES = {namespaces!r}
 PATH_PLACEHOLDER = {name!r} + ".__path_hook__"
 
 
-def _check_case(path, n):
-    '''Verify the last `n` parts of the path have correct case.'''
-    return (
-        (not sys.flags.ignore_environment and "PYTHONCASEOK" in os.environ)
-        or (
-            # check the case of the name by listing its parent directory
-            path.as_posix() in (p.as_posix() for p in path.parent.iterdir())
-            # check the case of the next n - 1 parent directories the same way
-            and all(
-                p1.as_posix() in (p.as_posix() for p in p2.iterdir())
-                for p1, p2 in list(zip(path.parents, path.parents[1:]))[:n - 1]
-            )
-        )
-    )
-
-
 class _EditableFinder:  # MetaPathFinder
     @classmethod
     def find_spec(cls, fullname, path=None, target=None):
@@ -815,6 +799,22 @@ class _EditableNamespaceFinder:  # PathEntryFinder
     @classmethod
     def find_module(cls, fullname):
         return None
+
+
+def _check_case(path, n):
+    '''Verify the last `n` parts of the path have correct case.'''
+    return (
+        (not sys.flags.ignore_environment and "PYTHONCASEOK" in os.environ)
+        or (
+            # check the case of the name by listing its parent directory
+            path.as_posix() in (p.as_posix() for p in path.parent.iterdir())
+            # check the case of the next n parent directories the same way
+            and all(
+                p1.as_posix() in (p.as_posix() for p in p2.iterdir())
+                for p1, p2 in list(zip(path.parents, path.parents[1:]))[:n]
+            )
+        )
+    )
 
 
 def install():

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -776,8 +776,7 @@ class _EditableFinder:  # MetaPathFinder
             if (
                 candidate.is_file()
                 and (
-                    candidate.parent.is_dir()
-                    and candidate in candidate.parent.iterdir()
+                    candidate in candidate.parent.iterdir()
                     or "PYTHONCASEOK" in os.environ
                 )
             ):

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -609,6 +609,9 @@ class TestFinderTemplate:
             with pytest.raises(ImportError, match="\'foo\\.BAR\'"):
                 import_module("foo.BAR.lowercase")
 
+            with pytest.raises(ImportError, match="\'FOO\'"):
+                import_module("FOO.bar.lowercase")
+
             mod = import_module("foo.lowercase")
             assert mod.x == 1
 
@@ -646,6 +649,9 @@ class TestFinderTemplate:
 
             bar = import_module("ns.othername.foo.bar")
             assert bar.c == 42
+
+            with pytest.raises(ImportError, match="\'NS\'"):
+                import_module("NS.othername.foo")
 
             with pytest.raises(ImportError, match="\'ns\\.othername\\.FOO\\'"):
                 import_module("ns.othername.FOO")

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -654,7 +654,6 @@ class TestFinderTemplate:
                 import_module("ns.othername.foo.BAR")
 
 
-
 def test_pkg_roots(tmp_path):
     """This test focus in getting a particular implementation detail right.
     If at some point in time the implementation is changed for something different,


### PR DESCRIPTION
## Summary of changes

This updates the `_EditableFinder` that is added to `sys.meta_path` for certain editable installations to respect filename case on case-insensitive (but case-preserving) filesystems. I believe this behavior better matches normal installations and [PEP 235](https://peps.python.org/pep-0235/).

The way the change works is by checking the path is in the directory listing (which returns proper case) in addition to checking if the file exists (which is generally case-insensitive if the filesystem is). I believe this is pretty much how it is done in the `FileFinder` in the standard library (see [here](https://github.com/python/cpython/blob/983305268e2291b0a7835621b81bf40cba7c27f3/Lib/importlib/_bootstrap_external.py#L1637C28-L1637C28) and [here](https://github.com/python/cpython/blob/983305268e2291b0a7835621b81bf40cba7c27f3/Lib/importlib/_bootstrap_external.py#L1652C17-L1652C17) for example).

Closes #3994

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
