### PR TITLE
NEWS: Put releases in numerical order

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -4,15 +4,6 @@ v69.5.1
 No significant changes.
 
 
-v69.4.2
-=======
-
-Bugfixes
---------
-
-- Merged bugfix for pypa/distutils#246 (#27489545)
-
-
 v69.5.0
 =======
 
@@ -23,19 +14,19 @@ Features
 - Updated vendored packaging to version 24.0. (#4301)
 
 
-v69.4.1
-=======
-
-No significant changes.
-
-
-v69.3.1
+v69.4.2
 =======
 
 Bugfixes
 --------
 
-- Remove attempt to canonicalize the version. It's already canonical enough. (#4302)
+- Merged bugfix for pypa/distutils#246 (#27489545)
+
+
+v69.4.1
+=======
+
+No significant changes.
 
 
 v69.4.0
@@ -45,6 +36,15 @@ Features
 --------
 
 - Merged with pypa/distutils@55982565e, including interoperability improvements for rfc822_escape (pypa/distutils#213), dynamic resolution of config_h_filename for Python 3.13 compatibility (pypa/distutils#219), added support for the z/OS compiler (pypa/distutils#216), modernized compiler options in unixcompiler (pypa/distutils#214), fixed accumulating flags bug after compile/link (pypa/distutils#207), fixed enconding warnings (pypa/distutils#236), and general quality improvements (pypa/distutils#234). (#4298)
+
+
+v69.3.1
+=======
+
+Bugfixes
+--------
+
+- Remove attempt to canonicalize the version. It's already canonical enough. (#4302)
 
 
 v69.3.0


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

I thought some releases were missing, but I guess they were added in chronological order rather than numerical.

Let's keep numerical, especially as no dates are shown.


### Pull Request Checklist
- [n/a] Changes have tests
- [n/a] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
