### PR TITLE
Deduplicate testing dependencies by referencing `[testing-integration]`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,8 +41,9 @@ exclude =
 
 [options.extras_require]
 testing =
+	setuptools[testing-integration]
+
 	# upstream
-	pytest >= 6
 	pytest-checkdocs >= 2.4
 	pytest-cov; \
 		# coverage seems to make PyPy extremely slow
@@ -50,20 +51,11 @@ testing =
 	pytest-mypy >= 0.9.1; \
 		# workaround for jaraco/skeleton#22
 		python_implementation != "PyPy"
-	pytest-enabler >= 2.2
 	# workaround for pypa/setuptools#3921
 	pytest-ruff >= 0.2.1; sys_platform != "cygwin"
 
 	# local
-	virtualenv>=13.0.0
-	wheel
 	pip>=19.1 # For proper file:// URLs support.
-	packaging>=23.2
-	jaraco.envs>=2.2
-	pytest-xdist>=3 # Dropped dependency on pytest-fork and py
-	jaraco.path>=3.2.0
-	build[virtualenv]
-	filelock>=3.4.0
 	ini2toml[lite]>=0.9
 	tomli-w>=1.0.0
 	pytest-timeout
@@ -74,23 +66,26 @@ testing =
 	jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"
 	pytest-home >= 0.5
 	mypy==1.9  # pin mypy version so a new version doesn't suddenly cause the CI to fail
-	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
-	tomli
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly
 	importlib_metadata
 
 testing-integration =
-	pytest
-	pytest-xdist
+	# upstream
+	pytest >= 6
+	pytest-enabler >= 2.2
+
+	# local
+	pytest-xdist>=3 # Dropped dependency on pytest-fork and py
 	pytest-enabler
 	virtualenv>=13.0.0
-	tomli
 	wheel
 	jaraco.path>=3.2.0
 	jaraco.envs>=2.2
 	build[virtualenv]>=1.0.3
 	filelock>=3.4.0
 	packaging>=23.2
+	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
+	tomli
 
 docs =
 	# upstream


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This was my original idea, but in https://github.com/pypa/setuptools/pull/4257#discussion_r1514754970, @abravalheri mentioned that:
> [...] I think we just remove the `testing-integration` and use `testing` everywhere...
> 
> Although it might add a bit of overhead for the integration tests, it will simplify and streamline the setup... This way we reduce the divergence with `skeleton`. The additional overhead in the integration tests should not be too much, and the integration tests just run before the releases anyway.

But I'm still opening this PR as an option / for comparison.

Accepting this closes #4282

### Pull Request Checklist
- [x] Changes have tests (these are test changes)
- [x] News fragment added in [`newsfragments/`]. (no user facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
