### PR TITLE
fix data_files kwarg documentation

### DIFF
--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -186,7 +186,9 @@ extensions).
         ``data_files`` is deprecated. It does not work with wheels, so it
         should be avoided.
 
-    A sequence of (*directory*, *files*) pairs.
+    A sequence of (*directory*, *files*) pairs specifying the data files to install.
+    *directory* is a str, *files* is a sequence of files.
+    Each (*directory*, *files*) pair in the sequence specifies the installation directory and the files to install there.
 
 .. _keyword/package_dir:
 

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -186,7 +186,7 @@ extensions).
         ``data_files`` is deprecated. It does not work with wheels, so it
         should be avoided.
 
-    A list of strings specifying the data files to install.
+    A sequence of (*directory*, *files*) pairs.
 
 .. _keyword/package_dir:
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

fix data_files kwarg documentation. Setting data_files to a list of str results in a warning being printed: https://github.com/pypa/setuptools/blob/259af91d90cc1259634e01c334caad3507ec9ad2/docs/deprecated/distutils/setupscript.rst#L549-L551

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
