### PR TITLE
Add `__pycache__/` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ setuptools/tests/bdist_wheel_testdata/*/*.egg-info/
 .cache
 .pytest_cache/
 .mypy_cache/
+__pycache__/


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Running `tox` locally leaves a lot of files behind in `__pycache__` folders.
![image](https://github.com/pypa/setuptools/assets/1350584/33edde1d-ec7f-4fc9-a900-6a104715576e)
This PR adds the cache folder to the .gitignore, since this is specific to this project (using tox) and not my personal environment.


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`]. (no user facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
