### PR TITLE
Fix potential problem with cog script for `vendored`

### DIFF
--- a/pkg_resources/extern/__init__.py
+++ b/pkg_resources/extern/__init__.py
@@ -72,8 +72,8 @@ class VendorImporter:
 
 # [[[cog
 # import cog
-# from tools.vendored import yield_root_package
-# names = "\n".join(f"    {x!r}," for x in yield_root_package('pkg_resources'))
+# from tools.vendored import yield_top_level
+# names = "\n".join(f"    {x!r}," for x in yield_top_level('pkg_resources'))
 # cog.outl(f"names = (\n{names}\n)")
 # ]]]
 names = (

--- a/pkg_resources/extern/__init__.py
+++ b/pkg_resources/extern/__init__.py
@@ -77,13 +77,13 @@ class VendorImporter:
 # cog.outl(f"names = (\n{names}\n)")
 # ]]]
 names = (
+    'backports',
+    'importlib_resources',
+    'jaraco',
+    'more_itertools',
     'packaging',
     'platformdirs',
-    'jaraco',
-    'importlib_resources',
     'zipp',
-    'more_itertools',
-    'backports',
 )
 # [[[end]]]
 VendorImporter(__name__, names).install()

--- a/setuptools/extern/__init__.py
+++ b/setuptools/extern/__init__.py
@@ -72,8 +72,8 @@ class VendorImporter:
 
 # [[[cog
 # import cog
-# from tools.vendored import yield_root_package
-# names = "\n".join(f"    {x!r}," for x in yield_root_package('setuptools'))
+# from tools.vendored import yield_top_level
+# names = "\n".join(f"    {x!r}," for x in yield_top_level('setuptools'))
 # cog.outl(f"names = (\n{names}\n)")
 # ]]]
 names = (

--- a/setuptools/extern/__init__.py
+++ b/setuptools/extern/__init__.py
@@ -77,15 +77,15 @@ class VendorImporter:
 # cog.outl(f"names = (\n{names}\n)")
 # ]]]
 names = (
-    'packaging',
-    'ordered_set',
-    'more_itertools',
-    'jaraco',
-    'importlib_resources',
-    'importlib_metadata',
-    'zipp',
-    'tomli',
     'backports',
+    'importlib_metadata',
+    'importlib_resources',
+    'jaraco',
+    'more_itertools',
+    'ordered_set',
+    'packaging',
+    'tomli',
+    'zipp',
 )
 # [[[end]]]
 VendorImporter(__name__, names, 'setuptools._vendor').install()

--- a/tools/vendored.py
+++ b/tools/vendored.py
@@ -175,7 +175,7 @@ def yield_top_level(name):
     vendor = Path(f"{name}/_vendor")
     ignore = {"__pycache__", "__init__.py", ".ruff_cache"}
 
-    for item in vendor.iterdir():
+    for item in sorted(vendor.iterdir()):
         if item.name in ignore:
             continue
         if item.is_dir() and item.suffix != ".dist-info":

--- a/tools/vendored.py
+++ b/tools/vendored.py
@@ -165,18 +165,23 @@ def update_setuptools():
     rewrite_more_itertools(vendor / "more_itertools")
 
 
-def yield_root_package(name):
-    """Useful when defining the MetaPathFinder
-    >>> examples = set(yield_root_package("setuptools")) & {"jaraco", "backports"}
+def yield_top_level(name):
+    """Iterate over all modules and (top level) packages vendored
+    >>> roots = set(yield_top_level("setuptools"))
+    >>> examples = roots & {"jaraco", "backports", "zipp"}
     >>> list(sorted(examples))
-    ['backports', 'jaraco']
+    ['backports', 'jaraco', 'zipp']
     """
-    vendored = Path(f"{name}/_vendor/vendored.txt")
-    yield from (
-        line.partition("=")[0].partition(".")[0].replace("-", "_")
-        for line in vendored.read_text(encoding="utf-8").splitlines()
-        if line and not line.startswith("#")
-    )
+    vendor = Path(f"{name}/_vendor")
+    ignore = {"__pycache__", "__init__.py", ".ruff_cache"}
+
+    for item in vendor.iterdir():
+        if item.name in ignore:
+            continue
+        if item.is_dir() and item.suffix != ".dist-info":
+            yield str(item.name)
+        if item.is_file() and item.suffix == ".py":
+            yield str(item.stem)
 
 
 __name__ == '__main__' and update_vendored()

--- a/tools/vendored.py
+++ b/tools/vendored.py
@@ -7,7 +7,7 @@ from path import Path
 
 def remove_all(paths):
     for path in paths:
-        path.rmtree() if path.isdir() else path.remove()
+        path.rmtree() if path.is_dir() else path.remove()
 
 
 def update_vendored():

--- a/tox.ini
+++ b/tox.ini
@@ -70,14 +70,14 @@ commands =
 
 [testenv:{vendor,check-extern}]
 skip_install = True
-allowlist_externals = sh
+allowlist_externals = git, sh
 deps =
 	path
 	cogapp
 commands =
 	vendor: python -m tools.vendored
-	vendor: sh -c "git grep -l -F '\[\[\[cog' | xargs cog -I {toxinidir} -r"  # update `*.extern`
-	check-extern: sh -c "git grep -l -F '\[\[\[cog' | xargs cog -I {toxinidir} --check"
+	sh -c "git grep -l -F '\[\[\[cog' | xargs -t cog -I {toxinidir} -r"  # update `*.extern`
+	check-extern: git diff --exit-code
 
 [testenv:generate-validation-code]
 skip_install = True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Currently, the cog script may miss packages that are not listed in `vendored.txt` but get installed by `pip` (transitive dependencies).

This change simply scans the vendored directories looking for both packages and modules that got installed.

The name was changed because it also consider `modules` (in opposition to `packages`).

The alphabetical reordering is a consequence of the way directories are listed in Python/OSs.


Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
