### PR TITLE
Turn `EncodingWarning` into errors and cleanup `pytest.ini`

### DIFF
--- a/newsfragments/4255.misc.rst
+++ b/newsfragments/4255.misc.rst
@@ -1,1 +1,1 @@
-Treat `EncodingWarning`s as an errors in tests. -- by :user:`Avasam`
+Treat ``EncodingWarning``s as an errors in tests. -- by :user:`Avasam`

--- a/newsfragments/4255.misc.rst
+++ b/newsfragments/4255.misc.rst
@@ -1,0 +1,1 @@
+Treat `EncodingWarning`s as an errors in tests. -- by :user:`Avasam`

--- a/newsfragments/4255.misc.rst
+++ b/newsfragments/4255.misc.rst
@@ -1,1 +1,1 @@
-Treat ``EncodingWarning``s as an errors in tests. -- by :user:`Avasam`
+Treat ``EncodingWarning``s as errors in tests. -- by :user:`Avasam`

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,18 @@ filterwarnings=
 	# Fail on warnings
 	error
 
+	# Workarounds for pypa/setuptools#3810
+	# Can't use EncodingWarning as it doesn't exist on Python 3.9.
+	# These warnings only appear on Python 3.10+
+	default:'encoding' argument not specified
+
+	# pypa/distutils#236
+	ignore:'encoding' argument not specified::distutils
+	ignore:'encoding' argument not specified::setuptools._distutils
+
+	# subprocess.check_output still warns with EncodingWarning even with encoding set
+	ignore:'encoding' argument not specified::setuptools.tests.environment
+
 	## upstream
 
 	# Ensure ResourceWarnings are emitted
@@ -18,14 +30,8 @@ filterwarnings=
 	# realpython/pytest-mypy#152
 	ignore:'encoding' argument not specified::pytest_mypy
 
-	# python/cpython#100750
-	ignore:'encoding' argument not specified::platform
-
-	# pypa/build#615
-	ignore:'encoding' argument not specified::build.env
-
-	# dateutil/dateutil#1284
-	ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:dateutil.tz.tz
+	# pytest-dev/pytest # TODO: Raise issue upstream 
+	ignore:'encoding' argument not specified::_pytest
 
 	## end upstream
 
@@ -68,11 +74,6 @@ filterwarnings=
 
 	# https://github.com/pypa/setuptools/issues/3655
 	ignore:The --rsyncdir command line argument and rsyncdirs config variable are deprecated.:DeprecationWarning
-
-	# Workarounds for pypa/setuptools#3810
-	# Can't use EncodingWarning as it doesn't exist on Python 3.9
-	default:'encoding' argument not specified
-	default:UTF-8 Mode affects locale.getpreferredencoding().
 
 	# Avoid errors when testing pkg_resources.declare_namespace
 	ignore:.*pkg_resources\.declare_namespace.*:DeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,6 +10,9 @@ filterwarnings=
 	# Fail on warnings
 	error
 
+	# Workarounds for pypa/setuptools#3810
+	# Can't use EncodingWarning as it doesn't exist on Python 3.9.
+	# These warnings only appear on Python 3.10+
 	## upstream
 
 	# Ensure ResourceWarnings are emitted

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,7 +28,7 @@ filterwarnings=
 	# realpython/pytest-mypy#152
 	ignore:'encoding' argument not specified::pytest_mypy
 
-	# pytest-dev/pytest # TODO: Raise issue upstream 
+	# TODO: Set encoding when openning tmpdir files with pytest's LocalPath.open
 	ignore:'encoding' argument not specified::_pytest
 
 	# Already fixed in pypa/distutils, but present in stdlib

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,10 +15,6 @@ filterwarnings=
 	# These warnings only appear on Python 3.10+
 	default:'encoding' argument not specified
 
