### PR TITLE
include-package-data can't find it in namespaces

### DIFF
--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -407,49 +407,6 @@ which enables the ``data`` directory to be identified, and then, we separately s
 files for the root package ``mypkg``, and the namespace package ``data`` under the package
 ``mypkg``.
 
-With ``include_package_data`` the configuration is simpler: you simply need to enable
-scanning of namespace packages in the ``src`` directory and the rest is handled by Setuptools.
-
-.. tab:: pyproject.toml
-
-   .. code-block:: toml
-
-        [tool.setuptools]
-        # ...
-        # By default, include-package-data is true in pyproject.toml, so you do
-        # NOT have to specify this line.
-        include-package-data = true
-
-        [tool.setuptools.packages.find]
-        # scanning for namespace packages is true by default in pyproject.toml, so
-        # you need NOT include the following line.
-        namespaces = true
-        where = ["src"]
-
-.. tab:: setup.cfg
-
-   .. code-block:: ini
-
-        [options]
-        packages = find_namespace:
-        package_dir =
-            = src
-        include_package_data = True
-
-        [options.packages.find]
-        where = src
-
-.. tab:: setup.py
-
-   .. code-block:: python
-
-        from setuptools import setup, find_namespace_packages
-        setup(
-            # ... ,
-            packages=find_namespace_packages(where="src"),
-            package_dir={"": "src"},
-            include_package_data=True,
-        )
 
 Summary
 =======

--- a/docs/userguide/datafiles.rst
+++ b/docs/userguide/datafiles.rst
@@ -12,6 +12,12 @@ Setuptools focuses on this most common type of data files and offers three ways
 of specifying which files should be included in your packages, as described in
 the following sections.
 
+The user may want to remove the automatically generated PKG-INFO, \*.egg-info,
+build, and dist folders when modifying the configuration files or doing
+structural changes in the directory/file structure. Failure to do so may result
+in an sdist that contains datafiles which are not in a simultaneously built
+wheel, and which will not be installed even if directly installing the sdist.
+
 include_package_data
 ====================
 


### PR DESCRIPTION
I generated a development release to demonstrate the issue: https://pypi.org/project/finitelycomputable-idtrust-common/24.0.dev1/#files

I was in this section of the documentation to try to get a templates data directory to be included in a package which is itself in the finitelycomputable namespace package.

The pyproject.toml uses the configuration described in the removed section. The sdist contains the needed template files, but they are not listed in SOURCES.txt, and the generated wheel does not include them. To include them it is not sufficient to uncomment the tool.setuptools.package-data table, you must also comment out the tool.setuptools.packages.find table. All of this revolves around SOURCES.txt, which is sometimes generated by the setuptools build backend. If you build it once in a way that adds the template files to SOURCES.txt, then even if you misconfigure the pyproject.toml, you are likely to get the template files anyway. I am sure I am not the first person to have been bitten by this, but I am even more certain that there are immovable obstacles preventing it from being better.

## Summary of changes

Removing misleading documentation about include-package-data

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
