### PR TITLE
Make `test_apply_pyprojecttoml` more deterministic with new version of `ini2toml`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ testing =
 	jaraco.path>=3.2.0
 	build[virtualenv]>=1.0.3
 	filelock>=3.4.0
-	ini2toml[lite]>=0.9
+	ini2toml[lite]>=0.14
 	tomli-w>=1.0.0
 	pytest-timeout
 	pytest-perf; \

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -14,7 +14,7 @@ from unittest.mock import Mock
 from zipfile import ZipFile
 
 import pytest
-from ini2toml.api import Translator
+from ini2toml.api import LiteTranslator
 
 from packaging.metadata import Metadata
 
@@ -46,7 +46,7 @@ def test_apply_pyproject_equivalent_to_setupcfg(url, monkeypatch, tmp_path):
     setupcfg_example = retrieve_file(url)
     pyproject_example = Path(tmp_path, "pyproject.toml")
     setupcfg_text = setupcfg_example.read_text(encoding="utf-8")
-    toml_config = Translator().translate(setupcfg_text, "setup.cfg")
+    toml_config = LiteTranslator().translate(setupcfg_text, "setup.cfg")
     pyproject_example.write_text(toml_config, encoding="utf-8")
 
     dist_toml = pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject_example)

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -37,7 +37,6 @@ def makedist(path, **attrs):
     return Distribution({"src_root": path, **attrs})
 
 
-@pytest.mark.xfail(reason="#4315")
 @pytest.mark.parametrize("url", urls_from_file(HERE / EXAMPLES_FILE))
 @pytest.mark.filterwarnings("ignore")
 @pytest.mark.uses_network


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Replace `Translator` with `LiteTranslator` from `ini2toml[lite]>=0.14`

Closes #4315

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
