### PR TITLE
Add workaround for tox errors during env setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
         run: python -m downloads.preload setupcfg_examples.txt
       - name: Install tox
         run: |
-          python -m pip install tox
+          python -m pip install tox 'pyproject-api<1.6.0'  # workaround #4031
       - name: Run
         run: tox
       - name: Create coverage report
@@ -120,7 +120,7 @@ jobs:
         uses: actions/setup-python@v4
       - name: Install tox
         run: |
-          python -m pip install tox
+          python -m pip install tox 'pyproject-api<1.6.0'  # workaround #4031
       - name: Run
         run: tox
 
@@ -220,7 +220,7 @@ jobs:
           python-version: "3.10"
       - name: Install tox
         run: |
-          python -m pip install tox
+          python -m pip install tox 'pyproject-api<1.6.0'  # workaround #4031
       - name: Run integration tests
         run: tox -e integration
 
@@ -240,7 +240,7 @@ jobs:
           python-version: 3.x
       - name: Install tox
         run: |
-          python -m pip install tox
+          python -m pip install tox 'pyproject-api<1.6.0'  # workaround #4031
       - name: Run
         run: tox -e release
         env:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This is a workaround for #4031.
- Add a cap for `pyproject-api<1.6.0'` in Github Actions.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
