### PR TITLE
Investigate limitations of GitHub Actions `setup-python` for Python 3.8 on `macos-latest`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,12 +61,6 @@ jobs:
         - platform: ubuntu-latest
           python: "3.10"
           distutils: stdlib
-        # Python 3.8, 3.9 are on macos-13 but not macos-latest (macos-14-arm64)
-        # https://github.com/actions/setup-python/issues/850
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        - {python: "3.8", platform: "macos-13"}
-        exclude:
-        - {python: "3.8", platform: "macos-latest"}
     runs-on: ${{ matrix.platform }}
     continue-on-error: ${{ matrix.python == '3.13' }}
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,13 +67,13 @@ jobs:
       SETUPTOOLS_USE_DISTUTILS: ${{ matrix.distutils || 'local' }}
     timeout-minutes: 75
     steps:
-      - uses: actions/checkout@v4
       - name: Setup Python
         id: python-install
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
           allow-prereleases: true
+      - uses: actions/checkout@v4
       - uses: actions/cache@v4
         id: cache
         with:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

- Second take on #4329
- As per https://github.com/actions/setup-python/issues/860 it seems that the installation of `pip` inside `setup-python` GHA is not isolated enough and ends up being influenced by the contents of the current working directory.

This PR is an attempt of investigating that, by answering the question "what if we install Python prior to cloning the repo?"

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
