### PR TITLE
Append arbitrary args instead of prepending.

### DIFF
--- a/newsfragments/4217.bugfix.rst
+++ b/newsfragments/4217.bugfix.rst
@@ -1,0 +1,2 @@
+Fix argument order of ``--config-settings["--build-option"]`` arguments.
+This was broken by <https://github.com/pypa/setuptools/pull/4079>`.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -369,7 +369,12 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         return self._bubble_up_info_directory(metadata_directory, ".dist-info")
 
     def _build_with_temp_dir(
-        self, setup_command, result_extension, result_directory, config_settings
+        self,
+        setup_command,
+        result_extension,
+        result_directory,
+        config_settings,
+        arbitrary_args=(),
     ):
         result_directory = os.path.abspath(result_directory)
 
@@ -384,6 +389,7 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
                 *setup_command,
                 "--dist-dir",
                 tmp_dist_dir,
+                *arbitrary_args,
             ]
             with no_install_setup_requires():
                 self.run_setup()
@@ -402,10 +408,11 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
     ):
         with suppress_known_deprecation():
             return self._build_with_temp_dir(
-                ['bdist_wheel', *self._arbitrary_args(config_settings)],
+                ['bdist_wheel'],
                 '.whl',
                 wheel_directory,
                 config_settings,
+                self._arbitrary_args(config_settings),
             )
 
     def build_sdist(self, sdist_directory, config_settings=None):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -720,6 +720,16 @@ class TestBuildMetaBackend:
         build_backend.build_editable("temp")
         assert not Path("build").exists()
 
+    def test_build_wheel_inplace(self, tmpdir_cwd):
+        config_settings = {"--build-option": ["build_ext", "--inplace"]}
+        path.build(self._simple_pyproject_example)
+        build_backend = self.get_build_backend()
+        assert not Path("build").exists()
+        Path("build").mkdir()
+        build_backend.prepare_metadata_for_build_wheel("build", config_settings)
+        build_backend.build_wheel("build", config_settings)
+        assert Path("build/proj-42-py3-none-any.whl").exists()
+
     @pytest.mark.parametrize("config_settings", [{"editable-mode": "strict"}])
     def test_editable_with_config_settings(self, tmpdir_cwd, config_settings):
         path.build({**self._simple_pyproject_example, '_meta': {}})


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Restore original argument append behavior which was changed in #4079.

Fixes:
```
error: option --dist-dir not recognized

ERROR Backend subprocess exited when trying to invoke build_wheel
```

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
