### PR TITLE
[Experiment] Add `PreprocessedExtension`

### DIFF
--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -253,10 +253,10 @@ class build_ext(_build_ext):
 
     def _preprocess_and_build(self, ext):
         if isinstance(ext, PreprocessedExtension):
-            target = ext.preprocess(self)
+            target = ext.preprocess(self)  # may be missing build info
             updates = self._update_ext_info(target)
             target.__dict__.update(updates)
-            ext.__dict__.update(updates)
+            ext.__dict__.update(updates)  # ... for the sake of consistency ...
         else:
             target = ext
 

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -169,8 +169,8 @@ class PreprocessedExtension(Extension):
 
         If necessary, a temporary directory **name** can be accessed via
         ``build_ext.build_temp`` (this directory might not have been created yet).
-        You can also access other attributes like ``build_ext.inplace`` or
-        ``build_ext.editable_mode``.
+        You can also access other attributes like ``build_ext.parallel``,
+        ``build_ext.inplace`` or ``build_ext.editable_mode``.
         """
         raise NotImplementedError  # needs to be implemented by the relevant plugin.
 

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -161,7 +161,7 @@ class PreprocessedExtension(Extension):
 
     def preprocess(self, build_ext: BuildExt) -> Extension:  # pragma: no cover
         """
-        The returned ``Extension`` object will be used instead of the
+        The returned ``Extension`` object will be used instead of the original
         ``PreprocessedExtension`` object when ``build_ext.build_extension`` runs
         (so that ``sources`` and ``dependencies`` can be augmented/replaced with
         temporary pre-processed files).

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -11,7 +11,7 @@ import distutils.extension
 from .monkey import get_unpatched
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .command.build_ext import build_ext as BuildExt
 
 
@@ -159,7 +159,7 @@ class PreprocessedExtension(Extension):
     Particularly useful when "transpiling" other languages to C.
     """
 
-    def preprocess(self, build_ext: BuildExt) -> Extension:
+    def preprocess(self, build_ext: BuildExt) -> Extension:  # pragma: no cover
         """
         The returned ``Extension`` object will be used instead of the
         ``PreprocessedExtension`` object when ``build_ext.build_extension`` runs

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -394,7 +394,7 @@ class TestBuildExamples:
         "foo.c": "#include <xxx-generate-compilation-error-if-not-preprocessed-xxx>\n",
         "fooc.template": SIMPLE["foo.c"],
         "fooh.template": "#define HELLO_WORLD 1\n",
-        "bar.c": '#include "foo.h"\n',
+        "bar.c": '#include "foo.h"\n' + SIMPLE["foo.c"].replace("foo", "bar"),
         "setup.py": DALS(
             """
             import os, shutil


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This is an experiment.

Currently, "transpilers" that want to plug into `setuptools` must either a) override `build_ext` or b) pre-compile files to C at every invocation of `setup.py`.

`mypycify` is an example of the approach in `(b)` and suffers from [performance issues](https://github.com/mypyc/mypyc/issues/946).

My idea with this experiment is to enable deferring the "pre-processing" step just before the compilation when creating the wheel, without requiring a new custom build step or overriding `build_ext`.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
