### PR TITLE
Restore egg link names with dashes for now

### DIFF
--- a/docs/deprecated/python_eggs.rst
+++ b/docs/deprecated/python_eggs.rst
@@ -193,6 +193,14 @@ Python version, or platform information is included.  When the runtime
 searches for available eggs, ``.egg-link`` files are opened and the
 actual egg file/directory name is read from them.
 
+Note: Due to `pypa/setuptools#4167
+<https://github.com/pypa/setuptools/issues/4167>`_, the name in the egg-link
+filename does not match the filename components used in similar files, but
+instead presents with dash separators instead of underscore separators. For
+compatibility with pip prior to version 24.0, these dash separators are
+retained. In a future release, pip 24 or later will be required and the
+underscore separators will be used.
+
 Each ``.egg-link`` file should contain a single file or directory name,
 with no newlines.  This filename should be the base location of one or
 more eggs.  That is, the name must either end in ``.egg``, or else it

--- a/docs/deprecated/python_eggs.rst
+++ b/docs/deprecated/python_eggs.rst
@@ -131,12 +131,12 @@ egg filename is as follows::
 
     name ["-" version ["-py" pyver ["-" required_platform]]] "." ext
 
-The "name" and "version" should be escaped using the ``to_filename()``
-function provided by ``pkg_resources``, after first processing them with
-``safe_name()`` and ``safe_version()`` respectively. Note that the escaping is
-irreversible and the original name can only be retrieved from the distribution
-metadata. For a detailed description of these transformations, please see the
-"Parsing Utilities" section of the ``pkg_resources`` manual.
+The "name" and "version" should be escaped using ``pkg_resources`` functions
+``safe_name()`` and ``safe_version()`` respectively then using
+``to_filename()``. Note that the escaping is irreversible and the original
+name can only be retrieved from the distribution metadata. For a detailed
+description of these transformations, please see the "Parsing Utilities"
+section of the ``pkg_resources`` manual.
 
 The "pyver" string is the Python major version, as found in the first
 3 characters of ``sys.version``.  "required_platform" is essentially

--- a/docs/deprecated/python_eggs.rst
+++ b/docs/deprecated/python_eggs.rst
@@ -133,10 +133,10 @@ egg filename is as follows::
 
 The "name" and "version" should be escaped using the ``to_filename()``
 function provided by ``pkg_resources``, after first processing them with
-``safe_name()`` and ``safe_version()`` respectively.  These latter two
-functions can also be used to later "unescape" these parts of the
-filename.  (For a detailed description of these transformations, please
-see the "Parsing Utilities" section of the ``pkg_resources`` manual.)
+``safe_name()`` and ``safe_version()`` respectively. Note that the escaping is
+irreversible and the original name can only be retrieved from the distribution
+metadata. For a detailed description of these transformations, please see the
+"Parsing Utilities" section of the ``pkg_resources`` manual.
 
 The "pyver" string is the Python major version, as found in the first
 3 characters of ``sys.version``.  "required_platform" is essentially

--- a/newsfragments/4167.bugfix.rst
+++ b/newsfragments/4167.bugfix.rst
@@ -1,0 +1,1 @@
+Restored expectation that egg-link files would be named with dash separators for compatibility with pip prior to version 24.

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -120,6 +120,21 @@ def filename_component(value: str) -> str:
     return value.replace("-", "_").strip("_")
 
 
+def filename_component_broken(value: str) -> str:
+    """
+    Produce the incorrect filename component for compatibility.
+
+    See pypa/setuptools#4167 for detailed analysis.
+
+    TODO: replace this with filename_component after pip 24 is
+    nearly-ubiquitous.
+
+    >>> filename_component_broken('foo_bar-baz')
+    'foo-bar-baz'
+    """
+    return value.replace('_', '-')
+
+
 def safer_name(value: str) -> str:
     """Like ``safe_name`` but can be used as filename component for wheel"""
     # See bdist_wheel.safer_name

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -5,6 +5,7 @@ import os
 import glob
 
 from setuptools.command.easy_install import easy_install
+from setuptools import _normalization
 from setuptools import _path
 from setuptools import namespaces
 import setuptools
@@ -52,7 +53,9 @@ class develop(namespaces.DevelopInstaller, easy_install):
         # pick up setup-dir .egg files only: no .egg-info
         self.package_index.scan(glob.glob('*.egg'))
 
-        egg_link_fn = ei.egg_name + '.egg-link'
+        egg_link_fn = (
+            _normalization.filename_component_broken(ei.egg_name) + '.egg-link'
+        )
         self.egg_link = os.path.join(self.install_dir, egg_link_fn)
         self.egg_base = ei.egg_base
         if self.egg_path is None:

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import subprocess
+import pathlib
 import platform
 
 from setuptools.command import test
@@ -81,6 +82,18 @@ class TestDevelop:
         cmd.install_dir = tmpdir
         cmd.run()
         # assert '0.0' not in foocmd_text
+
+    @pytest.mark.xfail(reason="legacy behavior retained for compatibility #4167")
+    def test_egg_link_filename(self):
+        settings = dict(
+            name='Foo $$$ Bar_baz-bing',
+        )
+        dist = Distribution(settings)
+        cmd = develop(dist)
+        cmd.ensure_finalized()
+        link = pathlib.Path(cmd.egg_link)
+        assert link.suffix == '.egg-link'
+        assert link.stem == 'Foo_Bar_baz_bing'
 
 
 class TestResolver:


### PR DESCRIPTION
- Restore expectation that egg-link files will be named with dashes and not underscores for compatibility with older pips.
- Replace the incorrect phrase about 'unescaping' and instead clarify that the transformations are irreversible.
- Rearrange escaping functions to describe them in the order they should be used.
- Document the incorrect behavior revealed by #4167.
- Add a test capturing the desired expectation, marked as xfail for now.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Ref #4167

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
