### PR TITLE
Remove unnecessary `getattr` for `tokenize.open`

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -130,7 +130,7 @@ def _open_setup_script(setup_script):
         # Supply a default setup.py
         return io.StringIO("from setuptools import setup; setup()")
 
-    return getattr(tokenize, 'open', open)(setup_script)
+    return tokenize.open(setup_script)
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Apparently `gettattr(tokenize, 'open', open)` is [causing problems for some users](https://github.com/pypa/setuptools/issues/4152#issuecomment-1848851990). Somehow 🤷‍♂️
- The good news is tath `tokenize.open` is available on Python 3.2+, so we should be able to safely remove this `getattr` call.

Closes #4152.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
