### PR TITLE
Avoid using cached normalised requirement lists in metadata for compatibility with plugins

### DIFF
--- a/newsfragments/4043.bugfix.rst
+++ b/newsfragments/4043.bugfix.rst
@@ -1,0 +1,4 @@
+Avoid using caching attributes in ``Distribution.metadata`` for requirements.
+This is done for backwards compatibility with customizations that attempt to
+modify ``install_requires`` or ``extras_require`` at a late point (still not
+recommended).

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from typing import Callable, Iterable, Iterator, TypeVar, Union, overload
 
 import setuptools.extern.jaraco.text as text
@@ -5,6 +6,12 @@ from setuptools.extern.packaging.requirements import Requirement
 
 _T = TypeVar("_T")
 _StrOrIter = Union[str, Iterable[str]]
+
+
+parse_req: Callable[[str], Requirement] = lru_cache()(Requirement)
+# Setuptools parses the same requirement many times
+# (e.g. first for validation than for normalisation),
+# so it might be worth to cache.
 
 
 def parse_strings(strs: _StrOrIter) -> Iterator[str]:
@@ -26,7 +33,7 @@ def parse(strs: _StrOrIter, parser: Callable[[str], _T]) -> Iterator[_T]:
     ...
 
 
-def parse(strs, parser=Requirement):
+def parse(strs, parser=parse_req):
     """
     Replacement for ``pkg_resources.parse_requirements`` that uses ``packaging``.
     """

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from itertools import filterfalse
 from typing import Dict, List, Tuple, Mapping, TypeVar
 
+from .. import _reqs
 from ..extern.jaraco.text import yield_lines
 from ..extern.packaging.requirements import Requirement
 
@@ -19,11 +20,11 @@ from ..extern.packaging.requirements import Requirement
 _T = TypeVar("_T")
 _Ordered = Dict[_T, None]
 _ordered = dict
+_StrOrIter = _reqs._StrOrIter
 
 
 def _prepare(
-    install_requires: Dict[str, Requirement],
-    extras_require: Mapping[str, Dict[str, Requirement]],
+    install_requires: _StrOrIter, extras_require: Mapping[str, _StrOrIter]
 ) -> Tuple[List[str], Dict[str, List[str]]]:
     """Given values for ``install_requires`` and ``extras_require``
     create modified versions in a way that can be written in ``requires.txt``
@@ -33,7 +34,7 @@ def _prepare(
 
 
 def _convert_extras_requirements(
-    extras_require: Dict[str, Dict[str, Requirement]],
+    extras_require: _StrOrIter,
 ) -> Mapping[str, _Ordered[Requirement]]:
     """
     Convert requirements in `extras_require` of the form
@@ -44,15 +45,14 @@ def _convert_extras_requirements(
     for section, v in extras_require.items():
         # Do not strip empty sections.
         output[section]
-        for r in v.values():
+        for r in _reqs.parse(v):
             output[section + _suffix_for(r)].setdefault(r)
 
     return output
 
 
 def _move_install_requirements_markers(
-    install_requires: Dict[str, Requirement],
-    extras_require: Mapping[str, _Ordered[Requirement]],
+    install_requires: _StrOrIter, extras_require: Mapping[str, _Ordered[Requirement]]
 ) -> Tuple[List[str], Dict[str, List[str]]]:
     """
     The ``requires.txt`` file has an specific format:
@@ -66,7 +66,7 @@ def _move_install_requirements_markers(
     # divide the install_requires into two sets, simple ones still
     # handled by install_requires and more complex ones handled by extras_require.
 
-    inst_reqs = install_requires.values()
+    inst_reqs = list(_reqs.parse(install_requires))
     simple_reqs = filter(_no_marker, inst_reqs)
     complex_reqs = filterfalse(_no_marker, inst_reqs)
     simple_install_requires = list(map(str, simple_reqs))
@@ -90,9 +90,8 @@ def _suffix_for(req):
 
 def _clean_req(req):
     """Given a Requirement, remove environment markers and return it"""
-    r = Requirement(str(req))  # create a copy before modifying.
-    r.marker = None
-    return r
+    req.marker = None
+    return req
 
 
 def _no_marker(req):
@@ -111,10 +110,9 @@ def _write_requirements(stream, reqs):
 
 def write_requirements(cmd, basename, filename):
     dist = cmd.distribution
-    meta = dist.metadata
     data = io.StringIO()
     install_requires, extras_require = _prepare(
-        meta._normalized_install_requires, meta._normalized_extras_require
+        dist.install_requires or (), dist.extras_require or {}
     )
     _write_requirements(data, install_requires)
     for extra in sorted(extras_require):

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -90,8 +90,9 @@ def _suffix_for(req):
 
 def _clean_req(req):
     """Given a Requirement, remove environment markers and return it"""
-    req.marker = None
-    return req
+    r = Requirement(str(req))  # create a copy before modifying
+    r.marker = None
+    return r
 
 
 def _no_marker(req):

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -125,7 +125,7 @@ def _set_config(dist: "Distribution", field: str, value: Any):
         setter(value)
     elif hasattr(dist.metadata, field) or field in SETUPTOOLS_PATCHES:
         setattr(dist.metadata, field, value)
-    else:
+    if hasattr(dist, field):
         setattr(dist, field, value)
 
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -296,14 +296,11 @@ class Distribution(_Distribution):
         self.setup_requires = attrs.pop('setup_requires', [])
         for ep in metadata.entry_points(group='distutils.setup_keywords'):
             vars(self).setdefault(ep.name, None)
-        _Distribution.__init__(
-            self,
-            {
-                k: v
-                for k, v in attrs.items()
-                if k not in self._DISTUTILS_UNSUPPORTED_METADATA
-            },
-        )
+
+        metadata_only = set(self._DISTUTILS_UNSUPPORTED_METADATA)
+        metadata_only -= {"install_requires", "extras_require"}
+        dist_attrs = {k: v for k, v in attrs.items() if k not in metadata_only}
+        _Distribution.__init__(self, dist_attrs)
 
         # Private API (setuptools-use only, not restricted to Distribution)
         # Stores files that are referenced by the configuration and need to be in the


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Avoid using `_normalized_install_requires` and `_normalized_extras_require` in dist.metadata
- Add `functools.lru_cache` to requirement parsing

Closes #4042

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
