### PR TITLE
`plistlib.readPlist()` is missing from Python ≥ 3.9

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -414,10 +414,10 @@ def _macos_vers(_cache=[]):
         if version == '':
             plist = '/System/Library/CoreServices/SystemVersion.plist'
             if os.path.exists(plist):
-                if hasattr(plistlib, 'readPlist'):
-                    plist_content = plistlib.readPlist(plist)
-                    if 'ProductVersion' in plist_content:
-                        version = plist_content['ProductVersion']
+                with open(plist, 'rb') as fh:
+                    plist_content = plistlib.load(fh)
+                if 'ProductVersion' in plist_content:
+                    version = plist_content['ProductVersion']
 
         _cache.append(version.split('.'))
     return _cache[0]

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -1,9 +1,11 @@
+import builtins
 import sys
 import tempfile
 import os
 import zipfile
 import datetime
 import time
+import plistlib
 import subprocess
 import stat
 import distutils.dist
@@ -321,6 +323,32 @@ def test_dist_info_is_not_dir(tmp_path, only):
     dist_info = tmp_path / 'foobar.dist-info'
     dist_info.touch()
     assert not pkg_resources.dist_factory(str(tmp_path), str(dist_info), only)
+
+
+@pytest.mark.skipif(sys.version_info >= (3, 9), reason="requires Python < 3.9")
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_macos_vers_fallback(monkeypatch, tmp_path):
+    """Regression test for pkg_resources._macos_vers"""
+    orig_open = builtins.open
+
+    # Pretend we need to use the plist file
+    monkeypatch.setattr('platform.mac_ver', mock.Mock(return_value=('', (), '')))
+
+    # Create fake content for the fake plist file
+    with open(tmp_path / 'fake.plist', 'wb') as fake_file:
+        plistlib.dump({"ProductVersion": "11.4"}, fake_file)
+
+    # Pretend the fake file exists
+    monkeypatch.setattr('os.path.exists', mock.Mock(return_value=True))
+
+    def fake_open(file, *args, **kwargs):
+        return orig_open(tmp_path / 'fake.plist', *args, **kwargs)
+
+    # Ensure that the _macos_vers works correctly
+    with mock.patch('builtins.open', mock.Mock(side_effect=fake_open)) as m:
+        assert pkg_resources._macos_vers([]) == ["11", "4"]
+
+    m.assert_called()
 
 
 class TestDeepVersionLookupDistutils:

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -325,8 +325,6 @@ def test_dist_info_is_not_dir(tmp_path, only):
     assert not pkg_resources.dist_factory(str(tmp_path), str(dist_info), only)
 
 
-@pytest.mark.skipif(sys.version_info >= (3, 9), reason="requires Python < 3.9")
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_macos_vers_fallback(monkeypatch, tmp_path):
     """Regression test for pkg_resources._macos_vers"""
     orig_open = builtins.open


### PR DESCRIPTION
## Summary of changes

This function has been deprecated since Python 3.4, replaced by `plistlib.load()`.

See https://github.com/python/cpython/pull/15615.

Fixes https://github.com/pypa/setuptools/pull/4168#discussion_r1440965290.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
