### PR TITLE
Ignore `newsfragments` and `launcher` directories in `setuptools` project itself.

### DIFF
--- a/newsfragments/4007.misc.rst
+++ b/newsfragments/4007.misc.rst
@@ -1,0 +1,1 @@
+Ignore ``newsfragments`` directories in the source tree when performing automatic discovery of packages.

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,8 @@ exclude =
 	*.tests.*
 	tools*
 	debian*
+	launcher*
+	newsfragments*
 
 [options.extras_require]
 testing =

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -219,6 +219,7 @@ class FlatLayoutPackageFinder(PEP420PackageFinder):
         "documentation",
         "manpages",
         "news",
+        "newsfragments",
         "changelog",
         "test",
         "tests",


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Add entries to `options.packages.find exclude` in `setup.py`
- I also take this opportunity to add `newsfragments` as a common directory to be ignored by auto-discovery

Closes #4006

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
