### PR TITLE
Standardize and centralize `StrPath` TypeAlias

### DIFF
--- a/newsfragments/4241.misc.rst
+++ b/newsfragments/4241.misc.rst
@@ -1,0 +1,1 @@
+Improvements to `Path`-related type annotations when it could be ``str | PathLike`` -- by :user:`Avasam`

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -4,12 +4,8 @@ and core metadata
 """
 
 import re
-from pathlib import Path
-from typing import Union
 
 from .extern import packaging
-
-_Path = Union[str, Path]
 
 # https://packaging.python.org/en/latest/specifications/core-metadata/#name
 _VALID_NAME = re.compile(r"^([A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])$", re.I)

--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -2,7 +2,10 @@ import os
 import sys
 from typing import Union
 
-_Path = Union[str, os.PathLike]
+if sys.version_info >= (3, 9):
+    StrPath = Union[str, os.PathLike[str]]  #  Same as _typeshed.StrPath
+else:
+    StrPath = Union[str, os.PathLike]
 
 
 def ensure_directory(path):
@@ -11,7 +14,7 @@ def ensure_directory(path):
     os.makedirs(dirname, exist_ok=True)
 
 
-def same_path(p1: _Path, p2: _Path) -> bool:
+def same_path(p1: StrPath, p2: StrPath) -> bool:
     """Differs from os.path.samefile because it does not require paths to exist.
     Purely string based (no comparison between i-nodes).
     >>> same_path("a/b", "./a/b")
@@ -30,7 +33,7 @@ def same_path(p1: _Path, p2: _Path) -> bool:
     return normpath(p1) == normpath(p2)
 
 
