### PR TITLE
Return an empty `list` by default in `pkg_resources.ResourceManager.cleanup_resources`

### DIFF
--- a/newsfragments/4244.bugfix.rst
+++ b/newsfragments/4244.bugfix.rst
@@ -1,0 +1,1 @@
+Return an empty `list` by default in ``pkg_resources.ResourceManager.cleanup_resources`` -- by :user:`Avasam`

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -27,7 +27,7 @@ import io
 import time
 import re
 import types
-from typing import Protocol
+from typing import List, Protocol
 import zipfile
 import zipimport
 import warnings
@@ -1339,7 +1339,7 @@ class ResourceManager:
 
         self.extraction_path = path
 
-    def cleanup_resources(self, force=False) -> list[str]:
+    def cleanup_resources(self, force=False) -> List[str]:
         """
         Delete all extracted resource files and directories, returning a list
         of the file and directory names that could not be successfully removed.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1339,7 +1339,7 @@ class ResourceManager:
 
         self.extraction_path = path
 
-    def cleanup_resources(self, force=False):
+    def cleanup_resources(self, force=False) -> list[str]:
         """
         Delete all extracted resource files and directories, returning a list
         of the file and directory names that could not be successfully removed.
@@ -1351,6 +1351,7 @@ class ResourceManager:
         directory used for extractions.
         """
         # XXX
+        return []
 
 
 def get_default_cache():


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Subclasses of are expected to return a `list`. There's no mention of this method potentially returning `None` in the docstring. If this is intended, then the docstring should be updated, and the return type be `Optional[list[str]]`

<!-- Summary goes here -->

Work towards #2345 and merging `pkg_resources`

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
