### PR TITLE
Fix missing backtick in changelog

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -119,7 +119,7 @@ Improved Documentation
 ----------------------
 
 - Updated documentation referencing obsolete Python 3.7 code. -- by :user:`Avasam` (#4096)
-- Changed ``versionadded`` for "Type information included by default" feature from ``v68.3.0`` to ``v69.0.0`` -- by :user:Avasam` (#4182)
+- Changed ``versionadded`` for "Type information included by default" feature from ``v68.3.0`` to ``v69.0.0`` -- by :user:`Avasam` (#4182)
 - Described the auto-generated files -- by :user:`VladimirFokow` (#4198)
 - Updated "Quickstart" to describe the current status of ``setup.cfg`` and ``pyproject.toml`` -- by :user:`VladimirFokow` (#4200)
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix a changelog rendering issue due to a missing backtick noticed here: https://github.com/pypa/setuptools/pull/4182#discussion_r1572904553

### Pull Request Checklist
I don't think this deserves a newsfragment.

- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
