### PR TITLE
Explicitly disallow resource paths starting with single backslash

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1604,6 +1604,7 @@ is not allowed.
             os.path.pardir in path.split(posixpath.sep)
             or posixpath.isabs(path)
             or ntpath.isabs(path)
+            or path.startswith("\\")
         )
         if not invalid:
             return
@@ -1611,7 +1612,7 @@ is not allowed.
         msg = "Use of .. or absolute path in a resource path is not allowed."
 
         # Aggressively disallow Windows absolute paths
-        if ntpath.isabs(path) and not posixpath.isabs(path):
+        if (path.startswith("\\") or ntpath.isabs(path)) and not posixpath.isabs(path):
             raise ValueError(msg)
 
         # for compatibility, warn; in future


### PR DESCRIPTION
## Summary of changes

Explicitly disallow resource paths starting with single backslash

Previously, such paths were disallowed implicitly
as they were treated as Windows absolute paths.

Since Python 3.13, paths starting with a single backslash are not considered Windows-absolute, so we treat them specially.

This change makes the existing doctest pass with Python 3.13.

Partially fixes https://github.com/pypa/setuptools/issues/4196

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
