### PR TITLE
PERF: remove isdir() check in copy_file(), about 10% of the run time was checking if the file to copy is a directory.

### DIFF
--- a/setuptools/_distutils/command/install_data.py
+++ b/setuptools/_distutils/command/install_data.py
@@ -54,7 +54,8 @@ class install_data(Command):
                         "setup script did not provide a directory for "
                         f"'{f}' -- installing right in '{self.install_dir}'"
                     )
-                (out, _) = self.copy_file(f, self.install_dir)
+                dst = os.path.join(self.install_dir, os.path.basename(f))
+                (out, _) = self.copy_file(f, dst)
                 self.outfiles.append(out)
             else:
                 # it's a tuple with path to install to and a list of files
@@ -74,7 +75,8 @@ class install_data(Command):
                     # Copy files, adding them to the list of output files.
                     for data in f[1]:
                         data = convert_path(data)
-                        (out, _) = self.copy_file(data, dir)
+                        dst = os.path.join(dir, os.path.basename(data))
+                        (out, _) = self.copy_file(data, dst)
                         self.outfiles.append(out)
 
     def get_inputs(self):

--- a/setuptools/_distutils/command/install_headers.py
+++ b/setuptools/_distutils/command/install_headers.py
@@ -3,6 +3,8 @@
 Implements the Distutils 'install_headers' command, to install C/C++ header
 files to the Python include directory."""
 
+import os
+
 from ..core import Command
 
 
@@ -34,7 +36,8 @@ class install_headers(Command):
 
         self.mkpath(self.install_dir)
         for header in headers:
-            (out, _) = self.copy_file(header, self.install_dir)
+            dst = os.path.join(self.install_dir, os.path.basename(header))
+            (out, _) = self.copy_file(header, dst)
             self.outfiles.append(out)
 
     def get_inputs(self):

--- a/setuptools/_distutils/file_util.py
+++ b/setuptools/_distutils/file_util.py
@@ -70,9 +70,8 @@ def copy_file(  # noqa: C901
     verbose=1,
     dry_run=0,
 ):
-    """Copy a file 'src' to 'dst'.  If 'dst' is a directory, then 'src' is
-    copied there with the same name; otherwise, it must be a filename.  (If
-    the file exists, it will be ruthlessly clobbered.)  If 'preserve_mode'
+    """Copy a file 'src' to 'dst'.
+    (If the file exists, it will be ruthlessly clobbered.)  If 'preserve_mode'
     is true (the default), the file's mode (type and permission bits, or
     whatever is analogous on the current platform) is copied.  If
     'preserve_times' is true (the default), the last-modified and
@@ -109,12 +108,6 @@ def copy_file(  # noqa: C901
             "can't copy '%s': doesn't exist or not a regular file" % src
         )
 
-    if os.path.isdir(dst):
-        dir = dst
-        dst = os.path.join(dst, os.path.basename(src))
-    else:
-        dir = os.path.dirname(dst)
-
     if update and not newer(src, dst):
         if verbose >= 1:
             log.debug("not copying %s (output up-to-date)", src)
@@ -126,10 +119,7 @@ def copy_file(  # noqa: C901
         raise ValueError("invalid value '%s' for 'link' argument" % link)
 
     if verbose >= 1:
-        if os.path.basename(dst) == os.path.basename(src):
-            log.info("%s %s -> %s", action, src, dir)
-        else:
-            log.info("%s %s -> %s", action, src, dst)
+        log.info("%s %s -> %s", action, src, dst)
 
     if dry_run:
         return (dst, 1)


### PR DESCRIPTION
Hello,

I was doing a bit of profiling on my CI builds. The step to build package (python setup.py bdist_wheel) is taking more time than I would like.

Going in with a commercial profiler, I am finding that nearly 10% of the time is taken in `isdir()` calls, mostly in the `copy_file()` function.
Which is quite surprising IMO because the copy file function should not be given directories anyway :D

Can I offer to remove the isdir() calls to get a speedup?
I've found 2 calls that were passing directories instead of a filepath and corrected them.

By the way, the whole `_copy_file_contents()` could be replaced by `shutil.copyfile()` for another little boost. The code goes back to year 2000 or before, which predates optimized shutil functions.

Screenshot of the profiler run. The whole run is about 20+ seconds. 
<img width="1481" alt="image" src="https://github.com/pypa/setuptools/assets/13528994/0a3734b1-0400-4b68-a154-b663abbdda1b">


Regards.
