### PR TITLE
Use `pathlib` instead of `py`

### DIFF
--- a/newsfragments/4237.misc.rst
+++ b/newsfragments/4237.misc.rst
@@ -1,0 +1,1 @@
+Drop dependency on `py`. Bump ``pytest-xdist`` to ``>=3`` and use `pathlib` instead in tests -- by :user:`Avasam`

--- a/pkg_resources/tests/test_find_distributions.py
+++ b/pkg_resources/tests/test_find_distributions.py
@@ -1,9 +1,10 @@
-import py
+from pathlib import Path
+import shutil
 import pytest
 import pkg_resources
 
 
-TESTS_DATA_DIR = py.path.local(__file__).dirpath('data')
+TESTS_DATA_DIR = Path(__file__).parent / 'data'
 
 
 class TestFindDistributions:
@@ -19,21 +20,31 @@ class TestFindDistributions:
         assert not list(dists)
 
     def test_standalone_egg_directory(self, target_dir):
-        (TESTS_DATA_DIR / 'my-test-package_unpacked-egg').copy(target_dir)
+        shutil.copytree(
+            TESTS_DATA_DIR / 'my-test-package_unpacked-egg',
+            target_dir,
+            dirs_exist_ok=True,
+        )
         dists = pkg_resources.find_distributions(str(target_dir))
         assert [dist.project_name for dist in dists] == ['my-test-package']
         dists = pkg_resources.find_distributions(str(target_dir), only=True)
         assert not list(dists)
 
     def test_zipped_egg(self, target_dir):
-        (TESTS_DATA_DIR / 'my-test-package_zipped-egg').copy(target_dir)
+        shutil.copytree(
+            TESTS_DATA_DIR / 'my-test-package_zipped-egg',
+            target_dir,
+            dirs_exist_ok=True,
+        )
         dists = pkg_resources.find_distributions(str(target_dir))
         assert [dist.project_name for dist in dists] == ['my-test-package']
         dists = pkg_resources.find_distributions(str(target_dir), only=True)
         assert not list(dists)
 
     def test_zipped_sdist_one_level_removed(self, target_dir):
-        (TESTS_DATA_DIR / 'my-test-package-zip').copy(target_dir)
+        shutil.copytree(
+            TESTS_DATA_DIR / 'my-test-package-zip', target_dir, dirs_exist_ok=True
+        )
         dists = pkg_resources.find_distributions(
             str(target_dir / "my-test-package.zip")
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -61,7 +61,7 @@ testing =
 	pip>=19.1 # For proper file:// URLs support.
 	packaging>=23.2
 	jaraco.envs>=2.2
-	pytest-xdist
+	pytest-xdist>=3 # Dropped dependency on pytest-fork and py
 	jaraco.path>=3.2.0
 	build[virtualenv]
 	filelock>=3.4.0


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
`py` was only installed as a dependency of `pytest-fork` which was only installed as a dependency of `pytest-xdist`. This also removes another untyped import for #2345  / #3979 / #4192 

I could've bumped it to >=1.9.0 (first typed version: https://py.readthedocs.io/en/latest/changelog.html#id3) but I figured may as well just stop using it since: https://pypi.org/project/py/
> **NOTE**: this library is in **maintenance mode** and should not be used in new code.
> The py lib is a Python development support library featuring the following tools and modules:
> **py.path**: uniform local and svn path objects -> please use pathlib/pathlib2 instead
<!-- Summary goes here -->

### Pull Request Checklist
- [x] Changes have tests (the changed tests themselves)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
