### PR TITLE
Modernize package_index VCS handling

### DIFF
--- a/newsfragments/4332.feature.rst
+++ b/newsfragments/4332.feature.rst
@@ -1,0 +1,1 @@
+Modernized and refactored VCS handling in package_index.

--- a/setup.cfg
+++ b/setup.cfg
@@ -76,6 +76,7 @@ testing =
 	tomli
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly
 	importlib_metadata
+	pytest-subprocess
 
 	# workaround for pypa/setuptools#4333
 	pyproject-hooks!=1.1

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -880,7 +880,7 @@ class PackageIndex(Environment):
 
     def _download_other(self, url, filename):
         scheme = urllib.parse.urlsplit(url).scheme
-        if scheme == 'file':
+        if scheme == 'file':  # pragma: no cover
             return urllib.request.url2pathname(urllib.parse.urlparse(url).path)
         # raise error if not allowed
         self.url_ok(url, True)

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1,6 +1,7 @@
 """PyPI and direct package downloading."""
 
 import sys
+import subprocess
 import os
 import re
 import io
@@ -865,15 +866,15 @@ class PackageIndex(Environment):
         url, rev = self._vcs_split_rev_from_url(url)
 
         self.info(f"Doing {vcs} clone from {url} to {filename}")
-        os.system(f"{vcs} clone --quiet {url} {filename}")
+        subprocess.check_call([vcs, 'clone', '--quiet', url, filename])
 
         co_commands = dict(
-            git=f"git -C {filename} checkout --quiet {rev}",
-            hg=f"hg --cwd {filename} up -C -r {rev} -q",
+            git=[vcs, '-C', filename, 'checkout', '--quiet', rev],
+            hg=[vcs, '--cwd', filename, 'up', '-C', '-r', rev, '-q'],
         )
         if rev is not None:
             self.info(f"Checking out {rev}")
-            os.system(co_commands[vcs])
+            subprocess.check_call(co_commands[vcs])
 
         return filename
 

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -831,19 +831,24 @@ class PackageIndex(Environment):
 
         filename = os.path.join(tmpdir, name)
 
-        # Download the file
-        #
+        return self._download_vcs(url, filename) or self._download_other(url, filename)
+
+    def _download_vcs(self, url, filename):
+        scheme = urllib.parse.urlsplit(url).scheme
         if scheme == 'svn' or scheme.startswith('svn+'):
             return self._download_svn(url, filename)
         elif scheme == 'git' or scheme.startswith('git+'):
             return self._download_git(url, filename)
         elif scheme.startswith('hg+'):
             return self._download_hg(url, filename)
-        elif scheme == 'file':
-            return urllib.request.url2pathname(urllib.parse.urlparse(url)[2])
-        else:
-            self.url_ok(url, True)  # raises error if not allowed
-            return self._attempt_download(url, filename)
+
+    def _download_other(self, url, filename):
+        scheme = urllib.parse.urlsplit(url).scheme
+        if scheme == 'file':
+            return urllib.request.url2pathname(urllib.parse.urlparse(url).path)
+        # raise error if not allowed
+        self.url_ok(url, True)
+        return self._attempt_download(url, filename)
 
     def scan_url(self, url):
         self.process_url(url, True)

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -864,6 +864,15 @@ class PackageIndex(Environment):
 
     @staticmethod
     def _vcs_split_rev_from_url(url):
+        """
+        >>> vsrfu = PackageIndex._vcs_split_rev_from_url
+        >>> vsrfu('git+https://github.com/pypa/setuptools@v69.0.0#egg-info=setuptools')
+        ('https://github.com/pypa/setuptools', 'v69.0.0')
+        >>> vsrfu('git+https://github.com/pypa/setuptools#egg-info=setuptools')
+        ('https://github.com/pypa/setuptools', None)
+        >>> vsrfu('http://foo/bar')
+        ('http://foo/bar', None)
+        """
         scheme, netloc, path, query, frag = urllib.parse.urlsplit(url)
 
         scheme = scheme.split('+', 1)[-1]

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -863,7 +863,7 @@ class PackageIndex(Environment):
         raise DistutilsError(f"Invalid config, SVN download is not supported: {url}")
 
     @staticmethod
-    def _vcs_split_rev_from_url(url, pop_prefix=False):
+    def _vcs_split_rev_from_url(url):
         scheme, netloc, path, query, frag = urllib.parse.urlsplit(url)
 
         scheme = scheme.split('+', 1)[-1]
@@ -882,7 +882,7 @@ class PackageIndex(Environment):
 
     def _download_git(self, url, filename):
         filename = filename.split('#', 1)[0]
-        url, rev = self._vcs_split_rev_from_url(url, pop_prefix=True)
+        url, rev = self._vcs_split_rev_from_url(url)
 
         self.info("Doing git clone from %s to %s", url, filename)
         os.system("git clone --quiet %s %s" % (url, filename))
@@ -901,7 +901,7 @@ class PackageIndex(Environment):
 
     def _download_hg(self, url, filename):
         filename = filename.split('#', 1)[0]
