### PR TITLE
Adopt more UTF-8

### DIFF
--- a/newsfragments/4309.removal.rst
+++ b/newsfragments/4309.removal.rst
@@ -1,0 +1,5 @@
+Further adoption of UTF-8 in ``setuptools``.
+This change regards mostly files produced and consumed during the build process
+(e.g. metadata files, script wrappers, automatically updated config files, etc..)
+Although precautions were taken to minimize disruptions, some edge cases might
+be subject to backwards incompatibility.

--- a/newsfragments/4309.removal.rst
+++ b/newsfragments/4309.removal.rst
@@ -3,3 +3,5 @@ This change regards mostly files produced and consumed during the build process
 (e.g. metadata files, script wrappers, automatically updated config files, etc..)
 Although precautions were taken to minimize disruptions, some edge cases might
 be subject to backwards incompatibility.
+
+Support for ``"locale"`` encoding is now **deprecated**.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -3323,14 +3323,33 @@ def _initialize_master_working_set():
     globals().update(locals())
 
 
-#  ---- Ported from ``setuptools`` to avoid introducing dependencies ----
+#  ---- Ported from ``setuptools`` to avoid introducing an import inter-dependency ----
 LOCALE_ENCODING = "locale" if sys.version_info >= (3, 10) else None
 
 
 def _read_utf8_with_fallback(file: str, fallback_encoding=LOCALE_ENCODING) -> str:
+    """See setuptools.unicode_utils._read_utf8_with_fallback"""
     try:
         with open(file, "r", encoding="utf-8") as f:
             return f.read()
     except UnicodeDecodeError:  # pragma: no cover
+        msg = f"""\
+        ********************************************************************************
+        `encoding="utf-8"` fails with {file!r}, trying `encoding={fallback_encoding!r}`.
+
+        This fallback behaviour is considered **deprecated** and future versions of
+        `setuptools/pkg_resources` may not implement it.
+
+        Please encode {file!r} with "utf-8" to ensure future builds will succeed.
+
+        If this file was produced by `setuptools` itself, cleaning up the cached files
+        and re-building/re-installing the package with a newer version of `setuptools`
+        (e.g. by updating `build-system.requires` in its `pyproject.toml`)
+        might solve the problem.
+        ********************************************************************************
+        """
+        # TODO: Add a deadline?
+        #       See comment in setuptools.unicode_utils._Utf8EncodingNeeded
+        warnings.warns(msg, PkgResourcesDeprecationWarning, stacklevel=2)
         with open(file, "r", encoding=fallback_encoding) as f:
             return f.read()

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -6,6 +6,7 @@ from the deprecated imp module.
 import os
 import importlib.util
 import importlib.machinery
+import tokenize
 
 from importlib.util import module_from_spec
 
@@ -60,13 +61,13 @@ def find_module(module, paths=None):
 
         if suffix in importlib.machinery.SOURCE_SUFFIXES:
             kind = PY_SOURCE
+            file = tokenize.open(path)
         elif suffix in importlib.machinery.BYTECODE_SUFFIXES:
             kind = PY_COMPILED
+            file = open(path, 'rb')
         elif suffix in importlib.machinery.EXTENSION_SUFFIXES:
             kind = C_EXTENSION
 
-        if kind in {PY_SOURCE, PY_COMPILED}:
-            file = open(path, mode)
     else:
         path = None
         suffix = mode = ''

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -200,10 +200,9 @@ class bdist_egg(Command):
             log.info("writing %s", native_libs)
             if not self.dry_run:
                 ensure_directory(native_libs)
-                libs_file = open(native_libs, 'wt')
-                libs_file.write('\n'.join(all_outputs))
-                libs_file.write('\n')
-                libs_file.close()
+                with open(native_libs, 'wt', encoding="utf-8") as libs_file:
+                    libs_file.write('\n'.join(all_outputs))
+                    libs_file.write('\n')
         elif os.path.isfile(native_libs):
             log.info("removing %s", native_libs)
             if not self.dry_run:

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -350,9 +350,8 @@ def write_safety_flag(egg_dir, safe):
             if safe is None or bool(safe) != flag:
                 os.unlink(fn)
         elif safe is not None and bool(safe) == flag:
