### PR TITLE
Only pass `--build-option` to `bdist_wheel` in build_meta

### DIFF
--- a/newsfragments/4079.removal.rst
+++ b/newsfragments/4079.removal.rst
@@ -1,0 +1,4 @@
+Removed handling of ``--config-settings["--build-option"]`` in ``setuptools.build_meta``
+from build-backend API hooks *other than* ``build_wheel``.
+This was motivate by `errors caused when passing this option
+<https://github.com/pypa/setuptools/issues/2491#issuecomment-1742859314>`_.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -318,7 +318,6 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
             *sys.argv[:1],
             *self._global_args(config_settings),
             "egg_info",
-            *self._arbitrary_args(config_settings),
         ]
         try:
             with Distribution.patch():
@@ -406,6 +405,7 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         # Build in a temporary directory, then copy to the target.
         os.makedirs(result_directory, exist_ok=True)
         temp_opts = {"prefix": ".tmp-", "dir": result_directory}
+
         with tempfile.TemporaryDirectory(**temp_opts) as tmp_dist_dir:
             sys.argv = [
                 *sys.argv[:1],
@@ -413,7 +413,6 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
                 *setup_command,
                 "--dist-dir",
                 tmp_dist_dir,
-                *self._arbitrary_args(config_settings),
             ]
             with no_install_setup_requires():
                 self.run_setup()
@@ -432,7 +431,10 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
     ):
         with suppress_known_deprecation():
             return self._build_with_temp_dir(
-                ['bdist_wheel'], '.whl', wheel_directory, config_settings
+                ['bdist_wheel', *self._arbitrary_args(config_settings)],
+                '.whl',
+                wheel_directory,
+                config_settings,
             )
 
     def build_sdist(self, sdist_directory, config_settings=None):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -706,25 +706,6 @@ class TestBuildMetaBackend:
         for file in files:
             assert file.is_symlink() or os.stat(file).st_nlink > 0
 
-    @pytest.mark.filterwarnings("ignore::setuptools.SetuptoolsDeprecationWarning")
-    # Since the backend is running via a process pool, in some operating systems
-    # we may have problems to make assertions based on warnings/stdout/stderr...
-    # So the best is to ignore them for the time being.
-    def test_editable_with_global_option_still_works(self, tmpdir_cwd):
-        """The usage of --global-option is now discouraged in favour of --build-option.
-        This is required to make more sense of the provided scape hatch and align with
-        previous pip behaviour. See pypa/setuptools#1928.
-        """
-        path.build({**self._simple_pyproject_example, '_meta': {}})
-        build_backend = self.get_build_backend()
-        assert not Path("build").exists()
-
-        cfg = {"--global-option": ["--mode", "strict"]}
-        build_backend.prepare_metadata_for_build_editable("_meta", cfg)
-        build_backend.build_editable("temp", cfg, "_meta")
-
-        self._assert_link_tree(next(Path("build").glob("__editable__.*")))
-
     def test_editable_without_config_settings(self, tmpdir_cwd):
         """
         Sanity check to ensure tests with --mode=strict are different from the ones
@@ -739,13 +720,7 @@ class TestBuildMetaBackend:
         build_backend.build_editable("temp")
         assert not Path("build").exists()
 
-    @pytest.mark.parametrize(
-        "config_settings",
-        [
-            {"--build-option": ["--mode", "strict"]},
-            {"editable-mode": "strict"},
-        ],
-    )
+    @pytest.mark.parametrize("config_settings", [{"editable-mode": "strict"}])
     def test_editable_with_config_settings(self, tmpdir_cwd, config_settings):
         path.build({**self._simple_pyproject_example, '_meta': {}})
         assert not Path("build").exists()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

In https://github.com/pypa/setuptools/issues/2491#issuecomment-1742859314 the discussion seems to lead to the idea that it is better for now to avoid passing any `--build-option` for commands that are not `bdist_wheel` in `setuptools.build_meta`.

## Summary of changes

- Only pass `config_settings["--build-option"]` to `bdist_wheel` in `setuptools.build_meta`
- Remove no longer valid tests for `config_settings["--build-option"]` and `config_settings["--global-option"]` and editable installs


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
