### PR TITLE
Fix ruff.toml

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,8 +1,4 @@
 [lint]
-extend-select = [
-	"C901",
-	"W",
-]
 ignore = [
 	# https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
 	"W191",
@@ -21,6 +17,8 @@ ignore = [
 	"ISC002",
 ]
 extend-select = [
+	"C901",
+	"W",
 	"UP",  # pyupgrade
 	"YTT",  # flake8-2020
 ]


### PR DESCRIPTION
https://github.com/pypa/setuptools/pull/4296 broke `ruff.toml`, by adding a second `extend-select` section. Merge them to fix ruff checking.