### PR TITLE
ruff: extend-exclude → exclude

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -26,14 +26,14 @@ extend-ignore = [
 	"UP032",  # temporarily disabled
 	"UP036",  # temporarily disabled
 ]
-extend-exclude = [
+exclude = [
 	"**/_vendor",
 	"setuptools/_distutils",
 	"setuptools/config/_validate_pyproject",
 ]
 
 [format]
-extend-exclude = [
+exclude = [
 	"**/_vendor",
 	"setuptools/_distutils",
 	"setuptools/config/_validate_pyproject",


### PR DESCRIPTION
## Summary of changes

There is no such thing as `extend-include`, at least in ruff 0.1.11:
````
ruff failed
  Cause: Failed to parse /path/to/ruff.toml
  Cause: TOML parse error at line 1, column 1
  |
1 | [lint]
  | ^^^^^^
unknown field `extend-exclude`
````

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
