### PR TITLE
Update integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install OS-level dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential gfortran libopenblas-dev
+          sudo apt-get install build-essential gfortran libopenblas-dev libyaml
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install OS-level dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential gfortran libopenblas-dev libyaml
+          sudo apt-get install build-essential gfortran libopenblas-dev libyaml-dev
       - name: Setup Python
         uses: actions/setup-python@v4
         with:

--- a/newsfragments/4027.misc.1.rst
+++ b/newsfragments/4027.misc.1.rst
@@ -1,0 +1,1 @@
+Removed ``pandas`` from integration tests.

--- a/newsfragments/4027.misc.2.rst
+++ b/newsfragments/4027.misc.2.rst
@@ -1,0 +1,1 @@
+Added ``pyyaml``, ``charset-normalizer`` and ``protobuf`` to integration tests.

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -64,6 +64,7 @@ EXTRA_BUILD_DEPS = {
 }
 
 EXTRA_ENV_VARS = {
+    "pyyaml": {"PYYAML_FORCE_CYTHON": "1"},
     "charset-normalizer": {"CHARSET_NORMALIZER_USE_MYPYC": "1"},
 }
 

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -131,14 +131,14 @@ def test_install_sdist(package, version, tmp_path, venv_python, setuptools_wheel
 
     # Use a virtualenv to simulate PEP 517 isolation
     # but install fresh setuptools wheel to ensure the version under development
+    env = EXTRA_ENV_VARS.get(package, {})
     run([*venv_pip, "install", "wheel", "-I", setuptools_wheel])
-    run([*venv_pip, "install", *INSTALL_OPTIONS, sdist])
+    run([*venv_pip, "install", *INSTALL_OPTIONS, sdist], env)
 
     # Execute a simple script to make sure the package was installed correctly
-    env = EXTRA_ENV_VARS.get(package, {})
     pkg = IMPORT_NAME.get(package, package).replace("-", "_")
     script = f"import {pkg}; print(getattr({pkg}, '__version__', 0))"
-    run([venv_python, "-c", script], env)
+    run([venv_python, "-c", script])
 
 
 # ---- Helper Functions ----

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -55,7 +55,7 @@ EXAMPLES = [
 
 # Some packages have "optional" dependencies that modify their build behaviour
 # and are not listed in pyproject.toml, others still use `setup_requires`
-EXTRA_BUILD_DEPS = {"sphinx": ("babel>=1.3",), "kiwisolver": ("cppy>=1.1.0",)}
+EXTRA_BUILD_DEPS = {}
 
 
 VIRTUALENV = (sys.executable, "-m", "virtualenv")

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -67,7 +67,7 @@ EXTRA_ENV_VARS = {
     "charset-normalizer": {"CHARSET_NORMALIZER_USE_MYPYC": "1"},
 }
 
-PKG_NAME = {
+IMPORT_NAME = {
     "pyyaml": "yaml",
     "protobuf": "google.protobuf",
 }
@@ -135,7 +135,7 @@ def test_install_sdist(package, version, tmp_path, venv_python, setuptools_wheel
 
     # Execute a simple script to make sure the package was installed correctly
     env = EXTRA_ENV_VARS.get(package, {})
-    pkg = PKG_NAME.get(package, package).replace("-", "_")
+    pkg = IMPORT_NAME.get(package, package).replace("-", "_")
     script = f"import {pkg}; print(getattr({pkg}, '__version__', 0))"
     run([venv_python, "-c", script], env)
 

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -41,7 +41,6 @@ pytestmark = pytest.mark.integration
 # that `build-essential`, `gfortran` and `libopenblas-dev` are installed,
 # due to their relevance to the numerical/scientific programming ecosystem)
 EXAMPLES = [
-    ("pandas", LATEST),  # cython + custom build_ext
     ("pip", LATEST),  # just in case...
     ("pytest", LATEST),  # uses setuptools_scm
     ("mypy", LATEST),  # custom build_py + ext_modules


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

It seems that `pandas` also moved away from `setuptools`, so it does not make sense to keep them in the integration tests.

Instead we can add other prominent packages from https://hugovk.github.io/top-pypi-packages/.

## Summary of changes

- Removed `pandas` from integration tests
- Added `pyyaml`, `charset-normalizer` and `protobuf` to integration tests.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
