### PR TITLE
Make the validation test for entry-points work with Python 3.13+

### DIFF
--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -17,7 +17,8 @@ def ensure_valid(ep):
     """
     try:
         ep.extras
-    except AttributeError as ex:
+    except (AttributeError, AssertionError) as ex:
+        # Why both? See https://github.com/python/importlib_metadata/issues/488
         msg = (
             f"Problems to parse {ep}.\nPlease ensure entry-point follows the spec: "
             "https://packaging.python.org/en/latest/specifications/entry-points/"


### PR DESCRIPTION
## Summary of changes

The exception in importlib.metadata has changed.
See https://github.com/python/importlib_metadata/issues/488

This makes an existing test pass with Python 3.13.

Partially fixes https://github.com/pypa/setuptools/issues/4196

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
