### PR TITLE
Fix ` *-nspkg.pth` files and imports for `pkg_resources`-style legacy namespaces in editable installs.

### DIFF
--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -341,7 +341,7 @@ class editable_wheel(Command):
         with unpacked_wheel as unpacked, build_lib as lib, build_tmp as tmp:
             unpacked_dist_info = Path(unpacked, Path(self.dist_info_dir).name)
             shutil.copytree(self.dist_info_dir, unpacked_dist_info)
-            self._install_namespaces(unpacked, dist_info.name)
+            self._install_namespaces(unpacked, dist_name)
             files, mapping = self._run_build_commands(dist_name, unpacked, lib, tmp)
             strategy = self._select_strategy(dist_name, tag, lib)
             with strategy, WheelFile(wheel_path, "w") as wheel_obj:
@@ -752,9 +752,9 @@ class _NamespaceInstaller(namespaces.Installer):
         self.outputs = []
         self.dry_run = False
 
-    def _get_target(self):
+    def _get_nspkg_file(self):
         """Installation target."""
-        return os.path.join(self.installation_dir, self.editable_name)
+        return os.path.join(self.installation_dir, self.editable_name + self.nspkg_ext)
 
     def _get_root(self):
         """Where the modules/packages should be loaded from."""

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -777,6 +777,8 @@ PATH_PLACEHOLDER = {name!r} + ".__path_hook__"
 class _EditableFinder:  # MetaPathFinder
     @classmethod
     def find_spec(cls, fullname, path=None, target=None):
+        extra_path = []
+
         # Top-level packages and modules (we know these exist in the FS)
         if fullname in MAPPING:
             pkg_path = MAPPING[fullname]
@@ -787,7 +789,7 @@ class _EditableFinder:  # MetaPathFinder
         # to the importlib.machinery implementation.
         parent, _, child = fullname.rpartition(".")
         if parent and parent in MAPPING:
-            return PathFinder.find_spec(fullname, path=[MAPPING[parent]])
+            return PathFinder.find_spec(fullname, path=[MAPPING[parent], *extra_path])
 
         # Other levels of nesting should be handled automatically by importlib
         # using the parent path.

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -505,9 +505,19 @@ class _TopLevelFinder:
             )
         )
 
+        legacy_namespaces = {
+            pkg: find_package_path(pkg, roots, self.dist.src_root or "")
+            for pkg in self.dist.namespace_packages or []
+        }
+
+        mapping = {**roots, **legacy_namespaces}
+        # ^-- We need to explicitly add the legacy_namespaces to the mapping to be
+        #     able to import their modules even if another package sharing the same
+        #     namespace is installed in a conventional (non-editable) way.
+
         name = f"__editable__.{self.name}.finder"
         finder = _normalization.safe_identifier(name)
-        content = bytes(_finder_template(name, roots, namespaces_), "utf-8")
+        content = bytes(_finder_template(name, mapping, namespaces_), "utf-8")
         wheel.writestr(f"{finder}.py", content)
 
         content = _encode_pth(f"import {finder}; {finder}.install()")

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -13,8 +13,7 @@ class Installer:
         nsp = self._get_all_ns_packages()
         if not nsp:
             return
-        filename, ext = os.path.splitext(self._get_target())
-        filename += self.nspkg_ext
+        filename = self._get_nspkg_file()
         self.outputs.append(filename)
         log.info("Installing %s", filename)
         lines = map(self._gen_nspkg_line, nsp)
@@ -28,12 +27,15 @@ class Installer:
             f.writelines(lines)
 
     def uninstall_namespaces(self):
-        filename, ext = os.path.splitext(self._get_target())
-        filename += self.nspkg_ext
+        filename = self._get_nspkg_file()
         if not os.path.exists(filename):
             return
         log.info("Removing %s", filename)
         os.remove(filename)
+
+    def _get_nspkg_file(self):
+        filename, _ = os.path.splitext(self._get_target())
+        return filename + self.nspkg_ext
 
     def _get_target(self):
         return self.target

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -75,7 +75,7 @@ class Installer:
     def _get_all_ns_packages(self):
         """Return sorted list of all package namespaces"""
         pkgs = self.distribution.namespace_packages or []
-        return sorted(flatten(map(self._pkg_names, pkgs)))
+        return sorted(set(flatten(map(self._pkg_names, pkgs))))
 
     @staticmethod
     def _pkg_names(pkg):

