### PR TITLE
Fix failing CI jobs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,7 +200,12 @@ nitpick_ignore = [
 
 # Allow linking objects on other Sphinx sites seamlessly:
 intersphinx_mapping.update(
-    python=('https://docs.python.org/3', None),
+    # python=('https://docs.python.org/3', None),
+    python=('https://docs.python.org/3.11/', None),
+    # ^-- Python 3.11 is required because it still contains `distutils`.
+    #     Just leaving it as `3` would imply 3.12+, but that causes an
+    #     error with the cross references to disutils functions.
+    #     Inventory cache may cause errors, deleting it solves the problem.
 )
 
 # Add support for the unreleased "next-version" change notes

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
 usedevelop = True
 extras =
 	testing
-passenv =
+pass_env =
 	SETUPTOOLS_USE_DISTUTILS
 	PRE_BUILT_SETUPTOOLS_WHEEL
 	PRE_BUILT_SETUPTOOLS_SDIST
@@ -25,8 +25,8 @@ passenv =
 [testenv:integration]
 deps = {[testenv]deps}
 extras = testing-integration
-passenv =
-	{[testenv]passenv}
+pass_env =
+	{[testenv]pass_env}
 	DOWNLOAD_PATH
 setenv =
     PROJECT_ROOT = {toxinidir}


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Unify `passenv` with `pass_env` in `tox.ini` so we don't have trouble with `TOX_OVERRIDE`
- Use Python 3.11 inventory to avoid errors with distutils references

Fix https://github.com/pypa/setuptools/commit/fbe0d7962822c2a1fdde8dd179f2f8b8c8bf8892#commitcomment-129798103

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
