### PR TITLE
Remove `sphinx-hoverxref` to improve usability

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,19 +114,6 @@ intersphinx_mapping.update(
     }
 )
 
-# Support tooltips on references
-extensions += ['hoverxref.extension']
-hoverxref_auto_ref = True
-hoverxref_intersphinx = [
-    'python',
-    'pip',
-    'build',
-    'PyPUG',
-    'packaging',
-    'twine',
-    'importlib-resources',
-]
-
 # Add support for linking usernames
 github_url = 'https://github.com'
 github_repo_org = 'pypa'

--- a/setup.cfg
+++ b/setup.cfg
@@ -109,7 +109,6 @@ docs =
 	sphinx-reredirects
 	sphinxcontrib-towncrier
 	sphinx-notfound-page >=1,<2
-	sphinx-hoverxref < 2
 
 ssl =
 


### PR DESCRIPTION
This change attempts to address an usability problem in the docs, that arise from the use of `sphinx-hoverxref`.

The approach used is to simply remove it, since it is not fundamental for the website.

Closes #4064.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
