### PR TITLE
Default optional-dependencies to dict if missing in pyproject, fixes #3801

### DIFF
--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -409,7 +409,7 @@ _RESET_PREVIOUSLY_DEFINED: dict = {
     "scripts": {},
     "gui-scripts": {},
     "dependencies": [],
-    "optional-dependencies": [],
+    "optional-dependencies": {},
 }
 
 


### PR DESCRIPTION

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