-	# pypa/distutils#236
-	ignore:'encoding' argument not specified::distutils
-	ignore:'encoding' argument not specified::setuptools._distutils
-
 	# subprocess.check_output still warns with EncodingWarning even with encoding set
 	ignore:'encoding' argument not specified::setuptools.tests.environment
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,12 @@ filterwarnings=
 	# Ensure ResourceWarnings are emitted
 	default::ResourceWarning
 
+	# python/mypy#17057
+	ignore:'encoding' argument not specified::mypy.config_parser
+	ignore:'encoding' argument not specified::mypy.build
+	ignore:'encoding' argument not specified::mypy.modulefinder
+	ignore:'encoding' argument not specified::mypy.metastore
+
 	# realpython/pytest-mypy#152
 	ignore:'encoding' argument not specified::pytest_mypy
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -19,10 +19,10 @@ filterwarnings=
 	default::ResourceWarning
 
 	# python/mypy#17057
-	ignore:'encoding' argument not specified::mypy.config_parser
-	ignore:'encoding' argument not specified::mypy.build
-	ignore:'encoding' argument not specified::mypy.modulefinder
-	ignore:'encoding' argument not specified::mypy.metastore
+	ignore:'encoding' argument not specified::mypy
+	ignore:'encoding' argument not specified::configparser
+	# ^-- ConfigParser is called by mypy,
+	#     but ignoring the warning in `mypy` is not enough on PyPy
 
 	# realpython/pytest-mypy#152
 	ignore:'encoding' argument not specified::pytest_mypy

--- a/pytest.ini
+++ b/pytest.ini
@@ -13,6 +13,7 @@ filterwarnings=
 	# Workarounds for pypa/setuptools#3810
 	# Can't use EncodingWarning as it doesn't exist on Python 3.9.
 	# These warnings only appear on Python 3.10+
+
 	## upstream
 
 	# Ensure ResourceWarnings are emitted
@@ -28,7 +29,8 @@ filterwarnings=
 	# realpython/pytest-mypy#152
 	ignore:'encoding' argument not specified::pytest_mypy
 
-	# TODO: Set encoding when openning tmpdir files with pytest's LocalPath.open
+	# TODO: Set encoding when openning/writing tmpdir files with pytest's LocalPath.open
+	# see pypa/setuptools#4326
 	ignore:'encoding' argument not specified::_pytest
 
 	# Already fixed in pypa/distutils, but present in stdlib

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,7 +22,8 @@ filterwarnings=
 	ignore:'encoding' argument not specified::mypy
 	ignore:'encoding' argument not specified::configparser
 	# ^-- ConfigParser is called by mypy,
-	#     but ignoring the warning in `mypy` is not enough on PyPy
+	#     but ignoring the warning in `mypy` is not enough
+	#     to make it work on PyPy
 
 	# realpython/pytest-mypy#152
 	ignore:'encoding' argument not specified::pytest_mypy

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,14 +10,6 @@ filterwarnings=
 	# Fail on warnings
 	error
 
-	# Workarounds for pypa/setuptools#3810
-	# Can't use EncodingWarning as it doesn't exist on Python 3.9.
-	# These warnings only appear on Python 3.10+
-	default:'encoding' argument not specified
-
-	# subprocess.check_output still warns with EncodingWarning even with encoding set
-	ignore:'encoding' argument not specified::setuptools.tests.environment
-
 	## upstream
 
 	# Ensure ResourceWarnings are emitted

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,6 +29,9 @@ filterwarnings=
 	# pytest-dev/pytest # TODO: Raise issue upstream 
 	ignore:'encoding' argument not specified::_pytest
 
