### PR TITLE
Emit warning for invalid [tools.setuptools] table

### DIFF
--- a/newsfragments/4150.feature.rst
+++ b/newsfragments/4150.feature.rst
@@ -1,0 +1,1 @@
+Emit a warning when ``[tools.setuptools]`` is present in ``pyproject.toml`` and will be ignored. -- by user:`SnoopJ`

--- a/newsfragments/4150.feature.rst
+++ b/newsfragments/4150.feature.rst
@@ -1,1 +1,1 @@
-Emit a warning when ``[tools.setuptools]`` is present in ``pyproject.toml`` and will be ignored. -- by user:`SnoopJ`
+Emit a warning when ``[tools.setuptools]`` is present in ``pyproject.toml`` and will be ignored. -- by :user:`SnoopJ`

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -108,6 +108,10 @@ def read_configuration(
     if not asdict or not (project_table or setuptools_table):
         return {}  # User is not using pyproject to configure setuptools
 
+    if "setuptools" in asdict.get("tools", {}):
+        # let the user know they probably have a typo in their metadata
+        _ToolsTypoInMetadata.emit()
+
     if "distutils" in tool_table:
         _ExperimentalConfiguration.emit(subject="[tool.distutils]")
 
@@ -438,4 +442,10 @@ class _ExperimentalConfiguration(SetuptoolsWarning):
     _SUMMARY = (
         "`{subject}` in `pyproject.toml` is still *experimental* "
         "and likely to change in future releases."
+    )
+
+
+class _ToolsTypoInMetadata(SetuptoolsWarning):
+    _SUMMARY = (
+        "Ignoring [tools.setuptools] in pyproject.toml, did you mean [tool.setuptools]?"
     )

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -394,4 +394,4 @@ def test_warn_tools_typo(tmp_path):
     pyproject.write_text(cleandoc(config), encoding="utf-8")
 
     with pytest.warns(_ToolsTypoInMetadata):
-        expanded = read_configuration(pyproject)
+        read_configuration(pyproject)

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -8,6 +8,7 @@ import tomli_w
 from path import Path
 
 from setuptools.config.pyprojecttoml import (
+    _ToolsTypoInMetadata,
     read_configuration,
     expand_configuration,
     apply_configuration,
@@ -369,3 +370,28 @@ def test_include_package_data_in_setuppy(tmp_path):
     assert dist.get_name() == "myproj"
     assert dist.get_version() == "42"
     assert dist.include_package_data is False
+
+
+def test_warn_tools_typo(tmp_path):
+    """Test that the common ``tools.setuptools`` typo in ``pyproject.toml`` issues a warning
+
+    See https://github.com/pypa/setuptools/issues/4150
+    """
+    config = """
+    [build-system]
+    requires = ["setuptools"]
+    build-backend = "setuptools.build_meta"
+
+    [project]
+    name = "myproj"
+    version = '42'
+
+    [tools.setuptools]
+    packages = ["package"]
+    """
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(cleandoc(config), encoding="utf-8")
+
+    with pytest.warns(_ToolsTypoInMetadata):
+        expanded = read_configuration(pyproject)

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -421,6 +421,7 @@ class TestTypeInfoFiles:
         jaraco.path.build(structure)
 
         build_py = get_finalized_build_py()
+        build_py.run_command("build")
         outputs = get_outputs(build_py)
         assert expected_type_files <= outputs
 

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -409,7 +409,14 @@ class TestTypeInfoFiles:
     }
 
     @pytest.mark.parametrize(
-        "pyproject", ["default_pyproject", "dont_include_package_data"]
+        "pyproject",
+        [
+            "default_pyproject",
+            pytest.param(
+                "dont_include_package_data",
+                marks=pytest.mark.xfail(reason="pypa/setuptools#4350"),
+            ),
+        ],
     )
     @pytest.mark.parametrize("example", EXAMPLES.keys())
     def test_type_files_included_by_default(self, tmpdir_cwd, pyproject, example):
@@ -421,7 +428,6 @@ class TestTypeInfoFiles:
         jaraco.path.build(structure)
 
         build_py = get_finalized_build_py()
-        build_py.run_command("build")
         outputs = get_outputs(build_py)
         assert expected_type_files <= outputs
 

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -349,7 +349,7 @@ class TestTypeInfoFiles:
             name = "foo"
             version = "1"
 
-            [tools.setuptools]
+            [tool.setuptools]
             include-package-data = false
             """
         ),
@@ -359,7 +359,7 @@ class TestTypeInfoFiles:
             name = "foo"
             version = "1"
 
-            [tools.setuptools]
+            [tool.setuptools]
             include-package-data = false
 
             [tool.setuptools.exclude-package-data]


### PR DESCRIPTION
## Summary of changes

This changeset adds a warning when the invalid `[tools.setuptools]` table is detected in `pyproject.toml` metadata, as a hint to users that any data they've declared there is being ignored by `setuptools`.

Closes #4150.

### Pull Request Checklist
- [ ] Changes have tests
  - I have not added a test because the `_ExperimentalConfiguration` warning in the affected module is also not tested. I'd be happy to write one if the maintainers would like one.
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
