### PR TITLE
Update and pin mypy to 1.9

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,6 @@
 [mypy]
 # CI should test for all versions, local development gets hints for oldest supported
+# Some upstream typeshed distutils stubs fixes are necessary before we can start testing on Python 3.12
 python_version = 3.8
 strict = False
 warn_unused_ignores = True
@@ -8,6 +9,7 @@ explicit_package_bases = True
 exclude = (?x)(
 	^build/
 	| ^.tox/
+	| ^.egg/
 	| ^pkg_resources/tests/data/my-test-package-source/setup.py$ # Duplicate module name
 	| ^.+?/(_vendor|extern)/ # Vendored
 	| ^setuptools/_distutils/ # Vendored

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,7 @@ testing =
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
 	pytest-home >= 0.5
+	mypy==1.9
 	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
 	tomli
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,7 +73,7 @@ testing =
 	# for tools/finalize.py
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
 	pytest-home >= 0.5
-	mypy==1.9
+	mypy==1.9  # pin mypy version so a new version doesn't suddenly cause the CI to fail
 	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
 	tomli
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -62,7 +62,7 @@ def _read_list_from_msg(msg: Message, field: str) -> Optional[List[str]]:
 
 
 def _read_payload_from_msg(msg: Message) -> Optional[str]:
-    value = msg.get_payload().strip()
+    value = str(msg.get_payload()).strip()
     if value == 'UNKNOWN' or not value:
         return None
     return value

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -620,8 +620,7 @@ def _simple_layout(
     layout = {pkg: find_package_path(pkg, package_dir, project_dir) for pkg in packages}
     if not layout:
         return set(package_dir) in ({}, {""})
-    # TODO: has been fixed upstream, waiting for new mypy release https://github.com/python/typeshed/pull/11310
-    parent = os.path.commonpath(starmap(_parent_path, layout.items()))  # type: ignore[call-overload]
+    parent = os.path.commonpath(starmap(_parent_path, layout.items()))
     return all(
         _path.same_path(Path(parent, *key.split('.')), value)
         for key, value in layout.items()


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- pin mypy version so a new version doesn't suddenly cause the CI to fail
- Fix new failures in 1.9
- Explain why we're not running mypy on Python 3.12 in the CI yet
- Ignore `.egg` folder for faster local runs

### Pull Request Checklist
- [x] Changes have tests (these are test fixes)
- [x] News fragment added in [`newsfragments/`]. (no user facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
