### PR TITLE
Enable mypy on CI

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -13,30 +13,21 @@ exclude = (?x)(
 	| ^setuptools/_distutils/ # Vendored
 	| ^setuptools/config/_validate_pyproject/ # Auto-generated
 	)
-disable_error_code = 
-	# TODO: Test environment is not yet properly configured to install all imported packages
-	# import-not-found, # This can be left commented out for local runs until we enforce running mypy in the CI
-	# TODO: Not all dependencies are typed. Namely: distutils._modified, wheel.wheelfile, and jaraco.*
-	import-untyped,
-	# Ignoring attr-defined because setuptools wraps a lot of distutils classes, adding new attributes,
-	# w/o updating all the attributes and return types from the base classes for type-checkers to understand
-	# Especially with setuptools.dist.command vs distutils.dist.command vs setuptools._distutils.dist.command
-	# *.extern modules that actually live in *._vendor will also cause attr-defined issues on import
-	attr-defined,
+# Ignoring attr-defined because setuptools wraps a lot of distutils classes, adding new attributes,
+# w/o updating all the attributes and return types from the base classes for type-checkers to understand
+# Especially with setuptools.dist.command vs distutils.dist.command vs setuptools._distutils.dist.command
+# *.extern modules that actually live in *._vendor will also cause attr-defined issues on import
+disable_error_code = attr-defined
 
-# Avoid raising issues when importing from "extern" modules, as those are added to path dynamically.
-# https://github.com/pypa/setuptools/pull/3979#discussion_r1367968993
-[mypy-pkg_resources.extern.*,setuptools.extern.*]
+# - Avoid raising issues when importing from "extern" modules, as those are added to path dynamically.
+#   https://github.com/pypa/setuptools/pull/3979#discussion_r1367968993
+# - distutils._modified has different errors on Python 3.8 [import-untyped], on Python 3.9+ [import-not-found]
+# - All jaraco modules are still untyped
+[mypy-pkg_resources.extern.*,setuptools.extern.*,distutils._modified,jaraco.*]
 ignore_missing_imports = True
 
-[mypy-pkg_resources.tests.*,setuptools.tests.*]
-disable_error_code =
-	# Tests include creating dynamic modules that won't exists statically before the test is run.
-	# Let's ignore all "import-not-found", as if an import really wasn't found, then the test would fail.
-	import-not-found,
-	# mmany untyped "jaraco" modules
-	import-untyped,
-
-# Mypy issue, this vendored module is already excluded!
-[mypy-setuptools._vendor.packaging._manylinux]
+# - pkg_resources tests create modules that won't exists statically before the test is run.
+#   Let's ignore all "import-not-found" since, if an import really wasn't found, then the test would fail.
+# - setuptools._vendor.packaging._manylinux: Mypy issue, this vendored module is already excluded!
+[mypy-pkg_resources.tests.*,setuptools._vendor.packaging._manylinux]
 disable_error_code = import-not-found

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,3 @@ build-backend = "setuptools.build_meta"
 backend-path = ["."]
 
 [tool.setuptools_scm]
-
-[tool.pytest-enabler.mypy]
-# disabled

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,10 @@ testing =
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
 	pytest-home >= 0.5
+	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
+	tomli
+	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly
+	importlib_metadata
 
 testing-integration =
 	pytest

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -16,7 +16,7 @@ from setuptools.extension import Extension, Library
 
 try:
     # Attempt to use Cython for building extensions, if available
-    from Cython.Distutils.build_ext import build_ext as _build_ext
+    from Cython.Distutils.build_ext import build_ext as _build_ext  # type: ignore[import-not-found] # Cython not installed on CI tests
 
     # Additionally, assert that the compiler module will load
     # also. Ref #1229.

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -59,7 +59,7 @@ from .install import install as install_cls
 from .install_scripts import install_scripts as install_scripts_cls
 
 if TYPE_CHECKING:
-    from wheel.wheelfile import WheelFile  # noqa
+    from wheel.wheelfile import WheelFile  # type:ignore[import-untyped] # noqa
 
 _P = TypeVar("_P", bound=StrPath)
 _logger = logging.getLogger(__name__)

--- a/setuptools/config/_validate_pyproject/fastjsonschema_validations.py
+++ b/setuptools/config/_validate_pyproject/fastjsonschema_validations.py
@@ -1,5 +1,4 @@
 # noqa
-# type: ignore
 # flake8: noqa
 # pylint: skip-file
 # mypy: ignore-errors


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Follow-up to #3979. Extracted from #4192. Enables mypy type-checking in the CI.

Example failure: https://github.com/pypa/setuptools/actions/runs/8158516102/job/22300634747?pr=4257#step:9:69
<!-- Summary goes here -->

### Pull Request Checklist
- [x] Changes have tests (this is enabling the tests! 😄  )
- [ ] News fragment added in [`newsfragments/`]. (no user-facing change)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
