### PR TITLE
Complain about (gui-)scripts that are not listed in `pyproject.toml`'s `dynamic`

### DIFF
--- a/newsfragments/4012.bugfix.rst
+++ b/newsfragments/4012.bugfix.rst
@@ -1,0 +1,2 @@
+Detects (and complain about) ``scripts`` and ``gui-scripts`` set via ``setup.py``
+when ``pyproject.toml`` does not include them in ``dynamic``.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -296,6 +296,16 @@ def _get_previous_entrypoints(dist: "Distribution") -> Dict[str, list]:
     return {k: v for k, v in value.items() if k not in ignore}
 
 
+def _get_previous_scripts(dist: "Distribution") -> Optional[list]:
+    value = getattr(dist, "entry_points", None) or {}
+    return value.get("console_scripts")
+
+
+def _get_previous_gui_scripts(dist: "Distribution") -> Optional[list]:
+    value = getattr(dist, "entry_points", None) or {}
+    return value.get("gui_scripts")
+
+
 def _attrgetter(attr):
     """
     Similar to ``operator.attrgetter`` but returns None if ``attr`` is not found
@@ -371,6 +381,8 @@ _PREVIOUSLY_DEFINED = {
     "classifiers": _attrgetter("metadata.classifiers"),
     "urls": _attrgetter("metadata.project_urls"),
     "entry-points": _get_previous_entrypoints,
+    "scripts": _get_previous_scripts,
+    "gui-scripts": _get_previous_gui_scripts,
     "dependencies": _some_attrgetter("_orig_install_requires", "install_requires"),
     "optional-dependencies": _some_attrgetter("_orig_extras_require", "extras_require"),
 }

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -330,6 +330,8 @@ class TestPresetField:
         [
             ("install_requires", "dependencies", ["six"]),
             ("classifiers", "classifiers", ["Private :: Classifier"]),
+            ("entry_points", "scripts", {"console_scripts": ["foobar=foobar:main"]}),
+            ("entry_points", "gui-scripts", {"gui_scripts": ["bazquux=bazquux:main"]}),
         ],
     )
     def test_not_listed_in_dynamic(self, tmp_path, attr, field, value):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Closes #4011 

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
