### PR TITLE
Made `pkg_resoursces.NullProvider`'s `has_metadata` and `metadata_isdir` methods return actual booleans like all other Providers

### DIFF
--- a/newsfragments/4254.bugfix.rst
+++ b/newsfragments/4254.bugfix.rst
@@ -1,0 +1,1 @@
+Made ``pkg_resoursces.NullProvider``'s ``has_metadata`` and ``metadata_isdir`` methods return actual booleans like all other Providers. -- by :user:`Avasam`

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -531,7 +531,7 @@ def get_entry_info(dist, group, name):
 
 
 class IMetadataProvider(Protocol):
-    def has_metadata(self, name):
+    def has_metadata(self, name) -> bool:
         """Does the package's distribution contain the named metadata?"""
 
     def get_metadata(self, name):
@@ -543,7 +543,7 @@ class IMetadataProvider(Protocol):
         Leading and trailing whitespace is stripped from each line, and lines
         with ``#`` as the first non-blank character are omitted."""
 
-    def metadata_isdir(self, name):
+    def metadata_isdir(self, name) -> bool:
         """Is the named metadata a directory?  (like ``os.path.isdir()``)"""
 
     def metadata_listdir(self, name):
@@ -1488,9 +1488,9 @@ class NullProvider:
     def _get_metadata_path(self, name):
         return self._fn(self.egg_info, name)
 
-    def has_metadata(self, name):
+    def has_metadata(self, name) -> bool:
         if not self.egg_info:
-            return self.egg_info
+            return False
 
         path = self._get_metadata_path(name)
         return self._has(path)
@@ -1514,8 +1514,8 @@ class NullProvider:
     def resource_isdir(self, resource_name):
         return self._isdir(self._fn(self.module_path, resource_name))
 
-    def metadata_isdir(self, name):
-        return self.egg_info and self._isdir(self._fn(self.egg_info, name))
+    def metadata_isdir(self, name) -> bool:
+        return bool(self.egg_info and self._isdir(self._fn(self.egg_info, name)))
 
     def resource_listdir(self, resource_name):
         return self._listdir(self._fn(self.module_path, resource_name))
@@ -1554,12 +1554,12 @@ class NullProvider:
             script_code = compile(script_text, script_filename, 'exec')
             exec(script_code, namespace, namespace)
 
-    def _has(self, path):
+    def _has(self, path) -> bool:
         raise NotImplementedError(
             "Can't perform this operation for unregistered loader type"
         )
 
-    def _isdir(self, path):
+    def _isdir(self, path) -> bool:
         raise NotImplementedError(
             "Can't perform this operation for unregistered loader type"
         )
@@ -1694,10 +1694,10 @@ class EggProvider(NullProvider):
 class DefaultProvider(EggProvider):
     """Provides access to package resources in the filesystem"""
 
-    def _has(self, path):
+    def _has(self, path) -> bool:
         return os.path.exists(path)
 
-    def _isdir(self, path):
+    def _isdir(self, path) -> bool:
         return os.path.isdir(path)
 
     def _listdir(self, path):
@@ -1939,11 +1939,11 @@ class ZipProvider(EggProvider):
             self._dirindex = ind
             return ind
 
-    def _has(self, fspath):
+    def _has(self, fspath) -> bool:
         zip_path = self._zipinfo_name(fspath)
         return zip_path in self.zipinfo or zip_path in self._index()
 
-    def _isdir(self, fspath):
+    def _isdir(self, fspath) -> bool:
         return self._zipinfo_name(fspath) in self._index()
 
     def _listdir(self, fspath):
@@ -1977,7 +1977,7 @@ class FileMetadata(EmptyProvider):
     def _get_metadata_path(self, name):
         return self.path
 
-    def has_metadata(self, name):
+    def has_metadata(self, name) -> bool:
         return name == 'PKG-INFO' and os.path.isfile(self.path)
 
     def get_metadata(self, name):

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -35,7 +35,7 @@ class Metadata(pkg_resources.EmptyProvider):
     def __init__(self, *pairs):
         self.metadata = dict(pairs)
 
-    def has_metadata(self, name):
+    def has_metadata(self, name) -> bool:
         return name in self.metadata
 
     def get_metadata(self, name):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Made `pkg_resoursces.NullProvider`'s `has_metadata` and `metadata_isdir` methods return actual booleans like all other Providers.
This was noticed when attempting to type the `pkg_resources` package for #2345 

xref https://github.com/python/typeshed/pull/11512#discussion_r1508147634
> \# Note: runtime forgets to coerce the return type to boolean,
> \# but we need to specify bool for NullProvider to respect the IResourceProvider protocol

### Pull Request Checklist
- [x] Changes have tests (existing tests should pass, type-checking tests will be added after #3979 )
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request