### PR TITLE
Replace call to deprecated `validate_pyproject` command

### DIFF
--- a/tools/generate_validation_code.py
+++ b/tools/generate_validation_code.py
@@ -14,7 +14,7 @@ def generate_pyproject_validation(dest: Union[str, PathLike]):
     cmd = [
         sys.executable,
         "-m",
-        "validate_pyproject.vendoring",
+        "validate_pyproject.pre_compile",
         f"--output-dir={dest}",
         "--enable-plugins",
         "setuptools",


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
