### PR TITLE
Sort imports for more consistent diff (ruff/isort)

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -1,7 +1,6 @@
 # don't import any costly modules
-import sys
 import os
-
+import sys
 
 report_url = (
     "https://github.com/pypa/setuptools/issues/new?"

--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,6 @@ import sys
 
 import pytest
 
-
 pytest_plugins = 'setuptools.tests.fixtures'
 
 

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -22,68 +22,66 @@ This module is deprecated. Users are directed to :mod:`importlib.resources`,
 
 from __future__ import annotations
 
-from abc import ABC
 import sys
+from abc import ABC
 
 if sys.version_info < (3, 8):  # noqa: UP036 # Check for unsupported versions
     raise RuntimeError("Python 3.8 or later is required")
 
-import os
+import _imp
+import collections
+import email.parser
+import errno
+import functools
+import importlib
+import importlib.abc
+import importlib.machinery
+import inspect
 import io
-import time
+import ntpath
+import operator
+import os
+import pkgutil
+import platform
+import plistlib
+import posixpath
 import re
+import stat
+import tempfile
+import textwrap
+import time
 import types
+import warnings
+import zipfile
+import zipimport
+from pkgutil import get_importer
 from typing import (
+    TYPE_CHECKING,
     Any,
     BinaryIO,
-    Literal,
+    Callable,
     Dict,
+    Iterable,
     Iterator,
+    Literal,
     Mapping,
     MutableSequence,
     NamedTuple,
     NoReturn,
-    Tuple,
-    Union,
-    TYPE_CHECKING,
     Protocol,
-    Callable,
-    Iterable,
+    Tuple,
     TypeVar,
+    Union,
     overload,
 )
-import zipfile
-import zipimport
-import warnings
-import stat
-import functools
-import pkgutil
-import operator
-import platform
-import collections
-import plistlib
-import email.parser
-import errno
-import tempfile
-import textwrap
-import inspect
-import ntpath
-import posixpath
-import importlib
-import importlib.abc
-import importlib.machinery
-from pkgutil import get_importer
-
-import _imp
 
 sys.path.extend(((vendor_path := os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setuptools', '_vendor')) not in sys.path) * [vendor_path])  # fmt: skip
 # workaround for #4476
 sys.modules.pop('backports', None)
 
 # capture these to bypass sandboxing
-from os import utime
-from os import open as os_open
-from os.path import isdir, split
+from os import open as os_open, utime  # isort: skip
+from os.path import isdir, split  # isort: skip
 
 try:
     from os import mkdir, rename, unlink
@@ -93,20 +91,16 @@ except ImportError:
     # no write support, probably under GAE
     WRITE_SUPPORT = False
 
-from jaraco.text import (
-    yield_lines,
-    drop_comment,
-    join_continuation,
-)
 import packaging.markers
 import packaging.requirements
 import packaging.specifiers
 import packaging.utils
 import packaging.version
+from jaraco.text import drop_comment, join_continuation, yield_lines
 from platformdirs import user_cache_dir as _user_cache_dir
 
 if TYPE_CHECKING:
-    from _typeshed import BytesPath, StrPath, StrOrBytesPath
+    from _typeshed import BytesPath, StrOrBytesPath, StrPath
     from typing_extensions import Self, TypeAlias
 
 warnings.warn(

--- a/pkg_resources/tests/test_find_distributions.py
+++ b/pkg_resources/tests/test_find_distributions.py
@@ -1,8 +1,9 @@
-from pathlib import Path
 import shutil
-import pytest
-import pkg_resources
+from pathlib import Path
 
+import pytest
+
+import pkg_resources
 
 TESTS_DATA_DIR = Path(__file__).parent / 'data'
 

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -1,28 +1,23 @@
 from __future__ import annotations
 
 import builtins
+import datetime
+import os
+import plistlib
+import stat
+import subprocess
 import sys
 import tempfile
-import os
 import zipfile
-import datetime
-import plistlib
-import subprocess
-import stat
-import distutils.dist
-import distutils.command.install_egg_info
-
 from unittest import mock
-
-from pkg_resources import (
-    DistInfoDistribution,
-    Distribution,
-    EggInfoDistribution,
-)
 
 import pytest
 
 import pkg_resources
+from pkg_resources import DistInfoDistribution, Distribution, EggInfoDistribution
+
+import distutils.command.install_egg_info
+import distutils.dist
 
 
 class EggRemover(str):

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -1,23 +1,23 @@
-import os
-import sys
-import string
-import platform
 import itertools
+import os
+import platform
+import string
+import sys
 
 import pytest
 from packaging.specifiers import SpecifierSet
 
 import pkg_resources
 from pkg_resources import (
-    parse_requirements,
-    VersionConflict,
-    parse_version,
     Distribution,
     EntryPoint,
     Requirement,
-    safe_version,
-    safe_name,
+    VersionConflict,
     WorkingSet,
+    parse_requirements,
+    parse_version,
+    safe_name,
+    safe_version,
 )
 
 
@@ -862,8 +862,8 @@ class TestNamespaces:
             (subpkg / '__init__.py').write_text(vers_str % number, encoding='utf-8')
 
         with pytest.warns(DeprecationWarning, match="pkg_resources.declare_namespace"):
-            import nspkg.subpkg
             import nspkg
+            import nspkg.subpkg
         expected = [str(site.realpath() / 'nspkg') for site in site_dirs]
         assert nspkg.__path__ == expected
         assert nspkg.subpkg.__version__ == 1

--- a/pkg_resources/tests/test_working_set.py
+++ b/pkg_resources/tests/test_working_set.py
@@ -1,7 +1,7 @@
+import functools
 import inspect
 import re
 import textwrap
-import functools
 
 import pytest
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,6 +14,7 @@ extend-select = [
 	"ANN2", # missing-return-type-*
 	"FA", # flake8-future-annotations
 	"F404", # late-future-import
+	"I", # isort
 	"PYI", # flake8-pyi
 	"UP", # pyupgrade
 	"TRY",
@@ -55,6 +56,16 @@ ignore = [
 # Suppress nuisance warnings about module-import-not-at-top-of-file (E402) due to workaround for #4476
 "setuptools/__init__.py" = ["E402"]
 "pkg_resources/__init__.py" = ["E402"]
+
+[lint.isort]
+combine-as-imports = true
+split-on-trailing-comma = false
+# Force Ruff/isort to always import setuptools before distutils in tests as long as distutils_hack is supported
+# This also ensures _distutils_hack is imported before distutils
+# https://github.com/pypa/setuptools/issues/4137
+section-order = ["future", "standard-library", "eager", "third-party", "first-party", "local-folder", "delayed"]
+sections.eager = ["_distutils_hack"]
+sections.delayed = ["distutils"]
 
 [lint.flake8-annotations]
 ignore-fully-untyped = true

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -2,29 +2,29 @@
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
 import functools
 import os
 import re
 import sys
+from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, TypeVar, overload
-
 
 sys.path.extend(((vendor_path := os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setuptools', '_vendor')) not in sys.path) * [vendor_path])  # fmt: skip
 # workaround for #4476
 sys.modules.pop('backports', None)
 
 import _distutils_hack.override  # noqa: F401
-import distutils.core
-from distutils.errors import DistutilsOptionError
 
 from . import logging, monkey
-from .version import __version__ as __version__
 from .depends import Require
 from .discovery import PackageFinder, PEP420PackageFinder
 from .dist import Distribution
 from .extension import Extension
+from .version import __version__ as __version__
 from .warnings import SetuptoolsDeprecationWarning
+
+import distutils.core
+from distutils.errors import DistutilsOptionError
 
 __all__ = [
     'setup',

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -13,14 +13,15 @@ from email import message_from_file
 from email.message import Message
 from tempfile import NamedTemporaryFile
 
-from distutils.util import rfc822_escape
-
-from . import _normalization, _reqs
 from packaging.markers import Marker
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name, canonicalize_version
 from packaging.version import Version
+
+from . import _normalization, _reqs
 from .warnings import SetuptoolsDeprecationWarning
+
+from distutils.util import rfc822_escape
 
 
 def get_metadata_version(self):

--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -1,13 +1,14 @@
 import functools
-import operator
 import itertools
+import operator
 
-from .errors import OptionError
-from jaraco.text import yield_lines
 from jaraco.functools import pass_none
+from jaraco.text import yield_lines
+from more_itertools import consume
+
 from ._importlib import metadata
 from ._itertools import ensure_unique
-from more_itertools import consume
+from .errors import OptionError
 
 
 def ensure_valid(ep):

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -3,13 +3,11 @@ Re-implementation of find_module and get_frozen_object
 from the deprecated imp module.
 """
 
-import os
-import importlib.util
 import importlib.machinery
+import importlib.util
+import os
 import tokenize
-
 from importlib.util import module_from_spec
-
 
 PY_SOURCE = 1
 PY_COMPILED = 2

--- a/setuptools/_importlib.py
+++ b/setuptools/_importlib.py
@@ -1,6 +1,5 @@
 import sys
 
-
 if sys.version_info < (3, 10):
     import importlib_metadata as metadata  # pragma: no cover
 else:

--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -3,14 +3,13 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-from typing import Union, TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
 
 from more_itertools import unique_everseen
-
 
 if sys.version_info >= (3, 9):
     StrPath: TypeAlias = Union[str, os.PathLike[str]]  #  Same as _typeshed.StrPath

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from functools import lru_cache
-from typing import Callable, Iterable, Iterator, TypeVar, Union, overload, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, TypeVar, Union, overload
+
 import jaraco.text as text
 from packaging.requirements import Requirement
 

--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -1,14 +1,15 @@
 """Utilities for extracting common archive formats"""
 
-import zipfile
-import tarfile
-import os
-import shutil
-import posixpath
 import contextlib
-from distutils.errors import DistutilsError
+import os
+import posixpath
+import shutil
+import tarfile
+import zipfile
 
 from ._path import ensure_directory
+
+from distutils.errors import DistutilsError
 
 __all__ = [
     "unpack_archive",

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -28,24 +28,26 @@ Again, this is not a formal definition! Just a "taste" of the module.
 
 from __future__ import annotations
 
+import contextlib
 import io
 import os
 import shlex
-import sys
-import tokenize
 import shutil
-import contextlib
+import sys
 import tempfile
+import tokenize
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Iterator, List, Union, Iterable
+from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Union
 
 import setuptools
-import distutils
+
 from . import errors
-from ._path import same_path, StrPath
+from ._path import StrPath, same_path
 from ._reqs import parse_strings
 from .warnings import SetuptoolsDeprecationWarning
+
+import distutils
 from distutils.util import strtobool
 
 if TYPE_CHECKING:

--- a/setuptools/command/__init__.py
+++ b/setuptools/command/__init__.py
@@ -1,5 +1,6 @@
-from distutils.command.bdist import bdist
 import sys
+
+from distutils.command.bdist import bdist
 
 if 'egg' not in bdist.format_commands:
     try:

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -14,10 +14,10 @@ from collections import defaultdict
 from itertools import filterfalse
 from typing import Dict, Mapping, TypeVar
 
-from .. import _reqs
 from jaraco.text import yield_lines
 from packaging.requirements import Requirement
 
+from .. import _reqs
 
 # dict can work as an ordered set
 _T = TypeVar("_T")

--- a/setuptools/command/alias.py
+++ b/setuptools/command/alias.py
@@ -1,6 +1,6 @@
-from distutils.errors import DistutilsOptionError
+from setuptools.command.setopt import config_file, edit_config, option_base
 
-from setuptools.command.setopt import edit_config, option_base, config_file
+from distutils.errors import DistutilsOptionError
 
 
 def shquote(arg):

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -2,20 +2,21 @@
 
 Build .egg distributions"""
 
-from distutils.dir_util import remove_tree, mkpath
-from distutils import log
-from types import CodeType
-import sys
+import marshal
 import os
 import re
+import sys
 import textwrap
-import marshal
+from sysconfig import get_path, get_python_version
+from types import CodeType
 
-from setuptools.extension import Library
 from setuptools import Command
+from setuptools.extension import Library
+
 from .._path import ensure_directory
 
-from sysconfig import get_path, get_python_version
+from distutils import log
+from distutils.dir_util import mkpath, remove_tree
 
 
 def _get_purelib():

--- a/setuptools/command/bdist_rpm.py
+++ b/setuptools/command/bdist_rpm.py
@@ -1,6 +1,6 @@
-import distutils.command.bdist_rpm as orig
-
 from ..warnings import SetuptoolsDeprecationWarning
+
+import distutils.command.bdist_rpm as orig
 
 
 class bdist_rpm(orig.bdist_rpm):

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -16,18 +16,19 @@ import sysconfig
 import warnings
 from email.generator import BytesGenerator, Generator
 from email.policy import EmailPolicy
-from distutils import log
 from glob import iglob
 from shutil import rmtree
 from typing import TYPE_CHECKING, Callable, Iterable, Literal, Sequence, cast
 from zipfile import ZIP_DEFLATED, ZIP_STORED
 
+from packaging import tags, version as _packaging_version
+from wheel.metadata import pkginfo_to_metadata
+from wheel.wheelfile import WheelFile
+
 from .. import Command, __version__
 from .egg_info import egg_info as egg_info_cls
-from wheel.metadata import pkginfo_to_metadata
-from packaging import tags
-from packaging import version as _packaging_version
-from wheel.wheelfile import WheelFile
+
+from distutils import log
 
 if TYPE_CHECKING:
     from _typeshed import ExcInfo

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Protocol
+
 from distutils.command.build import build as _build
 
 _ORIGINAL_SUBCOMMANDS = {"build_py", "build_clib", "build_ext", "build_scripts"}

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -1,6 +1,6 @@
 import distutils.command.build_clib as orig
-from distutils.errors import DistutilsSetupError
 from distutils import log
+from distutils.errors import DistutilsSetupError
 
 try:
     from distutils._modified import newer_pairwise_group

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -1,24 +1,26 @@
 from __future__ import annotations
 
+import itertools
 import os
 import sys
-import itertools
 from importlib.machinery import EXTENSION_SUFFIXES
 from importlib.util import cache_from_source as _compiled_file_name
-from typing import Iterator
 from pathlib import Path
-
-from distutils.ccompiler import new_compiler
-from distutils.sysconfig import customize_compiler, get_config_var
-from distutils import log
+from typing import Iterator
 
 from setuptools.dist import Distribution
 from setuptools.errors import BaseError
 from setuptools.extension import Extension, Library
 
+from distutils import log
+from distutils.ccompiler import new_compiler
+from distutils.sysconfig import customize_compiler, get_config_var
+
 try:
     # Attempt to use Cython for building extensions, if available
-    from Cython.Distutils.build_ext import build_ext as _build_ext  # type: ignore[import-not-found] # Cython not installed on CI tests
+    from Cython.Distutils.build_ext import (  # type: ignore[import-not-found] # Cython not installed on CI tests
+        build_ext as _build_ext,
+    )
 
     # Additionally, assert that the compiler module will load
     # also. Ref #1229.

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -1,15 +1,12 @@
 from __future__ import annotations
 
+import fnmatch
+import itertools
+import os
+import stat
+import textwrap
 from functools import partial
 from glob import glob
-from distutils.util import convert_path
-import distutils.command.build_py as orig
-import os
-import fnmatch
-import textwrap
-import distutils.errors
-import itertools
-import stat
 from pathlib import Path
 from typing import Iterable, Iterator
 
@@ -17,6 +14,10 @@ from more_itertools import unique_everseen
 
 from ..dist import Distribution
 from ..warnings import SetuptoolsDeprecationWarning
+
+import distutils.command.build_py as orig
+import distutils.errors
+from distutils.util import convert_path
 
 _IMPLICIT_DATA_FILES = ('*.pyi', 'py.typed')
 

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -1,16 +1,15 @@
-from distutils.util import convert_path
-from distutils import log
-from distutils.errors import DistutilsOptionError
-import os
 import glob
+import os
 
-from setuptools.command.easy_install import easy_install
-from setuptools import _normalization
-from setuptools import _path
-from setuptools import namespaces
 import setuptools
+from setuptools import _normalization, _path, namespaces
+from setuptools.command.easy_install import easy_install
 
 from ..unicode_utils import _read_utf8_with_fallback
+
+from distutils import log
+from distutils.errors import DistutilsOptionError
+from distutils.util import convert_path
 
 
 class develop(namespaces.DevelopInstaller, easy_install):

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -6,13 +6,14 @@ As defined in the wheel specification
 import os
 import shutil
 from contextlib import contextmanager
-from distutils import log
-from distutils.core import Command
 from pathlib import Path
 from typing import cast
 
 from .. import _normalization
 from .egg_info import egg_info as egg_info_cls
+
+from distutils import log
+from distutils.core import Command
 
 
 class dist_info(Command):

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -12,8 +12,8 @@ Create a wheel that, when installed, will make the source package 'editable'
 
 from __future__ import annotations
 
-import logging
 import io
+import logging
 import os
 import shutil
 import traceback
@@ -23,32 +23,14 @@ from inspect import cleandoc
 from itertools import chain, starmap
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    Iterator,
-    Mapping,
-    Protocol,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Iterable, Iterator, Mapping, Protocol, TypeVar, cast
 
-from .. import (
-    Command,
-    _normalization,
-    _path,
-    errors,
-    namespaces,
-)
+from .. import Command, _normalization, _path, errors, namespaces
 from .._path import StrPath
 from ..compat import py39
 from ..discovery import find_package_path
 from ..dist import Distribution
-from ..warnings import (
-    InformationOnly,
-    SetuptoolsDeprecationWarning,
-    SetuptoolsWarning,
-)
+from ..warnings import InformationOnly, SetuptoolsDeprecationWarning, SetuptoolsWarning
 from .build import build as build_cls
 from .build_py import build_py as build_py_cls
 from .dist_info import dist_info as dist_info_cls

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -2,35 +2,36 @@
 
 Create a distribution's .egg-info directory and contents"""
 
-from distutils.filelist import FileList as _FileList
-from distutils.errors import DistutilsInternalError
-from distutils.util import convert_path
-from distutils import log
-import distutils.errors
-import distutils.filelist
+import collections
 import functools
 import os
 import re
 import sys
 import time
-import collections
 
-from .._importlib import metadata
-from .. import _entry_points, _normalization
-from . import _requirestxt
-
-from setuptools import Command
-from setuptools.command.sdist import sdist
-from setuptools.command.sdist import walk_revctrl
-from setuptools.command.setopt import edit_config
-from setuptools.command import bdist_egg
-from setuptools.dist import Distribution
-import setuptools.unicode_utils as unicode_utils
-from setuptools.glob import glob
-
+import packaging
 import packaging.requirements
 import packaging.version
+
+import setuptools.unicode_utils as unicode_utils
+from setuptools import Command
+from setuptools.command import bdist_egg
+from setuptools.command.sdist import sdist, walk_revctrl
+from setuptools.command.setopt import edit_config
+from setuptools.dist import Distribution
+from setuptools.glob import glob
+
+from .. import _entry_points, _normalization
+from .._importlib import metadata
 from ..warnings import SetuptoolsDeprecationWarning
+from . import _requirestxt
+
+import distutils.errors
+import distutils.filelist
+from distutils import log
+from distutils.errors import DistutilsInternalError
+from distutils.filelist import FileList as _FileList
+from distutils.util import convert_path
 
 PY_MAJOR = '{}.{}'.format(*sys.version_info)
 

--- a/setuptools/command/install.py
+++ b/setuptools/command/install.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Callable
-from distutils.errors import DistutilsArgError
-import inspect
 import glob
+import inspect
 import platform
-import distutils.command.install as orig
+from collections.abc import Callable
 from typing import Any, ClassVar, cast
 
 import setuptools
+
 from ..dist import Distribution
 from ..warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
 from .bdist_egg import bdist_egg as bdist_egg_cls
+
+import distutils.command.install as orig
+from distutils.errors import DistutilsArgError
 
 # Prior to numpy 1.9, NumPy relies on the '_install' name, so provide it for
 # now. See https://github.com/pypa/setuptools/issues/199/

--- a/setuptools/command/install_egg_info.py
+++ b/setuptools/command/install_egg_info.py
@@ -1,10 +1,11 @@
-from distutils import log, dir_util
 import os
 
-from setuptools import Command
-from setuptools import namespaces
+from setuptools import Command, namespaces
 from setuptools.archive_util import unpack_archive
+
 from .._path import ensure_directory
+
+from distutils import dir_util, log
 
 
 class install_egg_info(namespaces.Installer, Command):

--- a/setuptools/command/install_lib.py
+++ b/setuptools/command/install_lib.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
+
 import os
 import sys
 from itertools import product, starmap
-import distutils.command.install_lib as orig
 
 from .._path import StrPath
 from ..dist import Distribution
+
+import distutils.command.install_lib as orig
 
 
 class install_lib(orig.install_lib):
@@ -107,6 +109,7 @@ class install_lib(orig.install_lib):
         # Exclude namespace package __init__.py* files from the output
 
         from setuptools.archive_util import unpack_directory
+
         from distutils import log
 
         outfiles: list[str] = []

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from distutils import log
-import distutils.command.install_scripts as orig
 import os
 import sys
 
 from .._path import ensure_directory
 from ..dist import Distribution
+
+import distutils.command.install_scripts as orig
+from distutils import log
 
 
 class install_scripts(orig.install_scripts):
@@ -32,6 +33,7 @@ class install_scripts(orig.install_scripts):
     def _install_ep_scripts(self):
         # Delay import side-effects
         from pkg_resources import Distribution, PathMetadata
+
         from . import easy_install as ei
 
         ei_cmd = self.get_finalized_command("egg_info")

--- a/setuptools/command/register.py
+++ b/setuptools/command/register.py
@@ -1,7 +1,7 @@
-from distutils import log
-import distutils.command.register as orig
-
 from setuptools.errors import RemovedCommandError
+
+import distutils.command.register as orig
+from distutils import log
 
 
 class register(orig.register):

--- a/setuptools/command/rotate.py
+++ b/setuptools/command/rotate.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from distutils.util import convert_path
-from distutils import log
-from distutils.errors import DistutilsOptionError
 import os
 import shutil
 
 from setuptools import Command
+
+from distutils import log
+from distutils.errors import DistutilsOptionError
+from distutils.util import convert_path
 
 
 class rotate(Command):

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -1,12 +1,13 @@
-from distutils import log
-import distutils.command.sdist as orig
-import os
 import contextlib
+import os
 from itertools import chain
 
 from .._importlib import metadata
 from ..dist import Distribution
 from .build import _ORIGINAL_SUBCOMMANDS
+
+import distutils.command.sdist as orig
+from distutils import log
 
 _default_revctrl = list
 

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -1,13 +1,14 @@
-from abc import ABC
-from distutils.util import convert_path
-from distutils import log
-from distutils.errors import DistutilsOptionError
-import distutils
-import os
 import configparser
+import os
+from abc import ABC
 
 from .. import Command
 from ..unicode_utils import _cfg_read_utf8_with_fallback
+
+import distutils
+from distutils import log
+from distutils.errors import DistutilsOptionError
+from distutils.util import convert_path
 
 __all__ = ['config_file', 'edit_config', 'option_base', 'setopt']
 

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -1,8 +1,8 @@
-from distutils import log
-from distutils.command import upload as orig
-
 from setuptools.dist import Distribution
 from setuptools.errors import RemovedCommandError
+
+from distutils import log
+from distutils.command import upload as orig
 
 
 class upload(orig.upload):

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -4,22 +4,22 @@ Implements a Distutils 'upload_docs' subcommand (upload documentation to
 sites other than PyPi such as devpi).
 """
 
-from base64 import standard_b64encode
-from distutils import log
-from distutils.errors import DistutilsOptionError
-import os
-import zipfile
-import tempfile
-import shutil
-import itertools
 import functools
 import http.client
+import itertools
+import os
+import shutil
+import tempfile
 import urllib.parse
+import zipfile
+from base64 import standard_b64encode
 
 from .._importlib import metadata
 from ..warnings import SetuptoolsDeprecationWarning
-
 from .upload import upload
+
+from distutils import log
+from distutils.errors import DistutilsOptionError
 
 
 def _encode(s):

--- a/setuptools/compat/py310.py
+++ b/setuptools/compat/py310.py
@@ -1,6 +1,5 @@
 import sys
 
-
 __all__ = ['tomllib']
 
 

--- a/setuptools/compat/py311.py
+++ b/setuptools/compat/py311.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import shutil
 import sys
-from typing import Any, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
-    from _typeshed import StrOrBytesPath, ExcInfo
+    from _typeshed import ExcInfo, StrOrBytesPath
     from typing_extensions import TypeAlias
 
 # Same as shutil._OnExcCallback from typeshed

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -17,23 +17,19 @@ from functools import partial, reduce
 from inspect import cleandoc
 from itertools import chain
 from types import MappingProxyType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Mapping,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, Union
+
 from .._path import StrPath
 from ..errors import RemovedConfigError
 from ..warnings import SetuptoolsWarning
 
 if TYPE_CHECKING:
-    from distutils.dist import _OptionsList
+    from typing_extensions import TypeAlias
+
     from setuptools._importlib import metadata
     from setuptools.dist import Distribution
-    from typing_extensions import TypeAlias
+
+    from distutils.dist import _OptionsList
 
 EMPTY: Mapping = MappingProxyType({})  # Immutable dict-like
 _ProjectReadmeValue: TypeAlias = Union[str, Dict[str, str]]
@@ -262,8 +258,9 @@ def _copy_command_options(pyproject: dict, dist: Distribution, filename: StrPath
 
 
 def _valid_command_options(cmdclass: Mapping = EMPTY) -> dict[str, set[str]]:
-    from .._importlib import metadata
     from setuptools.dist import Distribution
+
+    from .._importlib import metadata
 
     valid_options = {"global": _normalise_cmd_options(Distribution.global_options)}
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -25,27 +25,19 @@ import importlib
 import os
 import pathlib
 import sys
-from glob import iglob
 from configparser import ConfigParser
+from glob import iglob
 from importlib.machinery import ModuleSpec, all_suffixes
 from itertools import chain
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Iterable,
-    Iterator,
-    Mapping,
-    TypeVar,
-)
 from pathlib import Path
 from types import ModuleType
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, TypeVar
 
-from distutils.errors import DistutilsOptionError
-
-from .._path import same_path as _same_path, StrPath
+from .._path import StrPath, same_path as _same_path
 from ..discovery import find_package_path
 from ..warnings import SetuptoolsWarning
+
+from distutils.errors import DistutilsOptionError
 
 if TYPE_CHECKING:
     from setuptools.dist import Distribution
@@ -287,8 +279,9 @@ def find_packages(
 
     :rtype: list
     """
+    from more_itertools import always_iterable, unique_everseen
+
     from setuptools.discovery import construct_package_dir
-    from more_itertools import unique_everseen, always_iterable
 
     if namespaces:
         from setuptools.discovery import PEP420PackageFinder as PackageFinder

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -21,12 +21,12 @@ from .._path import StrPath
 from ..errors import FileError, InvalidConfigError
 from ..warnings import SetuptoolsWarning
 from . import expand as _expand
-from ._apply_pyprojecttoml import _PREVIOUSLY_DEFINED, _MissingDynamic
-from ._apply_pyprojecttoml import apply as _apply
+from ._apply_pyprojecttoml import _PREVIOUSLY_DEFINED, _MissingDynamic, apply as _apply
 
 if TYPE_CHECKING:
-    from setuptools.dist import Distribution
     from typing_extensions import Self
+
+    from setuptools.dist import Distribution
 
 _logger = logging.getLogger(__name__)
 

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -15,12 +15,11 @@ import contextlib
 import functools
 import os
 from collections import defaultdict
-from functools import partial
-from functools import wraps
+from functools import partial, wraps
 from typing import (
     TYPE_CHECKING,
-    Callable,
     Any,
+    Callable,
     Dict,
     Generic,
     Iterable,
@@ -30,19 +29,20 @@ from typing import (
     Union,
 )
 
-from .._path import StrPath
-from ..errors import FileError, OptionError
 from packaging.markers import default_environment as marker_env
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.version import InvalidVersion, Version
+
+from .._path import StrPath
+from ..errors import FileError, OptionError
 from ..warnings import SetuptoolsDeprecationWarning
 from . import expand
 
 if TYPE_CHECKING:
-    from distutils.dist import DistributionMetadata
-
     from setuptools.dist import Distribution
+
+    from distutils.dist import DistributionMetadata
 
 SingleCommandOptions = Dict["str", Tuple["str", Any]]
 """Dict that associate the name of the options of a particular command to a

--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -1,13 +1,12 @@
-import sys
-import marshal
 import contextlib
 import dis
+import marshal
+import sys
 
-
-from . import _imp
-from ._imp import find_module, PY_COMPILED, PY_FROZEN, PY_SOURCE
 from packaging.version import Version
 
+from . import _imp
+from ._imp import PY_COMPILED, PY_FROZEN, PY_SOURCE, find_module
 
 __all__ = ['Require', 'find_module']
 

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -44,16 +44,12 @@ import os
 from fnmatch import fnmatchcase
 from glob import glob
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Iterable,
-    Iterator,
-    Mapping,
-)
+from typing import TYPE_CHECKING, Iterable, Iterator, Mapping
 
 import _distutils_hack.override  # noqa: F401
 
 from ._path import StrPath
+
 from distutils import log
 from distutils.util import convert_path
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -10,6 +10,23 @@ from glob import iglob
 from pathlib import Path
 from typing import TYPE_CHECKING, MutableMapping
 
+from more_itertools import partition, unique_everseen
+from ordered_set import OrderedSet
+from packaging.markers import InvalidMarker, Marker
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import Version
+
+from . import (
+    _entry_points,
+    _reqs,
+    command as _,  # noqa: F401 # imported for side-effects
+)
+from ._importlib import metadata
+from .config import pyprojecttoml, setupcfg
+from .discovery import ConfigDiscovery
+from .monkey import get_unpatched
+from .warnings import InformationOnly, SetuptoolsDeprecationWarning
+
 import distutils.cmd
 import distutils.command
 import distutils.core
@@ -19,21 +36,6 @@ from distutils.debug import DEBUG
 from distutils.errors import DistutilsOptionError, DistutilsSetupError
 from distutils.fancy_getopt import translate_longopt
 from distutils.util import strtobool
-
-from more_itertools import partition, unique_everseen
-from ordered_set import OrderedSet
-from packaging.markers import InvalidMarker, Marker
-from packaging.specifiers import InvalidSpecifier, SpecifierSet
-from packaging.version import Version
-
-from . import _entry_points
-from . import _reqs
-from . import command as _  # noqa  -- imported for side-effects
-from ._importlib import metadata
-from .config import setupcfg, pyprojecttoml
-from .discovery import ConfigDiscovery
-from .monkey import get_unpatched
-from .warnings import InformationOnly, SetuptoolsDeprecationWarning
 
 __all__ = ['Distribution']
 

--- a/setuptools/errors.py
+++ b/setuptools/errors.py
@@ -5,7 +5,6 @@ Provides exceptions used by setuptools modules.
 
 from distutils import errors as _distutils_errors
 
-
 # Re-export errors from distutils to facilitate the migration to PEP632
 
 ByteCompileError = _distutils_errors.DistutilsByteCompileError

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
-import re
+
 import functools
-import distutils.core
-import distutils.errors
-import distutils.extension
+import re
 from typing import TYPE_CHECKING
 
 from .monkey import get_unpatched
+
+import distutils.core
+import distutils.errors
+import distutils.extension
 
 
 def _have_cython():

--- a/setuptools/glob.py
+++ b/setuptools/glob.py
@@ -6,9 +6,9 @@ Changes include:
  * Hidden files are not ignored.
 """
 
+import fnmatch
 import os
 import re
-import fnmatch
 
 __all__ = ["glob", "iglob", "escape"]
 

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -3,13 +3,14 @@ import os
 import subprocess
 import sys
 import tempfile
-from distutils import log
-from distutils.errors import DistutilsError
 from functools import partial
 
 from . import _reqs
-from .wheel import Wheel
 from .warnings import SetuptoolsDeprecationWarning
+from .wheel import Wheel
+
+from distutils import log
+from distutils.errors import DistutilsError
 
 
 def _fixup_find_links(find_links):

--- a/setuptools/launch.py
+++ b/setuptools/launch.py
@@ -6,8 +6,8 @@ setuptools is bootstrapped via import.
 # Note that setuptools gets imported implicitly by the
 # invocation of this script using python -m setuptools.launch
 
-import tokenize
 import sys
+import tokenize
 
 
 def run():

--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -1,8 +1,10 @@
-import sys
 import inspect
 import logging
-import distutils.log
+import sys
+
 from . import monkey
+
+import distutils.log
 
 
 def _not_warning(record):

--- a/setuptools/modified.py
+++ b/setuptools/modified.py
@@ -1,7 +1,7 @@
 from ._distutils._modified import (
     newer,
-    newer_pairwise,
     newer_group,
+    newer_pairwise,
     newer_pairwise_group,
 )
 

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -14,7 +14,6 @@ from typing import TypeVar
 
 import distutils.filelist
 
-
 _T = TypeVar("_T")
 
 __all__: list[str] = []

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -13,18 +13,19 @@ This may also support compilers shipped with compatible Visual Studio versions.
 
 from __future__ import annotations
 
-import json
-from os import listdir, pathsep
-from os.path import join, isfile, isdir, dirname
-from subprocess import CalledProcessError
 import contextlib
-import platform
 import itertools
+import json
+import platform
 import subprocess
-import distutils.errors
+from os import listdir, pathsep
+from os.path import dirname, isdir, isfile, join
+from subprocess import CalledProcessError
 from typing import TYPE_CHECKING
 
 from more_itertools import unique_everseen
+
+import distutils.errors
 
 # https://github.com/python/mypy/issues/8166
 if not TYPE_CHECKING and platform.system() == 'Windows':

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -1,9 +1,9 @@
-import os
-from distutils import log
 import itertools
+import os
 
 from .compat import py39
 
+from distutils import log
 
 flatten = itertools.chain.from_iterable
 

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1,49 +1,49 @@
 """PyPI and direct package downloading."""
 
-import sys
-import subprocess
-import os
-import re
-import io
-import shutil
-import socket
 import base64
-import hashlib
-import itertools
 import configparser
+import hashlib
 import html
 import http.client
+import io
+import itertools
+import os
+import re
+import shutil
+import socket
+import subprocess
+import sys
+import urllib.error
 import urllib.parse
 import urllib.request
-import urllib.error
-from functools import wraps
-
-import setuptools
-from pkg_resources import (
-    CHECKOUT_DIST,
-    Distribution,
-    BINARY_DIST,
-    normalize_path,
-    SOURCE_DIST,
-    Environment,
-    find_distributions,
-    safe_name,
-    safe_version,
-    to_filename,
-    Requirement,
-    DEVELOP_DIST,
-    EGG_DIST,
-    parse_version,
-)
-from distutils import log
-from distutils.errors import DistutilsError
 from fnmatch import translate
-from setuptools.wheel import Wheel
+from functools import wraps
 
 from more_itertools import unique_everseen
 
-from .unicode_utils import _read_utf8_with_fallback, _cfg_read_utf8_with_fallback
+import setuptools
+from pkg_resources import (
+    BINARY_DIST,
+    CHECKOUT_DIST,
+    DEVELOP_DIST,
+    EGG_DIST,
+    SOURCE_DIST,
+    Distribution,
+    Environment,
+    Requirement,
+    find_distributions,
+    normalize_path,
+    parse_version,
+    safe_name,
+    safe_version,
+    to_filename,
+)
+from setuptools.wheel import Wheel
 
+from .unicode_utils import _cfg_read_utf8_with_fallback, _read_utf8_with_fallback
+
+from distutils import log
+from distutils.errors import DistutilsError
 
 EGG_FRAGMENT = re.compile(r'^egg=([-A-Za-z0-9_.+!]+)$')
 HREF = re.compile(r"""href\s*=\s*['"]?([^'"> ]+)""", re.I)

--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
-from abc import ABC
-import os
-import sys
-import tempfile
-import operator
+import builtins
+import contextlib
 import functools
 import itertools
-import re
-import contextlib
+import operator
+import os
 import pickle
+import re
+import sys
+import tempfile
 import textwrap
-import builtins
+from abc import ABC
 
 import pkg_resources
-from distutils.errors import DistutilsError
 from pkg_resources import working_set
+
+from distutils.errors import DistutilsError
 
 if sys.platform.startswith('java'):
     import org.python.modules.posix.PosixModule as _os

--- a/setuptools/tests/__init__.py
+++ b/setuptools/tests/__init__.py
@@ -3,7 +3,6 @@ import sys
 
 import pytest
 
-
 __all__ = ['fail_on_ascii']
 
 if sys.version_info >= (3, 11):

--- a/setuptools/tests/compat/py39.py
+++ b/setuptools/tests/compat/py39.py
@@ -1,4 +1,3 @@
 from jaraco.test.cpython import from_test_support, try_import
 
-
 os_helper = try_import('os_helper') or from_test_support('can_symlink')

--- a/setuptools/tests/config/downloads/preload.py
+++ b/setuptools/tests/config/downloads/preload.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from . import retrieve_file, urls_from_file
 
-
 if __name__ == "__main__":
     urls = urls_from_file(Path(sys.argv[1]))
     list(map(retrieve_file, urls))

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -15,19 +15,16 @@ from unittest.mock import Mock
 
 import pytest
 from ini2toml.api import LiteTranslator
-
 from packaging.metadata import Metadata
 
 import setuptools  # noqa ensure monkey patch to metadata
-from setuptools.dist import Distribution
-from setuptools.config import setupcfg, pyprojecttoml
-from setuptools.config import expand
-from setuptools.config._apply_pyprojecttoml import _MissingDynamic, _some_attrgetter
 from setuptools.command.egg_info import write_requirements
+from setuptools.config import expand, pyprojecttoml, setupcfg
+from setuptools.config._apply_pyprojecttoml import _MissingDynamic, _some_attrgetter
+from setuptools.dist import Distribution
 from setuptools.errors import RemovedConfigError
 
 from .downloads import retrieve_file, urls_from_file
-
 
 HERE = Path(__file__).parent
 EXAMPLES_FILE = "setupcfg_examples.txt"

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -4,9 +4,10 @@ from pathlib import Path
 
 import pytest
 
-from distutils.errors import DistutilsOptionError
 from setuptools.config import expand
 from setuptools.discovery import find_package_path
+
+from distutils.errors import DistutilsOptionError
 
 
 def write_files(files, root_dir):

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -7,18 +7,17 @@ import pytest
 import tomli_w
 from path import Path
 
+import setuptools  # noqa: F401 # force distutils.core to be patched
 from setuptools.config.pyprojecttoml import (
     _ToolsTypoInMetadata,
-    read_configuration,
-    expand_configuration,
     apply_configuration,
+    expand_configuration,
+    read_configuration,
     validate,
 )
 from setuptools.dist import Distribution
 from setuptools.errors import OptionError
 
-
-import setuptools  # noqa -- force distutils.core to be patched
 import distutils.core
 
 EXAMPLE = """

--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -5,13 +5,15 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-
-from distutils.errors import DistutilsOptionError, DistutilsFileError
-from setuptools.dist import Distribution, _Distribution
-from setuptools.config.setupcfg import ConfigHandler, read_configuration
 from packaging.requirements import InvalidRequirement
+
+from setuptools.config.setupcfg import ConfigHandler, read_configuration
+from setuptools.dist import Distribution, _Distribution
 from setuptools.warnings import SetuptoolsDeprecationWarning
+
 from ..textwrap import DALS
+
+from distutils.errors import DistutilsFileError, DistutilsOptionError
 
 
 class ErrConfigHandler(ConfigHandler):

--- a/setuptools/tests/contexts.py
+++ b/setuptools/tests/contexts.py
@@ -1,10 +1,10 @@
-import tempfile
+import contextlib
+import io
 import os
 import shutil
-import sys
-import contextlib
 import site
-import io
+import sys
+import tempfile
 
 from filelock import FileLock
 

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -1,8 +1,8 @@
 import os
-import sys
 import subprocess
+import sys
 import unicodedata
-from subprocess import Popen as _Popen, PIPE as _PIPE
+from subprocess import PIPE as _PIPE, Popen as _Popen
 
 import jaraco.envs
 

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -1,11 +1,11 @@
-import os
 import contextlib
-import sys
+import os
 import subprocess
+import sys
 from pathlib import Path
 
-import pytest
 import path
+import pytest
 
 from . import contexts, environment
 

--- a/setuptools/tests/integration/helpers.py
+++ b/setuptools/tests/integration/helpers.py
@@ -8,8 +8,8 @@ facilitate debugging.
 import os
 import subprocess
 import tarfile
-from zipfile import ZipFile
 from pathlib import Path
+from zipfile import ZipFile
 
 
 def run(cmd, env=None):

--- a/setuptools/tests/server.py
+++ b/setuptools/tests/server.py
@@ -1,9 +1,9 @@
 """Basic http server for tests to simulate PyPI or custom indexes"""
 
-import os
-import time
-import threading
 import http.server
+import os
+import threading
+import time
 import urllib.parse
 import urllib.request
 

--- a/setuptools/tests/test_archive_util.py
+++ b/setuptools/tests/test_archive_util.py
@@ -1,5 +1,5 @@
-import tarfile
 import io
+import tarfile
 
 import pytest
 

--- a/setuptools/tests/test_bdist_deprecations.py
+++ b/setuptools/tests/test_bdist_deprecations.py
@@ -5,8 +5,8 @@ from unittest import mock
 
 import pytest
 
-from setuptools.dist import Distribution
 from setuptools import SetuptoolsDeprecationWarning
+from setuptools.dist import Distribution
 
 
 @pytest.mark.skipif(sys.platform == 'win32', reason='non-Windows only')

--- a/setuptools/tests/test_bdist_wheel.py
+++ b/setuptools/tests/test_bdist_wheel.py
@@ -16,9 +16,9 @@ from zipfile import ZipFile
 
 import jaraco.path
 import pytest
+from packaging import tags
 
 import setuptools
-from distutils.core import run_setup
 from setuptools.command.bdist_wheel import (
     bdist_wheel,
     get_abi_tag,
@@ -26,7 +26,8 @@ from setuptools.command.bdist_wheel import (
     remove_readonly_exc,
 )
 from setuptools.dist import Distribution
-from packaging import tags
+
+from distutils.core import run_setup
 
 DEFAULT_FILES = {
     "dummy_dist-1.0.dist-info/top_level.txt",

--- a/setuptools/tests/test_build.py
+++ b/setuptools/tests/test_build.py
@@ -1,6 +1,6 @@
 from setuptools import Command
-from setuptools.dist import Distribution
 from setuptools.command.build import build
+from setuptools.dist import Distribution
 
 
 def test_distribution_gives_setuptools_build_obj(tmpdir_cwd):

--- a/setuptools/tests/test_build_clib.py
+++ b/setuptools/tests/test_build_clib.py
@@ -1,11 +1,12 @@
+import random
 from unittest import mock
 
 import pytest
 
-import random
-from distutils.errors import DistutilsSetupError
 from setuptools.command.build_clib import build_clib
 from setuptools.dist import Distribution
+
+from distutils.errors import DistutilsSetupError
 
 
 class TestBuildCLib:

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -1,21 +1,20 @@
 import os
 import sys
-import distutils.command.build_ext as orig
-from distutils.sysconfig import get_config_var
 from importlib.util import cache_from_source as _compiled_file_name
 
+import pytest
 from jaraco import path
 
 from setuptools.command.build_ext import build_ext, get_abi3_suffix
 from setuptools.dist import Distribution
-from setuptools.extension import Extension
 from setuptools.errors import CompileError
+from setuptools.extension import Extension
 
 from . import environment
 from .textwrap import DALS
 
-import pytest
-
+import distutils.command.build_ext as orig
+from distutils.sysconfig import get_config_var
 
 IS_PYPY = '__pypy__' in sys.builtin_module_names
 

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -1,14 +1,14 @@
+import contextlib
+import importlib
 import os
-import sys
+import re
 import shutil
 import signal
+import sys
 import tarfile
-import importlib
-import contextlib
 from concurrent import futures
-import re
-from zipfile import ZipFile
 from pathlib import Path
+from zipfile import ZipFile
 
 import pytest
 from jaraco import path

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -1,12 +1,12 @@
 import os
-import stat
 import shutil
+import stat
 import warnings
 from pathlib import Path
 from unittest.mock import Mock
 
-import pytest
 import jaraco.path
+import pytest
 
 from setuptools import SetuptoolsDeprecationWarning
 from setuptools.dist import Distribution

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -3,21 +3,21 @@ import sys
 from configparser import ConfigParser
 from itertools import product
 
-from setuptools.command.sdist import sdist
-from setuptools.dist import Distribution
-from setuptools.discovery import find_package_path, find_parent_package
-from setuptools.errors import PackageDiscoveryError
-
-import setuptools  # noqa -- force distutils.core to be patched
-import distutils.core
-
-import pytest
 import jaraco.path
+import pytest
 from path import Path
+
+import setuptools  # noqa: F401 # force distutils.core to be patched
+from setuptools.command.sdist import sdist
+from setuptools.discovery import find_package_path, find_parent_package
+from setuptools.dist import Distribution
+from setuptools.errors import PackageDiscoveryError
 
 from .contexts import quiet
 from .integration.helpers import get_sdist_members, get_wheel_members, run
 from .textwrap import DALS
+
+import distutils.core
 
 
 class TestFindParentPackage:

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -1,17 +1,15 @@
 import functools
-import io
 import importlib
+import io
 from email import message_from_string
 
 import pytest
-
 from packaging.metadata import Metadata
 
-from setuptools import sic, _reqs
-from setuptools.dist import Distribution
+from setuptools import _reqs, sic
 from setuptools._core_metadata import rfc822_escape, rfc822_unescape
 from setuptools.command.egg_info import egg_info, write_requirements
-
+from setuptools.dist import Distribution
 
 EXAMPLE_BASE_INFO = dict(
     name="package",

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -1,18 +1,18 @@
 """develop tests"""
 
 import os
-import sys
-import subprocess
 import pathlib
 import platform
+import subprocess
+import sys
 
 import pytest
 
+from setuptools._path import paths_on_pythonpath
 from setuptools.command.develop import develop
 from setuptools.dist import Distribution
-from setuptools._path import paths_on_pythonpath
-from . import contexts
-from . import namespaces
+
+from . import contexts, namespaces
 
 SETUP_PY = """\
 from setuptools import setup

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -1,20 +1,19 @@
 import collections
-import re
 import os
-import urllib.request
+import re
 import urllib.parse
-from distutils.errors import DistutilsSetupError
-from setuptools.dist import (
-    check_package_data,
-    check_specifier,
-)
-from setuptools import Distribution
-
-from .textwrap import DALS
-from .test_easy_install import make_nspkg_sdist
-from .test_find_packages import ensure_files
+import urllib.request
 
 import pytest
+
+from setuptools import Distribution
+from setuptools.dist import check_package_data, check_specifier
+
+from .test_easy_install import make_nspkg_sdist
+from .test_find_packages import ensure_files
+from .textwrap import DALS
+
+from distutils.errors import DistutilsSetupError
 
 
 def test_dist_fetch_build_egg(tmpdir):

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -11,8 +11,8 @@ import pytest
 
 import pkg_resources
 from setuptools.archive_util import unpack_archive
-from .textwrap import DALS
 
+from .textwrap import DALS
 
 read = partial(pathlib.Path.read_text, encoding="utf-8")
 

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -1,10 +1,9 @@
 import os
-import sys
 import platform
+import sys
 import textwrap
 
 import pytest
-
 
 IS_PYPY = '__pypy__' in sys.builtin_module_names
 

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1,41 +1,41 @@
 """Easy install Tests"""
 
-import sys
-import os
-import tempfile
-import site
 import contextlib
-import tarfile
-import logging
-import itertools
-import distutils.errors
 import io
-from typing import NamedTuple
-import zipfile
-import time
-import re
-import subprocess
+import itertools
+import logging
+import os
 import pathlib
+import re
+import site
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
 import warnings
+import zipfile
 from pathlib import Path
+from typing import NamedTuple
 from unittest import mock
 
 import pytest
 from jaraco import path
 
-from setuptools import sandbox
-from setuptools.sandbox import run_setup
+import pkg_resources
 import setuptools.command.easy_install as ei
+from pkg_resources import Distribution as PRDistribution, normalize_path, working_set
+from setuptools import sandbox
 from setuptools.command.easy_install import PthDistributions
 from setuptools.dist import Distribution
-from pkg_resources import normalize_path, working_set
-from pkg_resources import Distribution as PRDistribution
-from setuptools.tests.server import MockServer, path_to_url
+from setuptools.sandbox import run_setup
 from setuptools.tests import fail_on_ascii
-import pkg_resources
+from setuptools.tests.server import MockServer, path_to_url
 
 from . import contexts
 from .textwrap import DALS
+
+import distutils.errors
 
 
 @pytest.fixture(autouse=True)

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -1,8 +1,8 @@
 import os
-import stat
-import sys
-import subprocess
 import platform
+import stat
+import subprocess
+import sys
 from copy import deepcopy
 from importlib import import_module
 from importlib.machinery import EXTENSION_SUFFIXES
@@ -11,30 +11,30 @@ from textwrap import dedent
 from unittest.mock import Mock
 from uuid import uuid4
 
-from distutils.core import run_setup
-
 import jaraco.envs
 import jaraco.path
 import pytest
 from path import Path as _Path
 
-from . import contexts, namespaces
-
 from setuptools._importlib import resources as importlib_resources
 from setuptools.command.editable_wheel import (
     _DebuggingTips,
-    _LinkTree,
-    _TopLevelFinder,
     _encode_pth,
-    _find_virtual_namespaces,
     _find_namespaces,
     _find_package_roots,
+    _find_virtual_namespaces,
     _finder_template,
+    _LinkTree,
+    _TopLevelFinder,
     editable_wheel,
 )
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
 from setuptools.warnings import SetuptoolsDeprecationWarning
+
+from . import contexts, namespaces
+
+from distutils.core import run_setup
 
 
 @pytest.fixture(params=["strict", "lenient"])

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import sys
 import ast
-import os
 import glob
+import os
 import re
 import stat
+import sys
 import time
 from pathlib import Path
 from unittest import mock
@@ -14,16 +14,11 @@ import pytest
 from jaraco import path
 
 from setuptools import errors
-from setuptools.command.egg_info import (
-    egg_info,
-    manifest_maker,
-    write_entries,
-)
+from setuptools.command.egg_info import egg_info, manifest_maker, write_entries
 from setuptools.dist import Distribution
 
-from . import environment
+from . import contexts, environment
 from .textwrap import DALS
-from . import contexts
 
 
 class Environment(str):

--- a/setuptools/tests/test_extern.py
+++ b/setuptools/tests/test_extern.py
@@ -1,8 +1,9 @@
 import importlib
 import pickle
 
-from setuptools import Distribution
 import ordered_set
+
+from setuptools import Distribution
 
 
 def test_reimport_extern():

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -6,8 +6,7 @@ import tempfile
 
 import pytest
 
-from setuptools import find_packages
-from setuptools import find_namespace_packages
+from setuptools import find_namespace_packages, find_packages
 from setuptools.discovery import FlatLayoutPackageFinder
 
 from .compat.py39 import os_helper

--- a/setuptools/tests/test_find_py_modules.py
+++ b/setuptools/tests/test_find_py_modules.py
@@ -6,8 +6,8 @@ import pytest
 
 from setuptools.discovery import FlatLayoutModuleFinder, ModuleFinder
 
-from .test_find_packages import ensure_files
 from .compat.py39 import os_helper
+from .test_find_packages import ensure_files
 
 
 class TestModuleFinder:

--- a/setuptools/tests/test_install_scripts.py
+++ b/setuptools/tests/test_install_scripts.py
@@ -6,6 +6,7 @@ import pytest
 
 from setuptools.command.install_scripts import install_scripts
 from setuptools.dist import Distribution
+
 from . import contexts
 
 

--- a/setuptools/tests/test_integration.py
+++ b/setuptools/tests/test_integration.py
@@ -10,10 +10,9 @@ import urllib.request
 
 import pytest
 
-from setuptools.command.easy_install import easy_install
 from setuptools.command import easy_install as easy_install_pkg
+from setuptools.command.easy_install import easy_install
 from setuptools.dist import Distribution
-
 
 pytestmark = pytest.mark.skipif(
     'platform.python_implementation() == "PyPy" and platform.system() == "Windows"',

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -5,7 +5,6 @@ import sys
 
 import pytest
 
-
 IS_PYPY = '__pypy__' in sys.builtin_module_names
 
 
@@ -25,6 +24,7 @@ setup(
 def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     """Make sure the correct verbosity level is set (issue #3038)"""
     import setuptools  # noqa: F401  # import setuptools to monkeypatch distutils
+
     import distutils  # <- load distutils after all the patches take place
 
     logger = logging.Logger(__name__)
@@ -61,7 +61,9 @@ def test_patching_does_not_cause_problems():
     # Ensure `dist.log` is only patched if necessary
 
     import _distutils_hack
+
     import setuptools.logging
+
     from distutils import dist
 
     setuptools.logging.configure()

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -3,22 +3,22 @@
 from __future__ import annotations
 
 import contextlib
+import io
+import itertools
+import logging
 import os
 import shutil
 import sys
 import tempfile
-import itertools
-import io
-import logging
-from distutils import log
-from distutils.errors import DistutilsTemplateError
+
+import pytest
 
 from setuptools.command.egg_info import FileList, egg_info, translate_pattern
 from setuptools.dist import Distribution
 from setuptools.tests.textwrap import DALS
 
-import pytest
-
+from distutils import log
+from distutils.errors import DistutilsTemplateError
 
 IS_PYPY = '__pypy__' in sys.builtin_module_names
 

--- a/setuptools/tests/test_msvc14.py
+++ b/setuptools/tests/test_msvc14.py
@@ -3,9 +3,11 @@ Tests for msvc support module (msvc14 unit tests).
 """
 
 import os
-from distutils.errors import DistutilsPlatformError
-import pytest
 import sys
+
+import pytest
+
+from distutils.errors import DistutilsPlatformError
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="These tests are only for win32")

--- a/setuptools/tests/test_namespaces.py
+++ b/setuptools/tests/test_namespaces.py
@@ -1,5 +1,5 @@
-import sys
 import subprocess
+import sys
 
 from setuptools._path import paths_on_pythonpath
 

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -1,12 +1,13 @@
-import distutils.errors
-import urllib.request
-import urllib.error
 import http.client
+import urllib.error
+import urllib.request
 from inspect import cleandoc
 
 import pytest
 
 import setuptools.package_index
+
+import distutils.errors
 
 
 class TestPackageIndex:

--- a/setuptools/tests/test_register.py
+++ b/setuptools/tests/test_register.py
@@ -1,10 +1,10 @@
-from setuptools.command.register import register
-from setuptools.dist import Distribution
-from setuptools.errors import RemovedCommandError
-
 from unittest import mock
 
 import pytest
+
+from setuptools.command.register import register
+from setuptools.dist import Distribution
+from setuptools.errors import RemovedCommandError
 
 
 class TestRegister:

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -1,32 +1,31 @@
 """sdist tests"""
 
-import os
-import sys
-import tempfile
-import unicodedata
 import contextlib
 import io
-import tarfile
 import logging
-import distutils
+import os
+import sys
+import tarfile
+import tempfile
+import unicodedata
 from inspect import cleandoc
 from unittest import mock
 
+import jaraco.path
 import pytest
 
-from distutils.core import run_setup
-from setuptools import Command
+from setuptools import Command, SetuptoolsDeprecationWarning
 from setuptools._importlib import metadata
-from setuptools import SetuptoolsDeprecationWarning
-from setuptools.command.sdist import sdist
 from setuptools.command.egg_info import manifest_maker
+from setuptools.command.sdist import sdist
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
 from setuptools.tests import fail_on_ascii
+
 from .text import Filenames
 
-import jaraco.path
-
+import distutils
+from distutils.core import run_setup
 
 SETUP_ATTRS = {
     'name': 'sdist_test',

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -1,22 +1,22 @@
 """Tests for the 'setuptools' package"""
 
+import os
 import re
 import sys
-import os
-import distutils.core
-import distutils.cmd
-from distutils.errors import DistutilsSetupError
-from distutils.core import Extension
 from zipfile import ZipFile
 
 import pytest
+from packaging.version import Version
 
 import setuptools
-import setuptools.dist
 import setuptools.depends as dep
+import setuptools.dist
 from setuptools.depends import Require
 
-from packaging.version import Version
+import distutils.cmd
+import distutils.core
+from distutils.core import Extension
+from distutils.errors import DistutilsSetupError
 
 
 @pytest.fixture(autouse=True)

--- a/setuptools/tests/test_upload.py
+++ b/setuptools/tests/test_upload.py
@@ -1,10 +1,10 @@
-from setuptools.command.upload import upload
-from setuptools.dist import Distribution
-from setuptools.errors import RemovedCommandError
-
 from unittest import mock
 
 import pytest
+
+from setuptools.command.upload import upload
+from setuptools.dist import Distribution
+from setuptools.errors import RemovedCommandError
 
 
 class TestUpload:

--- a/setuptools/tests/test_virtualenv.py
+++ b/setuptools/tests/test_virtualenv.py
@@ -1,9 +1,8 @@
 import os
-import sys
 import subprocess
-from urllib.request import urlopen
+import sys
 from urllib.error import URLError
-
+from urllib.request import urlopen
 
 import pytest
 

--- a/setuptools/tests/test_warnings.py
+++ b/setuptools/tests/test_warnings.py
@@ -4,7 +4,6 @@ import pytest
 
 from setuptools.warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
 
-
 _EXAMPLES = {
     "default": dict(
         args=("Hello {x}", "\n\t{target} {v:.1f}"),

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -2,31 +2,31 @@
 
 from __future__ import annotations
 
-from distutils.sysconfig import get_config_var
-from distutils.util import get_platform
 import contextlib
-import pathlib
-import stat
 import glob
 import inspect
 import os
+import pathlib
 import shutil
+import stat
 import subprocess
 import sys
-from typing import Any
 import zipfile
+from typing import Any
 
 import pytest
 from jaraco import path
-
-from pkg_resources import Distribution, PathMetadata, PY_MAJOR
-from packaging.utils import canonicalize_name
 from packaging.tags import parse_tag
+from packaging.utils import canonicalize_name
+
+from pkg_resources import PY_MAJOR, Distribution, PathMetadata
 from setuptools.wheel import Wheel
 
 from .contexts import tempdir
 from .textwrap import DALS
 
+from distutils.sysconfig import get_config_var
+from distutils.util import get_platform
 
 WHEEL_INFO_TESTS = (
     ('invalid.whl', ValueError),

--- a/setuptools/tests/test_windows_wrappers.py
+++ b/setuptools/tests/test_windows_wrappers.py
@@ -13,15 +13,15 @@ are to wrap.
 """
 
 import pathlib
-import sys
 import platform
-import textwrap
 import subprocess
+import sys
+import textwrap
 
 import pytest
 
-from setuptools.command.easy_install import nt_quote_arg
 import pkg_resources
+from setuptools.command.easy_install import nt_quote_arg
 
 pytestmark = pytest.mark.skipif(sys.platform != 'win32', reason="Windows only")
 

--- a/setuptools/unicode_utils.py
+++ b/setuptools/unicode_utils.py
@@ -1,5 +1,5 @@
-import unicodedata
 import sys
+import unicodedata
 from configparser import ConfigParser
 
 from .compat import py39

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -1,26 +1,25 @@
 """Wheels support."""
 
+import contextlib
 import email
-import itertools
 import functools
+import itertools
 import os
 import posixpath
 import re
 import zipfile
-import contextlib
 
-from packaging.version import Version as parse_version
 from packaging.tags import sys_tags
 from packaging.utils import canonicalize_name
-
-from distutils.util import get_platform
+from packaging.version import Version as parse_version
 
 import setuptools
-from setuptools.command.egg_info import write_requirements, _egg_basename
 from setuptools.archive_util import _unpack_zipfile_obj
+from setuptools.command.egg_info import _egg_basename, write_requirements
 
 from .unicode_utils import _read_utf8_with_fallback
 
+from distutils.util import get_platform
 
 WHEEL_NAME = re.compile(
     r"""^(?P<project_name>.+?)-(?P<version>\d.*?)

--- a/tools/build_launchers.py
+++ b/tools/build_launchers.py
@@ -17,14 +17,13 @@ List of components needed to install to compile on ARM:
 - C++ ATL for latest v143 build tools (ARM64)
 """
 
-import os
 import functools
 import itertools
+import os
 import pathlib
 import shutil
 import subprocess
 import tempfile
-
 
 BUILD_TARGETS = ["cli", "gui"]
 GUI = {"cli": 0, "gui": 1}

--- a/tools/finalize.py
+++ b/tools/finalize.py
@@ -5,13 +5,12 @@ Finalize the repo for a release. Invokes towncrier and bumpversion.
 __requires__ = ['bump2version', 'towncrier', 'jaraco.develop>=7.21']
 
 
-import subprocess
 import pathlib
 import re
+import subprocess
 import sys
 
 from jaraco.develop import towncrier
-
 
 bump_version_command = [
     sys.executable,

--- a/tools/ppc64le-patch.py
+++ b/tools/ppc64le-patch.py
@@ -6,9 +6,9 @@ the user running travis build to install pip packages.
 TODO: is someone tracking this issue? Maybe just move to bionic?
 """
 
-import subprocess
 import collections
 import os
+import subprocess
 
 
 def patch():


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

As title says.
I've made sure that `_distutils_hack` should be sorted before `_distutils`, and that `setuptools` gets sorted before `distutils` in tests as long as the hack is supported (ref: https://github.com/pypa/setuptools/issues/4137 )

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`]. (no user-facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
