### PR TITLE
Fix setuptools.depends:get_module_constant() on Python 3.13.0a1

### DIFF
--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -142,9 +142,9 @@ def extract_constant(code, symbol, default=-1):
 
     name_idx = list(code.co_names).index(symbol)
 
-    STORE_NAME = 90
-    STORE_GLOBAL = 97
-    LOAD_CONST = 100
+    STORE_NAME = dis.opmap['STORE_NAME']
+    STORE_GLOBAL = dis.opmap['STORE_GLOBAL']
+    LOAD_CONST = dis.opmap['LOAD_CONST']
 
     const = default
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Don't hardcode opcode numbers, look them up instead.

Fixes https://github.com/pypa/setuptools/issues/4090

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
