### PR TITLE
Prevent `bin` folders to be taken as extern packages when vendoring

### DIFF
--- a/tools/vendored.py
+++ b/tools/vendored.py
@@ -171,6 +171,8 @@ def yield_top_level(name):
     >>> examples = roots & {"jaraco", "backports", "zipp"}
     >>> list(sorted(examples))
     ['backports', 'jaraco', 'zipp']
+    >>> 'bin' in examples
+    False
     """
     vendor = Path(f"{name}/_vendor")
     ignore = {"__pycache__", "__init__.py", ".ruff_cache", "bin"}

--- a/tools/vendored.py
+++ b/tools/vendored.py
@@ -173,7 +173,7 @@ def yield_top_level(name):
     ['backports', 'jaraco', 'zipp']
     """
     vendor = Path(f"{name}/_vendor")
-    ignore = {"__pycache__", "__init__.py", ".ruff_cache"}
+    ignore = {"__pycache__", "__init__.py", ".ruff_cache", "bin"}
 
     for item in sorted(vendor.iterdir()):
         if item.name in ignore:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes


Closes https://github.com/pypa/setuptools/pull/4369/files#r1606421897

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
