### PR TITLE
Add missing estimated date for removing `setuptools.dep_util`

### DIFF
--- a/newsfragments/4131.bugfix.rst
+++ b/newsfragments/4131.bugfix.rst
@@ -1,0 +1,1 @@
+Added missing estimated date for removing ``setuptools.dep_util`` (deprecated in v69.0.0).

--- a/setuptools/dep_util.py
+++ b/setuptools/dep_util.py
@@ -1,14 +1,16 @@
-import warnings
-
 from ._distutils import _modified
+from .warnings import SetuptoolsDeprecationWarning
 
 
 def __getattr__(name):
     if name not in ['newer_group', 'newer_pairwise_group']:
         raise AttributeError(name)
-    warnings.warn(
+    SetuptoolsDeprecationWarning.emit(
         "dep_util is Deprecated. Use functions from setuptools.modified instead.",
-        DeprecationWarning,
-        stacklevel=2,
+        "Please use `setuptools.modified` instead of `setuptools.dep_util`.",
+        see_url="https://github.com/pypa/setuptools/pull/4069",
+        due_date=(2024, 5, 21),
+        # Warning added in v69.0.0 on 2023/11/20,
+        # See https://github.com/pypa/setuptools/discussions/4128
     )
     return getattr(_modified, name)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Improve warning visibility with due date and reference url.

Closes #4131
Closes #4128

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
