### PR TITLE
Replace Flake8-2020 by Ruff

### DIFF
--- a/newsfragments/4238.misc.rst
+++ b/newsfragments/4238.misc.rst
@@ -1,0 +1,1 @@
+Drop dependency on Flake8 by using Ruff's YTT rules instead of flake8-2020 -- by :user:`Avasam`

--- a/ruff.toml
+++ b/ruff.toml
@@ -18,6 +18,7 @@ ignore = [
 ]
 extend-select = [
 	"UP",  # pyupgrade
+	"YTT",  # flake8-2020
 ]
 extend-ignore = [
 	"UP015",  # redundant-open-modes, explicit is preferred

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,6 @@ testing =
 	pytest-ruff >= 0.2.1; sys_platform != "cygwin"
 
 	# local
-	flake8-2020
 	virtualenv>=13.0.0
 	wheel
 	pip>=19.1 # For proper file:// URLs support.

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -323,9 +323,9 @@ def test_parity_with_metadata_from_pypa_wheel(tmp_path):
             "testing": """
                 pytest >= 6
                 pytest-checkdocs >= 2.4
-                pytest-flake8 ; \\
-                        # workaround for tholo/pytest-flake8#87
-                        python_version < "3.12"
+                tomli ; \\
+                        # Using stdlib when possible
+                        python_version < "3.11"
                 ini2toml[lite]>=0.9
                 """,
             "other": [],
@@ -345,7 +345,7 @@ def test_parity_with_metadata_from_pypa_wheel(tmp_path):
         'Requires-Python: >=3.8',
         'Provides-Extra: other',
         'Provides-Extra: testing',
-        'Requires-Dist: pytest-flake8; python_version < "3.12" and extra == "testing"',
+        'Requires-Dist: tomli; python_version < "3.11" and extra == "testing"',
         'Requires-Dist: more-itertools==8.8.0; extra == "other"',
         'Requires-Dist: ini2toml[lite]>=0.9; extra == "testing"',
     ]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Replaced `Flake8-2020` by Ruff's https://docs.astral.sh/ruff/rules/#flake8-2020-ytt . This also essentially removes dependency on Flake8 as a whole.

I've also updated a test to be a bit more relevant (both from the fact that setuptools now only has references to flake8 in vendored code, and that the mentioned issue isn't relevant to setuptools)

<!-- Summary goes here -->



### Pull Request Checklist
- [x] Changes have tests (these are test updates)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
