### PR TITLE
Allow imports of `setuptools.dep_util.newer_group` with deprecation warning

### DIFF
--- a/newsfragments/4126.bugfix.rst
+++ b/newsfragments/4126.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed imports of ``setuptools.dep_util.newer_group``.
+A deprecation warning is issued instead of a hard failure.

--- a/setuptools/dep_util.py
+++ b/setuptools/dep_util.py
@@ -4,7 +4,7 @@ from ._distutils import _modified
 
 
 def __getattr__(name):
-    if name not in ['newer_pairwise_group']:
+    if name not in ['newer_group', 'newer_pairwise_group']:
         raise AttributeError(name)
     warnings.warn(
         "dep_util is Deprecated. Use functions from setuptools.modified instead.",


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4126 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
