### PR TITLE
Avoid using private `_config_vars`

### DIFF
--- a/setuptools/_distutils/tests/test_util.py
+++ b/setuptools/_distutils/tests/test_util.py
@@ -33,7 +33,7 @@ def environment(monkeypatch):
     monkeypatch.setattr(os.path, 'join', os.path.join)
     monkeypatch.setattr(os.path, 'isabs', os.path.isabs)
     monkeypatch.setattr(os.path, 'splitdrive', os.path.splitdrive)
-    monkeypatch.setattr(sysconfig, '_config_vars', copy(sysconfig._config_vars))
+    monkeypatch.setattr(sysconfig, 'get_config_vars', sysconfig.get_config_vars)
 
 
 @pytest.mark.usefixtures('save_env')

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from distutils.command.build_ext import build_ext as _du_build_ext
 from distutils.ccompiler import new_compiler
-from distutils.sysconfig import customize_compiler, get_config_var
+from distutils.sysconfig import customize_compiler, get_config_var, get_config_vars
 from distutils import log
 
 from setuptools.errors import BaseError
@@ -26,7 +26,8 @@ except ImportError:
 
 # make sure _config_vars is initialized
 get_config_var("LDSHARED")
-from distutils.sysconfig import _config_vars as _CONFIG_VARS  # noqa
+
+_CONFIG_VARS = get_config_vars()
 
 
 def _customize_compiler_for_shlib(compiler):

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -24,9 +24,6 @@ try:
 except ImportError:
     _build_ext = _du_build_ext
 
-# make sure _config_vars is initialized
-get_config_var("LDSHARED")
-
 _CONFIG_VARS = get_config_vars()
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
This PR attempts to avoid using a private global variables, to instead use the available public API. This resolves a `noqa` and upcomming `type: ignore` in https://github.com/pypa/setuptools/pull/3979/files#diff-820ceee125a584dd996725a342b2aaec47c5e96399faf426348dfeebe242ea4bR31  
All 3 implementations of `get_config_vars` (in `sysconfig`, `distutils.sysconfig`, and `setuptools._distutils.sysconfig`) return the global dictionary directly (not a copy), so usage in `build_ext` should be equivalent.
`get_config_vars` also already ensures `_config_vars` is initialized

I'm not sure about the test change however. 
<!-- Summary goes here -->


### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`]. (I don't think this counts as user-facing changes?)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
