### PR TITLE
[Docs] Quickstart - add `pyproject.toml` info to the declarative config section

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -11,7 +11,7 @@ Configuring setuptools using ``setup.cfg`` files
     build API) is desired, a ``setup.py`` file containing a ``setup()`` function
     call is still required even if your configuration resides in ``setup.cfg``.
 
-``Setuptools`` allows using configuration files (usually :file:`setup.cfg`)
+``Setuptools`` allows using configuration files (for example, :file:`setup.cfg`)
 to define a package’s metadata and other options that are normally supplied
 to the ``setup()`` function (declarative config).
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -450,15 +450,16 @@ declaratively - using ``setup.cfg`` or ``pyproject.toml``.
 
 To ease the challenges of transitioning, :doc:`here </userguide/declarative_config>`
 we provide a quick guide to understanding how ``setup.cfg`` is parsed by
-``setuptools``. Alternatively, :doc:`here <userguide/pyproject_config.html>`
-is the guide for ``pyproject.toml``.
+``setuptools``. Alternatively, :doc:`here <userguide/pyproject_config>` is the
+guide for ``pyproject.toml``.
 
-The approach ``setuptools`` would like to take is to eventually use a single
-declarative format (``pyproject.toml``) instead of maintaining 2
-(``pyproject.toml`` / ``setup.cfg``). Chances are, ``setup.cfg`` will
-continue to be maintained for a long time. Currently, ``pyproject.toml`` still
-has some `limitations <https://github.com/pypa/setuptools/issues/3683>`_.
+.. note::
 
+    The approach ``setuptools`` would like to take is to eventually use a single
+    declarative format (``pyproject.toml``) instead of maintaining 2
+    (``pyproject.toml`` / ``setup.cfg``). Chances are, ``setup.cfg`` will
+    continue to be maintained for a long time. Currently, ``pyproject.toml`` may 
+    still have some `limitations <https://github.com/pypa/setuptools/issues/3683>`_.
 
 .. _packaging-resources:
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -446,7 +446,7 @@ Transitioning from ``setup.py`` to declarative config
 -----------------------------------------------------
 To avoid executing arbitrary scripts and boilerplate code, we are transitioning
 from defining all your package information by running ``setup()`` to doing this
-declaratively - using ``pyproject.toml`` (or older ``setup.cfg``).
+declaratively - by using ``pyproject.toml`` (or older ``setup.cfg``).
 
 To ease the challenges of transitioning, we provide a quick 
 :doc:`guide </userguide/pyproject_config>` to understanding how ``pyproject.toml``
@@ -457,9 +457,8 @@ is the guide for ``setup.cfg``).
 
     The approach ``setuptools`` would like to take is to eventually use a single
     declarative format (``pyproject.toml``) instead of maintaining 2
-    (``pyproject.toml`` / ``setup.cfg``). Chances are, ``setup.cfg`` will
-    continue to be maintained for a long time. Currently, ``pyproject.toml`` may 
-    still have some `limitations <https://github.com/pypa/setuptools/issues/3683>`_.
+    (``pyproject.toml`` / ``setup.cfg``). Yet chances are, ``setup.cfg`` will
+    continue to be maintained for a long time.
 
 .. _packaging-resources:
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -446,12 +446,12 @@ Transitioning from ``setup.py`` to declarative config
 -----------------------------------------------------
 To avoid executing arbitrary scripts and boilerplate code, we are transitioning
 from defining all your package information by running ``setup()`` to doing this
-declaratively - using ``setup.cfg`` or ``pyproject.toml``.
+declaratively - using ``pyproject.toml`` (or older ``setup.cfg``).
 
-To ease the challenges of transitioning, :doc:`here </userguide/declarative_config>`
-we provide a quick guide to understanding how ``setup.cfg`` is parsed by
-``setuptools``. Alternatively, :doc:`here </userguide/pyproject_config>` is the
-guide for ``pyproject.toml``.
+To ease the challenges of transitioning, we provide a quick 
+:doc:`guide </userguide/pyproject_config>` to understanding how ``pyproject.toml``
+is parsed by ``setuptools``. (Alternatively, :doc:`here </userguide/declarative_config>`
+is the guide for ``setup.cfg``).
 
 .. note::
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -457,7 +457,7 @@ The approach ``setuptools`` would like to take is to eventually use a single
 declarative format (``pyproject.toml``) instead of maintaining 2
 (``pyproject.toml`` / ``setup.cfg``). Chances are, ``setup.cfg`` will
 continue to be maintained for a long time. Currently, ``pyproject.toml`` still
-has some `limitations <https://github.com/pypa/setuptools/issues/3683>`.
+has some `limitations <https://github.com/pypa/setuptools/issues/3683>`_.
 
 
 .. _packaging-resources:

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -457,8 +457,7 @@ The approach ``setuptools`` would like to take is to eventually use a single
 declarative format (``pyproject.toml``) instead of maintaining 2
 (``pyproject.toml`` / ``setup.cfg``). Chances are, ``setup.cfg`` will
 continue to be maintained for a long time. Currently, ``pyproject.toml`` still
