### PR TITLE
Simplify setuptools own `tool.setuptools.packages.find` by using include rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,15 +158,14 @@ PKG-INFO = "setuptools.command.egg_info:write_pkg_info"
 include-package-data = false
 
 [tool.setuptools.packages.find]
+include = [
+	"setuptools*",
+	"pkg_resources*",
+	"_distutils_hack*",
+]
 exclude = [
 	"*.tests",
 	"*.tests.*",
-	"tools*",
-	"debian*",
-	"launcher*",
-	"newsfragments*",
-	"docs",
-	"docs.*",
 ]
 namespaces = true
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Implements approach discussed in https://github.com/pypa/setuptools/pull/4389/files#r1613314607

This approach assumes that the probability of a new top-level package being added/removed from setuptools is lower than the probability/frequency of folders and files being added/removed in package root.

If this assumption holds, this PR not only solves #4394 but also simplifies maintenance.
If this assumption does not hold, this PR still solves #4394 but increases churn[^1].

Closes #4394 

[^1]: Although if the overall probability/frequency of these events happening is still low the churn increase is neglectable.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
