### PR TITLE
Improve backwards compatibility with deprecated CLI practices

### DIFF
--- a/newsfragments/4048.bugfix.rst
+++ b/newsfragments/4048.bugfix.rst
@@ -1,0 +1,1 @@
+Improve backwards compatibility with deprecated CLI practices.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -125,7 +125,7 @@ def _set_config(dist: "Distribution", field: str, value: Any):
         setter(value)
     elif hasattr(dist.metadata, field) or field in SETUPTOOLS_PATCHES:
         setattr(dist.metadata, field, value)
-    if hasattr(dist, field):
+    else:
         setattr(dist, field, value)
 
 
@@ -212,12 +212,12 @@ def _dependencies(dist: "Distribution", val: list, _root_dir):
     if getattr(dist, "install_requires", []):
         msg = "`install_requires` overwritten in `pyproject.toml` (dependencies)"
         SetuptoolsWarning.emit(msg)
-    _set_config(dist, "install_requires", val)
+    dist.install_requires = val
 
 
 def _optional_dependencies(dist: "Distribution", val: dict, _root_dir):
     existing = getattr(dist, "extras_require", None) or {}
-    _set_config(dist, "extras_require", {**existing, **val})
+    dist.extras_require = {**existing, **val}
 
 
 def _unify_entry_points(project_table: dict):

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -423,6 +423,25 @@ class TestMeta:
             assert not any(name.endswith(EXAMPLES_FILE) for name in zipfile.namelist())
 
 
+class TestInteropCommandLineParsing:
+    def test_version(self, tmp_path, monkeypatch, capsys):
+        # See pypa/setuptools#4047
+        # This test can be removed once the CLI interface of setup.py is removed
+        monkeypatch.chdir(tmp_path)
+        toml_config = """
+        [project]
+        name = "test"
+        version = "42.0"
+        """
+        pyproject = Path(tmp_path, "pyproject.toml")
+        pyproject.write_text(cleandoc(toml_config), encoding="utf-8")
+        opts = {"script_args": ["--version"]}
+        dist = pyprojecttoml.apply_configuration(Distribution(opts), pyproject)
+        dist.parse_command_line()  # <-- there should be no exception here.
+        captured = capsys.readouterr()
+        assert "42.0" in captured.out
+
+
 # --- Auxiliary Functions ---
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Closes #4047

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