--- a/setuptools/tests/namespaces.py
+++ b/setuptools/tests/namespaces.py
@@ -7,7 +7,7 @@ from pathlib import Path
 def iter_namespace_pkgs(namespace):
     parts = namespace.split(".")
     for i in range(len(parts)):
-        yield ".".join(parts[:i+1])
+        yield ".".join(parts[: i + 1])
 
 
 def build_namespace_package(tmpdir, name, version="1.0", impl="pkg_resources"):

--- a/setuptools/tests/namespaces.py
+++ b/setuptools/tests/namespaces.py
@@ -7,7 +7,7 @@ def iter_namespace_pkgs(namespace):
         yield ".".join(parts[:i+1])
 
 
-def build_namespace_package(tmpdir, name):
+def build_namespace_package(tmpdir, name, version="1.0"):
     src_dir = tmpdir / name
     src_dir.mkdir()
     setup_py = src_dir / 'setup.py'
@@ -18,7 +18,7 @@ def build_namespace_package(tmpdir, name):
         import setuptools
         setuptools.setup(
             name={name!r},
-            version="1.0",
+            version={version!r},
             namespace_packages={namespaces!r},
             packages={namespaces!r},
         )

--- a/setuptools/tests/namespaces.py
+++ b/setuptools/tests/namespaces.py
@@ -1,6 +1,7 @@
 import ast
 import json
 import textwrap
+from pathlib import Path
 
 
 def iter_namespace_pkgs(namespace):
@@ -41,7 +42,7 @@ def build_namespace_package(tmpdir, name, version="1.0", impl="pkg_resources"):
     ).format(args=args)
     setup_py.write_text(script, encoding='utf-8')
 
-    ns_pkg_dir = src_dir / namespace.replace(".", "/")
+    ns_pkg_dir = Path(src_dir, namespace.replace(".", "/"))
     ns_pkg_dir.mkdir(parents=True)
 
     for ns in namespaces:
@@ -69,7 +70,7 @@ def build_pep420_namespace_package(tmpdir, name):
         version = "3.14159"
         """
     pyproject.write_text(textwrap.dedent(script), encoding='utf-8')
-    ns_pkg_dir = src_dir / namespace.replace(".", "/")
+    ns_pkg_dir = Path(src_dir, namespace.replace(".", "/"))
     ns_pkg_dir.mkdir(parents=True)
     pkg_mod = ns_pkg_dir / (rest + ".py")
     some_functionality = f"name = {rest!r}"

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -266,7 +266,7 @@ class TestLegacyNamespaces:
         (
             "pkg_resources",
             #  "pkgutil",  => does not work
-        )
+        ),
     )
     @pytest.mark.parametrize("ns", ("myns.n",))
     def test_namespace_package_importable(

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -261,8 +261,17 @@ class TestLegacyNamespaces:
         files = list(installation_dir.glob("*-nspkg.pth"))
         assert len(files) == len(examples)
 
+    @pytest.mark.parametrize(
+        "impl",
+        (
+            "pkg_resources",
+            #  "pkgutil",  => does not work
+        )
+    )
     @pytest.mark.parametrize("ns", ("myns.n",))
-    def test_namespace_package_importable(self, venv, tmp_path, ns, editable_opts):
+    def test_namespace_package_importable(
+        self, venv, tmp_path, ns, impl, editable_opts
+    ):
         """
         Installing two packages sharing the same namespace, one installed
         naturally using pip or `--single-version-externally-managed`
@@ -275,8 +284,8 @@ class TestLegacyNamespaces:
         requires = ["setuptools"]
         build-backend = "setuptools.build_meta"
         """
-        pkg_A = namespaces.build_namespace_package(tmp_path, f"{ns}.pkgA")
-        pkg_B = namespaces.build_namespace_package(tmp_path, f"{ns}.pkgB")
+        pkg_A = namespaces.build_namespace_package(tmp_path, f"{ns}.pkgA", impl=impl)
+        pkg_B = namespaces.build_namespace_package(tmp_path, f"{ns}.pkgB", impl=impl)
         (pkg_A / "pyproject.toml").write_text(build_system, encoding="utf-8")
         (pkg_B / "pyproject.toml").write_text(build_system, encoding="utf-8")
         # use pip to install to the target directory

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -261,7 +261,8 @@ class TestLegacyNamespaces:
         files = list(installation_dir.glob("*-nspkg.pth"))
         assert len(files) == len(examples)
 
-    def test_namespace_package_importable(self, venv, tmp_path, editable_opts):
+    @pytest.mark.parametrize("ns", ("myns.n",))
+    def test_namespace_package_importable(self, venv, tmp_path, ns, editable_opts):
         """
         Installing two packages sharing the same namespace, one installed
         naturally using pip or `--single-version-externally-managed`
