### PR TITLE
Adopt UTF-8 for  `.pth` files on Python 3.13

### DIFF
--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -28,7 +28,7 @@ from typing import TYPE_CHECKING, Iterable, Iterator, Mapping, Protocol, TypeVar
 
 from .. import Command, _normalization, _path, errors, namespaces
 from .._path import StrPath
-from ..compat import py39
+from ..compat import py312
 from ..discovery import find_package_path
 from ..dist import Distribution
 from ..warnings import InformationOnly, SetuptoolsDeprecationWarning, SetuptoolsWarning
@@ -561,7 +561,9 @@ class _TopLevelFinder:
 
 
 def _encode_pth(content: str) -> bytes:
-    """.pth files are always read with 'locale' encoding, the recommendation
+    """
+    Prior to Python 3.13 (see https://github.com/python/cpython/issues/77102),
+    .pth files are always read with 'locale' encoding, the recommendation
     from the cpython core developers is to write them as ``open(path, "w")``
     and ignore warnings (see python/cpython#77102, pypa/setuptools#3937).
     This function tries to simulate this behaviour without having to create an
@@ -571,7 +573,8 @@ def _encode_pth(content: str) -> bytes:
     or ``locale.getencoding()``).
     """
     with io.BytesIO() as buffer:
-        wrapper = io.TextIOWrapper(buffer, encoding=py39.LOCALE_ENCODING)
+        wrapper = io.TextIOWrapper(buffer, encoding=py312.PTH_ENCODING)
+        # TODO: Python 3.13 replace the whole function with `bytes(content, "utf-8")`
         wrapper.write(content)
         wrapper.flush()
         buffer.seek(0)

--- a/setuptools/compat/py312.py
+++ b/setuptools/compat/py312.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import sys
 
 if sys.version_info >= (3, 12, 4):
     # Python 3.13 should support `.pth` files encoded in UTF-8
     # See discussion in https://github.com/python/cpython/issues/77102
-    PTH_ENCODING = "utf-8"
+    PTH_ENCODING: str | None = "utf-8"
 else:
     from .py39 import LOCALE_ENCODING
 

--- a/setuptools/compat/py312.py
+++ b/setuptools/compat/py312.py
@@ -1,6 +1,6 @@
 import sys
 
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 12, 4):
     # Python 3.13 should support `.pth` files encoded in UTF-8
     # See discussion in https://github.com/python/cpython/issues/77102
     PTH_ENCODING = "utf-8"

--- a/setuptools/compat/py312.py
+++ b/setuptools/compat/py312.py
@@ -1,0 +1,11 @@
+import sys
+
+if sys.version_info >= (3, 13):
+    # Python 3.13 should support `.pth` files encoded in UTF-8
+    # See discussion in https://github.com/python/cpython/issues/77102
+    PTH_ENCODING = "utf-8"
+else:
+    from .py39 import LOCALE_ENCODING
+
+    # PTH_ENCODING = "locale"
+    PTH_ENCODING = LOCALE_ENCODING

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 
-from .compat import py39
+from .compat import py312
 
 from distutils import log
 
@@ -25,8 +25,9 @@ class Installer:
             list(lines)
             return
 
-        with open(filename, 'wt', encoding=py39.LOCALE_ENCODING) as f:
-            # Requires encoding="locale" instead of "utf-8" (python/cpython#77102).
+        with open(filename, 'wt', encoding=py312.PTH_ENCODING) as f:
+            # Python<3.13 requires encoding="locale" instead of "utf-8"
+            # See: python/cpython#77102
             f.writelines(lines)
 
     def uninstall_namespaces(self):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

We should wait until a compatible version of Python3.13 is released (probably a beta).

## Summary of changes

- Use UTF-8 to write `.pth` files on Python 3.13
- When reading `.pth` on Python 3.13 tries first UTF-8 and then fallback to locale (this is done to avoid errors caused by mixing installations created by different versions of `setuptools` in the same environment)

See reasoning in https://github.com/python/cpython/issues/77102

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
