### PR TITLE
Remove IDE-specific folder from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,5 @@ setuptools.egg-info
 *~
 .hg*
 .cache
-.idea/
 .pytest_cache/
 .mypy_cache/


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

According to https://github.com/pypa/setuptools/pull/3979?notification_referrer_id=NT_kwDOABSbuLI3MDA2MzAwNzU2OjEzNTA1ODQ#discussion_r1499161632 and https://blog.jaraco.com/skeleton/#ignoring-artifacts this probably shouldn't be in there. This PR is a simple cleanup removing `.idea/` to respect that.

As a sidenote, maybe linking to the above documentation *in* the `.gitignore` file would be a good idea?
<!-- Summary goes here -->


### Pull Request Checklist
- [ ] Changes have tests (N/A)
- [ ] News fragment added in [`newsfragments/`]. (no user facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
