### PR TITLE
Mark flaky test on  PyPy with `xfail`

### DIFF
--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -1,6 +1,7 @@
 import inspect
 import logging
 import sys
+from contextlib import contextmanager
 
 import pytest
 
@@ -41,7 +42,8 @@ def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     assert log_level_name == expected_level
 
 
-def _flaky_on_pypy(func):
+@contextmanager
+def flaky_on_pypy(func):
     try:
         func()
     except AssertionError:  # pragma: no cover
@@ -51,7 +53,7 @@ def _flaky_on_pypy(func):
         raise
 
 
-@_flaky_on_pypy
+@flaky_on_pypy
 def test_patching_does_not_cause_problems():
     # Ensure `dist.log` is only patched if necessary
 

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -1,6 +1,5 @@
 import inspect
 import logging
-import os
 import sys
 
 import pytest

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -45,7 +45,7 @@ def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
 def _flaky_on_pypy(func):
     try:
         func()
-    except AssertionError:
+    except AssertionError:  # pragma: no cover
         if IS_PYPY:
             msg = "Flaky monkeypatch on PyPy"
             pytest.xfail(f"{msg}. Original discussion in #3707, #3709.")

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -1,8 +1,12 @@
 import inspect
 import logging
 import os
+import sys
 
 import pytest
+
+
+IS_PYPY = '__pypy__' in sys.builtin_module_names
 
 
 setup_py = """\
@@ -38,16 +42,29 @@ def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     assert log_level_name == expected_level
 
 
+def _flaky_on_pypy(func):
+    try:
+        func()
+    except AssertionError:
+        if IS_PYPY:
+            msg = "Flaky monkeypatch on PyPy"
+            pytest.xfail(f"{msg}. Original discussion in #3707, #3709.")
+        raise
+
+
+@_flaky_on_pypy
 def test_patching_does_not_cause_problems():
     # Ensure `dist.log` is only patched if necessary
 
+    import _distutils_hack
     import setuptools.logging
     from distutils import dist
 
     setuptools.logging.configure()
 
-    if os.getenv("SETUPTOOLS_USE_DISTUTILS", "local").lower() == "local":
+    if _distutils_hack.enabled():
         # Modern logging infra, no problematic patching.
+        assert dist.__file__ is None or "setuptools" in dist.__file__
         assert isinstance(dist.log, logging.Logger)
     else:
         assert inspect.ismodule(dist.log)

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -47,7 +47,7 @@ def _flaky_on_pypy(func):
         func()
     except AssertionError:  # pragma: no cover
         if IS_PYPY:
-            msg = "Flaky monkeypatch on PyPy"
+            msg = "Flaky monkeypatch on PyPy (#4124)"
             pytest.xfail(f"{msg}. Original discussion in #3707, #3709.")
         raise
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

It seems that the monkeypatching of `distutils.dist.log` started to be flaky on PyPy again: 
https://github.com/pypa/setuptools/actions/runs/6932122543/job/18855355764.

(Original discussion of the problem in #3707, #3709)


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
