### PR TITLE
Don't call `setuptools.extern.importlib_metadata.EntryPoints.names` for better backwards compatibility.

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -535,7 +535,8 @@ class Distribution(_Distribution):
 
     def _setuptools_commands(self):
         try:
-            return metadata.distribution('setuptools').entry_points.names
+            entry_points = metadata.distribution('setuptools').entry_points
+            return {ep.name for ep in entry_points}  # Avoid newer API for compatibility
         except metadata.PackageNotFoundError:
             # during bootstrapping, distribution doesn't exist
             return []


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

- Don't call `setuptools.extern.importlib_metadata.EntryPoints.names`, instead just iterate over `entry_points` (this is the [same underlying implementation](https://github.com/python/importlib_metadata/blob/v7.1.0/importlib_metadata/__init__.py#L286-L290), but it is backwards compatible).

Closes #4338 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
