### PR TITLE
pkg_resources: Merge `@overload` and `TypeVar` annotations from typeshed

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -16,6 +16,8 @@ exclude = (?x)(
 	| ^setuptools/config/_validate_pyproject/ # Auto-generated
     | ^setuptools/tests/bdist_wheel_testdata/  # Duplicate module name
 	)
+# Too many false-positives
+disable_error_code = overload-overlap
 
 # Ignoring attr-defined because setuptools wraps a lot of distutils classes, adding new attributes,
 # w/o updating all the attributes and return types from the base classes for type-checkers to understand

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -122,8 +122,9 @@ _MetadataType = Union["IResourceProvider", None]
 _ResolvedEntryPoint = Any  # Can be any attribute in the module
 _ResourceStream = Any  # TODO / Incomplete: A readable file-like object
 # Any object works, but let's indicate we expect something like a module (optionally has __loader__ or __file__)
-_ModuleLike = Any
-_ProviderFactoryType = Callable[[_ModuleLike], "IResourceProvider"]
+_ModuleLike = Union[object, types.ModuleType]
+# Any: Should be _ModuleLike but we end up with issues where _ModuleLike doesn't have _ZipLoaderModule's __loader__
+_ProviderFactoryType = Callable[[Any], "IResourceProvider"]
 _DistFinderType = Callable[[_T, str, bool], Iterable["Distribution"]]
 _NSHandlerType = Callable[[_T, str, str, types.ModuleType], Union[str, None]]
 _AdapterT = TypeVar(

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -34,6 +34,8 @@ import re
 import types
 from typing import (
     Any,
+    Iterator,
+    Literal,
     Mapping,
     MutableSequence,
     NamedTuple,
@@ -98,7 +100,7 @@ from pkg_resources.extern.packaging import version as _packaging_version
 from pkg_resources.extern.platformdirs import user_cache_dir as _user_cache_dir
 
 if TYPE_CHECKING:
-    from _typeshed import StrPath, StrOrBytesPath, BytesPath
+    from _typeshed import BytesPath, StrPath, StrOrBytesPath
 
 warnings.warn(
     "pkg_resources is deprecated as an API. "
@@ -109,14 +111,18 @@ warnings.warn(
 
 
 _T = TypeVar("_T")
+_DistributionT = TypeVar("_DistributionT", bound="Distribution")
 # Type aliases
 _NestedStr = Union[str, Iterable[Union[str, Iterable["_NestedStr"]]]]
+_InstallerTypeT = Callable[["Requirement"], "_DistributionT"]
 _InstallerType = Callable[["Requirement"], Optional["Distribution"]]
 _PkgReqType = Union[str, "Requirement"]
 _EPDistType = Union["Distribution", _PkgReqType]
 _MetadataType = Optional["IResourceProvider"]
+_ResolvedEntryPoint = Any  # Can be any attribute in the module
+_ResourceStream = Any  # TODO / Incomplete: A readable file-like object
 # Any object works, but let's indicate we expect something like a module (optionally has __loader__ or __file__)
-_ModuleLike = Union[object, types.ModuleType]
+_ModuleLike = Any
 _ProviderFactoryType = Callable[[_ModuleLike], "IResourceProvider"]
 _DistFinderType = Callable[[_T, str, bool], Iterable["Distribution"]]
 _NSHandlerType = Callable[[_T, str, str, types.ModuleType], Optional[str]]
@@ -128,6 +134,10 @@ _AdapterT = TypeVar(
 # Use _typeshed.importlib.LoaderProtocol once available https://github.com/python/typeshed/pull/11890
 class _LoaderProtocol(Protocol):
     def load_module(self, fullname: str, /) -> types.ModuleType: ...
+
+
+class _ZipLoaderModule(Protocol):
+    __loader__: zipimport.zipimporter
 
 
 _PEP440_FALLBACK = re.compile(r"^v?(?P<safe>(?:[0-9]+!)?[0-9]+(?:\.[0-9]+)*)", re.I)
@@ -403,7 +413,11 @@ def register_loader_type(
     _provider_factories[loader_type] = provider_factory
 
 
-def get_provider(moduleOrReq: str | Requirement):
+@overload
+def get_provider(moduleOrReq: str) -> IResourceProvider: ...
+@overload
+def get_provider(moduleOrReq: Requirement) -> Distribution: ...
+def get_provider(moduleOrReq: str | Requirement) -> IResourceProvider | Distribution:
     """Return an IResourceProvider for the named module or requirement"""
     if isinstance(moduleOrReq, Requirement):
         return working_set.find(moduleOrReq) or require(str(moduleOrReq))[0]
@@ -514,22 +528,33 @@ def compatible_platforms(provided: str | None, required: str | None):
     return False
 
 
-def get_distribution(dist: _EPDistType):
+@overload
+def get_distribution(dist: _DistributionT) -> _DistributionT: ...
+@overload
+def get_distribution(dist: _PkgReqType) -> Distribution: ...
+def get_distribution(dist: Distribution | _PkgReqType) -> Distribution:
     """Return a current distribution object for a Requirement or string"""
     if isinstance(dist, str):
         dist = Requirement.parse(dist)
     if isinstance(dist, Requirement):
-        dist = get_provider(dist)
+        # Bad type narrowing, dist has to be a Requirement here, so get_provider has to return Distribution
+        dist = get_provider(dist)  # type: ignore[assignment]
     if not isinstance(dist, Distribution):
-        raise TypeError("Expected string, Requirement, or Distribution", dist)
+        raise TypeError("Expected str, Requirement, or Distribution", dist)
     return dist
 
 
-def load_entry_point(dist: _EPDistType, group: str, name: str):
+def load_entry_point(dist: _EPDistType, group: str, name: str) -> _ResolvedEntryPoint:
     """Return `name` entry point of `group` for `dist` or raise ImportError"""
     return get_distribution(dist).load_entry_point(group, name)
 
 
+@overload
+def get_entry_map(
+    dist: _EPDistType, group: None = None
+) -> dict[str, dict[str, EntryPoint]]: ...
+@overload
+def get_entry_map(dist: _EPDistType, group: str) -> dict[str, EntryPoint]: ...
 def get_entry_map(dist: _EPDistType, group: str | None = None):
     """Return the entry point map for `group`, or the full entry map"""
     return get_distribution(dist).get_entry_map(group)
@@ -544,10 +569,10 @@ class IMetadataProvider(Protocol):
     def has_metadata(self, name: str) -> bool:
         """Does the package's distribution contain the named metadata?"""
 
-    def get_metadata(self, name: str):
+    def get_metadata(self, name: str) -> str:
         """The named metadata resource as a string"""
 
-    def get_metadata_lines(self, name: str):
+    def get_metadata_lines(self, name: str) -> Iterator[str]:
         """Yield named metadata resource as list of non-blank non-comment lines
 
         Leading and trailing whitespace is stripped from each line, and lines
@@ -556,22 +581,26 @@ class IMetadataProvider(Protocol):
     def metadata_isdir(self, name: str) -> bool:
         """Is the named metadata a directory?  (like ``os.path.isdir()``)"""
 
-    def metadata_listdir(self, name: str):
+    def metadata_listdir(self, name: str) -> list[str]:
         """List of metadata names in the directory (like ``os.listdir()``)"""
 
-    def run_script(self, script_name: str, namespace: dict[str, Any]):
+    def run_script(self, script_name: str, namespace: dict[str, Any]) -> None:
         """Execute the named script in the supplied namespace dictionary"""
 
 
 class IResourceProvider(IMetadataProvider, Protocol):
     """An object that provides access to package resources"""
 
-    def get_resource_filename(self, manager: ResourceManager, resource_name: str):
+    def get_resource_filename(
+        self, manager: ResourceManager, resource_name: str
+    ) -> str:
         """Return a true filesystem path for `resource_name`
 
         `manager` must be a ``ResourceManager``"""
 
-    def get_resource_stream(self, manager: ResourceManager, resource_name: str):
+    def get_resource_stream(
+        self, manager: ResourceManager, resource_name: str
+    ) -> _ResourceStream:
         """Return a readable file-like object for `resource_name`
 
         `manager` must be a ``ResourceManager``"""
@@ -583,13 +612,13 @@ class IResourceProvider(IMetadataProvider, Protocol):
 
         `manager` must be a ``ResourceManager``"""
 
-    def has_resource(self, resource_name: str):
+    def has_resource(self, resource_name: str) -> bool:
         """Does the package contain the named resource?"""
 
-    def resource_isdir(self, resource_name: str):
+    def resource_isdir(self, resource_name: str) -> bool:
         """Is the named resource a directory?  (like ``os.path.isdir()``)"""
 
-    def resource_listdir(self, resource_name: str):
+    def resource_listdir(self, resource_name: str) -> list[str]:
         """List of resource names in the directory (like ``os.listdir()``)"""
 
 
@@ -772,6 +801,26 @@ class WorkingSet:
             keys2.append(dist.key)
         self._added_new(dist)
 
+    @overload
+    def resolve(
+        self,
+        requirements: Iterable[Requirement],
+        env: Environment | None,
+        installer: _InstallerTypeT[_DistributionT],
+        replace_conflicting: bool = False,
+        extras: tuple[str, ...] | None = None,
+    ) -> list[_DistributionT]: ...
+    @overload
+    def resolve(
+        self,
+        requirements: Iterable[Requirement],
+        env: Environment | None = None,
+        *,
+        installer: _InstallerTypeT[_DistributionT],
+        replace_conflicting: bool = False,
+        extras: tuple[str, ...] | None = None,
+    ) -> list[_DistributionT]: ...
+    @overload
     def resolve(
         self,
         requirements: Iterable[Requirement],
@@ -779,7 +828,15 @@ class WorkingSet:
         installer: _InstallerType | None = None,
         replace_conflicting: bool = False,
         extras: tuple[str, ...] | None = None,
-    ):
+    ) -> list[Distribution]: ...
+    def resolve(
+        self,
+        requirements: Iterable[Requirement],
+        env: Environment | None = None,
+        installer: _InstallerType | None | _InstallerTypeT[_DistributionT] = None,
+        replace_conflicting: bool = False,
+        extras: tuple[str, ...] | None = None,
+    ) -> list[Distribution] | list[_DistributionT]:
         """List all distributions needed to (recursively) meet `requirements`
 
         `requirements` must be a sequence of ``Requirement`` objects.  `env`,
@@ -877,13 +934,41 @@ class WorkingSet:
             raise VersionConflict(dist, req).with_context(dependent_req)
         return dist
 
+    @overload
+    def find_plugins(
+        self,
+        plugin_env: Environment,
+        full_env: Environment | None,
+        installer: _InstallerTypeT[_DistributionT],
+        fallback: bool = True,
+    ) -> tuple[list[_DistributionT], dict[Distribution, Exception]]: ...
+    @overload
+    def find_plugins(
+        self,
+        plugin_env: Environment,
+        full_env: Environment | None = None,
+        *,
+        installer: _InstallerTypeT[_DistributionT],
+        fallback: bool = True,
+    ) -> tuple[list[_DistributionT], dict[Distribution, Exception]]: ...
+    @overload
     def find_plugins(
         self,
         plugin_env: Environment,
         full_env: Environment | None = None,
         installer: _InstallerType | None = None,
         fallback: bool = True,
-    ):
+    ) -> tuple[list[Distribution], dict[Distribution, Exception]]: ...
+    def find_plugins(
+        self,
+        plugin_env: Environment,
+        full_env: Environment | None = None,
+        installer: _InstallerType | None | _InstallerTypeT[_DistributionT] = None,
+        fallback: bool = True,
+    ) -> tuple[
+        list[Distribution] | list[_DistributionT],
+        dict[Distribution, Exception],
+    ]:
         """Find all activatable distributions in `plugin_env`
 
         Example usage::
@@ -922,8 +1007,8 @@ class WorkingSet:
         # scan project names in alphabetic order
         plugin_projects.sort()
 
-        error_info = {}
-        distributions = {}
+        error_info: dict[Distribution, Exception] = {}
+        distributions: dict[Distribution, Exception | None] = {}
 
         if full_env is None:
             env = Environment(self.entries)
@@ -1120,13 +1205,29 @@ class Environment:
                 dists.append(dist)
                 dists.sort(key=operator.attrgetter('hashcmp'), reverse=True)
 
+    @overload
     def best_match(
         self,
         req: Requirement,
         working_set: WorkingSet,
-        installer: Callable[[Requirement], Any] | None = None,
+        installer: _InstallerTypeT[_DistributionT],
         replace_conflicting: bool = False,
-    ):
+    ) -> _DistributionT: ...
+    @overload
+    def best_match(
+        self,
+        req: Requirement,
+        working_set: WorkingSet,
+        installer: _InstallerType | None = None,
+        replace_conflicting: bool = False,
+    ) -> Distribution | None: ...
+    def best_match(
+        self,
+        req: Requirement,
+        working_set: WorkingSet,
+        installer: _InstallerType | None | _InstallerTypeT[_DistributionT] = None,
+        replace_conflicting: bool = False,
+    ) -> Distribution | None:
         """Find distribution best matching `req` and usable on `working_set`
 
         This calls the ``find(req)`` method of the `working_set` to see if a
@@ -1153,11 +1254,32 @@ class Environment:
         # try to download/install
         return self.obtain(req, installer)
 
+    @overload
     def obtain(
         self,
         requirement: Requirement,
-        installer: Callable[[Requirement], Any] | None = None,
-    ):
+        installer: _InstallerTypeT[_DistributionT],
+    ) -> _DistributionT: ...
+    @overload
+    def obtain(
+        self,
+        requirement: Requirement,
+        installer: Callable[[Requirement], None] | None = None,
+    ) -> None: ...
+    @overload
+    def obtain(
+        self,
+        requirement: Requirement,
+        installer: _InstallerType | None = None,
+    ) -> Distribution | None: ...
+    def obtain(
+        self,
+        requirement: Requirement,
+        installer: Callable[[Requirement], None]
+        | _InstallerType
+        | None
+        | _InstallerTypeT[_DistributionT] = None,
+    ) -> Distribution | None:
         """Obtain a distribution matching `requirement` (e.g. via download)
 
         Obtain a distro that matches requirement (e.g. via download).  In the
@@ -1514,7 +1636,6 @@ class NullProvider:
     egg_name: str | None = None
     egg_info: str | None = None
     loader: _LoaderProtocol | None = None
-    module_path: str | None  # Some subclasses can have a None module_path
 
     def __init__(self, module: _ModuleLike):
         self.loader = getattr(module, '__loader__', None)
@@ -1557,7 +1678,7 @@ class NullProvider:
             exc.reason += ' in {} file at path: {}'.format(name, path)
             raise
 
-    def get_metadata_lines(self, name: str):
+    def get_metadata_lines(self, name: str) -> Iterator[str]:
         return yield_lines(self.get_metadata(name))
 
     def resource_isdir(self, resource_name: str):
@@ -1569,7 +1690,7 @@ class NullProvider:
     def resource_listdir(self, resource_name: str):
         return self._listdir(self._fn(self.module_path, resource_name))
 
-    def metadata_listdir(self, name: str):
+    def metadata_listdir(self, name: str) -> list[str]:
         if self.egg_info:
             return self._listdir(self._fn(self.egg_info, name))
         return []
@@ -1582,6 +1703,8 @@ class NullProvider:
                     **locals()
                 ),
             )
+        if not self.egg_info:
+            raise TypeError("Provider is missing egg_info", self.egg_info)
         script_text = self.get_metadata(script).replace('\r\n', '\n')
         script_text = script_text.replace('\r', '\n')
         script_filename = self._fn(self.egg_info, script)
@@ -1612,12 +1735,12 @@ class NullProvider:
             "Can't perform this operation for unregistered loader type"
         )
 
-    def _listdir(self, path):
+    def _listdir(self, path) -> list[str]:
         raise NotImplementedError(
             "Can't perform this operation for unregistered loader type"
         )
 
-    def _fn(self, base, resource_name: str):
+    def _fn(self, base: str, resource_name: str):
         self._validate_resource_path(resource_name)
         if resource_name:
             return os.path.join(base, *resource_name.split('/'))
@@ -1777,7 +1900,8 @@ DefaultProvider._register()
 class EmptyProvider(NullProvider):
     """Provider that returns nothing for all requests"""
 
-    module_path = None
+    # A special case, we don't want all Providers inheriting from NullProvider to have a potentially None module_path
+    module_path: str | None = None  # type: ignore[assignment]
 
     _isdir = _has = lambda self, path: False
 
@@ -1853,7 +1977,7 @@ class ZipProvider(EggProvider):
     # ZipProvider's loader should always be a zipimporter or equivalent
     loader: zipimport.zipimporter
 
-    def __init__(self, module: _ModuleLike):
+    def __init__(self, module: _ZipLoaderModule):
         super().__init__(module)
         self.zip_pre = self.loader.archive + os.sep
 
@@ -1902,7 +2026,7 @@ class ZipProvider(EggProvider):
         return timestamp, size
 
     # FIXME: 'ZipProvider._extract_resource' is too complex (12)
-    def _extract_resource(self, manager: ResourceManager, zip_path):  # noqa: C901
+    def _extract_resource(self, manager: ResourceManager, zip_path) -> str:  # noqa: C901
         if zip_path in self._index():
             for name in self._index()[zip_path]:
                 last = self._extract_resource(manager, os.path.join(zip_path, name))
@@ -2039,7 +2163,7 @@ class FileMetadata(EmptyProvider):
     def has_metadata(self, name: str) -> bool:
         return name == 'PKG-INFO' and os.path.isfile(self.path)
 
-    def get_metadata(self, name):
+    def get_metadata(self, name: str):
         if name != 'PKG-INFO':
             raise KeyError("No metadata except PKG-INFO is available")
 
@@ -2055,7 +2179,7 @@ class FileMetadata(EmptyProvider):
             msg = tmpl.format(**locals())
             warnings.warn(msg)
 
-    def get_metadata_lines(self, name):
+    def get_metadata_lines(self, name: str) -> Iterator[str]:
         return yield_lines(self.get_metadata(name))
 
 
@@ -2581,12 +2705,26 @@ class EntryPoint:
     def __repr__(self):
         return "EntryPoint.parse(%r)" % str(self)
 
+    @overload
+    def load(
+        self,
+        require: Literal[True] = True,
+        env: Environment | None = None,
+        installer: _InstallerType | None = None,
+    ) -> _ResolvedEntryPoint: ...
+    @overload
+    def load(
+        self,
+        require: Literal[False],
+        *args: Any,
+        **kwargs: Any,
+    ) -> _ResolvedEntryPoint: ...
     def load(
         self,
         require: bool = True,
         *args: Environment | _InstallerType | None,
         **kwargs: Environment | _InstallerType | None,
-    ):
+    ) -> _ResolvedEntryPoint:
         """
         Require packages for this EntryPoint, then resolve it.
         """
