### PR TITLE
Fix the 608de826 commit reference in changelog

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -20,7 +20,7 @@ v69.4.2
 Bugfixes
 --------
 
-- Merged bugfix for pypa/distutils#246 (#27489545)
+- Merged bugfix for pypa/distutils#246 (pypa/setuptools@608de826)
 
 
 v69.4.1


### PR DESCRIPTION
Previously, the orphaned filename was used, making the current Sphinx setup link a non-existing issue: https://github.com/pypa/setuptools/commit/f07b037161c9640e4518c5f71e78af49a478d5b2#commitcomment-141024072.