### PR TITLE
Simplify `setuptools.config.expand._find_module`

### DIFF
--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -251,9 +251,9 @@ def _find_module(
     from ..discovery import find_package_path
 
     path_start = find_package_path(module_name, package_dir or {}, root_dir)
-    candidates = chain(
-        [os.path.join(path_start, "__init__.py")],
-        (f"{path_start}{ext}" for ext in all_suffixes()),
+    candidates = chain.from_iterable(
+        (f"{path_start}{ext}", os.path.join(path_start, f"__init__{ext}"))
+        for ext in all_suffixes()
     )
     return next((x for x in candidates if os.path.isfile(x)), None)
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -252,19 +252,23 @@ def _find_module(
     parent_path = root_dir
     module_parts = module_name.split('.')
     if package_dir:
-        if module_parts[0] in package_dir:
-            # A custom path was specified for the module we want to import
-            custom_path = package_dir[module_parts[0]]
-            parts = custom_path.rsplit('/', 1)
-            if len(parts) > 1:
-                parent_path = os.path.join(root_dir, parts[0])
-                parent_module = parts[1]
-            else:
-                parent_module = custom_path
-            module_name = ".".join([parent_module, *module_parts[1:]])
-        elif '' in package_dir:
-            # A custom parent directory was specified for all root modules
-            parent_path = os.path.join(root_dir, package_dir[''])
+        for i in range(len(module_parts), 0, -1):
+            parent = ".".join(module_parts[:i])
+            if parent in package_dir:
+                # A custom path was specified for the module we want to import
+                custom_path = package_dir[parent]
+                parts = custom_path.rsplit('/', 1)
+                if len(parts) > 1:
+                    parent_path = os.path.join(root_dir, parts[0])
+                    parent_module = parts[1]
+                else:
+                    parent_module = custom_path
+                module_name = ".".join([parent_module, *module_parts[i:]])
+                break
+        else:
+            if '' in package_dir:
+                # A custom parent directory was specified for all root modules
+                parent_path = os.path.join(root_dir, package_dir[''])
 
     path_start = os.path.join(parent_path, *module_name.split("."))
     candidates = chain(

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -185,7 +185,7 @@ def read_attr(
     attr_name = attrs_path.pop()
     module_name = '.'.join(attrs_path)
     module_name = module_name or '__init__'
-    _parent_path, path, module_name = _find_module(module_name, package_dir, root_dir)
+    path = _find_module(module_name, package_dir, root_dir)
     spec = _find_spec(module_name, path)
 
     try:
@@ -218,11 +218,9 @@ def _load_spec(spec: ModuleSpec, module_name: str) -> ModuleType:
 
 def _find_module(
     module_name: str, package_dir: Optional[Mapping[str, str]], root_dir: StrPath
-) -> Tuple[StrPath, Optional[str], str]:
-    """Given a module (that could normally be imported by ``module_name``
-    after the build is complete), find the path to the parent directory where
-    it is contained and the canonical name that could be used to import it
-    considering the ``package_dir`` in the build configuration and ``root_dir``
+) -> Optional[str]:
+    """Find the path to the module named ``module_name``,
+    considering the ``package_dir`` in the build configuration and ``root_dir``.
 
     >>> import pytest
     >>> if os.sep != "/": pytest.skip("require UNIX path separator")
@@ -232,51 +230,32 @@ def _find_module(
     >>> cwd = tmp.as_cwd()
     >>> _ = cwd.__enter__()
     >>> _find_module("a.b.c", None, ".")
-    ('.', './a/b/c.py', 'a.b.c')
+    './a/b/c.py'
     >>> _find_module("a.b.d", None, ".")
-    ('.', './a/b/d/__init__.py', 'a.b.d')
+    './a/b/d/__init__.py'
     >>> _find_module("ab.c", {"ab": "a/b"}, "")
-    ('a', 'a/b/c.py', 'b.c')
+    'a/b/c.py'
     >>> _find_module("b.c", {"": "a"}, "")
-    ('a', 'a/b/c.py', 'b.c')
-    >>> [str(x).replace(str(tmp), ".") for x in  _find_module("a.b.c", None, tmp)]
-    ['.', './a/b/c.py', 'a.b.c']
+    'a/b/c.py'
+    >>> _find_module("a.b.c", None, tmp).replace(str(tmp), ".")
+    './a/b/c.py'
     >>> _find_module("f.c", {"f": "a/b"}, "")
-    ('a', 'a/b/c.py', 'b.c')
+    'a/b/c.py'
     >>> _find_module("f.g.c", {"f.g": "a/b"}, "")
-    ('a', 'a/b/c.py', 'b.c')
+    'a/b/c.py'
     >>> _find_module("f.g.h", {"": "1", "f": "2", "f.g": "3", "f.g.h": "a/b/d"}, "")
-    ('a/b', 'a/b/d/__init__.py', 'd')
+    'a/b/d/__init__.py'
     >>> _ = cwd.__exit__(None, None, None)
     """
-    parent_path = root_dir
-    module_parts = module_name.split('.')
-    if package_dir:
-        for i in range(len(module_parts), 0, -1):
-            parent = ".".join(module_parts[:i])
-            if parent in package_dir:
-                # A custom path was specified for the module we want to import
-                custom_path = package_dir[parent]
-                parts = custom_path.rsplit('/', 1)
-                if len(parts) > 1:
-                    parent_path = os.path.join(root_dir, parts[0])
-                    parent_module = parts[1]
-                else:
-                    parent_module = custom_path
-                module_name = ".".join([parent_module, *module_parts[i:]])
-                break
-        else:
-            if '' in package_dir:
-                # A custom parent directory was specified for all root modules
-                parent_path = os.path.join(root_dir, package_dir[''])
+    from importlib.machinery import all_suffixes
+    from ..discovery import find_package_path
 
-    path_start = os.path.join(parent_path, *module_name.split("."))
+    path_start = find_package_path(module_name, package_dir or {}, root_dir)
     candidates = chain(
-        (f"{path_start}.py", os.path.join(path_start, "__init__.py")),
-        iglob(f"{path_start}.*"),
+        [os.path.join(path_start, "__init__.py")],
+        (f"{path_start}{ext}" for ext in all_suffixes()),
     )
-    module_path = next((x for x in candidates if os.path.isfile(x)), None)
-    return parent_path, module_path, module_name
+    return next((x for x in candidates if os.path.isfile(x)), None)
 
 
 def resolve_class(
@@ -290,8 +269,8 @@ def resolve_class(
     class_name = qualified_class_name[idx + 1 :]
     pkg_name = qualified_class_name[:idx]
 
-    _parent_path, path, module_name = _find_module(pkg_name, package_dir, root_dir)
-    module = _load_spec(_find_spec(module_name, path), module_name)
+    path = _find_module(pkg_name, package_dir, root_dir)
+    module = _load_spec(_find_spec(pkg_name, path), pkg_name)
     return getattr(module, class_name)
 
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -52,10 +52,7 @@ from ..warnings import SetuptoolsWarning
 
 if TYPE_CHECKING:
     from setuptools.dist import Distribution  # noqa
-    from setuptools.discovery import ConfigDiscovery  # noqa
-    from distutils.dist import DistributionMetadata  # noqa
 
-chain_iter = chain.from_iterable
 _K = TypeVar("_K")
 _V = TypeVar("_V", covariant=True)
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -25,7 +25,7 @@ import pathlib
 import sys
 from glob import iglob
 from configparser import ConfigParser
-from importlib.machinery import ModuleSpec
+from importlib.machinery import ModuleSpec, all_suffixes
 from itertools import chain
 from typing import (
     TYPE_CHECKING,
@@ -47,6 +47,7 @@ from types import ModuleType
 from distutils.errors import DistutilsOptionError
 
 from .._path import same_path as _same_path, StrPath
+from ..discovery import find_package_path
 from ..warnings import SetuptoolsWarning
 
 if TYPE_CHECKING:
@@ -247,9 +248,6 @@ def _find_module(
     'a/b/d/__init__.py'
     >>> _ = cwd.__exit__(None, None, None)
     """
-    from importlib.machinery import all_suffixes
-    from ..discovery import find_package_path
-
     path_start = find_package_path(module_name, package_dir or {}, root_dir)
     candidates = chain.from_iterable(
         (f"{path_start}{ext}", os.path.join(path_start, f"__init__{ext}"))

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -223,6 +223,31 @@ def _find_module(
     after the build is complete), find the path to the parent directory where
     it is contained and the canonical name that could be used to import it
     considering the ``package_dir`` in the build configuration and ``root_dir``
+
+    >>> import pytest
+    >>> if os.sep != "/": pytest.skip("require UNIX path separator")
+    >>> tmp = getfixture('tmpdir')
+    >>> _ = tmp.ensure("a/b/c.py")
+    >>> _ = tmp.ensure("a/b/d/__init__.py")
+    >>> cwd = tmp.as_cwd()
+    >>> _ = cwd.__enter__()
+    >>> _find_module("a.b.c", None, ".")
+    ('.', './a/b/c.py', 'a.b.c')
+    >>> _find_module("a.b.d", None, ".")
+    ('.', './a/b/d/__init__.py', 'a.b.d')
+    >>> _find_module("ab.c", {"ab": "a/b"}, "")
+    ('a', 'a/b/c.py', 'b.c')
+    >>> _find_module("b.c", {"": "a"}, "")
+    ('a', 'a/b/c.py', 'b.c')
+    >>> [str(x).replace(str(tmp), ".") for x in  _find_module("a.b.c", None, tmp)]
+    ['.', './a/b/c.py', 'a.b.c']
+    >>> _find_module("f.c", {"f": "a/b"}, "")
+    ('a', 'a/b/c.py', 'b.c')
+    >>> _find_module("f.g.c", {"f.g": "a/b"}, "")
+    ('a', 'a/b/c.py', 'b.c')
+    >>> _find_module("f.g.h", {"": "1", "f": "2", "f.g": "3", "f.g.h": "a/b/d"}, "")
+    ('a/b', 'a/b/d/__init__.py', 'd')
+    >>> _ = cwd.__exit__(None, None, None)
     """
     parent_path = root_dir
     module_parts = module_name.split('.')

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -220,30 +220,14 @@ def _find_module(
     """Find the path to the module named ``module_name``,
     considering the ``package_dir`` in the build configuration and ``root_dir``.
 
-    >>> import pytest
-    >>> if os.sep != "/": pytest.skip("require UNIX path separator")
     >>> tmp = getfixture('tmpdir')
     >>> _ = tmp.ensure("a/b/c.py")
     >>> _ = tmp.ensure("a/b/d/__init__.py")
-    >>> cwd = tmp.as_cwd()
-    >>> _ = cwd.__enter__()
-    >>> _find_module("a.b.c", None, ".")
-    './a/b/c.py'
-    >>> _find_module("a.b.d", None, ".")
-    './a/b/d/__init__.py'
-    >>> _find_module("ab.c", {"ab": "a/b"}, "")
-    'a/b/c.py'
-    >>> _find_module("b.c", {"": "a"}, "")
-    'a/b/c.py'
-    >>> _find_module("a.b.c", None, tmp).replace(str(tmp), ".")
-    './a/b/c.py'
-    >>> _find_module("f.c", {"f": "a/b"}, "")
-    'a/b/c.py'
-    >>> _find_module("f.g.c", {"f.g": "a/b"}, "")
-    'a/b/c.py'
-    >>> _find_module("f.g.h", {"": "1", "f": "2", "f.g": "3", "f.g.h": "a/b/d"}, "")
-    'a/b/d/__init__.py'
-    >>> _ = cwd.__exit__(None, None, None)
+    >>> r = lambda x: x.replace(str(tmp), "tmp")
+    >>> r(_find_module("a.b.c", None, tmp))
+    'tmp/a/b/c.py'
+    >>> r(_find_module("f.g.h", {"": "1", "f": "2", "f.g": "3", "f.g.h": "a/b/d"}, tmp))
+    'tmp/a/b/d/__init__.py'
     """
     path_start = find_package_path(module_name, package_dir or {}, root_dir)
     candidates = chain.from_iterable(

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -147,7 +148,8 @@ class TestReadAttr:
         ({}, "flat_layout/pkg.py", "flat_layout.pkg", 836),
     ],
 )
-def test_resolve_class(tmp_path, package_dir, file, module, return_value):
+def test_resolve_class(monkeypatch, tmp_path, package_dir, file, module, return_value):
+    monkeypatch.setattr(sys, "modules", {})  # reproducibility
     files = {file: f"class Custom:\n    def testing(self): return {return_value}"}
     write_files(files, tmp_path)
     cls = expand.resolve_class(f"{module}.Custom", package_dir, tmp_path)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This PR attempts to reuse as much as possible `setuptools.discovery.find_package_path` in the implementation of `setuptools.config.expand._find_module`.

---

Currently `setuptools.config.expand._find_module` is a bit complex and it re-implements part of the functionality of `setuptools.discovery.find_package_path`.

Moreover, it is partially broken and cannot handle all the cases that `setuptools.discovery.find_package_path` can handle.

I also noticed that the other return values of `setuptools.config.expand._find_module` (`parent_path` and `module_name`) are very inconsistent and don't seem to be very useful.

This inconsistency and edge cases can be seen in the following snippet (using Setuptools v70.0.0):

```python
>>> from path import TempDir
>>> from setuptools.config.expand import _find_module
>>> tmp = TempDir()
>>> _ = (tmp / "a/b").makedirs_p().joinpath("c.py").touch()
>>> _ = (tmp / "a/b/d").makedirs_p().joinpath("__init__.py").touch()
>>> _find_module("a.b.c", None, tmp)
(TempDir('/tmp/tmpf253pijk'), '/tmp/tmpf253pijk/a/b/c.py', 'a.b.c')
>>> _find_module("f.g.h", {"": "1", "f": "2", "f.g": "3", "f.g.h": "a/b/d"}, tmp)
(TempDir('/tmp/tmpf253pijk'), None, '2.g.h')      # <---------------------------- broken
>>> _find_module("f.c", {"f": "a/b"}, tmp)
(Path('/tmp/tmpf253pijk/a'), '/tmp/tmpf253pijk/a/b/c.py', 'b.c')  # <------------ other returns not particularly useful
>>> _find_module("f.g.c", {"f.g": "a/b"}, tmp)
(TempDir('/tmp/tmpf253pijk'), None, 'f.g.c')      # <---------------------------- broken
>>> _find_module("b.c", {"": "a"}, tmp)
(Path('/tmp/tmpf253pijk/a'), '/tmp/tmpf253pijk/a/b/c.py', 'b.c')  # <------------ other returns not particularly useful
>>> _find_module("ab.c", {"ab": "a/b"}, tmp)
(Path('/tmp/tmpf253pijk/a'), '/tmp/tmpf253pijk/a/b/c.py', 'b.c')  # <------------ other returns not particularly useful
```

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
