### PR TITLE
remove claim that data_files does not work with wheels

### DIFF
--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -182,17 +182,32 @@ extensions).
 .. _keyword/data_files:
 
 ``data_files``
-    .. warning::
-        This is an advanced feature and it is *not intended to work with absolute installation paths*.
-        All files listed in ``data_files`` will be installed in paths relative to a directory
-        decided by the package installer (e.g. `pip`),
-        which usually results in nesting under a virtual environment.
-        See :doc:`/userguide/datafiles` for an alternative placing inside the package directory.
-        Please do not use this setting for things like man-pages, application launchers or anything that requires system-wide installation.
+    .. attention::
+        **DISCOURAGED** - This is an advanced feature and it is
+        *not intended to work with absolute paths*.
+        All files listed in ``data_files`` will be installed in paths relative
+        to a directory decided by the package installer (e.g. `pip`).
+        This usually results in nesting under a virtual environment.
+        We **STRONGLY ADVISE AGAINST** using this setting for things like
+        application launchers, desktop files or anything that requires
+        system-wide installation [#manpages]_, unless you have extensive
+        experience in Python packaging and has carefully considered all the
+        drawbacks, limitations and problems of this method.
+        Also note that this feature is provided *as is* with no plans of
+        further changes.
 
-    A sequence of (*directory*, *files*) pairs specifying the data files to install.
-    *directory* is a str, *files* is a sequence of files.
-    Each (*directory*, *files*) pair in the sequence specifies the installation directory and the files to install there.
+    .. tip::
+        See :doc:`/userguide/datafiles` for an alternative method that uses the
+        package directory itself and works well with :mod:`importlib.resources`,
+        or consider using libraries such as :pypi:`platformdirs` for creating
+        and managing files at runtime (i.e., **not** during the installation).
+
+    A sequence of ``(directory, files)`` pairs specifying the data files to install
+    (``directory`` is a :class:`str`, ``files`` is a sequence of :class:`str`).
+    Each ``(directory, files)`` pair in the sequence specifies the installation directory
+    and the files to install there.
+
+.. _discussion in Python discourse: https://discuss.python.org/t/should-there-be-a-new-standard-for-installing-arbitrary-data-files/7853/63
 
 .. _keyword/package_dir:
 
@@ -505,3 +520,10 @@ extensions).
     An arbitrary map of URL names to hyperlinks, allowing more extensible
     documentation of where various resources can be found than the simple
     ``url`` and ``download_url`` options provide.
+
+
+.. [#manpages] It is common for developers to attempt using ``data_files`` for manpages.
+   Please note however that depending on the installation directory, this will
+   not work out of the box - often the final user is required to change the
+   ``MANPATH`` environment variable.
+   See the `discussion in Python discourse`_ for more details.

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -183,7 +183,12 @@ extensions).
 
 ``data_files``
     .. warning::
-        ``data_files`` is deprecated.
+        This is an advanced feature and it is *not intended to work with absolute installation paths*.
+        All files listed in ``data_files`` will be installed in paths relative to a directory
+        decided by the package installer (e.g. `pip`),
+        which usually results in nesting under a virtual environment.
+        See :docs:`userguide/datafiles` for an alternative placing inside the package directory.
+        Please do not use this setting for things like man-pages, application launchers or anything that requires system-wide installation.
 
     A sequence of (*directory*, *files*) pairs specifying the data files to install.
     *directory* is a str, *files* is a sequence of files.

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -187,7 +187,7 @@ extensions).
         All files listed in ``data_files`` will be installed in paths relative to a directory
         decided by the package installer (e.g. `pip`),
         which usually results in nesting under a virtual environment.
-        See :doc:`userguide/datafiles` for an alternative placing inside the package directory.
+        See :doc:`/userguide/datafiles` for an alternative placing inside the package directory.
         Please do not use this setting for things like man-pages, application launchers or anything that requires system-wide installation.
 
     A sequence of (*directory*, *files*) pairs specifying the data files to install.

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -183,8 +183,7 @@ extensions).
 
 ``data_files``
     .. warning::
-        ``data_files`` is deprecated. It does not work with wheels, so it
-        should be avoided.
+        ``data_files`` is deprecated.
 
     A list of strings specifying the data files to install.
 

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -187,7 +187,7 @@ extensions).
         All files listed in ``data_files`` will be installed in paths relative to a directory
         decided by the package installer (e.g. `pip`),
         which usually results in nesting under a virtual environment.
-        See :docs:`userguide/datafiles` for an alternative placing inside the package directory.
+        See :doc:`userguide/datafiles` for an alternative placing inside the package directory.
         Please do not use this setting for things like man-pages, application launchers or anything that requires system-wide installation.
 
     A sequence of (*directory*, *files*) pairs specifying the data files to install.

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -191,7 +191,7 @@ extensions).
         We **STRONGLY ADVISE AGAINST** using this setting for things like
         application launchers, desktop files or anything that requires
         system-wide installation [#manpages]_, unless you have extensive
-        experience in Python packaging and has carefully considered all the
+        experience in Python packaging and have carefully considered all the
         drawbacks, limitations and problems of this method.
         Also note that this feature is provided *as is* with no plans of
         further changes.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

remove claim that data_files does not work with wheels, it does work with wheels, the data goes into the `distribution-1.0.data/data` dir which then gets copied into the installation prefix. What doesn't work is: "Distutils allows directory to be an absolute installation path, but this is discouraged since it is incompatible with the wheel packaging format"

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
