### PR TITLE
Use local schemas to define validation for `pyproject.toml`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,4 +17,5 @@ include mypy.ini
 include pytest.ini
 include tox.ini
 include setuptools/tests/config/setupcfg_examples.txt
+include setuptools/config/*.schema.json
 global-exclude *.py[cod] __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,7 +10,7 @@ recursive-include newsfragments *
 include *.py
 include *.rst
 include MANIFEST.in
-include LICENSE
+global-include LICEN[CS]E* COPYING* NOTICE* AUTHORS*
 include launcher.c
 include msvc-build-launcher.cmd
 include mypy.ini

--- a/setup.py
+++ b/setup.py
@@ -10,9 +10,10 @@ from setuptools.command.install import install
 here = os.path.dirname(__file__)
 
 
-package_data = dict(
-    setuptools=['script (dev).tmpl', 'script.tmpl', 'site-patch.py'],
-)
+package_data = {
+    "": ["LICEN[CS]E*", "COPYING*", "NOTICE*", "AUTHORS*"],
+    "setuptools": ['script (dev).tmpl', 'script.tmpl', 'site-patch.py'],
+}
 
 force_windows_specific_files = os.environ.get(
     "SETUPTOOLS_INSTALL_WINDOWS_SPECIFIC_FILES", "1"

--- a/setuptools/config/NOTICE
+++ b/setuptools/config/NOTICE
@@ -1,0 +1,10 @@
+The following files include code from opensource projects
+(either as direct copies or modified versions):
+
+- `setuptools.schema.json`, `distutils.schema.json`:
+    - project: `validate-pyproject` - licensed under MPL-2.0
+      (https://github.com/abravalheri/validate-pyproject):
+
+      This Source Code Form is subject to the terms of the Mozilla Public
+      License, v. 2.0. If a copy of the MPL was not distributed with this file,
+      You can obtain one at https://mozilla.org/MPL/2.0/.

--- a/setuptools/config/_validate_pyproject/NOTICE
+++ b/setuptools/config/_validate_pyproject/NOTICE
@@ -1,7 +1,7 @@
 The code contained in this directory was automatically generated using the
 following command:
 
-    python -m validate_pyproject.pre_compile --output-dir=setuptools/config/_validate_pyproject --enable-plugins setuptools distutils --very-verbose
+    python -m validate_pyproject.pre_compile --output-dir=setuptools/config/_validate_pyproject --enable-plugins setuptools distutils --very-verbose -t distutils=setuptools/config/distutils.schema.json -t setuptools=setuptools/config/setuptools.schema.json
 
 Please avoid changing it manually.
 

--- a/setuptools/config/_validate_pyproject/fastjsonschema_validations.py
+++ b/setuptools/config/_validate_pyproject/fastjsonschema_validations.py
@@ -10,7 +10,7 @@
 # *** PLEASE DO NOT MODIFY DIRECTLY: Automatically generated code *** 
 
 
-VERSION = "2.19.1"
+VERSION = "2.20.0"
 from decimal import Decimal
 import re
 from .fastjsonschema_exceptions import JsonSchemaValueException

--- a/setuptools/config/_validate_pyproject/formats.py
+++ b/setuptools/config/_validate_pyproject/formats.py
@@ -91,9 +91,9 @@ try:
         """
         try:
             _req.Requirement(value)
+            return True
         except _req.InvalidRequirement:
             return False
-        return True
 
 except ImportError:  # pragma: no cover
     _logger.warning(

--- a/setuptools/config/distutils.schema.json
+++ b/setuptools/config/distutils.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "$id": "https://setuptools.pypa.io/en/latest/deprecated/distutils/configfile.html",
+  "title": "``tool.distutils`` table",
+  "$$description": [
+    "**EXPERIMENTAL** (NOT OFFICIALLY SUPPORTED): Use ``tool.distutils``",
+    "subtables to configure arguments for ``distutils`` commands.",
+    "Originally, ``distutils`` allowed developers to configure arguments for",
+    "``setup.py`` commands via `distutils configuration files",
+    "<https://setuptools.pypa.io/en/latest/deprecated/distutils/configfile.html>`_.",
+    "See also `the old Python docs <https://docs.python.org/3.11/install/>_`."
+  ],
+
+  "type": "object",
+  "properties": {
+    "global": {
+      "type": "object",
+      "description": "Global options applied to all ``distutils`` commands"
+    }
+  },
+  "patternProperties": {
+    ".+": {"type": "object"}
+  },
+  "$comment": "TODO: Is there a practical way of making this schema more specific?"
+}

--- a/setuptools/config/setuptools.schema.json
+++ b/setuptools/config/setuptools.schema.json
@@ -1,0 +1,352 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+
+  "$id": "https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html",
+  "title": "``tool.setuptools`` table",
+  "$$description": [
+    "``setuptools``-specific configurations that can be set by users that require",
+    "customization.",
+    "These configurations are completely optional and probably can be skipped when",
+    "creating simple packages. They are equivalent to some of the `Keywords",
+    "<https://setuptools.pypa.io/en/latest/references/keywords.html>`_",
+    "used by the ``setup.py`` file, and can be set via the ``tool.setuptools`` table.",
+    "It considers only ``setuptools`` `parameters",
+    "<https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration>`_",
+    "that are not covered by :pep:`621`; and intentionally excludes ``dependency_links``",
+    "and ``setup_requires`` (incompatible with modern workflows/standards)."
+  ],
+
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "platforms": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "provides": {
+      "$$description": [
+        "Package and virtual package names contained within this package",
+        "**(not supported by pip)**"
+      ],
+      "type": "array",
+      "items": {"type": "string", "format": "pep508-identifier"}
+    },
+    "obsoletes": {
+      "$$description": [
+        "Packages which this package renders obsolete",
+        "**(not supported by pip)**"
+      ],
+      "type": "array",
+      "items": {"type": "string", "format": "pep508-identifier"}
+    },
+    "zip-safe": {
+      "$$description": [
+        "Whether the project can be safely installed and run from a zip file.",
+        "**OBSOLETE**: only relevant for ``pkg_resources``, ``easy_install`` and",
+        "``setup.py install`` in the context of ``eggs`` (**DEPRECATED**)."
+      ],
+      "type": "boolean"
+    },
+    "script-files": {
+      "$$description": [
+        "Legacy way of defining scripts (entry-points are preferred).",
+        "Equivalent to the ``script`` keyword in ``setup.py``",
+        "(it was renamed to avoid confusion with entry-point based ``project.scripts``",
+        "defined in :pep:`621`).",
+        "**DISCOURAGED**: generic script wrappers are tricky and may not work properly.",
+        "Whenever possible, please use ``project.scripts`` instead."
+      ],
+      "type": "array",
+      "items": {"type": "string"},
+      "$comment": "TODO: is this field deprecated/should be removed?"
+    },
+    "eager-resources": {
+      "$$description": [
+        "Resources that should be extracted together, if any of them is needed,",
+        "or if any C extensions included in the project are imported.",
+        "**OBSOLETE**: only relevant for ``pkg_resources``, ``easy_install`` and",
+        "``setup.py install`` in the context of ``eggs`` (**DEPRECATED**)."
+      ],
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "packages": {
+      "$$description": [
+        "Packages that should be included in the distribution.",
+        "It can be given either as a list of package identifiers",
+        "or as a ``dict``-like structure with a single key ``find``",
+        "which corresponds to a dynamic call to",
+        "``setuptools.config.expand.find_packages`` function.",
+        "The ``find`` key is associated with a nested ``dict``-like structure that can",
+        "contain ``where``, ``include``, ``exclude`` and ``namespaces`` keys,",
+        "mimicking the keyword arguments of the associated function."
+      ],
+      "oneOf": [
+        {
+          "title": "Array of Python package identifiers",
+          "type": "array",
+          "items": {"$ref": "#/definitions/package-name"}
+        },
+        {"$ref": "#/definitions/find-directive"}
+      ]
+    },
+    "package-dir": {
+      "$$description": [
+        ":class:`dict`-like structure mapping from package names to directories where their",
+        "code can be found.",
+        "The empty string (as key) means that all packages are contained inside",
+        "the given directory will be included in the distribution."
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [{"const": ""}, {"$ref": "#/definitions/package-name"}]
+      },
+      "patternProperties": {
+        "^.*$": {"type": "string" }
+      }
+    },
+    "package-data": {
+      "$$description": [
+        "Mapping from package names to lists of glob patterns.",
+        "Usually this option is not needed when using ``include-package-data = true``",
+        "For more information on how to include data files, check ``setuptools`` `docs",
+        "<https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [{"type": "string", "format": "python-module-name"}, {"const": "*"}]
+      },
+      "patternProperties": {
+        "^.*$": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "include-package-data": {
+      "$$description": [
+        "Automatically include any data files inside the package directories",
+        "that are specified by ``MANIFEST.in``",
+        "For more information on how to include data files, check ``setuptools`` `docs",
+        "<https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+      ],
+      "type": "boolean"
+    },
+    "exclude-package-data": {
+      "$$description": [
+        "Mapping from package names to lists of glob patterns that should be excluded",
+        "For more information on how to include data files, check ``setuptools`` `docs",
+        "<https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [{"type": "string", "format": "python-module-name"}, {"const": "*"}]
+      },
+      "patternProperties": {
+          "^.*$": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "namespace-packages": {
+      "type": "array",
+      "items": {"type": "string", "format": "python-module-name"},
+      "$comment": "https://setuptools.pypa.io/en/latest/userguide/package_discovery.html",
+      "description": "**DEPRECATED**: use implicit namespaces instead (:pep:`420`)."
+    },
+    "py-modules": {
+      "description": "Modules that setuptools will manipulate",
+      "type": "array",
+      "items": {"type": "string", "format": "python-module-name"},
+      "$comment": "TODO: clarify the relationship with ``packages``"
+    },
+    "data-files": {
+      "$$description": [
+        "``dict``-like structure where each key represents a directory and",
+        "the value is a list of glob patterns that should be installed in them.",
+        "**DISCOURAGED**: please notice this might not work as expected with wheels.",
+        "Whenever possible, consider using data files inside the package directories",
+        "(or create a new namespace package that only contains data files).",
+        "See `data files support",
+        "<https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+      ],
+      "type": "object",
+      "patternProperties": {
+          "^.*$": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+    "cmdclass": {
+      "$$description": [
+        "Mapping of distutils-style command names to ``setuptools.Command`` subclasses",
+        "which in turn should be represented by strings with a qualified class name",
+        "(i.e., \"dotted\" form with module), e.g.::\n\n",
+        "    cmdclass = {mycmd = \"pkg.subpkg.module.CommandClass\"}\n\n",
+        "The command class should be a directly defined at the top-level of the",
+        "containing module (no class nesting)."
+      ],
+      "type": "object",
+      "patternProperties": {
+          "^.*$": {"type": "string", "format": "python-qualified-identifier"}
+      }
+    },
+    "license-files": {
+      "type": "array",
+      "items": {"type": "string"},
+      "$$description": [
+        "**PROVISIONAL**: list of glob patterns for all license files being distributed.",
+        "(likely to become standard with :pep:`639`).",
+        "By default: ``['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']``"
+      ],
+      "$comment": "TODO: revise if PEP 639 is accepted. Probably ``project.license-files``?"
+    },
+    "dynamic": {
+      "type": "object",
+      "description": "Instructions for loading :pep:`621`-related metadata dynamically",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "$$description": [
+            "A version dynamically loaded via either the ``attr:`` or ``file:``",
+            "directives. Please make sure the given file or attribute respects :pep:`440`.",
+            "Also ensure to set ``project.dynamic`` accordingly."
+          ],
+          "oneOf": [
+            {"$ref": "#/definitions/attr-directive"},
+            {"$ref": "#/definitions/file-directive"}
+          ]
+        },
+        "classifiers": {"$ref": "#/definitions/file-directive"},
+        "description": {"$ref": "#/definitions/file-directive"},
+        "entry-points": {"$ref": "#/definitions/file-directive"},
+        "dependencies": {"$ref": "#/definitions/file-directive-for-dependencies"},
+        "optional-dependencies": {
+          "type": "object",
+          "propertyNames": {"type": "string", "format": "pep508-identifier"},
+          "additionalProperties": false,
+          "patternProperties": {
+            ".+": {"$ref": "#/definitions/file-directive-for-dependencies"}
+          }
+        },
+        "readme": {
+          "type": "object",
+          "anyOf": [
+            {"$ref": "#/definitions/file-directive"},
+            {
+              "type": "object",
+              "properties": {
+                "content-type": {"type": "string"},
+                "file": { "$ref": "#/definitions/file-directive/properties/file" }
+              },
+              "additionalProperties": false}
+          ],
+          "required": ["file"]
+        }
+      }
+    }
+  },
+
+  "definitions": {
+    "package-name": {
+      "$id": "#/definitions/package-name",
+      "title": "Valid package name",
+      "description": "Valid package name (importable or :pep:`561`).",
+      "type": "string",
+      "anyOf": [
+        {"type": "string", "format": "python-module-name"},
+        {"type": "string", "format": "pep561-stub-name"}
+      ]
+    },
+    "file-directive": {
+      "$id": "#/definitions/file-directive",
+      "title": "'file:' directive",
+      "description":
+        "Value is read from a file (or list of files and then concatenated)",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "oneOf": [
+            {"type": "string"},
+            {"type": "array", "items": {"type": "string"}}
+          ]
+        }
+      },
+      "required": ["file"]
+    },
+    "file-directive-for-dependencies": {
+      "title": "'file:' directive for dependencies",
+      "allOf": [
+        {
+          "$$description": [
+            "**BETA**: subset of the ``requirements.txt`` format",
+            "without ``pip`` flags and options",
+            "(one :pep:`508`-compliant string per line,",
+            "lines that are blank or start with ``#`` are excluded).",
+            "See `dynamic metadata",
+            "<https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata>`_."
+          ]
+        },
+        {"$ref": "#/definitions/file-directive"}
+      ]
+    },
+    "attr-directive": {
+      "title": "'attr:' directive",
+      "$id": "#/definitions/attr-directive",
+      "$$description": [
+        "Value is read from a module attribute. Supports callables and iterables;",
+        "unsupported types are cast via ``str()``"
+      ],
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attr": {"type": "string", "format": "python-qualified-identifier"}
+      },
+      "required": ["attr"]
+    },
+    "find-directive": {
+      "$id": "#/definitions/find-directive",
+      "title": "'find:' directive",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "find": {
+          "type": "object",
+          "$$description": [
+            "Dynamic `package discovery",
+            "<https://setuptools.pypa.io/en/latest/userguide/package_discovery.html>`_."
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "where": {
+              "description":
+                "Directories to be searched for packages (Unix-style relative path)",
+              "type": "array",
+              "items": {"type": "string"}
+            },
+            "exclude": {
+              "type": "array",
+              "$$description": [
+                "Exclude packages that match the values listed in this field.",
+                "Can container shell-style wildcards (e.g. ``'pkg.*'``)"
+              ],
+              "items": {"type": "string"}
+            },
+            "include": {
+              "type": "array",
+              "$$description": [
+                "Restrict the found packages to just the ones listed in this field.",
+                "Can container shell-style wildcards (e.g. ``'pkg.*'``)"
+              ],
+              "items": {"type": "string"}
+            },
+            "namespaces": {
+              "type": "boolean",
+              "$$description": [
+                "When ``True``, directories without a ``__init__.py`` file will also",
+                "be scanned for :pep:`420`-style implicit namespaces"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tools/generate_validation_code.py
+++ b/tools/generate_validation_code.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from os import PathLike
+import itertools
 import subprocess
 import sys
-
 from pathlib import Path
 
 
-def generate_pyproject_validation(dest: str | PathLike[str]):
+def generate_pyproject_validation(dest: Path, schemas: Path):
     """
     Generates validation code for ``pyproject.toml`` based on JSON schemas and the
     ``validate-pyproject`` library.
     """
+    schema_args = (("-t", f"{f.name.partition('.')[0]}={f}") for f in schemas)
     cmd = [
         sys.executable,
         "-m",
@@ -21,13 +21,17 @@ def generate_pyproject_validation(dest: str | PathLike[str]):
         "setuptools",
         "distutils",
         "--very-verbose",
+        *itertools.chain.from_iterable(schema_args),
     ]
     subprocess.check_call(cmd)
     print(f"Validation code generated at: {dest}")
 
 
 def main():
-    generate_pyproject_validation(Path("setuptools/config/_validate_pyproject"))
+    generate_pyproject_validation(
+        Path("setuptools/config/_validate_pyproject"),
+        schemas=Path("setuptools/config").glob("*.schema.json"),
+    )
 
 
 __name__ == '__main__' and main()

--- a/tools/generate_validation_code.py
+++ b/tools/generate_validation_code.py
@@ -4,9 +4,10 @@ import itertools
 import subprocess
 import sys
 from pathlib import Path
+from typing import Iterable
 
 
-def generate_pyproject_validation(dest: Path, schemas: Path):
+def generate_pyproject_validation(dest: Path, schemas: Iterable[Path]) -> bool:
     """
     Generates validation code for ``pyproject.toml`` based on JSON schemas and the
     ``validate-pyproject`` library.
@@ -25,10 +26,11 @@ def generate_pyproject_validation(dest: Path, schemas: Path):
     ]
     subprocess.check_call(cmd)
     print(f"Validation code generated at: {dest}")
+    return True
 
 
-def main():
-    generate_pyproject_validation(
+def main() -> bool:
+    return generate_pyproject_validation(
         Path("setuptools/config/_validate_pyproject"),
         schemas=Path("setuptools/config").glob("*.schema.json"),
     )

--- a/tox.ini
+++ b/tox.ini
@@ -84,8 +84,7 @@ commands =
 [testenv:generate-validation-code]
 skip_install = True
 deps =
-	# validate-pyproject[all]==0.18
-	validate-pyproject[all] @ https://github.com/abravalheri/validate-pyproject/archive/refs/heads/allow-overwrite.zip
+	validate-pyproject[all]==0.18
 commands =
 	python -m tools.generate_validation_code
 

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,8 @@ commands =
 [testenv:generate-validation-code]
 skip_install = True
 deps =
-	validate-pyproject[all]==0.17
+	# validate-pyproject[all]==0.17
+	validate-pyproject[all] @ https://github.com/abravalheri/validate-pyproject/archive/refs/heads/allow-overwrite.zip
 commands =
 	python -m tools.generate_validation_code
 

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,7 @@ commands =
 [testenv:generate-validation-code]
 skip_install = True
 deps =
-	# validate-pyproject[all]==0.17
+	# validate-pyproject[all]==0.18
 	validate-pyproject[all] @ https://github.com/abravalheri/validate-pyproject/archive/refs/heads/allow-overwrite.zip
 commands =
 	python -m tools.generate_validation_code


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This facilitates adding/removing options without having to release a whole new version of `validate-pyproject`.

In general it should help to improve the developer experience when dealing with `pyproject.toml` validations.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
