### PR TITLE
Type-check on all Python versions

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,7 +1,7 @@
 [mypy]
 # CI should test for all versions, local development gets hints for oldest supported
-# Some upstream typeshed distutils stubs fixes are necessary before we can start testing on Python 3.12
-python_version = 3.8
+# But our testing setup doesn't allow passing CLI arguments, so local devs have to set this manually.
+# python_version = 3.8
 strict = False
 warn_unused_ignores = True
 warn_redundant_casts = True
@@ -30,15 +30,19 @@ disable_error_code = attr-defined
 [mypy-pkg_resources.tests.*]
 disable_error_code = import-not-found
 
-# - distutils._modified has different errors on Python 3.8 [import-untyped], on Python 3.9+ [import-not-found]
+# - distutils doesn't exist on Python 3.12, unfortunately, this means typing
+#   will be missing for subclasses of distutils on Python 3.12 until either:
+#     - support for `SETUPTOOLS_USE_DISTUTILS=stdlib` is dropped (#3625)
+#       for setuptools to import `_distutils` directly
+#     - or non-stdlib distutils typings are exposed
 # - All jaraco modules are still untyped
 # - _validate_project sometimes complains about trove_classifiers (#4296)
 # - wheel appears to be untyped
-[mypy-distutils._modified,jaraco.*,trove_classifiers,wheel.*]
+[mypy-distutils.*,jaraco.*,trove_classifiers,wheel.*]
 ignore_missing_imports = True
 
 # Even when excluding a module, import issues can show up due to following import
 # https://github.com/python/mypy/issues/11936#issuecomment-1466764006
-[mypy-setuptools.config._validate_pyproject.*]
+[mypy-setuptools.config._validate_pyproject.*,setuptools._distutils.*]
 follow_imports = silent
 # silent => ignore errors when following imports

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -1,4 +1,9 @@
 """Extensions to the 'distutils' for large or complex distributions"""
+# mypy: disable_error_code=override
+# Command.reinitialize_command has an extra **kw param that distutils doesn't have
+# Can't disable on the exact line because distutils doesn't exists on Python 3.12
+# and mypy isn't aware of distutils_hack, causing distutils.core.Command to be Any,
+# and a [unused-ignore] to be raised on 3.12+
 
 from __future__ import annotations
 
@@ -114,8 +119,10 @@ def setup(**attrs):
 setup.__doc__ = distutils.core.setup.__doc__
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     # Work around a mypy issue where type[T] can't be used as a base: https://github.com/python/mypy/issues/10962
-    _Command = distutils.core.Command
+    _Command: TypeAlias = distutils.core.Command
 else:
     _Command = monkey.get_unpatched(distutils.core.Command)
 
@@ -207,7 +214,7 @@ class Command(_Command):
                     "'%s' must be a list of strings (got %r)" % (option, val)
                 )
 
-    @overload  # type:ignore[override] # Extra **kw param
+    @overload
     def reinitialize_command(
         self, command: str, reinit_subcommands: bool = False, **kw
     ) -> _Command: ...

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -387,9 +387,10 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
 
         # Build in a temporary directory, then copy to the target.
         os.makedirs(result_directory, exist_ok=True)
-        temp_opts = {"prefix": ".tmp-", "dir": result_directory}
 
-        with tempfile.TemporaryDirectory(**temp_opts) as tmp_dist_dir:
+        with tempfile.TemporaryDirectory(
+            prefix=".tmp-", dir=result_directory
+        ) as tmp_dist_dir:
             sys.argv = [
                 *sys.argv[:1],
                 *self._global_args(config_settings),

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -32,7 +32,7 @@ except ImportError:
 get_config_var("LDSHARED")
 # Not publicly exposed in typeshed distutils stubs, but this is done on purpose
 # See https://github.com/pypa/setuptools/pull/4228#issuecomment-1959856400
-from distutils.sysconfig import _config_vars as _CONFIG_VARS  # type: ignore # noqa
+from distutils.sysconfig import _config_vars as _CONFIG_VARS  # noqa: E402
 
 
 def _customize_compiler_for_shlib(compiler):

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import os
 from itertools import chain
@@ -46,7 +48,7 @@ class sdist(orig.sdist):
     ]
 
     distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
-    negative_opt = {}
+    negative_opt: dict[str, str] = {}
 
     README_EXTENSIONS = ['', '.rst', '.txt', '.md']
     READMES = tuple('README{0}'.format(ext) for ext in README_EXTENSIONS)

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -24,9 +24,11 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    List,
     Tuple,
     TypeVar,
     Union,
