### PR TITLE
Adequate tests to the latest changes in wheel 0.41.1

### DIFF
--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -429,13 +429,17 @@ class TestBuildMetaBackend:
             "foo-0.1.dist-info/RECORD",
         }
         assert license == "---- placeholder MIT license ----"
+
+        metadata = metadata.replace("(", "").replace(")", "")
+        # ^-- compatibility hack for pypa/wheel#552
+
         for line in (
             "Summary: This is a Python package",
             "License: MIT",
             "Classifier: Intended Audience :: Developers",
             "Requires-Dist: appdirs",
-            "Requires-Dist: tomli (>=1) ; extra == 'all'",
-            "Requires-Dist: importlib ; (python_version == \"2.6\") and extra == 'all'",
+            "Requires-Dist: tomli >=1 ; extra == 'all'",
+            "Requires-Dist: importlib ; python_version == \"2.6\" and extra == 'all'",
         ):
             assert line in metadata
 


### PR DESCRIPTION
pypa/wheel changed recently how `Requires-Dist` is written to the METADATA file.

This change adds a little pre-processing to side-step these differences when using assertions in the setuptools tests.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
