### PR TITLE
Uses RST substitution to put badges in 1 line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,31 +1,33 @@
-.. image:: https://img.shields.io/pypi/v/setuptools.svg
+.. |pypi-version| image:: https://img.shields.io/pypi/v/setuptools.svg
    :target: https://pypi.org/project/setuptools
 
-.. image:: https://img.shields.io/pypi/pyversions/setuptools.svg
+.. |py-version| image:: https://img.shields.io/pypi/pyversions/setuptools.svg
 
-.. image:: https://github.com/pypa/setuptools/actions/workflows/main.yml/badge.svg
+.. |test-badge| image:: https://github.com/pypa/setuptools/actions/workflows/main.yml/badge.svg
    :target: https://github.com/pypa/setuptools/actions?query=workflow%3A%22tests%22
    :alt: tests
 
-.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json
-    :target: https://github.com/astral-sh/ruff
-    :alt: Ruff
+.. |ruff-badge| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v2.json
+   :target: https://github.com/astral-sh/ruff
+   :alt: Ruff
 
-.. image:: https://img.shields.io/readthedocs/setuptools/latest.svg
-    :target: https://setuptools.pypa.io
+.. |docs-badge| image:: https://img.shields.io/readthedocs/setuptools/latest.svg
+   :target: https://setuptools.pypa.io
 
-.. image:: https://img.shields.io/badge/skeleton-2024-informational
+.. |skeleton-badge| image:: https://img.shields.io/badge/skeleton-2024-informational
    :target: https://blog.jaraco.com/skeleton
 
-.. image:: https://img.shields.io/codecov/c/github/pypa/setuptools/master.svg?logo=codecov&logoColor=white
+.. |codecov-badge| image:: https://img.shields.io/codecov/c/github/pypa/setuptools/master.svg?logo=codecov&logoColor=white
    :target: https://codecov.io/gh/pypa/setuptools
 
-.. image:: https://tidelift.com/badges/github/pypa/setuptools?style=flat
+.. |tidelift-badge| image:: https://tidelift.com/badges/github/pypa/setuptools?style=flat
    :target: https://tidelift.com/subscription/pkg/pypi-setuptools?utm_source=pypi-setuptools&utm_medium=readme
 
-.. image:: https://img.shields.io/discord/803025117553754132
+.. |discord-badge| image:: https://img.shields.io/discord/803025117553754132
    :target: https://discord.com/channels/803025117553754132/815945031150993468
    :alt: Discord
+
+|pypi-version| |py-version| |test-badge| |ruff-badge| |docs-badge| |skeleton-badge| |codecov-badge| |discord-badge|
 
 See the `Quickstart <https://setuptools.pypa.io/en/latest/userguide/quickstart.html>`_
 and the `User's Guide <https://setuptools.pypa.io/en/latest/userguide/>`_ for

--- a/newsfragments/4312.doc.rst
+++ b/newsfragments/4312.doc.rst
@@ -1,0 +1,1 @@
+Uses RST substitution to put badges in 1 line.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

It might be some update to Github's RST renderer caused badges to display in multiple lines. uses RST substitution to put badges in 1 line.

Before the change

<img width="215" alt="image" src="https://github.com/pypa/setuptools/assets/3353385/60fd5f7b-822c-4bdc-acb6-347e6031d48a">

After the change

<img width="633" alt="image" src="https://github.com/pypa/setuptools/assets/3353385/7ab4eba0-a93f-4324-9c34-6125a0c76905">

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
