### PR TITLE
Replace use of mktemp with can_symlink from the stdlib test suite.

### DIFF
--- a/newsfragments/4403.bugfix.rst
+++ b/newsfragments/4403.bugfix.rst
@@ -1,0 +1,1 @@
+Replace use of mktemp with can_symlink from the stdlib test suite.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ testing = [
 
 	# workaround for pypa/setuptools#4333
 	"pyproject-hooks!=1.1",
+
+	"jaraco.test",
 ]
 docs = [
 	# upstream

--- a/setuptools/tests/compat/py39.py
+++ b/setuptools/tests/compat/py39.py
@@ -1,0 +1,4 @@
+from jaraco.test.cpython import from_test_support, try_import
+
+
+os_helper = try_import('os_helper') or from_test_support('can_symlink')

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -10,20 +10,7 @@ from setuptools import find_packages
 from setuptools import find_namespace_packages
 from setuptools.discovery import FlatLayoutPackageFinder
 
-
-# modeled after CPython's test.support.can_symlink
-def can_symlink():
-    TESTFN = tempfile.mktemp()
-    symlink_path = TESTFN + "can_symlink"
-    try:
-        os.symlink(TESTFN, symlink_path)
-        can = True
-    except (OSError, NotImplementedError, AttributeError):
-        can = False
-    else:
-        os.remove(symlink_path)
-    globals().update(can_symlink=lambda: can)
-    return can
+from .compat.py39 import os_helper
 
 
 class TestFindPackages:
@@ -123,7 +110,7 @@ class TestFindPackages:
         packages = find_packages(self.dist_dir)
         assert 'build.pkg' not in packages
 
-    @pytest.mark.skipif(not can_symlink(), reason='Symlink support required')
+    @pytest.mark.skipif(not os_helper.can_symlink(), reason='Symlink support required')
     def test_symlinked_packages_are_included(self):
         """
         A symbolically-linked directory should be treated like any other

--- a/setuptools/tests/test_find_py_modules.py
+++ b/setuptools/tests/test_find_py_modules.py
@@ -6,7 +6,8 @@ import pytest
 
 from setuptools.discovery import FlatLayoutModuleFinder, ModuleFinder
 
-from .test_find_packages import can_symlink, ensure_files
+from .test_find_packages import ensure_files
+from .compat.py39 import os_helper
 
 
 class TestModuleFinder:
@@ -39,7 +40,7 @@ class TestModuleFinder:
         ensure_files(tmp_path, files)
         assert self.find(tmp_path, **kwargs) == set(expected_modules)
 
-    @pytest.mark.skipif(not can_symlink(), reason='Symlink support required')
+    @pytest.mark.skipif(not os_helper.can_symlink(), reason='Symlink support required')
     def test_symlinked_packages_are_included(self, tmp_path):
         src = "_myfiles/file.py"
         ensure_files(tmp_path, [src])


### PR DESCRIPTION
Closes #4403

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
