### PR TITLE
Explicitly use `"locale"` encoding for `.pth` files

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,10 @@ link_files = {
                 url='https://bugs.python.org/issue{python}',
             ),
             dict(
+                pattern=r'\bpython/cpython#(?P<cpython>\d+)',
+                url='{GH}/python/cpython/issues/{cpython}',
+            ),
+            dict(
                 pattern=r'Interop #(?P<interop>\d+)',
                 url='{GH}/pypa/interoperability-peps/issues/{interop}',
             ),

--- a/newsfragments/4265.feature.rst
+++ b/newsfragments/4265.feature.rst
@@ -1,0 +1,3 @@
+Explicitly use ``encoding="locale"`` for ``.pth`` files whenever possible,
+to  reduce ``EncodingWarnings``.
+This avoid errors with UTF-8 (see discussion in python/cpython#77102).

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -873,7 +873,7 @@ class easy_install(Command):
         ensure_directory(target)
         if os.path.exists(target):
             os.unlink(target)
-        with open(target, "w" + mode) as f:  # TODO: is it safe to use "utf-8"?
+        with open(target, "w" + mode) as f:  # TODO: is it safe to use utf-8?
             f.write(contents)
         chmod(target, 0o777 - mask)
 
@@ -1017,7 +1017,7 @@ class easy_install(Command):
 
         # Write EGG-INFO/PKG-INFO
         if not os.path.exists(pkg_inf):
-            f = open(pkg_inf, 'w')  # TODO: probably it is safe to use "utf-8"
+            f = open(pkg_inf, 'w')  # TODO: probably it is safe to use utf-8
             f.write('Metadata-Version: 1.0\n')
             for k, v in cfg.items('metadata'):
                 if k != 'target_version':
@@ -1088,7 +1088,7 @@ class easy_install(Command):
             if locals()[name]:
                 txt = os.path.join(egg_tmp, 'EGG-INFO', name + '.txt')
                 if not os.path.exists(txt):
-                    f = open(txt, 'w')
+                    f = open(txt, 'w')  # TODO: probably it is safe to use utf-8
                     f.write('\n'.join(locals()[name]) + '\n')
                     f.close()
 

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -14,7 +14,6 @@ import logging
 import io
 import os
 import shutil
-import sys
 import traceback
 from contextlib import suppress
 from enum import Enum
@@ -44,6 +43,7 @@ from .. import (
     namespaces,
 )
 from .._path import StrPath
+from ..compat import py39
 from ..discovery import find_package_path
 from ..dist import Distribution
 from ..warnings import (
@@ -558,9 +558,8 @@ def _encode_pth(content: str) -> bytes:
     (There seems to be some variety in the way different version of Python handle
     ``encoding=None``, not all of them use ``locale.getpreferredencoding(False)``).
     """
-    encoding = "locale" if sys.version_info >= (3, 10) else None
     with io.BytesIO() as buffer:
-        wrapper = io.TextIOWrapper(buffer, encoding)
+        wrapper = io.TextIOWrapper(buffer, encoding=py39.LOCALE_ENCODING)
         wrapper.write(content)
         wrapper.flush()
         buffer.seek(0)

--- a/setuptools/compat/py39.py
+++ b/setuptools/compat/py39.py
@@ -1,0 +1,9 @@
+import sys
+
+# Explicitly use the ``"locale"`` encoding in versions that support it,
+# otherwise just rely on the implicit handling of ``encoding=None``.
+# Since all platforms that support ``EncodingWarning`` also support
+# ``encoding="locale"``, this can be used to suppress the warning.
+# However, please try to use UTF-8 when possible
+# (.pth files are the notorious exception: python/cpython#77102, pypa/setuptools#3937).
+LOCALE_ENCODING = "locale" if sys.version_info >= (3, 10) else None

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -2,6 +2,8 @@ import os
 from distutils import log
 import itertools
 
+from .compat import py39
+
 
 flatten = itertools.chain.from_iterable
 
@@ -23,7 +25,8 @@ class Installer:
             list(lines)
             return
 
-        with open(filename, 'wt') as f:
+        with open(filename, 'wt', encoding=py39.LOCALE_ENCODING) as f:
+            # Requires encoding="locale" instead of "utf-8" (python/cpython#77102).
             f.writelines(lines)
 
     def uninstall_namespaces(self):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

For the time being `.pth` files in UTF-8 cause problems, see python/cpython#77102.
CPython maintainers' recommendation is to use the default encoding of the underlying system.

The motivation of this PR is to help with the encoding warnings.

## Summary of changes

- Use `"locale"` encoding for `.pth` files.
- Add `TODO` comments as reminders of other parts that may be moved to UTF-8, but there might be a risk.
- Introduce the `setuptools.compat.py39` module. This tries to follow the methodology in https://github.com/pypa/setuptools/pull/4212.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