-        url, rev = self._vcs_split_rev_from_url(url, pop_prefix=True)
+        url, rev = self._vcs_split_rev_from_url(url)
 
         self.info("Doing hg clone from %s to %s", url, filename)
         os.system("hg clone --quiet %s %s" % (url, filename))

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -170,11 +170,11 @@ class TestPackageIndex:
             assert dists[0].version == ''
             assert dists[1].version == vc
 
-    def test_download_git_with_rev(self, tmpdir, fp):
+    def test_download_git_with_rev(self, tmp_path, fp):
         url = 'git+https://github.example/group/project@master#egg=foo'
         index = setuptools.package_index.PackageIndex()
 
-        expected_dir = str(tmpdir / 'project@master')
+        expected_dir = tmp_path / 'project@master'
         fp.register([
             'git',
             'clone',
@@ -184,16 +184,16 @@ class TestPackageIndex:
         ])
         fp.register(['git', '-C', expected_dir, 'checkout', '--quiet', 'master'])
 
-        result = index.download(url, str(tmpdir))
+        result = index.download(url, tmp_path)
 
-        assert result == expected_dir
+        assert result == str(expected_dir)
         assert len(fp.calls) == 2
 
-    def test_download_git_no_rev(self, tmpdir, fp):
+    def test_download_git_no_rev(self, tmp_path, fp):
         url = 'git+https://github.example/group/project#egg=foo'
         index = setuptools.package_index.PackageIndex()
 
-        expected_dir = str(tmpdir / 'project')
+        expected_dir = tmp_path / 'project'
         fp.register([
             'git',
             'clone',
@@ -201,15 +201,15 @@ class TestPackageIndex:
             'https://github.example/group/project',
             expected_dir,
         ])
-        index.download(url, str(tmpdir))
+        index.download(url, tmp_path)
 
-    def test_download_svn(self, tmpdir):
+    def test_download_svn(self, tmp_path):
         url = 'svn+https://svn.example/project#egg=foo'
         index = setuptools.package_index.PackageIndex()
 
         msg = r".*SVN download is not supported.*"
         with pytest.raises(distutils.errors.DistutilsError, match=msg):
-            index.download(url, str(tmpdir))
+            index.download(url, tmp_path)
 
 
 class TestContentCheckers:

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -3,7 +3,6 @@ import urllib.request
 import urllib.error
 import http.client
 from inspect import cleandoc
-from unittest import mock
 
 import pytest
 
@@ -171,41 +170,38 @@ class TestPackageIndex:
             assert dists[0].version == ''
             assert dists[1].version == vc
 
-    def test_download_git_with_rev(self, tmpdir):
+    def test_download_git_with_rev(self, tmpdir, fp):
         url = 'git+https://github.example/group/project@master#egg=foo'
         index = setuptools.package_index.PackageIndex()
 
-        with mock.patch("os.system") as os_system_mock:
-            result = index.download(url, str(tmpdir))
-
-        os_system_mock.assert_called()
-
         expected_dir = str(tmpdir / 'project@master')
-        expected = (
-            'git clone --quiet ' 'https://github.example/group/project {expected_dir}'
-        ).format(**locals())
-        first_call_args = os_system_mock.call_args_list[0][0]
-        assert first_call_args == (expected,)
+        fp.register([
+            'git',
+            'clone',
+            '--quiet',
+            'https://github.example/group/project',
+            expected_dir,
+        ])
+        fp.register(['git', '-C', expected_dir, 'checkout', '--quiet', 'master'])
 
-        tmpl = 'git -C {expected_dir} checkout --quiet master'
-        expected = tmpl.format(**locals())
-        assert os_system_mock.call_args_list[1][0] == (expected,)
+        result = index.download(url, str(tmpdir))
+
         assert result == expected_dir
+        assert len(fp.calls) == 2
 
-    def test_download_git_no_rev(self, tmpdir):
+    def test_download_git_no_rev(self, tmpdir, fp):
         url = 'git+https://github.example/group/project#egg=foo'
         index = setuptools.package_index.PackageIndex()
 
-        with mock.patch("os.system") as os_system_mock:
-            result = index.download(url, str(tmpdir))
-
-        os_system_mock.assert_called()
-
         expected_dir = str(tmpdir / 'project')
-        expected = (
-            'git clone --quiet ' 'https://github.example/group/project {expected_dir}'
-        ).format(**locals())
-        os_system_mock.assert_called_once_with(expected)
+        fp.register([
+            'git',
+            'clone',
+            '--quiet',
+            'https://github.example/group/project',
+            expected_dir,
+        ])
+        index.download(url, str(tmpdir))
 
     def test_download_svn(self, tmpdir):
         url = 'svn+https://svn.example/project#egg=foo'


### PR DESCRIPTION
- **Remove pop_prefix parameter, unused.**
- **Add a test capturing the basic expectation.**
- **Update _vcs_split_rev_from_url to use modern constructs.**
- **package-index: Extract fall-through methods _download_vcs and _download_other.**
- **Extract _resolve_vcs for resolving a VCS from a URL.**
- **Consolidated all _download_vcs methods into one.**
- **Replace os.system calls with subprocess calls.**
- **Prefer tmp_path fixture.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