-            f = open(fn, 'wt')
-            f.write('\n')
-            f.close()
+            with open(fn, 'wt', encoding="utf-8") as f:
+                f.write('\n')
 
 
 safety_flags = {

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -54,7 +54,7 @@ def write_stub(resource, pyfile):
         __bootstrap__()
         """
     ).lstrip()
-    with open(pyfile, 'w') as f:
+    with open(pyfile, 'w', encoding="utf-8") as f:
         f.write(_stub_template % resource)
 
 

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -342,8 +342,7 @@ class build_ext(_build_ext):
         if compile and os.path.exists(stub_file):
             raise BaseError(stub_file + " already exists! Please delete.")
         if not self.dry_run:
-            f = open(stub_file, 'w')
-            f.write(
+            content = (
                 '\n'.join([
                     "def __bootstrap__():",
                     "   global __bootstrap__, __file__, __loader__",
@@ -369,7 +368,8 @@ class build_ext(_build_ext):
                     "",  # terminal \n
                 ])
             )
-            f.close()
+            with open(stub_file, 'w', encoding="utf-8") as f:
+                f.write(content)
         if compile:
             self._compile_and_remove_stub(stub_file)
 

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -342,8 +342,8 @@ class build_ext(_build_ext):
         if compile and os.path.exists(stub_file):
             raise BaseError(stub_file + " already exists! Please delete.")
         if not self.dry_run:
-            content = (
-                '\n'.join([
+            with open(stub_file, 'w', encoding="utf-8") as f:
+                content = '\n'.join([
                     "def __bootstrap__():",
                     "   global __bootstrap__, __file__, __loader__",
                     "   import sys, os, pkg_resources, importlib.util" + if_dl(", dl"),
@@ -367,8 +367,6 @@ class build_ext(_build_ext):
                     "__bootstrap__()",
                     "",  # terminal \n
                 ])
-            )
-            with open(stub_file, 'w', encoding="utf-8") as f:
                 f.write(content)
         if compile:
             self._compile_and_remove_stub(stub_file)

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -10,7 +10,7 @@ from setuptools import _path
 from setuptools import namespaces
 import setuptools
 
-from ..unicode_utils import read_utf8_with_fallback
+from ..unicode_utils import _read_utf8_with_fallback
 
 
 class develop(namespaces.DevelopInstaller, easy_install):
@@ -133,7 +133,7 @@ class develop(namespaces.DevelopInstaller, easy_install):
 
             contents = [
                 line.rstrip()
-                for line in read_utf8_with_fallback(self.egg_link).splitlines()
+                for line in _read_utf8_with_fallback(self.egg_link).splitlines()
             ]
 
             if contents not in ([self.egg_path], [self.egg_path, self.setup_path]):
@@ -161,7 +161,7 @@ class develop(namespaces.DevelopInstaller, easy_install):
         for script_name in self.distribution.scripts or []:
             script_path = os.path.abspath(convert_path(script_name))
             script_name = os.path.basename(script_path)
-            script_text = read_utf8_with_fallback(script_path)
+            script_text = _read_utf8_with_fallback(script_path)
             self.install_script(dist, script_name, script_text, script_path)
 
         return None

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -873,7 +873,13 @@ class easy_install(Command):
         ensure_directory(target)
         if os.path.exists(target):
             os.unlink(target)
-        with open(target, "w" + mode) as f:  # TODO: is it safe to use utf-8?
+
+        if "b" not in mode and isinstance(contents, str):
+            kw = {"encoding": "utf-8"}
+        else:
+            kw = {}
+
+        with open(target, "w" + mode, **kw) as f:
             f.write(contents)
         chmod(target, 0o777 - mask)
 

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1023,12 +1023,11 @@ class easy_install(Command):
 
         # Write EGG-INFO/PKG-INFO
         if not os.path.exists(pkg_inf):
-            f = open(pkg_inf, 'w')  # TODO: probably it is safe to use utf-8
-            f.write('Metadata-Version: 1.0\n')
-            for k, v in cfg.items('metadata'):
-                if k != 'target_version':
-                    f.write('%s: %s\n' % (k.replace('_', '-').title(), v))
-            f.close()
+            with open(pkg_inf, 'w', encoding="utf-8") as f:
+                f.write('Metadata-Version: 1.0\n')
+                for k, v in cfg.items('metadata'):
+                    if k != 'target_version':
+                        f.write('%s: %s\n' % (k.replace('_', '-').title(), v))
         script_dir = os.path.join(_egg_info, 'scripts')
         # delete entry-point scripts to avoid duping
         self.delete_blockers([
@@ -1094,9 +1093,8 @@ class easy_install(Command):
             if locals()[name]:
                 txt = os.path.join(egg_tmp, 'EGG-INFO', name + '.txt')
                 if not os.path.exists(txt):
-                    f = open(txt, 'w')  # TODO: probably it is safe to use utf-8
-                    f.write('\n'.join(locals()[name]) + '\n')
-                    f.close()
+                    with open(txt, 'w', encoding="utf-8") as f:
+                        f.write('\n'.join(locals()[name]) + '\n')
 
     def install_wheel(self, wheel_path, tmpdir):
         wheel = Wheel(wheel_path)

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -874,12 +874,8 @@ class easy_install(Command):
         if os.path.exists(target):
             os.unlink(target)
 
-        if "b" not in mode and isinstance(contents, str):
-            kw = {"encoding": "utf-8"}
-        else:
-            kw = {}
-
-        with open(target, "w" + mode, **kw) as f:
+        encoding = None if "b" in mode else "utf-8"
+        with open(target, "w" + mode, encoding=encoding) as f:
             f.write(contents)
         chmod(target, 0o777 - mask)
 

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -57,14 +57,10 @@ class install_scripts(orig.install_scripts):
         target = os.path.join(self.install_dir, script_name)
         self.outfiles.append(target)
 
-        if "b" not in mode and isinstance(contents, str):
-            kw = {"encoding": "utf-8"}
-        else:
-            kw = {}
-
+        encoding = None if "b" in mode else "utf-8"
         mask = current_umask()
         if not self.dry_run:
             ensure_directory(target)
-            with open(target, "w" + mode, **kw) as f:
+            with open(target, "w" + mode, encoding=encoding) as f:
                 f.write(contents)
             chmod(target, 0o777 - mask)

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -57,10 +57,14 @@ class install_scripts(orig.install_scripts):
         target = os.path.join(self.install_dir, script_name)
         self.outfiles.append(target)
 
+        if "b" not in mode and isinstance(contents, str):
+            kw = {"encoding": "utf-8"}
+        else:
+            kw = {}
+
         mask = current_umask()
         if not self.dry_run:
             ensure_directory(target)
-            f = open(target, "w" + mode)
-            f.write(contents)
-            f.close()
+            with open(target, "w" + mode, **kw) as f:
+                f.write(contents)
             chmod(target, 0o777 - mask)

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -69,7 +69,7 @@ def edit_config(filename, settings, dry_run=False):
 
     log.info("Writing %s", filename)
     if not dry_run:
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding="utf-8") as f:
             opts.write(f)
 
 

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -6,7 +6,7 @@ import os
 import configparser
 
 from .. import Command
-from ..compat import py39
+from ..unicode_utils import _cfg_read_utf8_with_fallback
 
 __all__ = ['config_file', 'edit_config', 'option_base', 'setopt']
 
@@ -37,12 +37,7 @@ def edit_config(filename, settings, dry_run=False):
     log.debug("Reading configuration from %s", filename)
     opts = configparser.RawConfigParser()
     opts.optionxform = lambda x: x
-
-    try:
-        opts.read([filename], encoding="utf-8")
-    except UnicodeDecodeError:  # pragma: no cover
-        opts.clear()
-        opts.read([filename], encoding=py39.LOCALE_ENCODING)
+    _cfg_read_utf8_with_fallback(opts, filename)
 
     for section, options in settings.items():
         if options is None:

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -5,7 +5,8 @@ import distutils
 import os
 import configparser
 
-from setuptools import Command
+from .. import Command
+from ..compat import py39
 
 __all__ = ['config_file', 'edit_config', 'option_base', 'setopt']
 
@@ -36,7 +37,13 @@ def edit_config(filename, settings, dry_run=False):
     log.debug("Reading configuration from %s", filename)
     opts = configparser.RawConfigParser()
     opts.optionxform = lambda x: x
-    opts.read([filename])
+
+    try:
+        opts.read([filename], encoding="utf-8")
+    except UnicodeDecodeError:  # pragma: no cover
+        opts.clear()
+        opts.read([filename], encoding=py39.LOCALE_ENCODING)
+
     for section, options in settings.items():
         if options is None:
             log.info("Deleting section [%s] from %s", section, filename)

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -685,7 +685,7 @@ class Distribution(_Distribution):
             os.mkdir(egg_cache_dir)
             windows_support.hide_file(egg_cache_dir)
             readme_txt_filename = os.path.join(egg_cache_dir, 'README.txt')
-            with open(readme_txt_filename, 'w') as f:
+            with open(readme_txt_filename, 'w', encoding="utf-8") as f:
                 f.write(
                     'This directory contains eggs that were downloaded '
                     'by setuptools to build, test, and run plug-ins.\n\n'

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -41,7 +41,7 @@ from setuptools.wheel import Wheel
 from setuptools.extern.more_itertools import unique_everseen
 
 from .compat import py39
-from .unicode_utils import read_utf8_with_fallback
+from .unicode_utils import _read_utf8_with_fallback
 
 
 EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.+!]+)$')
@@ -1121,7 +1121,7 @@ def local_open(url):
         for f in os.listdir(filename):
             filepath = os.path.join(filename, f)
             if f == 'index.html':
-                body = read_utf8_with_fallback(filepath)
+                body = _read_utf8_with_fallback(filepath)
                 break
             elif os.path.isdir(filepath):
                 f += '/'

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -40,8 +40,7 @@ from fnmatch import translate
 from setuptools.wheel import Wheel
 from setuptools.extern.more_itertools import unique_everseen
 
-from .compat import py39
-from .unicode_utils import _read_utf8_with_fallback
+from .unicode_utils import _read_utf8_with_fallback, _cfg_read_utf8_with_fallback
 
 
 EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.+!]+)$')
@@ -1014,11 +1013,7 @@ class PyPIConfig(configparser.RawConfigParser):
 
         rc = os.path.join(os.path.expanduser('~'), '.pypirc')
         if os.path.exists(rc):
-            try:
-                self.read(rc, encoding="utf-8")
-            except UnicodeDecodeError:  # pragma: no cover
-                self.clean()
-                self.read(rc, encoding=py39.LOCALE_ENCODING)
+            _cfg_read_utf8_with_fallback(self, rc)
 
     @property
     def creds_by_repository(self):

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -41,6 +41,7 @@ from setuptools.wheel import Wheel
 from setuptools.extern.more_itertools import unique_everseen
 
 from .compat import py39
+from .unicode_utils import read_utf8_with_fallback
 
 
 EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.+!]+)$')
@@ -1120,12 +1121,7 @@ def local_open(url):
         for f in os.listdir(filename):
             filepath = os.path.join(filename, f)
             if f == 'index.html':
-                try:
-                    with open(filepath, 'r', encoding="utf-8") as fp:
-                        body = fp.read()
-                except UnicodeDecodeError:  # pragma: no cover
-                    with open(filepath, 'r', encoding=py39.LOCALE_ENCODING) as fp:
-                        body = fp.read()
+                body = read_utf8_with_fallback(filepath)
                 break
             elif os.path.isdir(filepath):
                 f += '/'

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -422,9 +422,9 @@ class PackageIndex(Environment):
         list(itertools.starmap(self.scan_egg_link, egg_links))
 
     def scan_egg_link(self, path, entry):
-        with open(os.path.join(path, entry)) as raw_lines:
-            # filter non-empty lines
-            lines = list(filter(None, map(str.strip, raw_lines)))
+        content = _read_utf8_with_fallback(os.path.join(path, entry))
+        # filter non-empty lines
+        lines = list(filter(None, map(str.strip, content.splitlines())))
 
         if len(lines) != 2:
             # format is not recognized; punt

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -717,7 +717,7 @@ class PackageIndex(Environment):
                     shutil.copy2(filename, dst)
                     filename = dst
 
-            with open(os.path.join(tmpdir, 'setup.py'), 'w') as file:
+            with open(os.path.join(tmpdir, 'setup.py'), 'w', encoding="utf-8") as file:
                 file.write(
                     "from setuptools import setup\n"
                     "setup(name=%r, version=%r, py_modules=[%r])\n"

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -76,6 +76,7 @@ def run_setup_py(cmd, pypath=None, path=None, data_stream=0, env=None):
             stderr=_PIPE,
             shell=shell,
             env=env,
+            encoding="utf-8",
         )
 
         if isinstance(data_stream, tuple):

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -17,7 +17,7 @@ class VirtualEnv(jaraco.envs.VirtualEnv):
 
     def run(self, cmd, *args, **kwargs):
         cmd = [self.exe(cmd[0])] + cmd[1:]
-        kwargs = {"cwd": self.root, **kwargs}  # Allow overriding
+        kwargs = {"cwd": self.root, "encoding": "utf-8", **kwargs}  # Allow overriding
         # In some environments (eg. downstream distro packaging), where:
         # - tox isn't used to run tests and
         # - PYTHONPATH is set to point to a specific setuptools codebase and

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -941,14 +941,14 @@ def test_legacy_editable_install(venv, tmpdir, tmpdir_cwd):
 
     # First: sanity check
     cmd = ["pip", "install", "--no-build-isolation", "-e", "."]
-    output = str(venv.run(cmd, cwd=tmpdir), "utf-8").lower()
+    output = venv.run(cmd, cwd=tmpdir).lower()
     assert "running setup.py develop for myproj" not in output
     assert "created wheel for myproj" in output
 
     # Then: real test
     env = {**os.environ, "SETUPTOOLS_ENABLE_FEATURES": "legacy-editable"}
     cmd = ["pip", "install", "--no-build-isolation", "-e", "."]
-    output = str(venv.run(cmd, cwd=tmpdir, env=env), "utf-8").lower()
+    output = venv.run(cmd, cwd=tmpdir, env=env).lower()
     assert "running setup.py develop for myproj" in output
 
 

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -361,7 +361,7 @@ class TestPTHFileWriter:
 
 @pytest.fixture
 def setup_context(tmpdir):
-    with (tmpdir / 'setup.py').open('w') as f:
+    with (tmpdir / 'setup.py').open('w', encoding="utf-8") as f:
         f.write(SETUP_PY)
     with tmpdir.as_cwd():
         yield tmpdir

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -131,7 +131,7 @@ def test_editable_with_pyproject(tmp_path, venv, files, editable_opts):
     jaraco.path.build(files, prefix=project)
 
     cmd = [
-        venv.exe(),
+        "python",
         "-m",
         "pip",
         "install",
@@ -140,14 +140,14 @@ def test_editable_with_pyproject(tmp_path, venv, files, editable_opts):
         str(project),
         *editable_opts,
     ]
-    print(str(subprocess.check_output(cmd), "utf-8"))
+    print(venv.run(cmd))
 
-    cmd = [venv.exe(), "-m", "mypkg"]
-    assert subprocess.check_output(cmd).strip() == b"3.14159.post0 Hello World"
+    cmd = ["python", "-m", "mypkg"]
+    assert venv.run(cmd).strip() == "3.14159.post0 Hello World"
 
     (project / "src/mypkg/data.txt").write_text("foobar", encoding="utf-8")
     (project / "src/mypkg/mod.py").write_text("x = 42", encoding="utf-8")
-    assert subprocess.check_output(cmd).strip() == b"3.14159.post0 foobar 42"
+    assert venv.run(cmd).strip() == "3.14159.post0 foobar 42"
 
 
 def test_editable_with_flat_layout(tmp_path, venv, editable_opts):
@@ -176,7 +176,7 @@ def test_editable_with_flat_layout(tmp_path, venv, editable_opts):
     project = tmp_path / "mypkg"
 
     cmd = [
-        venv.exe(),
+        "python",
         "-m",
         "pip",
         "install",
@@ -185,9 +185,9 @@ def test_editable_with_flat_layout(tmp_path, venv, editable_opts):
         str(project),
         *editable_opts,
     ]
-    print(str(subprocess.check_output(cmd), "utf-8"))
-    cmd = [venv.exe(), "-c", "import pkg, mod; print(pkg.a, mod.b)"]
-    assert subprocess.check_output(cmd).strip() == b"4 2"
+    print(venv.run(cmd))
+    cmd = ["python", "-c", "import pkg, mod; print(pkg.a, mod.b)"]
+    assert venv.run(cmd).strip() == "4 2"
 
 
 def test_editable_with_single_module(tmp_path, venv, editable_opts):
@@ -214,7 +214,7 @@ def test_editable_with_single_module(tmp_path, venv, editable_opts):
     project = tmp_path / "mypkg"
 
     cmd = [
-        venv.exe(),
+        "python",
         "-m",
         "pip",
         "install",
@@ -223,9 +223,9 @@ def test_editable_with_single_module(tmp_path, venv, editable_opts):
         str(project),
         *editable_opts,
     ]
-    print(str(subprocess.check_output(cmd), "utf-8"))
-    cmd = [venv.exe(), "-c", "import mod; print(mod.b)"]
-    assert subprocess.check_output(cmd).strip() == b"2"
+    print(venv.run(cmd))
+    cmd = ["python", "-c", "import mod; print(mod.b)"]
+    assert venv.run(cmd).strip() == "2"
 
 
 class TestLegacyNamespaces:
@@ -384,7 +384,7 @@ class TestPep420Namespaces:
         opts = ["--no-build-isolation"]  # force current version of setuptools
         venv.run(["python", "-m", "pip", "-v", "install", "-e", str(pkg_A), *opts])
         out = venv.run(["python", "-c", "from mypkg.n import pkgA; print(pkgA.a)"])
-        assert str(out, "utf-8").strip() == "1"
+        assert out.strip() == "1"
         cmd = """\
         try:
             import mypkg.other
@@ -392,7 +392,7 @@ class TestPep420Namespaces:
             print("mypkg.other not defined")
         """
         out = venv.run(["python", "-c", dedent(cmd)])
-        assert "mypkg.other not defined" in str(out, "utf-8")
+        assert "mypkg.other not defined" in out
 
 
 # Moved here from test_develop:
@@ -911,7 +911,7 @@ class TestOverallBehaviour:
             print(ex)
         """
         out = venv.run(["python", "-c", dedent(cmd_import_error)])
-        assert b"No module named 'otherfile'" in out
+        assert "No module named 'otherfile'" in out
 
         # Ensure the modules are importable
         cmd_get_vars = """\
@@ -919,7 +919,7 @@ class TestOverallBehaviour:
         print(mypkg.mod1.var, mypkg.subpackage.mod2.var)
         """
         out = venv.run(["python", "-c", dedent(cmd_get_vars)])
-        assert b"42 13" in out
+        assert "42 13" in out
 
         # Ensure resources are reachable
         cmd_get_resource = """\
@@ -929,7 +929,7 @@ class TestOverallBehaviour:
         print(text.read_text(encoding="utf-8"))
         """
         out = venv.run(["python", "-c", dedent(cmd_get_resource)])
-        assert b"resource 39" in out
+        assert "resource 39" in out
 
         # Ensure files are editable
         mod1 = next(project.glob("**/mod1.py"))
@@ -941,12 +941,12 @@ class TestOverallBehaviour:
         resource_file.write_text("resource 374", encoding="utf-8")
 
         out = venv.run(["python", "-c", dedent(cmd_get_vars)])
-        assert b"42 13" not in out
-        assert b"17 781" in out
+        assert "42 13" not in out
+        assert "17 781" in out
 
         out = venv.run(["python", "-c", dedent(cmd_get_resource)])
-        assert b"resource 39" not in out
-        assert b"resource 374" in out
+        assert "resource 39" not in out
+        assert "resource 374" in out
 
 
 class TestLinkTree:
@@ -1005,7 +1005,7 @@ class TestLinkTree:
         install_project("mypkg", venv, tmp_path, self.FILES, *opts)
 
         out = venv.run(["python", "-c", "import mypkg.mod1; print(mypkg.mod1.var)"])
-        assert b"42" in out
+        assert "42" in out
 
         # Ensure packages excluded from distribution are not importable
         cmd_import_error = """\
@@ -1015,7 +1015,7 @@ class TestLinkTree:
             print(ex)
         """
         out = venv.run(["python", "-c", dedent(cmd_import_error)])
-        assert b"cannot import name 'subpackage'" in out
+        assert "cannot import name 'subpackage'" in out
 
         # Ensure resource files excluded from distribution are not reachable
         cmd_get_resource = """\
@@ -1028,8 +1028,8 @@ class TestLinkTree:
             print(ex)
         """
         out = venv.run(["python", "-c", dedent(cmd_get_resource)])
-        assert b"No such file or directory" in out
-        assert b"resource.not_in_manifest" in out
+        assert "No such file or directory" in out
+        assert "resource.not_in_manifest" in out
 
 
 @pytest.mark.filterwarnings("ignore:.*compat.*:setuptools.SetuptoolsDeprecationWarning")
@@ -1040,7 +1040,7 @@ def test_compat_install(tmp_path, venv):
     install_project("mypkg", venv, tmp_path, files, *opts)
 
     out = venv.run(["python", "-c", "import mypkg.mod1; print(mypkg.mod1.var)"])
-    assert b"42" in out
+    assert "42" in out
 
     expected_path = comparable_path(str(tmp_path))
 
@@ -1051,7 +1051,7 @@ def test_compat_install(tmp_path, venv):
         "import other; print(other)",
         "import mypkg; print(mypkg)",
     ):
