### PR TITLE
Remove deprecated code after warnings have been issued for a long period.

### DIFF
--- a/newsfragments/4322.removal.1.rst
+++ b/newsfragments/4322.removal.1.rst
@@ -1,0 +1,3 @@
+Remove ``setuptools.convert_path`` after long deprecation period.
+This function was never defined by ``setuptools`` itself, but rather a
+side-effect of an import for internal usage.

--- a/newsfragments/4322.removal.2.rst
+++ b/newsfragments/4322.removal.2.rst
@@ -1,0 +1,3 @@
+Remove fallback for customisations of ``distutils``' ``build.sub_command`` after long
+deprecated period.
+Users are advised to import ``build`` directly from ``setuptools.command.build``.

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 import _distutils_hack.override  # noqa: F401
 import distutils.core
 from distutils.errors import DistutilsOptionError
-from distutils.util import convert_path as _convert_path
 
 from . import logging, monkey
 from . import version as _version_module
@@ -245,22 +244,6 @@ def findall(dir=os.curdir):
         make_rel = functools.partial(os.path.relpath, start=dir)
         files = map(make_rel, files)
     return list(files)
-
-
-@functools.wraps(_convert_path)
-def convert_path(pathname):
-    SetuptoolsDeprecationWarning.emit(
-        "Access to implementation detail",
-        """
-        The function `convert_path` is not provided by setuptools itself,
-        and therefore not part of the public API.
-
-        Its direct usage by 3rd-party packages is considered improper and the function
-        may be removed in the future.
-        """,
-        due_date=(2023, 12, 13),  # initial deprecation 2022-03-25, see #3201
-    )
-    return _convert_path(pathname)
 
 
 class sic(str):

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -1,30 +1,12 @@
 from typing import Dict, List, Protocol
 from distutils.command.build import build as _build
 
-from ..warnings import SetuptoolsDeprecationWarning
-
 _ORIGINAL_SUBCOMMANDS = {"build_py", "build_clib", "build_ext", "build_scripts"}
 
 
 class build(_build):
     # copy to avoid sharing the object with parent class
     sub_commands = _build.sub_commands[:]
-
-    def get_sub_commands(self):
-        subcommands = {cmd[0] for cmd in _build.sub_commands}
-        if subcommands - _ORIGINAL_SUBCOMMANDS:
-            SetuptoolsDeprecationWarning.emit(
-                "Direct usage of `distutils` commands",
-                """
-                It seems that you are using `distutils.command.build` to add
-                new subcommands. Using `distutils` directly is considered deprecated,
-                please use `setuptools.command.build`.
-                """,
-                due_date=(2023, 12, 13),  # Warning introduced in 13 Jun 2022.
-                see_url="https://peps.python.org/pep-0632/",
-            )
-            self.sub_commands = _build.sub_commands
-        return super().get_sub_commands()
 
 
 class SubCommand(Protocol):

--- a/setuptools/tests/test_build.py
+++ b/setuptools/tests/test_build.py
@@ -1,10 +1,6 @@
-from contextlib import contextmanager
-from setuptools import Command, SetuptoolsDeprecationWarning
+from setuptools import Command
 from setuptools.dist import Distribution
 from setuptools.command.build import build
-from distutils.command.build import build as distutils_build
-
-import pytest
 
 
 def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
@@ -24,15 +20,6 @@ def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):
     assert isinstance(dist.get_command_obj("build"), build)
 
 
-@contextmanager
-def _restore_sub_commands():
-    orig = distutils_build.sub_commands[:]
-    try:
-        yield
-    finally:
-        distutils_build.sub_commands = orig
-
-
 class Subcommand(Command):
     """Dummy command to be used in tests"""
 
@@ -44,24 +31,3 @@ class Subcommand(Command):
 
     def run(self):
         raise NotImplementedError("just to check if the command runs")
-
-
-@_restore_sub_commands()
-def test_subcommand_in_distutils(tmpdir_cwd):
-    """
-    Ensure that sub commands registered in ``distutils`` run,
-    after instructing the users to migrate to ``setuptools``.
-    """
-    dist = Distribution(
-        dict(
-            packages=[],
-            cmdclass={'subcommand': Subcommand},
-        )
-    )
-    distutils_build.sub_commands.append(('subcommand', None))
-
-    warning_msg = "please use .setuptools.command.build."
-    with pytest.warns(SetuptoolsDeprecationWarning, match=warning_msg):
-        # For backward compatibility, the subcommand should run anyway:
-        with pytest.raises(NotImplementedError, match="the command runs"):
-            dist.run_command("build")

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -307,8 +307,3 @@ def test_its_own_wheel_does_not_contain_tests(setuptools_wheel):
 
     for member in contents:
         assert '/tests/' not in member
-
-
-def test_convert_path_deprecated():
-    with pytest.warns(setuptools.SetuptoolsDeprecationWarning):
-        setuptools.convert_path('setuptools/tests')

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,7 @@ deps =
 	# Ideally all the dependencies should be set as "extras"
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
-	SETUPTOOLS_ENFORCE_DEPRECATION = {env:SETUPTOOLS_ENFORCE_DEPRECATION:0}
-	# ^-- Temporarily disable enforcement so CI don't fail on due dates
+	SETUPTOOLS_ENFORCE_DEPRECATION = {env:SETUPTOOLS_ENFORCE_DEPRECATION:1}
 commands =
 	pytest {posargs}
 usedevelop = True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Remove ``setuptools.convert_path``
- Remove fallback for customisations of ``distutils``' ``build.sub_command``
- Re-enable enforcement via `tox` so that the maintainers of `setuptools` are "notified" when the next deprecation comes[^1]

The deprecation warnings have been issued for almost 2 years for these features.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request

[^1]: By "notified", I mean the CI builds will start to fail and require manual intervention...