-def normpath(filename: _Path) -> str:
+def normpath(filename: StrPath) -> str:
     """Normalize a file/dir name for comparison purposes."""
     # See pkg_resources.normalize_path for notes about cygwin
     file = os.path.abspath(filename) if sys.platform == 'cygwin' else filename

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -33,7 +33,6 @@ from typing import (
     Protocol,
     Tuple,
     TypeVar,
-    Union,
 )
 
 from .. import (
@@ -43,6 +42,7 @@ from .. import (
     errors,
     namespaces,
 )
+from .._path import StrPath
 from ..discovery import find_package_path
 from ..dist import Distribution
 from ..warnings import (
@@ -55,8 +55,7 @@ from .build_py import build_py as build_py_cls
 if TYPE_CHECKING:
     from wheel.wheelfile import WheelFile  # noqa
 
-_Path = Union[str, Path]
-_P = TypeVar("_P", bound=_Path)
+_P = TypeVar("_P", bound=StrPath)
 _logger = logging.getLogger(__name__)
 
 
@@ -181,7 +180,7 @@ class editable_wheel(Command):
         return next(candidates, None)
 
     def _configure_build(
-        self, name: str, unpacked_wheel: _Path, build_lib: _Path, tmp_dir: _Path
+        self, name: str, unpacked_wheel: StrPath, build_lib: StrPath, tmp_dir: StrPath
     ):
         """Configure commands to behave in the following ways:
 
@@ -256,7 +255,11 @@ class editable_wheel(Command):
         return files, mapping
 
     def _run_build_commands(
-        self, dist_name: str, unpacked_wheel: _Path, build_lib: _Path, tmp_dir: _Path
+        self,
+        dist_name: str,
+        unpacked_wheel: StrPath,
+        build_lib: StrPath,
+        tmp_dir: StrPath,
     ) -> Tuple[List[str], Dict[str, str]]:
         self._configure_build(dist_name, unpacked_wheel, build_lib, tmp_dir)
         self._run_build_subcommands()
@@ -354,7 +357,7 @@ class editable_wheel(Command):
         self,
         name: str,
         tag: str,
-        build_lib: _Path,
+        build_lib: StrPath,
     ) -> "EditableStrategy":
         """Decides which strategy to use to implement an editable installation."""
         build_name = f"__editable__.{name}-{tag}"
@@ -424,8 +427,8 @@ class _LinkTree(_StaticPth):
         self,
         dist: Distribution,
         name: str,
-        auxiliary_dir: _Path,
-        build_lib: _Path,
+        auxiliary_dir: StrPath,
+        build_lib: StrPath,
     ):
         self.auxiliary_dir = Path(auxiliary_dir)
         self.build_lib = Path(build_lib).resolve()
@@ -567,7 +570,7 @@ def _can_symlink_files(base_dir: Path) -> bool:
 
 
 def _simple_layout(
-    packages: Iterable[str], package_dir: Dict[str, str], project_dir: Path
+    packages: Iterable[str], package_dir: Dict[str, str], project_dir: StrPath
 ) -> bool:
     """Return ``True`` if:
     - all packages are contained by the same parent directory, **and**
@@ -649,7 +652,7 @@ def _find_top_level_modules(dist: Distribution) -> Iterator[str]:
 def _find_package_roots(
     packages: Iterable[str],
     package_dir: Mapping[str, str],
-    src_root: _Path,
+    src_root: StrPath,
 ) -> Dict[str, str]:
     pkg_roots: Dict[str, str] = {
         pkg: _absolute_root(find_package_path(pkg, package_dir, src_root))
@@ -659,7 +662,7 @@ def _find_package_roots(
     return _remove_nested(pkg_roots)
 
 
-def _absolute_root(path: _Path) -> str:
+def _absolute_root(path: StrPath) -> str:
     """Works for packages and top-level modules"""
     path_ = Path(path)
     parent = path_.parent

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -29,7 +29,7 @@ from typing import (
     Union,
     cast,
 )
-
+from .._path import StrPath
 from ..errors import RemovedConfigError
 from ..warnings import SetuptoolsWarning
 
@@ -38,15 +38,14 @@ if TYPE_CHECKING:
     from setuptools.dist import Distribution  # noqa
 
 EMPTY: Mapping = MappingProxyType({})  # Immutable dict-like
-_Path = Union[os.PathLike, str]
 _DictOrStr = Union[dict, str]
-_CorrespFn = Callable[["Distribution", Any, _Path], None]
+_CorrespFn = Callable[["Distribution", Any, StrPath], None]
 _Correspondence = Union[str, _CorrespFn]
 
 _logger = logging.getLogger(__name__)
 
 
-def apply(dist: "Distribution", config: dict, filename: _Path) -> "Distribution":
+def apply(dist: "Distribution", config: dict, filename: StrPath) -> "Distribution":
     """Apply configuration dict read with :func:`read_configuration`"""
 
     if not config:
@@ -68,7 +67,7 @@ def apply(dist: "Distribution", config: dict, filename: _Path) -> "Distribution"
     return dist
 
 
-def _apply_project_table(dist: "Distribution", config: dict, root_dir: _Path):
+def _apply_project_table(dist: "Distribution", config: dict, root_dir: StrPath):
     project_table = config.get("project", {}).copy()
     if not project_table:
         return  # short-circuit
@@ -85,7 +84,7 @@ def _apply_project_table(dist: "Distribution", config: dict, root_dir: _Path):
             _set_config(dist, corresp, value)
 
 
-def _apply_tool_table(dist: "Distribution", config: dict, filename: _Path):
+def _apply_tool_table(dist: "Distribution", config: dict, filename: StrPath):
     tool_table = config.get("tool", {}).get("setuptools", {})
     if not tool_table:
         return  # short-circuit
@@ -153,7 +152,7 @@ def _guess_content_type(file: str) -> Optional[str]:
     raise ValueError(f"Undefined content type for {file}, {msg}")
 
 
-def _long_description(dist: "Distribution", val: _DictOrStr, root_dir: _Path):
+def _long_description(dist: "Distribution", val: _DictOrStr, root_dir: StrPath):
     from setuptools.config import expand
 
     if isinstance(val, str):
@@ -174,7 +173,7 @@ def _long_description(dist: "Distribution", val: _DictOrStr, root_dir: _Path):
         dist._referenced_files.add(cast(str, file))
 
 
-def _license(dist: "Distribution", val: dict, root_dir: _Path):
+def _license(dist: "Distribution", val: dict, root_dir: StrPath):
     from setuptools.config import expand
 
     if "file" in val:
@@ -184,7 +183,7 @@ def _license(dist: "Distribution", val: dict, root_dir: _Path):
         _set_config(dist, "license", val["text"])
 
 
-def _people(dist: "Distribution", val: List[dict], _root_dir: _Path, kind: str):
+def _people(dist: "Distribution", val: List[dict], _root_dir: StrPath, kind: str):
     field = []
     email_field = []
     for person in val:
@@ -244,7 +243,7 @@ def _unify_entry_points(project_table: dict):
         # intentional (for resetting configurations that are missing `dynamic`).
 
 
-def _copy_command_options(pyproject: dict, dist: "Distribution", filename: _Path):
+def _copy_command_options(pyproject: dict, dist: "Distribution", filename: StrPath):
     tool_table = pyproject.get("tool", {})
     cmdclass = tool_table.get("setuptools", {}).get("cmdclass", {})
     valid_options = _valid_command_options(cmdclass)

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -46,7 +46,7 @@ from types import ModuleType
 
 from distutils.errors import DistutilsOptionError
 
-from .._path import same_path as _same_path
+from .._path import same_path as _same_path, StrPath
 from ..warnings import SetuptoolsWarning
 
 if TYPE_CHECKING:
@@ -55,7 +55,6 @@ if TYPE_CHECKING:
     from distutils.dist import DistributionMetadata  # noqa
 
 chain_iter = chain.from_iterable
-_Path = Union[str, os.PathLike]
 _K = TypeVar("_K")
 _V = TypeVar("_V", covariant=True)
 
@@ -88,7 +87,7 @@ class StaticModule:
 
 
 def glob_relative(
-    patterns: Iterable[str], root_dir: Optional[_Path] = None
+    patterns: Iterable[str], root_dir: Optional[StrPath] = None
 ) -> List[str]:
     """Expand the list of glob patterns, but preserving relative paths.
 
@@ -120,7 +119,7 @@ def glob_relative(
     return expanded_values
 
 
-def read_files(filepaths: Union[str, bytes, Iterable[_Path]], root_dir=None) -> str:
+def read_files(filepaths: Union[str, bytes, Iterable[StrPath]], root_dir=None) -> str:
     """Return the content of the files concatenated using ``\n`` as str
 
     This function is sandboxed and won't reach anything outside ``root_dir``
@@ -138,7 +137,7 @@ def read_files(filepaths: Union[str, bytes, Iterable[_Path]], root_dir=None) -> 
     )
 
 
-def _filter_existing_files(filepaths: Iterable[_Path]) -> Iterator[_Path]:
+def _filter_existing_files(filepaths: Iterable[StrPath]) -> Iterator[StrPath]:
     for path in filepaths:
         if os.path.isfile(path):
             yield path
@@ -146,12 +145,12 @@ def _filter_existing_files(filepaths: Iterable[_Path]) -> Iterator[_Path]:
             SetuptoolsWarning.emit(f"File {path!r} cannot be found")
 
 
-def _read_file(filepath: Union[bytes, _Path]) -> str:
+def _read_file(filepath: Union[bytes, StrPath]) -> str:
     with open(filepath, encoding='utf-8') as f:
         return f.read()
 
 
-def _assert_local(filepath: _Path, root_dir: str):
+def _assert_local(filepath: StrPath, root_dir: str):
     if Path(os.path.abspath(root_dir)) not in Path(os.path.abspath(filepath)).parents:
         msg = f"Cannot access {filepath!r} (or anything outside {root_dir!r})"
         raise DistutilsOptionError(msg)
@@ -162,7 +161,7 @@ def _assert_local(filepath: _Path, root_dir: str):
 def read_attr(
     attr_desc: str,
     package_dir: Optional[Mapping[str, str]] = None,
-    root_dir: Optional[_Path] = None,
+    root_dir: Optional[StrPath] = None,
 ):
     """Reads the value of an attribute from a module.
 
@@ -197,7 +196,7 @@ def read_attr(
         return getattr(module, attr_name)
 
 
-def _find_spec(module_name: str, module_path: Optional[_Path]) -> ModuleSpec:
+def _find_spec(module_name: str, module_path: Optional[StrPath]) -> ModuleSpec:
     spec = importlib.util.spec_from_file_location(module_name, module_path)
     spec = spec or importlib.util.find_spec(module_name)
 
@@ -218,8 +217,8 @@ def _load_spec(spec: ModuleSpec, module_name: str) -> ModuleType:
 
 
 def _find_module(
-    module_name: str, package_dir: Optional[Mapping[str, str]], root_dir: _Path
-) -> Tuple[_Path, Optional[str], str]:
+    module_name: str, package_dir: Optional[Mapping[str, str]], root_dir: StrPath
+) -> Tuple[StrPath, Optional[str], str]:
     """Given a module (that could normally be imported by ``module_name``
     after the build is complete), find the path to the parent directory where
     it is contained and the canonical name that could be used to import it
@@ -254,7 +253,7 @@ def _find_module(
 def resolve_class(
     qualified_class_name: str,
     package_dir: Optional[Mapping[str, str]] = None,
-    root_dir: Optional[_Path] = None,
+    root_dir: Optional[StrPath] = None,
 ) -> Callable:
     """Given a qualified class name, return the associated class object"""
     root_dir = root_dir or os.getcwd()
@@ -270,7 +269,7 @@ def resolve_class(
 def cmdclass(
     values: Dict[str, str],
     package_dir: Optional[Mapping[str, str]] = None,
-    root_dir: Optional[_Path] = None,
+    root_dir: Optional[StrPath] = None,
 ) -> Dict[str, Callable]:
     """Given a dictionary mapping command names to strings for qualified class
     names, apply :func:`resolve_class` to the dict values.
@@ -282,7 +281,7 @@ def find_packages(
     *,
     namespaces=True,
     fill_package_dir: Optional[Dict[str, str]] = None,
-    root_dir: Optional[_Path] = None,
+    root_dir: Optional[StrPath] = None,
     **kwargs,
 ) -> List[str]:
     """Works similarly to :func:`setuptools.find_packages`, but with all
@@ -331,7 +330,7 @@ def find_packages(
     return packages
 
 
-def _nest_path(parent: _Path, path: _Path) -> str:
+def _nest_path(parent: StrPath, path: StrPath) -> str:
     path = parent if path in {".", ""} else os.path.join(parent, path)
     return os.path.normpath(path)
 
@@ -361,7 +360,7 @@ def canonic_package_data(package_data: dict) -> dict:
 
 
 def canonic_data_files(
-    data_files: Union[list, dict], root_dir: Optional[_Path] = None
+    data_files: Union[list, dict], root_dir: Optional[StrPath] = None
 ) -> List[Tuple[str, List[str]]]:
     """For compatibility with ``setup.py``, ``data_files`` should be a list
     of pairs instead of a dict.

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -13,8 +13,9 @@ import logging
 import os
 from contextlib import contextmanager
 from functools import partial
-from typing import TYPE_CHECKING, Callable, Dict, Mapping, Optional, Set, Union
+from typing import TYPE_CHECKING, Callable, Dict, Mapping, Optional, Set
 
+from .._path import StrPath
 from ..errors import FileError, InvalidConfigError
 from ..warnings import SetuptoolsWarning
 from . import expand as _expand
@@ -24,18 +25,17 @@ from ._apply_pyprojecttoml import apply as _apply
 if TYPE_CHECKING:
     from setuptools.dist import Distribution  # noqa
 
-_Path = Union[str, os.PathLike]
 _logger = logging.getLogger(__name__)
 
 
-def load_file(filepath: _Path) -> dict:
+def load_file(filepath: StrPath) -> dict:
     from ..compat.py310 import tomllib
 
     with open(filepath, "rb") as file:
         return tomllib.load(file)
 
 
-def validate(config: dict, filepath: _Path) -> bool:
+def validate(config: dict, filepath: StrPath) -> bool:
     from . import _validate_pyproject as validator
 
     trove_classifier = validator.FORMAT_FUNCTIONS.get("trove-classifier")
@@ -58,7 +58,7 @@ def validate(config: dict, filepath: _Path) -> bool:
 
 def apply_configuration(
     dist: "Distribution",
-    filepath: _Path,
+    filepath: StrPath,
     ignore_option_errors=False,
 ) -> "Distribution":
     """Apply the configuration from a ``pyproject.toml`` file into an existing
@@ -69,7 +69,7 @@ def apply_configuration(
 
 
 def read_configuration(
-    filepath: _Path,
+    filepath: StrPath,
     expand=True,
     ignore_option_errors=False,
     dist: Optional["Distribution"] = None,
@@ -136,7 +136,7 @@ def read_configuration(
 
 def expand_configuration(
     config: dict,
-    root_dir: Optional[_Path] = None,
+    root_dir: Optional[StrPath] = None,
     ignore_option_errors: bool = False,
     dist: Optional["Distribution"] = None,
 ) -> dict:
@@ -161,7 +161,7 @@ class _ConfigExpander:
     def __init__(
         self,
         config: dict,
-        root_dir: Optional[_Path] = None,
+        root_dir: Optional[StrPath] = None,
         ignore_option_errors: bool = False,
         dist: Optional["Distribution"] = None,
     ):

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -30,6 +30,7 @@ from typing import (
     Union,
 )
 
+from .._path import StrPath
 from ..errors import FileError, OptionError
 from ..extern.packaging.markers import default_environment as marker_env
 from ..extern.packaging.requirements import InvalidRequirement, Requirement
@@ -43,7 +44,6 @@ if TYPE_CHECKING:
 
     from setuptools.dist import Distribution  # noqa
 
-_Path = Union[str, os.PathLike]
 SingleCommandOptions = Dict["str", Tuple["str", Any]]
 """Dict that associate the name of the options of a particular command to a
 tuple. The first element of the tuple indicates the origin of the option value
@@ -55,7 +55,7 @@ Target = TypeVar("Target", bound=Union["Distribution", "DistributionMetadata"])
 
 
 def read_configuration(
-    filepath: _Path, find_others=False, ignore_option_errors=False
+    filepath: StrPath, find_others=False, ignore_option_errors=False
 ) -> dict:
     """Read given configuration file and returns options from it as a dict.
 
@@ -80,7 +80,7 @@ def read_configuration(
     return configuration_to_dict(handlers)
 
 
-def apply_configuration(dist: "Distribution", filepath: _Path) -> "Distribution":
+def apply_configuration(dist: "Distribution", filepath: StrPath) -> "Distribution":
     """Apply the configuration from a ``setup.cfg`` file into an existing
     distribution object.
     """
@@ -91,8 +91,8 @@ def apply_configuration(dist: "Distribution", filepath: _Path) -> "Distribution"
 
 def _apply(
     dist: "Distribution",
-    filepath: _Path,
-    other_files: Iterable[_Path] = (),
+    filepath: StrPath,
+    other_files: Iterable[StrPath] = (),
     ignore_option_errors: bool = False,
 ) -> Tuple["ConfigHandler", ...]:
     """Read configuration from ``filepath`` and applies to the ``dist`` object."""
@@ -371,7 +371,7 @@ class ConfigHandler(Generic[Target]):
 
         return parser
 
-    def _parse_file(self, value, root_dir: _Path):
+    def _parse_file(self, value, root_dir: StrPath):
         """Represents value as a string, allowing including text
         from nearest files using `file:` directive.
 
@@ -397,7 +397,7 @@ class ConfigHandler(Generic[Target]):
         self._referenced_files.update(filepaths)
         return expand.read_files(filepaths, root_dir)
 
-    def _parse_attr(self, value, package_dir, root_dir: _Path):
+    def _parse_attr(self, value, package_dir, root_dir: StrPath):
         """Represents value as a module attribute.
 
         Examples:
@@ -539,7 +539,7 @@ class ConfigMetadataHandler(ConfigHandler["DistributionMetadata"]):
         ignore_option_errors: bool,
         ensure_discovered: expand.EnsurePackagesDiscovered,
         package_dir: Optional[dict] = None,
-        root_dir: _Path = os.curdir,
+        root_dir: StrPath = os.curdir,
     ):
         super().__init__(target_obj, options, ignore_option_errors, ensure_discovered)
         self.package_dir = package_dir

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -4,7 +4,7 @@ from inspect import cleandoc
 
 import pytest
 import tomli_w
-from path import Path as _Path
+from path import Path
 
 from setuptools.config.pyprojecttoml import (
     read_configuration,
@@ -352,7 +352,7 @@ def test_include_package_data_in_setuppy(tmp_path):
     setuppy = tmp_path / "setup.py"
     setuppy.write_text("__import__('setuptools').setup(include_package_data=False)")
 
-    with _Path(tmp_path):
+    with Path(tmp_path):
         dist = distutils.core.run_setup("setup.py", {}, stop_after="config")
 
     assert dist.get_name() == "myproj"

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -13,7 +13,7 @@ import distutils.core
 
 import pytest
 import jaraco.path
-from path import Path as _Path
+from path import Path
 
 from .contexts import quiet
 from .integration.helpers import get_sdist_members, get_wheel_members, run
@@ -304,7 +304,7 @@ class TestWithAttrDirective:
         assert dist.package_dir
         package_path = find_package_path("pkg", dist.package_dir, tmp_path)
         assert os.path.exists(package_path)
-        assert folder in _Path(package_path).parts()
+        assert folder in Path(package_path).parts()
 
         _run_build(tmp_path, "--sdist")
         dist_file = tmp_path / "dist/pkg-42.tar.gz"
@@ -607,14 +607,14 @@ def _get_dist(dist_path, attrs):
 
     script = dist_path / 'setup.py'
     if script.exists():
-        with _Path(dist_path):
+        with Path(dist_path):
             dist = distutils.core.run_setup("setup.py", {}, stop_after="init")
     else:
         dist = Distribution(attrs)
 
     dist.src_root = root
     dist.script_name = "setup.py"
-    with _Path(dist_path):
+    with Path(dist_path):
         dist.parse_config_files()
 
     dist.set_defaults()
@@ -627,7 +627,7 @@ def _run_sdist_programatically(dist_path, attrs):
     cmd.ensure_finalized()
     assert cmd.distribution.packages or cmd.distribution.py_modules
 
-    with quiet(), _Path(dist_path):
+    with quiet(), Path(dist_path):
         cmd.run()
 
     return dist, cmd

--- a/tools/generate_validation_code.py
+++ b/tools/generate_validation_code.py
@@ -1,10 +1,12 @@
+from os import PathLike
 import subprocess
 import sys
 
 from pathlib import Path
+from typing import Union
 
 
-def generate_pyproject_validation(dest: Path):
+def generate_pyproject_validation(dest: Union[str, PathLike]):
     """
     Generates validation code for ``pyproject.toml`` based on JSON schemas and the
     ``validate-pyproject`` library.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Brought all aliases `_Path` and unions `str | Path` and `str | PathLike` closer to typeshed's `StrPath` and centralized the TypeAlias in `setuptools._path`.
<!-- Summary goes here -->

Works towards #2345 

### Pull Request Checklist
- [x] Changes have tests (existing tests should pass, type-checking tests are coming in a different PR)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