+	# Already fixed in pypa/distutils, but present in stdlib
+	ignore:'encoding' argument not specified::distutils
+
 	## end upstream
 
 	# https://github.com/pypa/setuptools/issues/1823

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -565,7 +565,8 @@ def _encode_pth(content: str) -> bytes:
     This function tries to simulate this behaviour without having to create an
     actual file, in a way that supports a range of active Python versions.
     (There seems to be some variety in the way different version of Python handle
-    ``encoding=None``, not all of them use ``locale.getpreferredencoding(False)``).
+    ``encoding=None``, not all of them use ``locale.getpreferredencoding(False)``
+    or ``locale.getencoding()``).
     """
     with io.BytesIO() as buffer:
         wrapper = io.TextIOWrapper(buffer, encoding=py39.LOCALE_ENCODING)

--- a/setuptools/tests/__init__.py
+++ b/setuptools/tests/__init__.py
@@ -1,10 +1,15 @@
 import locale
+import sys
 
 import pytest
 
 
 __all__ = ['fail_on_ascii']
 
-
-is_ascii = locale.getpreferredencoding() == 'ANSI_X3.4-1968'
+locale_encoding = (
+    locale.getencoding()
+    if sys.version_info >= (3, 11)
+    else locale.getpreferredencoding(False)
+)
+is_ascii = locale_encoding == 'ANSI_X3.4-1968'
 fail_on_ascii = pytest.mark.xfail(is_ascii, reason="Test fails in this locale")

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -160,7 +160,7 @@ defns = [
             # to obtain a distribution object first, and then run the distutils
             # commands later, because these files will be removed in the meantime.
 
-            with open('world.py', 'w') as f:
+            with open('world.py', 'w', encoding="utf-8") as f:
                 f.write('x = 42')
 
             try:

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -1,6 +1,7 @@
 import os
 import stat
 import shutil
+import warnings
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -162,11 +163,23 @@ def test_excluded_subpackages(tmpdir_cwd):
     dist.parse_config_files()
 
     build_py = dist.get_command_obj("build_py")
+
     msg = r"Python recognizes 'mypkg\.tests' as an importable package"
     with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
         # TODO: To fix #3260 we need some transition period to deprecate the
         # existing behavior of `include_package_data`. After the transition, we
         # should remove the warning and fix the behaviour.
+
+        if os.getenv("SETUPTOOLS_USE_DISTUTILS") == "stdlib":
+            # pytest.warns reset the warning filter temporarily
+            # https://github.com/pytest-dev/pytest/issues/4011#issuecomment-423494810
+            warnings.filterwarnings(
+                "ignore",
+                "'encoding' argument not specified",
+                module="distutils.text_file",
+                # This warning is already fixed in pypa/distutils but not in stdlib
+            )
+
         build_py.finalize_options()
         build_py.run()
 

--- a/setuptools/tests/test_windows_wrappers.py
+++ b/setuptools/tests/test_windows_wrappers.py
@@ -110,7 +110,11 @@ class TestCLI(WrapperTester):
             'arg5 a\\\\b',
         ]
         proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, text=True
+            cmd,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
         )
         stdout, stderr = proc.communicate('hello\nworld\n')
         actual = stdout.replace('\r\n', '\n')
@@ -143,7 +147,11 @@ class TestCLI(WrapperTester):
             'arg5 a\\\\b',
         ]
         proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stdin=subprocess.PIPE, text=True
+            cmd,
+            stdout=subprocess.PIPE,
+            stdin=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
         )
         stdout, stderr = proc.communicate('hello\nworld\n')
         actual = stdout.replace('\r\n', '\n')
@@ -191,6 +199,7 @@ class TestCLI(WrapperTester):
             stdin=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
         )
         stdout, stderr = proc.communicate()
         actual = stdout.replace('\r\n', '\n')
@@ -240,6 +249,7 @@ class TestGUI(WrapperTester):
             stdin=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            encoding="utf-8",
         )
         stdout, stderr = proc.communicate()
         assert not stdout


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Attempt at supeerseding https://github.com/pypa/setuptools/pull/4234#discussion_r1511342695 w/o any potential breaking change
Essentially a band-aid for #3810 to make reading failed tests results more bearable.
<!-- Summary goes here -->


### Pull Request Checklist
- [x] Changes have tests (these are the test changes)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
