### PR TITLE
Fix editable install finder handling of nested packages

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,7 @@ extensions += ['sphinx_favicon']
 html_static_path = ['images']  # should contain the folder with icons
 
 # Add support for nice Not Found 404 pages
-extensions += ['notfound.extension']
+# extensions += ['notfound.extension']  # readthedocs/sphinx-notfound-page#219
 
 # List of dicts with <link> HTML attributes
 # static-file points to files in the html_static_path (href is computed)

--- a/newsfragments/4020.bugfix.rst
+++ b/newsfragments/4020.bugfix.rst
@@ -1,0 +1,3 @@
+Fix editable install finder handling of nested packages, by only handling 1
+level of nesting and relying on ``importlib.machinery`` to find the remaining
+modules based on the parent package path.

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ testing-integration =
 
 docs =
 	# upstream
-	sphinx >= 3.5
+	sphinx >= 3.5,<=7.1.2  # workaround, see comments in pypa/setuptools#4020
 	jaraco.packaging >= 9.3
 	rst.linker >= 1.9
 	furo


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Only handle 1 level of nesting (necessary for the namespace packages to work properly)
- Rely on the `importlib.machinery` to find other levels of nested packages to find the correct files based on the parent path.

Closes #4019

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
