### PR TITLE
Rely on pytest-home for the alternate home directory.

### DIFF
--- a/newsfragments/4072.bugfix.rst
+++ b/newsfragments/4072.bugfix.rst
@@ -1,0 +1,1 @@
+In tests, rely on pytest-home for reusable fixture.

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ testing =
 		sys_platform != "cygwin"
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
-	pytest-home
+	pytest-home >= 0.5
 
 testing-integration =
 	pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,6 +74,7 @@ testing =
 		sys_platform != "cygwin"
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
+	pytest-home
 
 testing-integration =
 	pytest

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -1,7 +1,5 @@
 import sys
-import os
 import distutils.errors
-import platform
 import urllib.request
 import urllib.error
 import http.client
@@ -267,8 +265,8 @@ class TestContentCheckers:
 
 
 class TestPyPIConfig:
-    def test_percent_in_password(self, alt_home):
-        pypirc = alt_home / '.pypirc'
+    def test_percent_in_password(self, tmp_home_dir):
+        pypirc = tmp_home_dir / '.pypirc'
         pypirc.write_text(
             DALS(
                 """

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -266,22 +266,10 @@ class TestContentCheckers:
         assert rep == 'My message about md5'
 
 
-@pytest.fixture
-def temp_home(tmpdir, monkeypatch):
-    key = (
-        'USERPROFILE'
-        if platform.system() == 'Windows' and sys.version_info > (3, 8)
-        else 'HOME'
-    )
-
-    monkeypatch.setitem(os.environ, key, str(tmpdir))
-    return tmpdir
-
-
 class TestPyPIConfig:
-    def test_percent_in_password(self, temp_home):
-        pypirc = temp_home / '.pypirc'
-        pypirc.write(
+    def test_percent_in_password(self, alt_home):
+        pypirc = alt_home / '.pypirc'
+        pypirc.write_text(
             DALS(
                 """
             [pypi]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
