### PR TITLE
Exclude debian dir

### DIFF
--- a/newsfragments/4001.misc.rst
+++ b/newsfragments/4001.misc.rst
@@ -1,0 +1,1 @@
+Ignore `debian` directories in the source tree.

--- a/newsfragments/4001.misc.rst
+++ b/newsfragments/4001.misc.rst
@@ -1,1 +1,1 @@
-Ignore `debian` directories in the source tree.
+Ignore `debian` directories in the source tree when performing automatic discovery of packages.

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ exclude =
 	*.tests
 	*.tests.*
 	tools*
+	debian*
 
 [options.extras_require]
 testing =

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -213,6 +213,7 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
     _EXCLUDE = (
         "ci",
         "bin",
+        "debian",
         "doc",
         "docs",
         "documentation",


### PR DESCRIPTION
## Summary of changes

In a Debian package build, there is going to be a top-level `debian` directory. Exclude this from `namespace_package` searches by default.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
