### PR TITLE
Fix docs issues

### DIFF
--- a/docs/deprecated/commands.rst
+++ b/docs/deprecated/commands.rst
@@ -266,8 +266,8 @@ installation options for dependencies.
     this option is automatically in effect, because ``.pth`` files can only be
     used in ``site-packages`` (at least in Python 2.3 and 2.4). So, if you use
     the ``--install-dir`` or ``-d`` option (or they are set via configuration
-    file(s)) your project and its dependencies will be deployed in multi-
-    version mode.
+    file(s)) your project and its dependencies will be deployed in
+    multi-version mode.
 
 ``--install-dir=DIR, -d DIR``
     Set the installation directory (staging area).  If this option is not

--- a/docs/pkg_resources.rst
+++ b/docs/pkg_resources.rst
@@ -228,10 +228,10 @@ affected distribution is activated. For example::
 Basic ``WorkingSet`` Methods
 ----------------------------
 
-The following methods of ``WorkingSet`` objects are also available as module-
-level functions in ``pkg_resources`` that apply to the default ``working_set``
-instance.  Thus, you can use e.g. ``pkg_resources.require()`` as an
-abbreviation for ``pkg_resources.working_set.require()``:
+The following methods of ``WorkingSet`` objects are also available as
+module-level functions in ``pkg_resources`` that apply to the default
+``working_set`` instance.  Thus, you can use e.g. ``pkg_resources.require()``
+as an abbreviation for ``pkg_resources.working_set.require()``:
 
 
 ``require(*requirements)``
@@ -1552,11 +1552,11 @@ Parsing Utilities
 .. _yield_lines():
 
 ``yield_lines(strs)``
-    Yield non-empty/non-comment lines from a string/unicode or a possibly-
-    nested sequence thereof.  If ``strs`` is an instance of ``basestring``, it
-    is split into lines, and each non-blank, non-comment line is yielded after
-    stripping leading and trailing whitespace.  (Lines whose first non-blank
-    character is ``#`` are considered comment lines.)
+    Yield non-empty/non-comment lines from a string/unicode or a
+    possibly-nested sequence thereof.  If ``strs`` is an instance of
+    ``basestring``, it is split into lines, and each non-blank, non-comment
+    line is yielded after stripping leading and trailing whitespace.  (Lines
+    whose first non-blank character is ``#`` are considered comment lines.)
 
     If ``strs`` is not an instance of ``basestring``, it is iterated over, and
     each item is passed recursively to ``yield_lines()``, so that an arbitrarily
@@ -1887,8 +1887,8 @@ History
  * Fixed a bug in resource extraction from nested packages in a zipped egg.
 
 0.5a12
- * Updated extraction/cache mechanism for zipped resources to avoid inter-
-   process and inter-thread races during extraction.  The default cache
+ * Updated extraction/cache mechanism for zipped resources to avoid
+   inter-process and inter-thread races during extraction.  The default cache
    location can now be set via the ``PYTHON_EGGS_CACHE`` environment variable,
    and the default Windows cache is now a ``Python-Eggs`` subdirectory of the
    current user's "Application Data" directory, if the ``PYTHON_EGGS_CACHE``

--- a/docs/userguide/distribution.rst
+++ b/docs/userguide/distribution.rst
@@ -61,11 +61,11 @@ equal to "final", or a dash (``-``) - for example ``2.4-r1263`` or
 
 Notice that after each legacy pre or post-release tag, you are free to place
 another release number, followed again by more pre- or post-release tags.  For
-example, ``0.6a9.dev41475`` could denote Subversion revision 41475 of the in-
-development version of the ninth alpha of release 0.6.  Notice that ``dev`` is
-a pre-release tag, so this version is a *lower* version number than ``0.6a9``,
-which would be the actual ninth alpha of release 0.6.  But the ``41475`` is
-a post-release tag, so this version is *newer* than ``0.6a9.dev``.
+example, ``0.6a9.dev41475`` could denote Subversion revision 41475 of the
+in-development version of the ninth alpha of release 0.6.  Notice that ``dev``
+is a pre-release tag, so this version is a *lower* version number than
+``0.6a9``, which would be the actual ninth alpha of release 0.6.  But the
+``41475`` is a post-release tag, so this version is *newer* than ``0.6a9.dev``.
 
 For the most part, setuptools' interpretation of version numbers is intuitive,
 but here are a few tips that will keep you out of trouble in the corner cases:

--- a/tox.ini
+++ b/tox.ini
@@ -40,6 +40,8 @@ extras =
 	docs
 	testing
 changedir = docs
+deps =
+	importlib_resources < 6  # twisted/towncrier#528 (waiting for release)
 commands =
 	python -m sphinx -W --keep-going . {toxinidir}/build/html
 	python -m sphinxlint
@@ -50,6 +52,7 @@ deps =
 	towncrier
 	bump2version
 	jaraco.develop >= 7.23
+	importlib_resources < 6  # twisted/towncrier#528 (waiting for release)
 passenv = *
 commands =
 	python tools/finalize.py


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This PR extracts the parts contributed in #3995 that target fixing docs
(it seems that new versions of the linter got more strict).

I also added a workaround for the problem involving `towncrier`, `sphinxcontrib-towncrier` and `importlib_resources` (see `twisted/towncrier#528`).
Once a new version of `towncrier` is published, we can remove the workaround.

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