-        out = comparable_path(str(venv.run(["python", "-c", cmd]), "utf-8"))
+        out = comparable_path(venv.run(["python", "-c", cmd]))
         assert expected_path in out
 
     # Compatible behaviour will not consider custom mappings
@@ -1061,7 +1061,7 @@ def test_compat_install(tmp_path, venv):
     except ImportError as ex:
         print(ex)
     """
-    out = str(venv.run(["python", "-c", dedent(cmd)]), "utf-8")
+    out = venv.run(["python", "-c", dedent(cmd)])
     assert "cannot import name 'subpackage'" in out
 
 
@@ -1105,7 +1105,7 @@ def test_pbr_integration(tmp_path, venv, editable_opts):
         install_project("mypkg", venv, tmp_path, files, *editable_opts)
 
     out = venv.run(["python", "-c", "import mypkg.hello"])
-    assert b"Hello world!" in out
+    assert "Hello world!" in out
 
 
 class TestCustomBuildPy:
@@ -1143,11 +1143,11 @@ class TestCustomBuildPy:
         """Ensure that errors in custom build_py are reported as warnings"""
         # Warnings should show up
         _, out = install_project("mypkg", venv, tmp_path, self.FILES)
-        assert b"SetuptoolsDeprecationWarning" in out
-        assert b"ValueError: TEST_RAISE" in out
+        assert "SetuptoolsDeprecationWarning" in out
+        assert "ValueError: TEST_RAISE" in out
         # but installation should be successful
         out = venv.run(["python", "-c", "import mypkg.mod1; print(mypkg.mod1.var)"])
-        assert b"42" in out
+        assert "42" in out
 
 
 class TestCustomBuildWheel:

--- a/setuptools/tests/test_integration.py
+++ b/setuptools/tests/test_integration.py
@@ -99,10 +99,11 @@ def test_pbr(install_context):
 
 
 @pytest.mark.xfail
-@pytest.mark.filterwarnings("ignore::EncodingWarning")
+@pytest.mark.filterwarnings("ignore:'encoding' argument not specified")
 # ^-- Dependency chain: `python-novaclient` < `oslo-utils` < `netifaces==0.11.0`
 #     netifaces' setup.py uses `open` without `encoding="utf-8"` which is hijacked by
 #     `setuptools.sandbox._open` and triggers the EncodingWarning.
+#     Can't use EncodingWarning in the filter, as it does not exist on Python < 3.10.
 def test_python_novaclient(install_context):
     _install_one('python-novaclient', install_context, 'novaclient', 'base.py')
 

--- a/setuptools/tests/test_integration.py
+++ b/setuptools/tests/test_integration.py
@@ -99,6 +99,10 @@ def test_pbr(install_context):
 
 
 @pytest.mark.xfail
+@pytest.mark.filterwarnings("ignore::EncodingWarning")
+# ^-- Dependency chain: `python-novaclient` < `oslo-utils` < `netifaces==0.11.0`
+#     netifaces' setup.py uses `open` without `encoding="utf-8"` which is hijacked by
+#     `setuptools.sandbox._open` and triggers the EncodingWarning.
 def test_python_novaclient(install_context):
     _install_one('python-novaclient', install_context, 'novaclient', 'base.py')
 

--- a/setuptools/unicode_utils.py
+++ b/setuptools/unicode_utils.py
@@ -1,7 +1,9 @@
 import unicodedata
 import sys
+from configparser import ConfigParser
 
 from .compat import py39
+from .warnings import SetuptoolsDeprecationWarning
 
 
 # HFS Plus uses decomposed UTF-8
@@ -57,5 +59,44 @@ def _read_utf8_with_fallback(file: str, fallback_encoding=py39.LOCALE_ENCODING) 
         with open(file, "r", encoding="utf-8") as f:
             return f.read()
     except UnicodeDecodeError:  # pragma: no cover
+        _Utf8EncodingNeeded.emit(file=file, fallback_encoding=fallback_encoding)
         with open(file, "r", encoding=fallback_encoding) as f:
             return f.read()
+
+
+def _cfg_read_utf8_with_fallback(
+    cfg: ConfigParser, file: str, fallback_encoding=py39.LOCALE_ENCODING
+) -> str:
+    """Same idea as :func:`_read_utf8_with_fallback`, but for the
+    :meth:`ConfigParser.read` method.
+
+    This method may call ``cfg.clear()``.
+    """
+    try:
+        cfg.read(file, encoding="utf-8")
+    except UnicodeDecodeError:  # pragma: no cover
+        _Utf8EncodingNeeded.emit(file=file, fallback_encoding=fallback_encoding)
+        cfg.clear()
+        cfg.read(file, encoding=fallback_encoding)
+
+
+class _Utf8EncodingNeeded(SetuptoolsDeprecationWarning):
+    _SUMMARY = """
+    `encoding="utf-8"` fails with {file!r}, trying `encoding={fallback_encoding!r}`.
+    """
+
+    _DETAILS = """
+    Fallback behaviour for UTF-8 is considered **deprecated** and future versions of
+    `setuptools` may not implement it.
+
+    Please encode {file!r} with "utf-8" to ensure future builds will succeed.
+
+    If this file was produced by `setuptools` itself, cleaning up the cached files
+    and re-building/re-installing the package with a newer version of `setuptools`
+    (e.g. by updating `build-system.requires` in its `pyproject.toml`)
+    might solve the problem.
+    """
+    # TODO: Add a deadline?
+    #       Will we be able to remove this?
+    #       The question comes to mind mainly because of sdists that have been produced
+    #       by old versions of setuptools and published to PyPI...

--- a/setuptools/unicode_utils.py
+++ b/setuptools/unicode_utils.py
@@ -46,7 +46,7 @@ def try_encode(string, enc):
         return None
 
 
-def read_utf8_with_fallback(file: str, fallback_encoding=py39.LOCALE_ENCODING) -> str:
+def _read_utf8_with_fallback(file: str, fallback_encoding=py39.LOCALE_ENCODING) -> str:
     """
     First try to read the file with UTF-8, if there is an error fallback to a
     different encoding ("locale" by default). Returns the content of the file.

