### PR TITLE
Reactivate `sphinx-notfound-page`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,7 @@ extensions += ['sphinx_favicon']
 html_static_path = ['images']  # should contain the folder with icons
 
 # Add support for nice Not Found 404 pages
-# extensions += ['notfound.extension']  # readthedocs/sphinx-notfound-page#219
+extensions += ['notfound.extension']
 
 # List of dicts with <link> HTML attributes
 # static-file points to files in the html_static_path (href is computed)

--- a/setup.cfg
+++ b/setup.cfg
@@ -108,7 +108,7 @@ docs =
 	sphinx-inline-tabs
 	sphinx-reredirects
 	sphinxcontrib-towncrier
-	sphinx-notfound-page == 0.8.3
+	sphinx-notfound-page >=1,<2
 	sphinx-hoverxref < 2
 
 ssl =


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Bump version (the compatibility issues with Sphinx>7.5 have been solved in `sphinx-notfound-page==1.0.0`

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
