### PR TITLE
Fix CI

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -388,7 +388,7 @@ class Distribution(_Distribution):
     def _finalize_license_files(self) -> None:
         """Compute names of all license files which should be included."""
         license_files: Optional[List[str]] = self.metadata.license_files
-        patterns: List[str] = license_files if license_files else []
+        patterns: List[str] = license_files or []
 
         license_file: Optional[str] = self.metadata.license_file
         if license_file and license_file not in patterns:


### PR DESCRIPTION
## Summary of changes

The problem might be that _pytest-ruff_ enforces ruff 0.3.2 and I cannot find a way to force it to use a decently recent version. Why use _pytest-ruff_ in the first place instead of using _ruff_ directly?
```
platform linux -- Python 3.10.12, pytest-8.2.1, pluggy-1.5.0
cachedir: .tox/py/.pytest_cache
rootdir: /volatile/src/pypa/setuptools
configfile: pytest.ini
plugins: perf-0.15.0, subprocess-1.5.0, enabler-3.1.1, timeout-2.3.1, typeguard-4.2.1, xdist-3.6.1, ruff-0.3.2, cov-5.0.0, mypy-0.10.3, checkdocs-2.13.0, home-0.5.1
```

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
