### PR TITLE
Simplified `pkg_resources._declare_state`

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -117,11 +117,11 @@ class PEP440Warning(RuntimeWarning):
 parse_version = packaging.version.Version
 
 
-_state_vars: Dict[str, Any] = {}
+_state_vars: Dict[str, str] = {}
 
 
-def _declare_state(vartype: str, **kw: object) -> None:
-    _state_vars.update(dict.fromkeys(kw, vartype))
+def _declare_state(vartype: str, varname: str) -> None:
+    _state_vars[varname] = vartype
 
 
 def __getstate__():
@@ -2024,7 +2024,7 @@ class EggMetadata(ZipProvider):
 _distribution_finders: Dict[
     type, Callable[[object, str, bool], Iterable["Distribution"]]
 ] = {}
-_declare_state('dict', _distribution_finders=_distribution_finders)
+_declare_state('dict', '_distribution_finders')
 
 
 def register_finder(importer_type, distribution_finder):
@@ -2200,9 +2200,9 @@ register_finder(importlib.machinery.FileFinder, find_on_path)
 _namespace_handlers: Dict[
     type, Callable[[object, str, str, types.ModuleType], Optional[str]]
 ] = {}
-_declare_state('dict', _namespace_handlers=_namespace_handlers)
+_declare_state('dict', '_namespace_handlers')
 _namespace_packages: Dict[Optional[str], List[str]] = {}
-_declare_state('dict', _namespace_packages=_namespace_packages)
+_declare_state('dict', '_namespace_packages')
 
 
 def register_namespace_handler(importer_type, namespace_handler):
@@ -3302,7 +3302,7 @@ def _initialize_master_working_set():
     at their own risk.
     """
     working_set = WorkingSet._build_master()
-    _declare_state('object', working_set=working_set)
+    _declare_state('object', 'working_set')
 
     require = working_set.require
     iter_entry_points = working_set.iter_entry_points

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -27,7 +27,7 @@ import io
 import time
 import re
 import types
-from typing import Any, Callable, Dict, Iterable, List, Protocol, Optional
+from typing import Any, Callable, Dict, Iterable, List, Protocol, Optional, TypeVar
 import zipfile
 import zipimport
 import warnings
@@ -103,6 +103,8 @@ warnings.warn(
     stacklevel=2,
 )
 
+T = TypeVar("T")
+
 
 _PEP440_FALLBACK = re.compile(r"^v?(?P<safe>(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*)", re.I)
 
@@ -120,8 +122,9 @@ parse_version = packaging.version.Version
 _state_vars: Dict[str, str] = {}
 
 
-def _declare_state(vartype: str, varname: str) -> None:
+def _declare_state(vartype: str, varname: str, initial_value: T) -> T:
     _state_vars[varname] = vartype
+    return initial_value
 
 
 def __getstate__():
@@ -2023,8 +2026,7 @@ class EggMetadata(ZipProvider):
 
 _distribution_finders: Dict[
     type, Callable[[object, str, bool], Iterable["Distribution"]]
-] = {}
-_declare_state('dict', '_distribution_finders')
+] = _declare_state('dict', '_distribution_finders', {})
 
 
 def register_finder(importer_type, distribution_finder):
@@ -2199,10 +2201,10 @@ register_finder(importlib.machinery.FileFinder, find_on_path)
 
 _namespace_handlers: Dict[
     type, Callable[[object, str, str, types.ModuleType], Optional[str]]
-] = {}
-_declare_state('dict', '_namespace_handlers')
-_namespace_packages: Dict[Optional[str], List[str]] = {}
-_declare_state('dict', '_namespace_packages')
+] = _declare_state('dict', '_namespace_handlers', {})
+_namespace_packages: Dict[Optional[str], List[str]] = _declare_state(
+    'dict', '_namespace_packages', {}
+)
 
 
 def register_namespace_handler(importer_type, namespace_handler):
@@ -3301,8 +3303,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
-    _declare_state('object', 'working_set')
+    working_set = _declare_state('object', 'working_set', WorkingSet._build_master())
 
     require = working_set.require
     iter_entry_points = working_set.iter_entry_points

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -27,7 +27,7 @@ import io
 import time
 import re
 import types
-from typing import Any, Callable, Dict, Iterable, List, Protocol, Optional, TypeVar
+from typing import Callable, Dict, Iterable, List, Protocol, Optional, TypeVar
 import zipfile
 import zipimport
 import warnings


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Simplified `pkg_resources._declare_state`. As per @abravalheri 's suggestion in https://github.com/pypa/setuptools/pull/4258#discussion_r1518185927

### Pull Request Checklist
- [x] Changes have tests (existing tests for this functionality should pass)
- [x] News fragment added in [`newsfragments/`]. (no user-facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
