### PR TITLE
Use the stdlib toml library on sufficiently new python

### DIFF
--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -11,6 +11,7 @@ with the help of ``tomllib`` or ``tomli``.
 
 import logging
 import os
+import sys
 from contextlib import contextmanager
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, Mapping, Optional, Set, Union
@@ -29,10 +30,13 @@ _logger = logging.getLogger(__name__)
 
 
 def load_file(filepath: _Path) -> dict:
-    from setuptools.extern import tomli  # type: ignore
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else: # pragma: no cover
+        from setuptools.extern import tomli as tomllib
 
     with open(filepath, "rb") as file:
-        return tomli.load(file)
+        return tomllib.load(file)
 
 
 def validate(config: dict, filepath: _Path) -> bool:


### PR DESCRIPTION
Although tomli is vendored and always available, it is more clean to avoid using the backport on python 3.11. This makes it easier to automatically drop outdated branches in the future, and is a micro-optimization when user code imports a toml library in the same process space.

Additionally, setuptools.extern.VendorImporter explicitly supports removing vendored modules as long as they are globally installed and available. For distributors that rely on this, importing tomllib first permits those distributors to avoid packaging tomli on versions of python that already have tomllib.