### PR TITLE
Properly lookup MSVC path for VS 2017 and newer

### DIFF
--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -774,6 +774,19 @@ class SystemInfo:
 
         guess_vc = join(vs_dir, r'VC\Tools\MSVC')
 
+        # Try to see if Tools version default file exists, and use that for version
+        # https://devblogs.microsoft.com/cppblog/finding-the-visual-c-compiler-tools-in-visual-studio-2017/#identifying-the-vc-compiler-tools-version
+        try:
+            default_file = join(vs_dir, r'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt')
+            with open(default_file) as f:
+                default_version = f.read().strip()
+            vc_ver_folder = join(guess_vc, default_version)
+            if isdir(vc_ver_folder):
+                self.vc_ver = self._as_float_version(default_version)
+                return vc_ver_folder
+        except:
+            pass
+
         # Subdir with VC exact version as name
         try:
             # Update the VC version with real one instead of VS version


### PR DESCRIPTION
## Summary of changes

The search method for finding toolchains installed with VS 2017 or newer is not correct. It currently performs a listdir() on the MSVC directory, and selects the last one in the list. However, listdir() is not guaranteed to be sorted. This can result in an older toolchain being selected, and at random. Whereas most users would probably prefer the newest toolchain (And it appears like the function is meant to do so.

Microsoft actually provides a recommended way to search for the default toolchain for a Visual Studio version at https://devblogs.microsoft.com/cppblog/finding-the-visual-c-compiler-tools-in-visual-studio-2017/#identifying-the-vc-compiler-tools-version

How this works is in VC\Auxiliary\Build, there is a file `Microsoft.VCToolsVersion.default.txt`. That file contains just the version of the default toolchain. Plugging that version into `VC\Tools\MSVC\VERSION_NUMBER_HERE` will result in the default toolchain for that copy of Visual Studio. 

This PR updates the MSVC lookup to use the proper default toolchain search mechanism. If that fails, the old directory search mechanism is attempted.

We ran into this issue on GitHub actions, where the newest Windows runners pushed this week actually seem to pick up an older version of the toolchain. This is because the sort order of the toolchain folders is not stable, and cannot be trusted.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
