### PR TITLE
Import PUG guide to MANIFEST.in

### DIFF
--- a/docs/setuptools.rst
+++ b/docs/setuptools.rst
@@ -21,9 +21,9 @@ Feature Highlights:
   individually in setup.py
 
 * Automatically include all relevant files in your source distributions,
-  without needing to create a |MANIFEST.in|_ file, and without having to force
-  regeneration of the ``MANIFEST`` file when your source tree changes
-  [#manifest]_.
+  without needing to create a :ref:`MANIFEST.in <Using MANIFEST.in>` file,
+  and without having to force regeneration of the ``MANIFEST`` file when your
+  source tree changes [#manifest]_.
 
 * Automatically generate wrapper scripts or Windows (console and GUI) .exe
   files for any number of "main" functions in your project.  (Note: this is not
@@ -221,7 +221,3 @@ set of steps to reproduce.
    any special C header). See :ref:`Controlling files in the distribution` and
    :doc:`userguide/datafiles` for more information about complex scenarios, if
    you want to include other types of files.
-
-
-.. |MANIFEST.in| replace:: ``MANIFEST.in``
-.. _MANIFEST.in: https://packaging.python.org/en/latest/guides/using-manifest-in/

--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -72,7 +72,8 @@ and you supply this configuration:
 then all the ``.txt`` and ``.rst`` files will be automatically installed with
 your package, provided:
 
-1. These files are included via the |MANIFEST.in|_ file, like so::
+1. These files are included via the :ref:`MANIFEST.in <Using MANIFEST.in>` file,
+   like so::
 
         include src/mypkg/*.txt
         include src/mypkg/*.rst
@@ -149,8 +150,8 @@ data files:
 
 The ``package_data`` argument is a dictionary that maps from package names to
 lists of glob patterns. Note that the data files specified using the ``package_data``
-option neither require to be included within a |MANIFEST.in|_ file, nor
-require to be added by a revision control system plugin.
+option neither require to be included within a :ref:`MANIFEST.in <Using MANIFEST.in>`
+file, nor require to be added by a revision control system plugin.
 
 .. note::
         If your glob patterns use paths, you *must* use a forward slash (``/``) as
@@ -426,13 +427,14 @@ Summary
 In summary, the three options allow you to:
 
 ``include_package_data``
-    Accept all data files and directories matched by |MANIFEST.in|_ or added by
+    Accept all data files and directories matched by
+    :ref:`MANIFEST.in <Using MANIFEST.in>` or added by
     a :ref:`plugin <Adding Support for Revision Control Systems>`.
 
 ``package_data``
     Specify additional patterns to match files that may or may
-    not be matched by |MANIFEST.in|_ or added by
-    a :ref:`plugin <Adding Support for Revision Control Systems>`.
+    not be matched by :ref:`MANIFEST.in <Using MANIFEST.in>`
+    or added by a :ref:`plugin <Adding Support for Revision Control Systems>`.
 
 ``exclude_package_data``
     Specify patterns for data files and directories that should *not* be
@@ -537,7 +539,3 @@ run time be included **inside the package**.
 .. [#files_api] Reference: https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy
 
 .. [#namespace_support] Reference: https://github.com/python/importlib_resources/pull/196#issuecomment-734520374
-
-
-.. |MANIFEST.in| replace:: ``MANIFEST.in``
-.. _MANIFEST.in: https://packaging.python.org/en/latest/guides/using-manifest-in/

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -43,8 +43,6 @@ to specify any files that the default file location algorithm doesn't catch.
 
 This file contains instructions that tell ``setuptools`` which files exactly
 should be part of the ``sdist`` (or not).
-A comprehensive guide to ``MANIFEST.in`` syntax is available at the
-:doc:`PyPA's Packaging User Guide <PyPUG:guides/using-manifest-in>`.
 
 .. attention::
    Please note that ``setuptools`` supports the ``MANIFEST.in``,
@@ -60,6 +58,58 @@ A comprehensive guide to ``MANIFEST.in`` syntax is available at the
    A good idea is to start with a ``graft`` command (to add all
    files inside a set of directories) and then fine tune the file selection
    by removing the excess or adding isolated files.
+
+
+A :file:`MANIFEST.in` file consists of commands, one per line, instructing
+setuptools to add or remove some set of files from the sdist.  The commands
+are:
+
+=========================================================  ==================================================================================================
+Command                                                    Description
+=========================================================  ==================================================================================================
+:samp:`include {pat1} {pat2} ...`                          Add all files matching any of the listed patterns
+                                                           (Files must be given as paths relative to the root of the project)
+:samp:`exclude {pat1} {pat2} ...`                          Remove all files matching any of the listed patterns
+                                                           (Files must be given as paths relative to the root of the project)
+:samp:`recursive-include {dir-pattern} {pat1} {pat2} ...`  Add all files under directories matching ``dir-pattern`` that match any of the listed patterns
+:samp:`recursive-exclude {dir-pattern} {pat1} {pat2} ...`  Remove all files under directories matching ``dir-pattern`` that match any of the listed patterns
+:samp:`global-include {pat1} {pat2} ...`                   Add all files anywhere in the source tree matching any of the listed patterns
+:samp:`global-exclude {pat1} {pat2} ...`                   Remove all files anywhere in the source tree matching any of the listed patterns
+:samp:`graft {dir-pattern}`                                Add all files under directories matching ``dir-pattern``
+:samp:`prune {dir-pattern}`                                Remove all files under directories matching ``dir-pattern``
+=========================================================  ==================================================================================================
+
+The patterns here are glob-style patterns: ``*`` matches zero or more regular
+filename characters (on Unix, everything except forward slash; on Windows,
+everything except backslash and colon); ``?`` matches a single regular filename
+character, and ``[chars]`` matches any one of the characters between the square
+brackets (which may contain character ranges, e.g., ``[a-z]`` or
+``[a-fA-F0-9]``).  Setuptools also has support for ``**`` matching
+zero or more characters including forward slash, backslash, and colon.
+
+Directory patterns are relative to the root of the project directory; e.g.,
+``graft example*`` will include a directory named :file:`examples` in the
+project root but will not include :file:`docs/examples/`.
+
+File & directory names in :file:`MANIFEST.in` should be ``/``-separated;
+setuptools will automatically convert the slashes to the local platform's
+appropriate directory separator.
+
+Commands are processed in the order they appear in the :file:`MANIFEST.in`
+file.  For example, given the commands:
+
+.. code-block:: bash
+
+    graft tests
+    global-exclude *.py[cod]
+
+the contents of the directory tree :file:`tests` will first be added to the
+sdist, and then after that all files in the sdist with a ``.pyc``, ``.pyo``, or
+``.pyd`` extension will be removed from the sdist.  If the commands were in the
+opposite order, then ``*.pyc`` files etc. would be only be removed from what
+was already in the sdist before adding :file:`tests`, and if :file:`tests`
+happened to contain any ``*.pyc`` files, they would end up included in the
+sdist because the exclusion happened before they were included.
 
 An example of ``MANIFEST.in`` for a simple project that organized according to a
 :ref:`src-layout` is:

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -31,6 +31,8 @@ files are included in a source distribution by default:
 - ``README``, ``README.txt``, ``README.rst`` or ``README.md``;
 - ``MANIFEST.in``
 
+Please note that the list above is guaranteed to work with the last stable version
+of ``setuptools``. The behavior of older versions might differ.
 
 .. note::
    .. versionadded:: v68.3.0

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -7,25 +7,28 @@ For the most common use cases, ``setuptools`` will automatically find out which
 files are necessary for distributing the package. More precisely, the following
 files are included in a source distribution by default:
 
-- All Python source files implied by the ``py_modules`` and ``packages``
-  ``setup()`` arguments
+- All Python source files implied by the ``py-modules`` and ``packages``
+  configuration parameters in ``pyproject.toml`` and/or equivalent
+  in ``setup.cfg``/``setup.py``;
 - All C source files mentioned in the ``ext_modules`` or ``libraries``
-  ``setup()`` arguments
-- Scripts specified by the ``scripts`` ``setup()`` argument
-- All files specified by the ``package_data`` and ``data_files``
-  ``setup()`` arguments
-- The file specified by the ``license_file`` option in ``setup.cfg``
-  (setuptools 40.8.0+)
-- All files specified by the ``license_files`` option in ``setup.cfg``
-  (setuptools 42.0.0+)
-- All files matching the pattern ``test/test*.py``
-- ``setup.py`` (or whatever you called your setup script)
-- ``setup.cfg``
-- ``README``
-- ``README.txt``
-- ``README.rst`` (Python 3.7+ or setuptools 0.6.27+)
-- ``README.md`` (setuptools 36.4.0+)
-- ``pyproject.toml`` (setuptools 43.0.0+)
+  ``setup()`` arguments;
+- Files that match the following glob patterns: ``tests/test*.py``,
+  ``test/test*.py``;
+- Scripts specified by the ``scripts-files`` configuration parameter
+  in ``pyproject.toml`` or ``scripts`` in ``setup.py``/``setup.cfg``;
+- All files specified by the ``package-data`` and ``data-files``
+  configuration parameters in ``pyproject.toml`` and/or equivalent
+  in ``setup.cfg``/``setup.py``;
+- The file specified by the ``license_file`` option in ``setup.cfg``;
+- All files specified by the ``license-files`` configuration parameter
+  in ``pyproject.toml`` and/or equivalent in ``setup.cfg``/``setup.py``;
+  note that if you don't explicitly set this parameter, ``setuptools``
+  will include any files that match the following glob patterns:
+  ``LICENSE*``, ``LICENCE*``, ``COPYING*``, ``NOTICE*``, ``AUTHORS**``;
+- ``pyproject.toml``;
+- ``setup.cfg``;
+- ``setup.py``;
+- ``README``, ``README.txt``, ``README.rst`` or ``README.md``;
 - ``MANIFEST.in``
 
 

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -4,11 +4,30 @@ Controlling files in the distribution
 =====================================
 
 For the most common use cases, ``setuptools`` will automatically find out which
-files are necessary for distributing the package.
-These include all :term:`pure Python modules <Pure Module>` in the
-``py_modules`` or ``packages`` configuration, and the C sources (but not C
-headers) listed as part of extensions when creating a :term:`source
-distribution (or "sdist")`.
+files are necessary for distributing the package. More precisely, the following
+files are included in a source distribution by default:
+
+- All Python source files implied by the ``py_modules`` and ``packages``
+  ``setup()`` arguments
+- All C source files mentioned in the ``ext_modules`` or ``libraries``
+  ``setup()`` arguments
+- Scripts specified by the ``scripts`` ``setup()`` argument
+- All files specified by the ``package_data`` and ``data_files``
+  ``setup()`` arguments
+- The file specified by the ``license_file`` option in ``setup.cfg``
+  (setuptools 40.8.0+)
+- All files specified by the ``license_files`` option in ``setup.cfg``
+  (setuptools 42.0.0+)
+- All files matching the pattern ``test/test*.py``
+- ``setup.py`` (or whatever you called your setup script)
+- ``setup.cfg``
+- ``README``
+- ``README.txt``
+- ``README.rst`` (Python 3.7+ or setuptools 0.6.27+)
+- ``README.md`` (setuptools 36.4.0+)
+- ``pyproject.toml`` (setuptools 43.0.0+)
+- ``MANIFEST.in``
+
 
 .. note::
    .. versionadded:: v68.3.0

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -7,10 +7,10 @@ For the most common use cases, ``setuptools`` will automatically find out which
 files are necessary for distributing the package. More precisely, the following
 files are included in a source distribution by default:
 
-- All Python source files implied by the ``py-modules`` and ``packages``
+- :term:`pure Python module <Pure Module>` files implied by the ``py-modules`` and ``packages``
   configuration parameters in ``pyproject.toml`` and/or equivalent
   in ``setup.cfg``/``setup.py``;
-- All C source files mentioned in the ``ext_modules`` or ``libraries``
+- C source files mentioned in the ``ext_modules`` or ``libraries``
   ``setup()`` arguments;
 - Files that match the following glob patterns: ``tests/test*.py``,
   ``test/test*.py``;

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -390,8 +390,8 @@ For the simplest use, you can simply use the ``include_package_data`` keyword:
         )
 
 This tells setuptools to install any data files it finds in your packages.
-The data files must be specified via the |MANIFEST.in|_ file
-or automatically added by a :ref:`Revision Control System plugin
+The data files must be specified via the :ref:`MANIFEST.in <Using MANIFEST.in>`
+file or automatically added by a :ref:`Revision Control System plugin
 <Adding Support for Revision Control Systems>`.
 For more details, see :doc:`datafiles`.
 
@@ -458,9 +458,6 @@ Packaging in Python can be hard and is constantly evolving.
 `Python Packaging User Guide <https://packaging.python.org>`_ has tutorials and
 up-to-date references that can help you when it is time to distribute your work.
 
-
-.. |MANIFEST.in| replace:: ``MANIFEST.in``
-.. _MANIFEST.in: https://packaging.python.org/en/latest/guides/using-manifest-in/
 
 
 ----


### PR DESCRIPTION
## Summary of changes

The Packaging User Guide has a [page](https://packaging.python.org/en/latest/guides/using-manifest-in/) on using `MANIFEST.in` to control the data files in a distribution. This is very setuptools-specific since other build backends do not use `MANIFEST.in` files. Thus, I think it is better for this information to live in the setuptools documentation.

After this is merged, I will open a PR on the PUG to make https://packaging.python.org/en/latest/guides/using-manifest-in/ a redirect.

