### PR TITLE
GNU: use -Wl,-rpath,<dir> instead of -Wl,-R<dir>

### DIFF
--- a/newsfragments/4060.feature.rst
+++ b/newsfragments/4060.feature.rst
@@ -1,0 +1,1 @@
+Pass more common `-Wl,--enable-new-dtags -Wl,-rpath,<path>` flags instead of `-Wl,--enable-new-dtags,-R<path>` to compilers with GNU linkers -- by :user:`haampie`

--- a/setuptools/_distutils/tests/test_unixccompiler.py
+++ b/setuptools/_distutils/tests/test_unixccompiler.py
@@ -186,7 +186,10 @@ class TestUnixCCompiler(support.TempdirManager):
                 return 'yes'
 
         sysconfig.get_config_var = gcv
-        assert self.cc.rpath_foo() == '-Wl,--enable-new-dtags,-R/foo'
+        assert self.cc.rpath_foo() == [
+            '-Wl,--enable-new-dtags',
+            '-Wl,-rpath,/foo'
+        ]
 
         # non-GCC GNULD
         sys.platform = 'bar'

--- a/setuptools/_distutils/unixccompiler.py
+++ b/setuptools/_distutils/unixccompiler.py
@@ -311,13 +311,14 @@ class UnixCCompiler(CCompiler):
                 "-L" + dir,
             ]
 
-        # For all compilers, `-Wl` is the presumed way to
-        # pass a compiler option to the linker and `-R` is
-        # the way to pass an RPATH.
+        # For all compilers, `-Wl` is the presumed way to pass a
+        # compiler option to the linker
         if sysconfig.get_config_var("GNULD") == "yes":
-            # GNU ld needs an extra option to get a RUNPATH
-            # instead of just an RPATH.
-            return "-Wl,--enable-new-dtags,-R" + dir
+            return [
+                # Force RUNPATH instead of RPATH
+                "-Wl,--enable-new-dtags",
+                "-Wl,-rpath," + dir
+            ]
         else:
             return "-Wl,-R" + dir
 


### PR DESCRIPTION
Closes #4060

## Summary of changes
Use `-rpath` instead of `-R` when using binutils.

The latter is supported in binutils for backwards compatibility, but in
general `-R<path>` is equivalent to `--just-symbols=<path>` when `path`
is a file; only when it's a directory, it's treated as `-rpath=<path>`.

Better avoid that ambiguity and use `-rpath`.

Also split `-Wl,--enable-new-dtags` and `-Wl,-rpath,...` into two
separate arguments, which is more common, and more likely to be parsed
correctly by compiler wrappers.

This commit does not attempt to add `--enable-new-dtags` to other
linkers than binutils ld/gold that support the flag.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].