@@ -2603,7 +2741,7 @@ class EntryPoint:
             self.require(*args, **kwargs)  # type: ignore
         return self.resolve()
 
-    def resolve(self):
+    def resolve(self) -> _ResolvedEntryPoint:
         """
         Resolve the entry point from its module and attrs.
         """
@@ -3031,13 +3169,17 @@ class Distribution:
 
         return Requirement.parse(spec)
 
-    def load_entry_point(self, group: str, name: str):
+    def load_entry_point(self, group: str, name: str) -> _ResolvedEntryPoint:
         """Return the `name` entry point of `group` or raise ImportError"""
         ep = self.get_entry_info(group, name)
         if ep is None:
             raise ImportError("Entry point %r not found" % ((group, name),))
         return ep.load()
 
+    @overload
+    def get_entry_map(self, group: None = None) -> dict[str, dict[str, EntryPoint]]: ...
+    @overload
+    def get_entry_map(self, group: str) -> dict[str, EntryPoint]: ...
     def get_entry_map(self, group: str | None = None):
         """Return the entry point map for `group`, or the full entry map"""
         if not hasattr(self, "_ep_map"):

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -1704,8 +1704,7 @@ class NullProvider:
                     **locals()
                 ),
             )
-        if not self.egg_info:
-            raise TypeError("Provider is missing egg_info", self.egg_info)
+
         script_text = self.get_metadata(script).replace('\r\n', '\n')
         script_text = script_text.replace('\r', '\n')
         script_filename = self._fn(self.egg_info, script)
