### PR TITLE
Remove double negative in package_discovery.rst

### DIFF
--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -446,8 +446,8 @@ distribution, then you will need to specify:
             # ...
         )
 
-    When you use ``find_packages()``, all directories with an
-    ``__init__.py`` file will be disconsidered.
+    When you use ``find_packages()``, all directories without an
+    ``__init__.py`` file will be ignored.
     On the other hand, ``find_namespace_packages()`` will scan all
     directories.
 

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -446,7 +446,7 @@ distribution, then you will need to specify:
             # ...
         )
 
-    When you use ``find_packages()``, all directories without an
+    When you use ``find_packages()``, all directories with an
     ``__init__.py`` file will be disconsidered.
     On the other hand, ``find_namespace_packages()`` will scan all
     directories.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

`find_packages()` only finds the folder which contains `__init__.py`.

