### PR TITLE
Deduplicate testing dependencies by dropping `[testing-integration]`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -24,6 +24,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "integration: integration tests")
     config.addinivalue_line("markers", "uses_network: tests may try to download files")
+    _IntegrationTestSpeedups.disable_plugins_already_run(config)
 
 
 collect_ignore = [
@@ -47,9 +48,25 @@ if sys.version_info < (3, 9) or sys.platform == 'cygwin':
 
 @pytest.fixture(autouse=True)
 def _skip_integration(request):
-    running_integration_tests = request.config.getoption("--integration")
-    is_integration_test = request.node.get_closest_marker("integration")
-    if running_integration_tests and not is_integration_test:
-        pytest.skip("running integration tests only")
-    if not running_integration_tests and is_integration_test:
-        pytest.skip("skipping integration tests")
+    _IntegrationTestSpeedups.conditional_skip(request)
+
+
+class _IntegrationTestSpeedups:
+    """Speed-up integration tests by only running what does not run in other tests."""
+
+    RUNS_ON_NORMAL_TESTS = ("checkdocks", "cov", "mypy", "perf", "ruff")
+
+    @classmethod
+    def disable_plugins_already_run(cls, config):
+        if config.getoption("--integration"):
+            for plugin in cls.RUNS_ON_NORMAL_TESTS:  # no need to run again
+                config.pluginmanager.set_blocked(plugin)
+
+    @staticmethod
+    def conditional_skip(request):
+        running_integration_tests = request.config.getoption("--integration")
+        is_integration_test = request.node.get_closest_marker("integration")
+        if running_integration_tests and not is_integration_test:
+            pytest.skip("running integration tests only")
+        if not running_integration_tests and is_integration_test:
+            pytest.skip("skipping integration tests")

--- a/mypy.ini
+++ b/mypy.ini
@@ -32,5 +32,5 @@ ignore_missing_imports = True
 # - pkg_resources tests create modules that won't exists statically before the test is run.
 #   Let's ignore all "import-not-found" since, if an import really wasn't found, then the test would fail.
 # - setuptools._vendor.packaging._manylinux: Mypy issue, this vendored module is already excluded!
-[mypy-pkg_resources.tests.*,setuptools._vendor.packaging._manylinux]
+[mypy-pkg_resources.tests.*,setuptools._vendor.packaging._manylinux,setuptools.config._validate_pyproject.*]
 disable_error_code = import-not-found

--- a/newsfragments/4282.misc.rst
+++ b/newsfragments/4282.misc.rst
@@ -1,0 +1,1 @@
+Removed the ``setuptools[testing-integration]`` in favor of ``setuptools[testing]`` -- by :user:`Avasam`

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,7 @@ testing =
 	jaraco.envs>=2.2
 	pytest-xdist>=3 # Dropped dependency on pytest-fork and py
 	jaraco.path>=3.2.0
-	build[virtualenv]
+	build[virtualenv]>=1.0.3
 	filelock>=3.4.0
 	ini2toml[lite]>=0.9
 	tomli-w>=1.0.0
@@ -76,19 +76,6 @@ testing =
 	tomli
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly
 	importlib_metadata
-
-testing-integration =
-	pytest
-	pytest-xdist
-	pytest-enabler
-	virtualenv>=13.0.0
-	tomli
-	wheel
-	jaraco.path>=3.2.0
-	jaraco.envs>=2.2
-	build[virtualenv]>=1.0.3
-	filelock>=3.4.0
-	packaging>=23.2
 
 docs =
 	# upstream

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ pass_env =
 
 [testenv:integration]
 deps = {[testenv]deps}
-extras = testing
+extras = {[testenv]extras}
 pass_env =
 	{[testenv]pass_env}
 	DOWNLOAD_PATH

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ pass_env =
 
 [testenv:integration]
 deps = {[testenv]deps}
-extras = testing-integration
+extras = testing
 pass_env =
 	{[testenv]pass_env}
 	DOWNLOAD_PATH


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

In https://github.com/pypa/setuptools/pull/4257#discussion_r1514754970, @abravalheri mentioned that:
> [...] I think we just remove the `testing-integration` and use `testing` everywhere...
> 
> Although it might add a bit of overhead for the integration tests, it will simplify and streamline the setup... This way we reduce the divergence with `skeleton`. The additional overhead in the integration tests should not be too much, and the integration tests just run before the releases anyway.

This PR is doing just that.

Accepting this closes #4282 , which was my original idea.

### Pull Request Checklist
- [x] Changes have tests (these are test changes)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
