### PR TITLE
Update cygwin-install-action to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -160,7 +160,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Cygwin with Python
-        uses: cygwin/cygwin-install-action@v2
+        uses: cygwin/cygwin-install-action@v4
         with:
           platform: x86_64
           packages: >-


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

~~Hoping this fixes failing cygwin action. Otherwise it's still~~ updating an outdated action
Updating actions separately just in case one happens to have breaking changes that affects setuptools and/or requires further changes.

Edit: From what I understand, https://mirrors.kernel.org/sourceware/cygwin/x86_64/ got updated today and it's missing all the sig files :/
I've opened https://bugzilla.kernel.org/show_bug.cgi?id=218575 
Edit 2: `.sig` files have been added back today


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
