### PR TITLE
Use default encoding when creating .pth files in `editable_wheel`

### DIFF
--- a/newsfragments/4009.misc.rst
+++ b/newsfragments/4009.misc.rst
@@ -1,0 +1,1 @@
+Use default encoding to create ``.pth`` files with ``editable_wheel``.

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -22,6 +22,7 @@ from setuptools._importlib import resources as importlib_resources
 from setuptools.command.editable_wheel import (
     _DebuggingTips,
     _LinkTree,
+    _encode_pth,
     _find_virtual_namespaces,
     _find_namespaces,
     _find_package_roots,
@@ -1023,6 +1024,13 @@ def test_debugging_tips(tmpdir_cwd, monkeypatch):
     expected_msg = "following steps are recommended to help debugging"
     with pytest.raises(SimulatedErr), pytest.warns(_DebuggingTips, match=expected_msg):
         cmd.run()
+
+
+@pytest.mark.filterwarnings("error")
+def test_encode_pth():
+    """Ensure _encode_pth function does not produce encoding warnings"""
+    content = _encode_pth("hellò ŵørld")  # no warnings (would be turned into errors)
+    assert isinstance(content, bytes)
 
 
 def install_project(name, venv, tmp_path, files, *opts):

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -1029,7 +1029,7 @@ def test_debugging_tips(tmpdir_cwd, monkeypatch):
 @pytest.mark.filterwarnings("error")
 def test_encode_pth():
     """Ensure _encode_pth function does not produce encoding warnings"""
-    content = _encode_pth("hellò ŵørld")  # no warnings (would be turned into errors)
+    content = _encode_pth("tkmilan_ç_utf8")  # no warnings (would be turned into errors)
     assert isinstance(content, bytes)
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This is an attempt to follow the suggestions in [python/cpython#77102](https://github.com/python/cpython/issues/77102#issuecomment-1670160349) about how to handle `.pth` files.

The difference is that instead of using a `open(path, 'w')`, I emulated it with `io.TextIOWrapper` (to do the operation in memory instead of writing in the file system).

Closes #3937 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
