### PR TITLE
Link to the new pyproject.toml guide the PUG

### DIFF
--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -29,8 +29,8 @@ be used with ``setuptools``. It contains two TOML tables (identified by the
 The ``build-system`` table is used to tell the build frontend (e.g.
 :pypi:`build` or :pypi:`pip`) to use ``setuptools`` and any other plugins (e.g.
 ``setuptools-scm``) to build the package.
-The ``project`` table contains metadata fields as described by
-:doc:`PyPUG:specifications/declaring-project-metadata` guide.
+The ``project`` table contains metadata fields as described by the
+:doc:`PyPUG:guides/writing-pyproject-toml` guide.
 
 .. _example-pyproject-config:
 
@@ -67,8 +67,8 @@ The ``project`` table contains metadata fields as described by
    [project.scripts]
    my-script = "my_package.module:function"
 
-   # ... other project metadata fields as specified in:
-   #     https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
+   # ... other project metadata fields as listed in:
+   #     https://packaging.python.org/en/latest/guides/writing-pyproject-toml/
 
 .. _setuptools-table:
 


### PR DESCRIPTION
## Summary of changes

The PUG now has a pyproject.toml guide, meant for users, distinct from the specification, meant for tool developers.