### PR TITLE
Fix `setuptools_wheel` fixture

### DIFF
--- a/newsfragments/4308.misc.rst
+++ b/newsfragments/4308.misc.rst
@@ -1,0 +1,2 @@
+Fix ``setuptools_wheel`` fixture and avoid the recursive creation of
+``build/lib/build/lib/build/...`` directories in the project root during tests.

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -63,6 +63,37 @@ def sample_project(tmp_path):
 # sdist and wheel artifacts should be stable across a round of tests
 # so we can build them once per session and use the files as "readonly"
 
+# In the case of setuptools, building the wheel without sdist may cause
+# it to contain the `build` directory, and therefore create situations with
+# `setuptools/build/lib/build/lib/...`. To avoid that, build both artifacts at once.
+
+
+def _build_distributions(tmp_path_factory, request):
+    with contexts.session_locked_tmp_dir(
+        request, tmp_path_factory, "dist_build"
+    ) as tmp:  # pragma: no cover
+        sdist = next(tmp.glob("*.tar.gz"), None)
+        wheel = next(tmp.glob("*.whl"), None)
+        if sdist and wheel:
+            return (sdist, wheel)
+
+        # Sanity check: should not create recursive setuptools/build/lib/build/lib/...
+        assert not Path(request.config.rootdir, "build/lib/build").exists()
+
+        subprocess.check_output([
+            sys.executable,
+            "-m",
+            "build",
+            "--outdir",
+            str(tmp),
+            str(request.config.rootdir),
+        ])
+
+        # Sanity check: should not create recursive setuptools/build/lib/build/lib/...
+        assert not Path(request.config.rootdir, "build/lib/build").exists()
+
+        return next(tmp.glob("*.tar.gz")), next(tmp.glob("*.whl"))
+
 
 @pytest.fixture(scope="session")
 def setuptools_sdist(tmp_path_factory, request):
@@ -70,32 +101,8 @@ def setuptools_sdist(tmp_path_factory, request):
     if prebuilt and os.path.exists(prebuilt):  # pragma: no cover
         return Path(prebuilt).resolve()
 
-    with contexts.session_locked_tmp_dir(
-        request, tmp_path_factory, "sdist_build"
-    ) as tmp:  # pragma: no cover
-        dist = next(tmp.glob("*.tar.gz"), None)
-        if dist:
-            return dist
-
-        # Sanity check
-        # Building should not create recursive `setuptools/build/lib/build/lib/...`
-        assert not Path(request.config.rootdir, "build/lib/build").exists()
-
-        subprocess.check_output([
-            sys.executable,
-            "-m",
-            "build",
-            "--sdist",
-            "--outdir",
-            str(tmp),
-            str(request.config.rootdir),
-        ])
-
-        # Sanity check
-        # Building should not create recursive `setuptools/build/lib/build/lib/...`
-        assert not Path(request.config.rootdir, "build/lib/build").exists()
-
-        return next(tmp.glob("*.tar.gz"))
+    sdist, _ = _build_distributions(tmp_path_factory, request)
+    return sdist
 
 
 @pytest.fixture(scope="session")
@@ -104,32 +111,8 @@ def setuptools_wheel(tmp_path_factory, request):
     if prebuilt and os.path.exists(prebuilt):  # pragma: no cover
         return Path(prebuilt).resolve()
 
-    with contexts.session_locked_tmp_dir(
-        request, tmp_path_factory, "wheel_build"
-    ) as tmp:  # pragma: no cover
-        dist = next(tmp.glob("*.whl"), None)
-        if dist:
-            return dist
-
-        # Sanity check
-        # Building should not create recursive `setuptools/build/lib/build/lib/...`
-        assert not Path(request.config.rootdir, "build/lib/build").exists()
-
-        subprocess.check_output([
-            sys.executable,
-            "-m",
-            "build",
-            "--wheel",
-            "--outdir",
-            str(tmp),
-            str(request.config.rootdir),
-        ])
-
-        # Sanity check
-        # Building should not create recursive `setuptools/build/lib/build/lib/...`
-        assert not Path(request.config.rootdir, "build/lib/build").exists()
-
-        return next(tmp.glob("*.whl"))
+    _, wheel = _build_distributions(tmp_path_factory, request)
+    return wheel
 
 
 @pytest.fixture

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -77,6 +77,10 @@ def setuptools_sdist(tmp_path_factory, request):
         if dist:
             return dist
 
+        # Sanity check
+        # Building should not create recursive `setuptools/build/lib/build/lib/...`
+        assert not Path(request.config.rootdir, "build/lib/build").exists()
+
         subprocess.check_output([
             sys.executable,
             "-m",
@@ -86,6 +90,11 @@ def setuptools_sdist(tmp_path_factory, request):
             str(tmp),
             str(request.config.rootdir),
         ])
+
+        # Sanity check
+        # Building should not create recursive `setuptools/build/lib/build/lib/...`
+        assert not Path(request.config.rootdir, "build/lib/build").exists()
+
         return next(tmp.glob("*.tar.gz"))
 
 
@@ -102,6 +111,10 @@ def setuptools_wheel(tmp_path_factory, request):
         if dist:
             return dist
 
+        # Sanity check
+        # Building should not create recursive `setuptools/build/lib/build/lib/...`
+        assert not Path(request.config.rootdir, "build/lib/build").exists()
+
         subprocess.check_output([
             sys.executable,
             "-m",
@@ -111,6 +124,11 @@ def setuptools_wheel(tmp_path_factory, request):
             str(tmp),
             str(request.config.rootdir),
         ])
+
+        # Sanity check
+        # Building should not create recursive `setuptools/build/lib/build/lib/...`
+        assert not Path(request.config.rootdir, "build/lib/build").exists()
+
         return next(tmp.glob("*.whl"))
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Based on the test introduced in https://github.com/pypa/setuptools/commit/b4d3e83f0764e0c38ed57d688c301624ef08d1ea, we can see that when none of `PRE_BUILT_SETUPTOOLS_SDIST` or `PRE_BUILT_SETUPTOOLS_WHEEL` is set, the `setuptools_wheel` fixture keeps recursively creating `build/lib/build/lib/...` directories which slows down the tests and creates a huge amount of unnecessary files.

This change tries to avoid that by building simultaneously `sdist`/`wheel`.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