@@ -1741,7 +1740,11 @@ class NullProvider:
             "Can't perform this operation for unregistered loader type"
         )
 
-    def _fn(self, base: str, resource_name: str):
+    def _fn(self, base: str | None, resource_name: str):
+        if base is None:
+            raise TypeError(
+                "`base` parameter in `_fn` is `None`. Either override this method or check the parameter first."
+            )
         self._validate_resource_path(resource_name)
         if resource_name:
             return os.path.join(base, *resource_name.split('/'))

--- a/ruff.toml
+++ b/ruff.toml
@@ -12,7 +12,7 @@ extend-select = [
 	# local
 	"FA", # flake8-future-annotations
 	"F404", # late-future-import
-  "PYI", # flake8-pyi
+	"PYI", # flake8-pyi
 	"UP", # pyupgrade
 	"YTT", # flake8-2020
 ]
@@ -39,10 +39,6 @@ ignore = [
 	"ISC001",
 	"ISC002",
 ]
-
-[lint.per-file-ignores]
-# Auto-generated code
-"setuptools/config/_validate_pyproject/*" = ["FA100"]
 
 [format]
 # Enable preview to get hugged parenthesis unwrapping


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Step 3.2 of https://github.com/pypa/setuptools/issues/2345#issuecomment-1627561833

Once this #4355 and #4391 are merged, `pkg_setuptools` will be on par with Typeshed

### Pull Request Checklist
- [x] Changes have tests (type-checking)
- [x] News fragment added in [`newsfragments/`]. (no user facing changes yet until pkg_resources is considered typed)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
