### PR TITLE
Fix "ModuleNotFoundError" for bdist_wheel on Python 3.12

### DIFF
--- a/newsfragments/4229.bugfix.rst
+++ b/newsfragments/4229.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed distutils ``ModuleNotFoundError`` for ``setup.py bdist_wheel`` on Python 3.12 -- by :user:`christian-krieg`

--- a/setuptools/_distutils/util.py
+++ b/setuptools/_distutils/util.py
@@ -430,6 +430,7 @@ def byte_compile(  # noqa: C901
             with script:
                 script.write(
                     """\
+import setuptools
 from distutils.util import byte_compile
 files = [
 """


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
When running ``python3 setup.py bdist_wheel`` on Python 3.12, setuptools exits with:

```
writing byte-compilation script '/tmp/<tmpfilename>.py'
[...]
Traceback (most recent call last):
  File "/tmp/<tmpfilename>.py", line 1, in <module>
    from distutils.util import byte_compile
ModuleNotFoundError: No module named 'distutils'
```
After some research, I learned that `distutils` moved to `setuptools` (https://github.com/pypa/setuptools/issues/3661).

Importing `setuptools` in the generated byte-compilation script solves the issue.

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
