### PR TITLE
Make `pkg_resources.find_nothing` return an (empty) `Generator` of `Distribution`

### DIFF
--- a/newsfragments/4249.bugfix.rst
+++ b/newsfragments/4249.bugfix.rst
@@ -1,0 +1,1 @@
+Ensured ``pkg_resources.find_distributions`` always returns a `Generator` as per its docstring by making ``pkg_resources.find_nothing`` yield nothing rather than returning an empty `tuple` -- by :user:`Avasam`

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -27,7 +27,7 @@ import io
 import time
 import re
 import types
-from typing import Protocol
+from typing import Generator, Protocol
 import zipfile
 import zipimport
 import warnings
@@ -2089,8 +2089,11 @@ def find_eggs_in_zip(importer, path_item, only=False):
 register_finder(zipimport.zipimporter, find_eggs_in_zip)
 
 
-def find_nothing(importer, path_item, only=False):
-    return ()
+def find_nothing(
+    importer, path_item, only=False
+) -> Generator["Distribution", None, None]:
+    return
+    yield
 
 
 register_finder(object, find_nothing)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This aligns with `find_eggs_in_zip` and `find_on_path` and ensures `find_distributions` always returns a generator.

This was noticed when attempting to type the `pkg_resoruces` package for #2345 

xref https://github.com/python/typeshed/pull/11512#discussion_r1508147634

### Pull Request Checklist
- [x] Changes have tests (existing tests should pass, type-checking tests will be added after #3979 )
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