@@ -274,8 +275,8 @@ class TestLegacyNamespaces:
         requires = ["setuptools"]
         build-backend = "setuptools.build_meta"
         """
-        pkg_A = namespaces.build_namespace_package(tmp_path, 'myns.pkgA')
-        pkg_B = namespaces.build_namespace_package(tmp_path, 'myns.pkgB')
+        pkg_A = namespaces.build_namespace_package(tmp_path, f"{ns}.pkgA")
+        pkg_B = namespaces.build_namespace_package(tmp_path, f"{ns}.pkgB")
         (pkg_A / "pyproject.toml").write_text(build_system, encoding="utf-8")
         (pkg_B / "pyproject.toml").write_text(build_system, encoding="utf-8")
         # use pip to install to the target directory
@@ -283,7 +284,7 @@ class TestLegacyNamespaces:
         opts.append("--no-build-isolation")  # force current version of setuptools
         venv.run(["python", "-m", "pip", "install", str(pkg_A), *opts])
         venv.run(["python", "-m", "pip", "install", "-e", str(pkg_B), *opts])
-        venv.run(["python", "-c", "import myns.pkgA; import myns.pkgB"])
+        venv.run(["python", "-c", f"import {ns}.pkgA; import {ns}.pkgB"])
         # additionally ensure that pkg_resources import works
         venv.run(["python", "-c", "import pkg_resources"])
 

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -11,6 +11,8 @@ from textwrap import dedent
 from unittest.mock import Mock
 from uuid import uuid4
 
+from distutils.core import run_setup
+
 import jaraco.envs
 import jaraco.path
 import pytest
@@ -31,6 +33,7 @@ from setuptools.command.editable_wheel import (
 )
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
+from setuptools.warnings import SetuptoolsDeprecationWarning
 
 
 @pytest.fixture(params=["strict", "lenient"])
@@ -230,7 +233,33 @@ def test_editable_with_single_module(tmp_path, venv, editable_opts):
 
 
 class TestLegacyNamespaces:
-    """Ported from test_develop"""
+    # legacy => pkg_resources.declare_namespace(...) + setup(namespace_packages=...)
+
+    def test_nspkg_file_is_unique(self, tmp_path, monkeypatch):
+        deprecation = pytest.warns(
+            SetuptoolsDeprecationWarning, match=".*namespace_packages parameter.*"
+        )
+        installation_dir = tmp_path / ".installation_dir"
+        installation_dir.mkdir()
+        examples = (
+            "myns.pkgA",
+            "myns.pkgB",
+            "myns.n.pkgA",
+            "myns.n.pkgB",
+        )
+
+        for name in examples:
+            pkg = namespaces.build_namespace_package(tmp_path, name, version="42")
+            with deprecation, monkeypatch.context() as ctx:
+                ctx.chdir(pkg)
+                dist = run_setup("setup.py", stop_after="config")
+                cmd = editable_wheel(dist)
+                cmd.finalize_options()
+                editable_name = cmd.get_finalized_command("dist_info").name
+                cmd._install_namespaces(installation_dir, editable_name)
+
+        files = list(installation_dir.glob("*-nspkg.pth"))
+        assert len(files) == len(examples)
 
     def test_namespace_package_importable(self, venv, tmp_path, editable_opts):
         """
@@ -238,6 +267,7 @@ class TestLegacyNamespaces:
         naturally using pip or `--single-version-externally-managed`
         and the other installed in editable mode should leave the namespace
         intact and both packages reachable by import.
+        (Ported from test_develop).
         """
         build_system = """\
         [build-system]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Fix the name given to the `*-nspkg.pth` files in editable installs, ensuring they are unique per distribution.
- Workaround limitations on `pkg_resources`-style legacy namespaces in editable installations.

Closes #4039 

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
