### PR TITLE
pkg_resources: Clarify some methods return `bytes`, not `str`

### DIFF
--- a/newsfragments/4243.bugfix.rst
+++ b/newsfragments/4243.bugfix.rst
@@ -1,1 +1,1 @@
-Clarify some `pkg_resources` methods return `bytes`, not `str`. Also return an empty `bytes` in `EmptyProvider._get` -- by :user:`Avasam`
+Clarify some `pkg_resources` methods return `bytes`, not `str`. Also return an empty `bytes` in ``EmptyProvider._get`` -- by :user:`Avasam`

--- a/newsfragments/4243.bugfix.rst
+++ b/newsfragments/4243.bugfix.rst
@@ -1,0 +1,1 @@
+Clarify some `pkg_resources` methods return `bytes`, not `str`. Also return an empty `bytes` in `EmptyProvider._get` -- by :user:`Avasam`

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -567,7 +567,7 @@ class IResourceProvider(IMetadataProvider, Protocol):
         `manager` must be an ``IResourceManager``"""
 
     def get_resource_string(self, manager, resource_name) -> bytes:
-        """Return a bytes string containing the contents of `resource_name`
+        """Return the contents of `resource_name` as :obj:`bytes`
 
         `manager` must be an ``IResourceManager``"""
 
@@ -1204,7 +1204,7 @@ class ResourceManager:
         )
 
     def resource_string(self, package_or_requirement, resource_name) -> bytes:
-        """Return specified resource as a bytes string"""
+        """Return specified resource as :obj:`bytes`"""
         return get_provider(package_or_requirement).get_resource_string(
             self, resource_name
         )

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -566,8 +566,8 @@ class IResourceProvider(IMetadataProvider, Protocol):
 
         `manager` must be an ``IResourceManager``"""
 
-    def get_resource_string(self, manager, resource_name):
-        """Return a string containing the contents of `resource_name`
+    def get_resource_string(self, manager, resource_name) -> bytes:
+        """Return a bytes string containing the contents of `resource_name`
 
         `manager` must be an ``IResourceManager``"""
 
@@ -1203,8 +1203,8 @@ class ResourceManager:
             self, resource_name
         )
 
-    def resource_string(self, package_or_requirement, resource_name):
-        """Return specified resource as a string"""
+    def resource_string(self, package_or_requirement, resource_name) -> bytes:
+        """Return specified resource as a bytes string"""
         return get_provider(package_or_requirement).get_resource_string(
             self, resource_name
         )
@@ -1479,7 +1479,7 @@ class NullProvider:
     def get_resource_stream(self, manager, resource_name):
         return io.BytesIO(self.get_resource_string(manager, resource_name))
 
-    def get_resource_string(self, manager, resource_name):
+    def get_resource_string(self, manager, resource_name) -> bytes:
         return self._get(self._fn(self.module_path, resource_name))
 
     def has_resource(self, resource_name):
@@ -1649,7 +1649,7 @@ is not allowed.
             DeprecationWarning,
         )
 
-    def _get(self, path):
+    def _get(self, path) -> bytes:
         if hasattr(self.loader, 'get_data'):
             return self.loader.get_data(path)
         raise NotImplementedError(
@@ -1706,7 +1706,7 @@ class DefaultProvider(EggProvider):
     def get_resource_stream(self, manager, resource_name):
         return open(self._fn(self.module_path, resource_name), 'rb')
 
-    def _get(self, path):
+    def _get(self, path) -> bytes:
         with open(path, 'rb') as stream:
             return stream.read()
 
@@ -1731,8 +1731,8 @@ class EmptyProvider(NullProvider):
 
     _isdir = _has = lambda self, path: False
 
-    def _get(self, path):
-        return ''
+    def _get(self, path) -> bytes:
+        return b''
 
     def _listdir(self, path):
         return []


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Clarify some `pkg_resources` methods return `bytes`, not `str`. Also return an empty `bytes` in `EmptyProvider._get`
<!-- Summary goes here -->

Works towards #2345 and merging `pkg_resources` stubs from typeshed

### Pull Request Checklist
- [ ] Changes have tests (`EmptyProvider._get` doesn't have tests. type-checking tests are coming in an upcoming PR)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
