### PR TITLE
Prevent a `TypeError` in `compat.py311.shutil_rmtree`

### DIFF
--- a/newsfragments/4382.bugfix.rst
+++ b/newsfragments/4382.bugfix.rst
@@ -1,0 +1,1 @@
+Prevent a ``TypeError: 'NoneType' object is not callable`` when ``shutil_rmtree`` is called without an ``onexc`` parameter on Python<=3.11 -- by :user:`Avasam`

--- a/setuptools/compat/py311.py
+++ b/setuptools/compat/py311.py
@@ -1,12 +1,26 @@
-import sys
+from __future__ import annotations
+
 import shutil
+import sys
+from typing import Any, Callable, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _typeshed import StrOrBytesPath, ExcInfo
+
+# Same as shutil._OnExcCallback from typeshed
+_OnExcCallback = Callable[[Callable[..., Any], str, BaseException], object]
 
 
-def shutil_rmtree(path, ignore_errors=False, onexc=None):
+def shutil_rmtree(
+    path: StrOrBytesPath,
+    ignore_errors: bool = False,
+    onexc: _OnExcCallback | None = None,
+) -> None:
     if sys.version_info >= (3, 12):
         return shutil.rmtree(path, ignore_errors, onexc=onexc)
 
-    def _handler(fn, path, excinfo):
-        return onexc(fn, path, excinfo[1])
+    def _handler(fn: Callable[..., Any], path: str, excinfo: ExcInfo) -> None:
+        if onexc:
+            onexc(fn, path, excinfo[1])
 
     return shutil.rmtree(path, ignore_errors, onerror=_handler)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Noticed while adding pyright checks to setuptools (https://github.com/pypa/setuptools/pull/4192)
Also typed `shutil_rmtree` (xref https://github.com/python/typeshed/pull/12002 )

### Pull Request Checklist
- [ ] Changes have tests (#4192 would add the changes that caught this)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