--- a/setuptools/unicode_utils.py
+++ b/setuptools/unicode_utils.py
@@ -1,6 +1,8 @@
 import unicodedata
 import sys
 
+from .compat import py39
+
 
 # HFS Plus uses decomposed UTF-8
 def decompose(path):
@@ -42,3 +44,18 @@ def try_encode(string, enc):
         return string.encode(enc)
     except UnicodeEncodeError:
         return None
+
+
+def read_utf8_with_fallback(file: str, fallback_encoding=py39.LOCALE_ENCODING) -> str:
+    """
+    First try to read the file with UTF-8, if there is an error fallback to a
+    different encoding ("locale" by default). Returns the content of the file.
+    Also useful when reading files that might have been produced by an older version of
+    setuptools.
+    """
+    try:
+        with open(file, "r", encoding="utf-8") as f:
+            return f.read()
+    except UnicodeDecodeError:  # pragma: no cover
+        with open(file, "r", encoding=fallback_encoding) as f:
+            return f.read()

--- a/setuptools/unicode_utils.py
+++ b/setuptools/unicode_utils.py
@@ -66,7 +66,7 @@ def _read_utf8_with_fallback(file: str, fallback_encoding=py39.LOCALE_ENCODING) 
 
 def _cfg_read_utf8_with_fallback(
     cfg: ConfigParser, file: str, fallback_encoding=py39.LOCALE_ENCODING
-) -> str:
+) -> None:
     """Same idea as :func:`_read_utf8_with_fallback`, but for the
     :meth:`ConfigParser.read` method.
 

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -18,7 +18,7 @@ from setuptools.extern.packaging.utils import canonicalize_name
 from setuptools.command.egg_info import write_requirements, _egg_basename
 from setuptools.archive_util import _unpack_zipfile_obj
 
-from .compat import py39
+from .unicode_utils import read_utf8_with_fallback
 
 
 WHEEL_NAME = re.compile(
@@ -224,12 +224,7 @@ class Wheel:
     def _fix_namespace_packages(egg_info, destination_eggdir):
         namespace_packages = os.path.join(egg_info, 'namespace_packages.txt')
         if os.path.exists(namespace_packages):
-            try:
-                with open(namespace_packages, encoding="utf-8") as fp:
-                    namespace_packages = fp.read().split()
-            except UnicodeDecodeError:  # pragma: no cover
-                with open(namespace_packages, encoding=py39.LOCALE_ENCODING) as fp:
-                    namespace_packages = fp.read().split()
+            namespace_packages = read_utf8_with_fallback(namespace_packages).split()
 
             for mod in namespace_packages:
                 mod_dir = os.path.join(destination_eggdir, *mod.split('.'))

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -237,5 +237,5 @@ class Wheel:
                 if not os.path.exists(mod_dir):
                     os.mkdir(mod_dir)
                 if not os.path.exists(mod_init):
-                    with open(mod_init, 'w') as fp:
+                    with open(mod_init, 'w', encoding="utf-8") as fp:
                         fp.write(NAMESPACE_PACKAGE_INIT)

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -18,7 +18,7 @@ from setuptools.extern.packaging.utils import canonicalize_name
 from setuptools.command.egg_info import write_requirements, _egg_basename
 from setuptools.archive_util import _unpack_zipfile_obj
 
-from .unicode_utils import read_utf8_with_fallback
+from .unicode_utils import _read_utf8_with_fallback
 
 
 WHEEL_NAME = re.compile(
@@ -224,7 +224,7 @@ class Wheel:
     def _fix_namespace_packages(egg_info, destination_eggdir):
         namespace_packages = os.path.join(egg_info, 'namespace_packages.txt')
         if os.path.exists(namespace_packages):
-            namespace_packages = read_utf8_with_fallback(namespace_packages).split()
+            namespace_packages = _read_utf8_with_fallback(namespace_packages).split()
 
             for mod in namespace_packages:
                 mod_dir = os.path.join(destination_eggdir, *mod.split('.'))


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Previously, changes regarding UTF-8 avoided touching complicated parts of the code where it could cause incompatibility.

This PR is a bit more aggressive, but still try to maintain backwards compatibility:
- When reading files, first try to read them as UTF-8, then we fallback to the `locale` encoding.
- When writing files, use UTF-8.

In my opinion the highest risk here are in the `easy_install/install_scripts` commands, because it might be the case some scripts are not meant to be UTF-8... But hopefully that risk would be minimal[^1].

[^1]: Once file contents are encoded as Python strings they are already encoded as UTF-8, so it should be OK to write them directly to files. Moreover, most popular scripting languages nowadays support UTF-8.


Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
