### PR TITLE
Using vendored distutils._modified directly in build_clib

### DIFF
--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -3,7 +3,7 @@ from distutils.errors import DistutilsSetupError
 from distutils import log
 
 # Using vendored version directly because distutils._modified doesn't exist in stdlib
-from .._distutils._modified import newer_pairwise_group
+from setuptools.modified import newer_pairwise_group
 
 
 class build_clib(orig.build_clib):

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -2,11 +2,8 @@ import distutils.command.build_clib as orig
 from distutils.errors import DistutilsSetupError
 from distutils import log
 
-try:
-    from distutils._modified import newer_pairwise_group
-except ImportError:
-    # fallback for SETUPTOOLS_USE_DISTUTILS=stdlib
-    from .._distutils._modified import newer_pairwise_group
+# Using vendored version directly because distutils._modified doesn't exist in stdlib
+from .._distutils._modified import newer_pairwise_group
 
 
 class build_clib(orig.build_clib):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Noticed here https://github.com/pypa/setuptools/pull/3979#discussion_r1498494873
>  `_modified` [doesn't exist in stdlib](https://github.com/python/cpython/tree/3.11/Lib/distutils) (it was added in the vendored distutils). And `distutils.dep_util.newer_pairwise_group` doesn't exist either. So I don't see why `setuptools.modified` or `.._distutils._modified` couldn't always be used directly.

Work towards #2345 by having 1 less untyped import
<!-- Summary goes here -->


### Pull Request Checklist
- [x] Changes have tests (existing `SETUPTOOLS_USE_DISTUTILS` tests should pass)
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
