### PR TITLE
Move `tomllib` import to `py311compat`

### DIFF
--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -11,7 +11,6 @@ with the help of ``tomllib`` or ``tomli``.
 
 import logging
 import os
-import sys
 from contextlib import contextmanager
 from functools import partial
 from typing import TYPE_CHECKING, Callable, Dict, Mapping, Optional, Set, Union
@@ -30,10 +29,7 @@ _logger = logging.getLogger(__name__)
 
 
 def load_file(filepath: _Path) -> dict:
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else: # pragma: no cover
-        from setuptools.extern import tomli as tomllib
+    from ..py311compat import tomllib
 
     with open(filepath, "rb") as file:
         return tomllib.load(file)

--- a/setuptools/py311compat.py
+++ b/setuptools/py311compat.py
@@ -1,0 +1,7 @@
+import sys
+
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    from setuptools.extern import tomli as tomllib


### PR DESCRIPTION
This approach follows pre-existing practices in the setuptools repository.

It makes it easier in the future to recognise code that can be updated and fallbacks that can be removed.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
