### PR TITLE
Type `pkg_resources._declare_state` and make it work statically

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -27,7 +27,7 @@ import io
 import time
 import re
 import types
-from typing import List, Protocol
+from typing import Any, Dict, List, Protocol
 import zipfile
 import zipimport
 import warnings
@@ -94,9 +94,6 @@ iter_entry_points = None
 resource_listdir = None
 resource_filename = None
 resource_exists = None
-_distribution_finders = None
-_namespace_handlers = None
-_namespace_packages = None
 
 
 warnings.warn(
@@ -120,11 +117,10 @@ class PEP440Warning(RuntimeWarning):
 parse_version = packaging.version.Version
 
 
-_state_vars = {}
+_state_vars: Dict[str, Any] = {}
 
 
-def _declare_state(vartype, **kw):
-    globals().update(kw)
+def _declare_state(vartype: str, **kw: object) -> None:
     _state_vars.update(dict.fromkeys(kw, vartype))
 
 
@@ -2025,7 +2021,8 @@ class EggMetadata(ZipProvider):
         self._setup_prefix()
 
 
-_declare_state('dict', _distribution_finders={})
+_distribution_finders = {}
+_declare_state('dict', _distribution_finders=_distribution_finders)
 
 
 def register_finder(importer_type, distribution_finder):
@@ -2198,8 +2195,10 @@ if hasattr(pkgutil, 'ImpImporter'):
 
 register_finder(importlib.machinery.FileFinder, find_on_path)
 
-_declare_state('dict', _namespace_handlers={})
-_declare_state('dict', _namespace_packages={})
+_namespace_handlers = {}
+_declare_state('dict', _namespace_handlers=_namespace_handlers)
+_namespace_packages = {}
+_declare_state('dict', _namespace_packages=_namespace_packages)
 
 
 def register_namespace_handler(importer_type, namespace_handler):

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -27,7 +27,7 @@ import io
 import time
 import re
 import types
-from typing import Any, Dict, List, Protocol
+from typing import Any, Callable, Dict, Iterable, List, Protocol, Optional
 import zipfile
 import zipimport
 import warnings
@@ -2021,7 +2021,9 @@ class EggMetadata(ZipProvider):
         self._setup_prefix()
 
 
-_distribution_finders = {}
+_distribution_finders: Dict[
+    type, Callable[[object, str, bool], Iterable["Distribution"]]
+] = {}
 _declare_state('dict', _distribution_finders=_distribution_finders)
 
 
@@ -2195,9 +2197,11 @@ if hasattr(pkgutil, 'ImpImporter'):
 
 register_finder(importlib.machinery.FileFinder, find_on_path)
 
-_namespace_handlers = {}
+_namespace_handlers: Dict[
+    type, Callable[[object, str, str, types.ModuleType], Optional[str]]
+] = {}
 _declare_state('dict', _namespace_handlers=_namespace_handlers)
-_namespace_packages = {}
+_namespace_packages: Dict[Optional[str], List[str]] = {}
 _declare_state('dict', _namespace_packages=_namespace_packages)
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

After playing around with previous PRs with whether `_distribution_finders`, `_namespace_handlers` and `_namespace_packages` definitions should be moved closer to declarations, I noticed that, since we have to define the variables for other reasons anyway, there's no point to `_declare_state`'s global namespace shenanigans. This PR makes it work for static analysis and, after #4246 is merged, will reduce changes in #4242
<!-- Summary goes here -->


### Pull Request Checklist
- [ ] Changes have tests (existing tests should pass, no intended behaviour change)
- [ ] News fragment added in [`newsfragments/`]. (even typing-wise there's no user-facing change here, it's all privates)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
