### PR TITLE
Write a `compile_commands.json` from `build_ext`

### DIFF
--- a/newsfragments/4358.feature.rst
+++ b/newsfragments/4358.feature.rst
@@ -1,0 +1,1 @@
+A ``compile_commands.json`` is now written to the ``build/`` directory when building extension modules.

--- a/setuptools/_distutils/unixccompiler.py
+++ b/setuptools/_distutils/unixccompiler.py
@@ -145,6 +145,10 @@ class UnixCCompiler(CCompiler):
     if sys.platform == "cygwin":
         exe_extension = ".exe"
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.compile_commands = []
+
     def preprocess(
         self,
         source,
@@ -185,7 +189,11 @@ class UnixCCompiler(CCompiler):
     def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
         compiler_so = compiler_fixup(self.compiler_so, cc_args + extra_postargs)
         try:
-            self.spawn(compiler_so + cc_args + [src, '-o', obj] + extra_postargs)
+            cmd = compiler_so + cc_args + [src, '-o', obj] + extra_postargs
+            self.spawn(cmd)
+            self.compile_commands.append(
+                {"directory": os.getcwd(), "arguments": cmd, "file": src}
+            )
         except DistutilsExecError as msg:
             raise CompileError(msg)
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Produce a JSON database of the compiler commands executed while building extension modules as `build/compile_commands.json`. This is usable by various C and C++ language servers, linters, and IDEs, like `clangd`, `clang-tidy`, and CLion. These tools need to understand the header search path and macros passed on the compiler command line in order to correctly interpret source files. In the case of Python extension modules, the developer might not even know all of the compiler flags that are being used, since some are inherited from the interpreter via `sysconfig`.

Closes #1975

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
