### PR TITLE
Revert GitHub Actions for Python 3.8 to `macos-latest`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,12 +61,6 @@ jobs:
         - platform: ubuntu-latest
           python: "3.10"
           distutils: stdlib
-        # Python 3.8, 3.9 are on macos-13 but not macos-latest (macos-14-arm64)
-        # https://github.com/actions/setup-python/issues/850
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        - {python: "3.8", platform: "macos-13"}
-        exclude:
-        - {python: "3.8", platform: "macos-latest"}
     runs-on: ${{ matrix.platform }}
     continue-on-error: ${{ matrix.python == '3.13' }}
     env:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The issue might have been solved in https://github.com/actions/setup-python/issues/850#issuecomment-2077454891

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