+    cast,
 )
 
 from packaging.markers import default_environment as marker_env
@@ -108,7 +110,8 @@ def _apply(
     filenames = [*other_files, filepath]
 
     try:
-        _Distribution.parse_config_files(dist, filenames=filenames)  # type: ignore[arg-type] # TODO: fix in distutils stubs
+        # TODO: Temporary cast until mypy 1.12 is released with upstream fixes from typeshed
+        _Distribution.parse_config_files(dist, filenames=cast(List[str], filenames))
         handlers = parse_configuration(
             dist, dist.command_options, ignore_option_errors=ignore_option_errors
         )

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -195,8 +195,10 @@ def check_packages(dist, attr, value):
 
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     # Work around a mypy issue where type[T] can't be used as a base: https://github.com/python/mypy/issues/10962
-    _Distribution = distutils.core.Distribution
+    _Distribution: TypeAlias = distutils.core.Distribution
 else:
     _Distribution = get_unpatched(distutils.core.Distribution)
 

--- a/setuptools/errors.py
+++ b/setuptools/errors.py
@@ -3,29 +3,36 @@
 Provides exceptions used by setuptools modules.
 """
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from distutils import errors as _distutils_errors
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 # Re-export errors from distutils to facilitate the migration to PEP632
 
-ByteCompileError = _distutils_errors.DistutilsByteCompileError
-CCompilerError = _distutils_errors.CCompilerError
-ClassError = _distutils_errors.DistutilsClassError
-CompileError = _distutils_errors.CompileError
-ExecError = _distutils_errors.DistutilsExecError
-FileError = _distutils_errors.DistutilsFileError
-InternalError = _distutils_errors.DistutilsInternalError
-LibError = _distutils_errors.LibError
-LinkError = _distutils_errors.LinkError
-ModuleError = _distutils_errors.DistutilsModuleError
-OptionError = _distutils_errors.DistutilsOptionError
-PlatformError = _distutils_errors.DistutilsPlatformError
-PreprocessError = _distutils_errors.PreprocessError
-SetupError = _distutils_errors.DistutilsSetupError
-TemplateError = _distutils_errors.DistutilsTemplateError
-UnknownFileError = _distutils_errors.UnknownFileError
+ByteCompileError: TypeAlias = _distutils_errors.DistutilsByteCompileError
+CCompilerError: TypeAlias = _distutils_errors.CCompilerError
+ClassError: TypeAlias = _distutils_errors.DistutilsClassError
+CompileError: TypeAlias = _distutils_errors.CompileError
+ExecError: TypeAlias = _distutils_errors.DistutilsExecError
+FileError: TypeAlias = _distutils_errors.DistutilsFileError
+InternalError: TypeAlias = _distutils_errors.DistutilsInternalError
+LibError: TypeAlias = _distutils_errors.LibError
+LinkError: TypeAlias = _distutils_errors.LinkError
+ModuleError: TypeAlias = _distutils_errors.DistutilsModuleError
+OptionError: TypeAlias = _distutils_errors.DistutilsOptionError
+PlatformError: TypeAlias = _distutils_errors.DistutilsPlatformError
+PreprocessError: TypeAlias = _distutils_errors.PreprocessError
+SetupError: TypeAlias = _distutils_errors.DistutilsSetupError
+TemplateError: TypeAlias = _distutils_errors.DistutilsTemplateError
+UnknownFileError: TypeAlias = _distutils_errors.UnknownFileError
 
 # The root error class in the hierarchy
-BaseError = _distutils_errors.DistutilsError
+BaseError: TypeAlias = _distutils_errors.DistutilsError
 
 
 class InvalidConfigError(OptionError):

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -27,8 +27,10 @@ def _have_cython():
 # for compatibility
 have_pyrex = _have_cython
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     # Work around a mypy issue where type[T] can't be used as a base: https://github.com/python/mypy/issues/10962
-    _Extension = distutils.core.Extension
+    _Extension: TypeAlias = distutils.core.Extension
 else:
     _Extension = get_unpatched(distutils.core.Extension)
 


### PR DESCRIPTION
## Summary of changes

Actually type-check targeting all Python versions in CI, including 3.12 & 3.13

I'd rather if it was possible for the CI to tell mypy which python version to target to override `python_version` config.

### Pull Request Checklist
- [x] Changes have tests (these are the test changes)
- [x] News fragment added in [`newsfragments/`]. (not public-facing)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
