### PR TITLE
Merge latest skeleton

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,3 +10,7 @@ disable_warnings =
 
 [report]
 show_missing = True
+exclude_also =
+	# jaraco/skeleton#97
+	@overload
+	if TYPE_CHECKING:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,6 @@ python:
 
 # required boilerplate readthedocs/readthedocs.org#10401
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3"
+    python: latest

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@
 .. image:: https://img.shields.io/readthedocs/setuptools/latest.svg
     :target: https://setuptools.pypa.io
 
-.. image:: https://img.shields.io/badge/skeleton-2023-informational
+.. image:: https://img.shields.io/badge/skeleton-2024-informational
    :target: https://blog.jaraco.com/skeleton
 
 .. image:: https://img.shields.io/codecov/c/github/pypa/setuptools/master.svg?logo=codecov&logoColor=white

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,5 +38,7 @@ exclude = [
 	"setuptools/_distutils",
 	"setuptools/config/_validate_pyproject",
 ]
+# Enable preview, required for quote-style = "preserve"
+preview = true
 # https://docs.astral.sh/ruff/settings/#format-quote-style
 quote-style = "preserve"

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,10 +30,6 @@ install_requires =
 
 [options.packages.find]
 exclude =
-	build*
-	dist*
-	docs*
-	tests*
 	*.tests
 	*.tests.*
 	tools*

--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -161,6 +161,7 @@ def extract_constant(code, symbol, default=-1):
 
     return None
 
+
 def _update_globals():
     """
     Patch the globals to remove the objects not available on some platforms.

--- a/setuptools/py311compat.py
+++ b/setuptools/py311compat.py
@@ -1,6 +1,9 @@
 import sys
 
 
+__all__ = ['tomllib']
+
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:  # pragma: no cover

--- a/setuptools/tests/integration/helpers.py
+++ b/setuptools/tests/integration/helpers.py
@@ -16,7 +16,7 @@ def run(cmd, env=None):
     r = subprocess.run(
         cmd,
         capture_output=True,
-        universal_newlines=True,
+        text=True,
         env={**os.environ, **(env or {})},
         # ^-- allow overwriting instead of discarding the current env
     )

--- a/setuptools/tests/server.py
+++ b/setuptools/tests/server.py
@@ -1,5 +1,4 @@
-"""Basic http server for tests to simulate PyPI or custom indexes
-"""
+"""Basic http server for tests to simulate PyPI or custom indexes"""
 
 import os
 import time

--- a/setuptools/tests/test_bdist_deprecations.py
+++ b/setuptools/tests/test_bdist_deprecations.py
@@ -1,5 +1,4 @@
-"""develop tests
-"""
+"""develop tests"""
 
 import sys
 from unittest import mock

--- a/setuptools/tests/test_bdist_egg.py
+++ b/setuptools/tests/test_bdist_egg.py
@@ -1,5 +1,4 @@
-"""develop tests
-"""
+"""develop tests"""
 
 import os
 import re

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -1,5 +1,4 @@
-"""develop tests
-"""
+"""develop tests"""
 
 import os
 import sys

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -1,5 +1,4 @@
-"""Test .dist-info style distributions.
-"""
+"""Test .dist-info style distributions."""
 
 import pathlib
 import re

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1,5 +1,4 @@
-"""Easy install Tests
-"""
+"""Easy install Tests"""
 
 import sys
 import os

--- a/setuptools/tests/test_install_scripts.py
+++ b/setuptools/tests/test_install_scripts.py
@@ -1,5 +1,4 @@
-"""install_scripts tests
-"""
+"""install_scripts tests"""
 
 import sys
 

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -1,4 +1,3 @@
-import sys
 import distutils.errors
 import urllib.request
 import urllib.error

--- a/setuptools/tests/test_sandbox.py
+++ b/setuptools/tests/test_sandbox.py
@@ -1,5 +1,4 @@
-"""develop tests
-"""
+"""develop tests"""
 
 import os
 import types

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -1,5 +1,4 @@
-"""wheel tests
-"""
+"""wheel tests"""
 
 from distutils.sysconfig import get_config_var
 from distutils.util import get_platform


### PR DESCRIPTION
- Bump year on badge
- Remove build and dist from excludes. It appears they are not needed and their presence blocks the names of packages like 'builder' and 'distutils'. Ref pypa/distutils#224.
- Exclude docs and tests directories properly per Setuptools behavior.
- Rely on default discovery for good heuristics for finding packages.
- Enable preview to enable preserving quotes.
- Tweak coverage configuration for type checking (jaraco/skeleton#97)
- Use latest versions in RTD boilerplate.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
