### PR TITLE
Fix - normalize cwd path on dist path check (#4088)

### DIFF
--- a/newsfragments/4088.bugfix.rst
+++ b/newsfragments/4088.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed path comparison in ``easy_install`` via normalization.
+(This affects only deprecated calls to ``python setup.py install/develop``,
+users are still encouraged to use ``python -m build`` or ``pip install -e .``
+with build isolation).

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1256,7 +1256,7 @@ class easy_install(Command):
 
             log.info("Removing %s from easy-install.pth file", d)
             self.pth_file.remove(d)
-            if d_location in self.shadow_path:
+            if d_location in map(normalize_path, self.shadow_path):
                 self.shadow_path.remove(d_location)
 
         if not self.multi_version:
@@ -1268,7 +1268,7 @@ class easy_install(Command):
             else:
                 log.info("Adding %s to easy-install.pth file", dist)
                 self.pth_file.add(dist)  # add new entry
-                if dist_location not in self.shadow_path:
+                if dist_location not in map(normalize_path, self.shadow_path):
                     self.shadow_path.append(dist_location)
 
         if self.dry_run:
@@ -1717,8 +1717,8 @@ class PthDistributions(Environment):
     def add(self, dist):
         """Add `dist` to the distribution map"""
         dist_location = normalize_path(dist.location)
-        new_path = dist_location not in self.paths and (
-            dist_location not in self.sitedirs
+        new_path = dist_location not in map(normalize_path, self.paths) and (
+            dist_location not in map(normalize_path, self.sitedirs)
             or
             # account for '.' being in PYTHONPATH
             dist_location == normalize_path(os.getcwd())
@@ -1731,7 +1731,7 @@ class PthDistributions(Environment):
     def remove(self, dist):
         """Remove `dist` from the distribution map"""
         dist_location = normalize_path(dist.location)
-        while dist_location in self.paths:
+        while dist_location in map(normalize_path, self.paths):
             self.paths.remove(dist_location)
             self.dirty = True
         super().remove(dist)

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1717,7 +1717,7 @@ class PthDistributions(Environment):
             dist.location not in self.sitedirs
             or
             # account for '.' being in PYTHONPATH
-            dist.location == os.getcwd()
+            dist.location == normalize_path(os.getcwd())
         )
         if new_path:
             self.paths.append(dist.location)

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -316,20 +316,26 @@ class TestPTHFileWriter:
         pth.add(PRDistribution(location))
         assert not pth.dirty
 
-    def test_add_for_normalize_cwd_path(self):
+    def test_add_remove_for_normalized_path(self):
         """
         In windows, path is not case sensitive, 
         This is test when the distiribution path is cwd and normalized.
         """
         path_org = 'C:/Location/package'
         path_norm = pkg_resources.normalize_path(path_org)
+
+        pth = PthDistributions('test-package', [path_org])
+        dist = PRDistribution(location=path_norm, version='1.0')
+
         with mock.patch('os.getcwd') as mock_getcwd:
             mock_getcwd.return_value = path_org
-            pth = PthDistributions('test-package', [path_org])
-            dist = PRDistribution(path_norm)
             assert not pth.dirty
             pth.add(dist)
             assert pth.dirty
+
+        assert len(pth.paths) == 1
+        pth.remove(dist)
+        assert len(pth.paths) == 0
 
     def test_many_pth_distributions_merge_together(self, tmpdir):
         """

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -316,6 +316,21 @@ class TestPTHFileWriter:
         pth.add(PRDistribution(location))
         assert not pth.dirty
 
+    def test_add_for_normalize_cwd_path(self):
+        """
+        In windows, path is not case sensitive, 
+        This is test when the distiribution path is cwd and normalized.
+        """
+        path_org = 'C:/Location/package'
+        path_norm = pkg_resources.normalize_path(path_org)
+        with mock.patch('os.getcwd') as mock_getcwd:
+            mock_getcwd.return_value = path_org
+            pth = PthDistributions('test-package', [path_org])
+            dist = PRDistribution(path_norm)
+            assert not pth.dirty
+            pth.add(dist)
+            assert pth.dirty
+
     def test_many_pth_distributions_merge_together(self, tmpdir):
         """
         If the pth file is modified under the hood, then PthDistribution

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -321,7 +321,7 @@ class TestPTHFileWriter:
         In windows, path is not case sensitive,
         This is test when the distribution path is cwd and normalized.
         """
-        if sys.platform.startswith('win'):
+        if sys.platform.startswith('win'):  # pragma: no cover
             path_org = 'C:/Location/package'
         else:
             path_org = '/Location/package'

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -321,7 +321,10 @@ class TestPTHFileWriter:
         In windows, path is not case sensitive, 
         This is test when the distiribution path is cwd and normalized.
         """
-        path_org = 'C:/Location/package'
+        if sys.platform.startswith('win'):
+            path_org = 'C:/Location/package'
+        else:
+            path_org = '/Location/package'
         path_norm = pkg_resources.normalize_path(path_org)
 
         pth = PthDistributions('test-package', [path_org])

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -318,8 +318,8 @@ class TestPTHFileWriter:
 
     def test_add_remove_for_normalized_path(self):
         """
-        In windows, path is not case sensitive, 
-        This is test when the distiribution path is cwd and normalized.
+        In windows, path is not case sensitive,
+        This is test when the distribution path is cwd and normalized.
         """
         if sys.platform.startswith('win'):
             path_org = 'C:/Location/package'


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Normalize CWD path for the comparing of distribute location.

Fixes #4088 <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
