### PR TITLE
Prevent `pkg_resources._find_adapter` from ever returning `None`

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -3207,7 +3207,9 @@ def _find_adapter(registry, ob):
     for t in types:
         if t in registry:
             return registry[t]
-    return None
+    # _find_adapter would previously return None, and immediatly be called.
+    # So we're raising a TypeError to keep backward compatibility if anyone depended on that behaviour.
+    raise TypeError(f"Could not find adapter for {registry} and {ob}")
 
 
 def ensure_directory(path):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Prevent `pkg_resources._find_adapter` from ever returning `None`, whilst keeping the exact same public API behaviour (the message of the error changes, but the error will be the same).
Doesn't immediately fix anything, but will be necessary to type-check `pkg_resources` w/o errors, which will be needed to validate annotations from merging typeshed stubs.

### Pull Request Checklist
- [x] Changes have tests (all existing test should pass as-is, type-checking tests are coming in a different PR)
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
