### PR TITLE
Address circular imports complaints by Sphinx 7.2+

### DIFF
--- a/newsfragments/4023.misc.rst
+++ b/newsfragments/4023.misc.rst
@@ -1,0 +1,2 @@
+Avoid circular imports (particularly between ``setuptools/{__init__,dist,monkey}.py``),
+or at least delay them, so tools like ``sphinx`` don't have problems analysing the codebase.

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,7 +92,7 @@ testing-integration =
 
 docs =
 	# upstream
-	sphinx >= 3.5,<=7.1.2  # workaround, see comments in pypa/setuptools#4020
+	sphinx >= 3.5
 	jaraco.packaging >= 9.3
 	rst.linker >= 1.9
 	furo

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -5,21 +5,17 @@ import os
 import re
 
 import _distutils_hack.override  # noqa: F401
-
 import distutils.core
 from distutils.errors import DistutilsOptionError
 from distutils.util import convert_path as _convert_path
 
+from . import logging, monkey
+from . import version as _version_module
+from .depends import Require
+from .discovery import PackageFinder, PEP420PackageFinder
+from .dist import Distribution
+from .extension import Extension
 from .warnings import SetuptoolsDeprecationWarning
-
-import setuptools.version
-from setuptools.extension import Extension
-from setuptools.dist import Distribution
-from setuptools.depends import Require
-from setuptools.discovery import PackageFinder, PEP420PackageFinder
-from . import monkey
-from . import logging
-
 
 __all__ = [
     'setup',
@@ -32,7 +28,7 @@ __all__ = [
     'find_namespace_packages',
 ]
 
-__version__ = setuptools.version.__version__
+__version__ = _version_module.__version__
 
 bootstrap_install_from = None
 

--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -3,10 +3,10 @@ import marshal
 import contextlib
 import dis
 
-from setuptools.extern.packaging import version
 
-from ._imp import find_module, PY_COMPILED, PY_FROZEN, PY_SOURCE
 from . import _imp
+from ._imp import find_module, PY_COMPILED, PY_FROZEN, PY_SOURCE
+from .extern.packaging.version import Version
 
 
 __all__ = ['Require', 'find_module', 'get_module_constant', 'extract_constant']
@@ -19,7 +19,7 @@ class Require:
         self, name, requested_version, module, homepage='', attribute=None, format=None
     ):
         if format is None and requested_version is not None:
-            format = version.Version
+            format = Version
 
         if format is not None:
             requested_version = format(requested_version)

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -2,15 +2,15 @@
 Monkey patching of distutils.
 """
 
-import sys
-import distutils.filelist
-import platform
-import types
 import functools
-from importlib import import_module
 import inspect
+import platform
+import sys
+import types
+from importlib import import_module
 
-import setuptools
+import distutils.filelist
+
 
 __all__ = []
 """
@@ -61,6 +61,8 @@ def get_unpatched_class(cls):
 
 
 def patch_all():
+    import setuptools
+
     # we can't patch distutils.cmd, alas
     distutils.core.Command = setuptools.Command
 
@@ -97,9 +99,11 @@ def patch_all():
 
 
 def _patch_distribution_metadata():
+    from . import dist
+
     """Patch write_pkg_file and read_pkg_file for higher metadata standards"""
     for attr in ('write_pkg_file', 'read_pkg_file', 'get_metadata_version'):
-        new_val = getattr(setuptools.dist, attr)
+        new_val = getattr(dist, attr)
         setattr(distutils.dist.DistributionMetadata, attr, new_val)
 
 

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -11,12 +11,12 @@ from zipfile import ZipFile
 
 import pytest
 
-from setuptools.extern.packaging import version
-
 import setuptools
 import setuptools.dist
 import setuptools.depends as dep
 from setuptools.depends import Require
+
+from setuptools.extern.packaging.version import Version
 
 
 @pytest.fixture(autouse=True)
@@ -94,7 +94,7 @@ class TestDepends:
 
         assert req.name == 'Json'
         assert req.module == 'json'
-        assert req.requested_version == version.Version('1.0.3')
+        assert req.requested_version == Version('1.0.3')
         assert req.attribute == '__version__'
         assert req.full_name() == 'Json-1.0.3'
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The latest version of `sphinx` started failing in https://github.com/pypa/setuptools/pull/4020#issuecomment-1683535358 due to circular imports.

Examples of the error messages are:

```python
ImportError: cannot import name 'Distribution' from partially initialized module 'setuptools.dist'

AttributeError: partially initialized module 'setuptools' has no attribute 'version' (most likely due to a circular import)

Failed to import class 'Command' from module 'setuptools'
```

In this PR, I am attempting to address this problem.

The approach I used was:

- Rewrite the imports in `setuptools/__init__.py`, `setuptools/monkey.py`  and `setuptools/dist.py` to avoid circular imports.
  - I also took this chance to try to tide up a bit (e.g. sorting them, separating `import ...` and `from ... import ...` statements, etc)
- I had to change slightly the way we are importing `setuptools.extern.packaging` and `setuptools/depends.py` and `setuptools/tests/test_setuptools.py` because for some reason the tests where complaining that the `Version` class was differing from itself (maybe the module is loaded twice?)

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