-has some `limitations <pypa/setuptools#3518>` for certain users.
-
+has some `limitations <https://github.com/pypa/setuptools/issues/3683>`.
 
 
 .. _packaging-resources:

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -457,7 +457,7 @@ is the guide for ``setup.cfg``).
 
     The approach ``setuptools`` would like to take is to eventually use a single
     declarative format (``pyproject.toml``) instead of maintaining 2
-    (``pyproject.toml`` / ``setup.cfg``). Yet chances are, ``setup.cfg`` will
+    (``pyproject.toml`` / ``setup.cfg``). Yet, chances are, ``setup.cfg`` will
     continue to be maintained for a long time.
 
 .. _packaging-resources:

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -450,7 +450,7 @@ declaratively - using ``setup.cfg`` or ``pyproject.toml``.
 
 To ease the challenges of transitioning, :doc:`here </userguide/declarative_config>`
 we provide a quick guide to understanding how ``setup.cfg`` is parsed by
-``setuptools``. Alternatively, :doc:`here <userguide/pyproject_config>` is the
+``setuptools``. Alternatively, :doc:`here </userguide/pyproject_config>` is the
 guide for ``pyproject.toml``.
 
 .. note::

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -442,14 +442,24 @@ distribution so others can use it. This functionality is provided by
 <PyPUG:tutorials/packaging-projects>`.
 
 
-Transitioning from ``setup.py`` to ``setup.cfg``
-------------------------------------------------
+Transitioning from ``setup.py`` to declarative config
+-----------------------------------------------------
 To avoid executing arbitrary scripts and boilerplate code, we are transitioning
-into a full-fledged ``setup.cfg`` to declare your package information instead
-of running ``setup()``. This inevitably brings challenges due to a different
-syntax. :doc:`Here </userguide/declarative_config>` we provide a quick guide to
-understanding how ``setup.cfg`` is parsed by ``setuptools`` to ease the pain of
-transition.
+from defining all your package information by running ``setup()`` to doing this
+declaratively - using ``setup.cfg`` or ``pyproject.toml``.
+
+To ease the challenges of transitioning, :doc:`here </userguide/declarative_config>`
+we provide a quick guide to understanding how ``setup.cfg`` is parsed by
+``setuptools``. Alternatively, :doc:`here <userguide/pyproject_config.html>`
+is the guide for ``pyproject.toml``.
+
+The approach ``setuptools`` would like to take is to eventually use a single
+declarative format (``pyproject.toml``) instead of maintaining 2
+(``pyproject.toml`` / ``setup.cfg``). Chances are, ``setup.cfg`` will
+continue to be maintained for a long time. Currently, ``pyproject.toml`` still
+has some `limitations <pypa/setuptools#3518>` for certain users.
+
+
 
 .. _packaging-resources:
 

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -450,8 +450,8 @@ declaratively - by using ``pyproject.toml`` (or older ``setup.cfg``).
 
 To ease the challenges of transitioning, we provide a quick 
 :doc:`guide </userguide/pyproject_config>` to understanding how ``pyproject.toml``
-is parsed by ``setuptools``. (Alternatively, :doc:`here </userguide/declarative_config>`
-is the guide for ``setup.cfg``).
+is parsed by ``setuptools``. (Alternatively, here is the 
+:doc:`guide </userguide/declarative_config>` for ``setup.cfg``).
 
 .. note::
 

--- a/newsfragments/4200.doc.rst
+++ b/newsfragments/4200.doc.rst
@@ -1,0 +1,1 @@
+Updated "Quickstart" to describe the current status of ``setup.cfg`` and ``pyproject.toml`` -- by :user:`VladimirFokow`


### PR DESCRIPTION
## Summary of changes

[Preview](https://setuptools--4204.org.readthedocs.build/en/4204/userguide/quickstart.html#transitioning-from-setup-py-to-declarative-config).

- Update the section about transitioning from ``setup.py`` to declarative config - so that it not only has `setup.cfg` but also `pyproject.toml`, and gives important context to the new users who are learning about these files for the first time.

- Extract useful information about these files from GitHub comments to the docs. The new description conforms to the comments:

  - [quote](https://github.com/pypa/setuptools/issues/3214#issue-1181816465)
  > the approach `setuptools` would like to take is to eventually use a single declarative format (pyproject.toml) instead of maintaining 2 (`pyproject.toml` / `setup.cfg`).

  - [quote](https://github.com/pypa/setuptools/issues/3214#issuecomment-1715689591)
  > For the time being there it is not in the horizon of events to drop `setup.cfg` completely. `setup.cfg` has not even been deprecated yet.
Even if we eventually drop the custom parsing, chances are it will still keep working via "transpiling" it to `pyproject.toml` syntax for a long time, until it is safe to assume everyone moved out of it.

  - [quote](https://github.com/pypa/setuptools/issues/3683#issuecomment-1380668530)
  > Using pyproject.toml, however, imposes [constraints (specially around dynamic)](https://peps.python.org/pep-0621/#dynamic) to the build. Some users are not comfortable with these constraints, so I don't think there should be a "black and white" recommendation.

Note:
Maybe an `info` box was more appropriate than `note`? 
I don't know the rules here or if it even matters, but `info`'s syntax looked complicated so I chose a simple `.. note::`

<br />

Please, suggest edits if this section can be made more accurate. 
I think it's important to update this section from what it [currently is](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#transitioning-from-setup-py-to-setup-cfg).


<br />

Closes  #4200

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`]