### PR TITLE
Update test deps

### DIFF
--- a/newsfragments/4045.misc.rst
+++ b/newsfragments/4045.misc.rst
@@ -1,0 +1,2 @@
+Update test dependency on ``build==1.0.3`` and
+add fallback for ``packaging==23.1`` (regarding ``Metadata`` validation).

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ testing-integration =
 	wheel
 	jaraco.path>=3.2.0
 	jaraco.envs>=2.2
-	build[virtualenv]
+	build[virtualenv]>=1.0.3
 	filelock>=3.4.0
 	packaging
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -89,7 +89,7 @@ testing-integration =
 	jaraco.envs>=2.2
 	build[virtualenv]>=1.0.3
 	filelock>=3.4.0
-	packaging
+	packaging>=23.1  # TODO: update once packaging 23.2 is available
 
 docs =
 	# upstream

--- a/setuptools/tests/_packaging_compat.py
+++ b/setuptools/tests/_packaging_compat.py
@@ -1,0 +1,9 @@
+from packaging import __version__ as packaging_version
+
+if tuple(packaging_version.split(".")) >= ("23", "2"):
+    from packaging.metadata import Metadata
+else:
+    # Just pretend it exists while waiting for release...
+    from unittest.mock import MagicMock
+
+    Metadata = MagicMock()

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -13,7 +13,9 @@ from zipfile import ZipFile
 
 import pytest
 from ini2toml.api import Translator
-from packaging.metadata import Metadata
+
+# TODO: replace with `from packaging.metadata import Metadata` in future versions
+from .._packaging_compat import Metadata
 
 import setuptools  # noqa ensure monkey patch to metadata
 from setuptools.dist import Distribution

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -5,7 +5,8 @@ from email import message_from_string
 
 import pytest
 
-from packaging.metadata import Metadata
+# TODO: replace with `from packaging.metadata import Metadata` in future versions:
+from ._packaging_compat import Metadata
 
 from setuptools import sic, _reqs
 from setuptools.dist import Distribution

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [testenv]
 deps =
 	# Ideally all the dependencies should be set as "extras"
-	build[virtualenv] @ git+https://github.com/pypa/build@59c1f87
-	# ^-- pypa/build#630, use dev version while we wait for the new release
 	packaging @ git+https://github.com/pypa/packaging@7e68d82
 	# ^-- use dev version while we wait for the new release
 setenv =


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Update test dependency on `build==1.0.3`
- Add fallback for `packaging==23.1`

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
