### PR TITLE
Enforce ruff/flake8-implicit-str-concat rules (ISC)

### DIFF
--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -382,8 +382,9 @@ def scan_module(egg_dir, base, name, stubs):
         for bad in [
             'getsource',
             'getabsfile',
+            'getfile',
             'getsourcefile',
-            'getfile' 'getsourcelines',
+            'getsourcelines',
             'findsource',
             'getcomments',
             'getframeinfo',

--- a/setuptools/tests/test_find_packages.py
+++ b/setuptools/tests/test_find_packages.py
@@ -180,7 +180,8 @@ class TestFlatLayoutPackageFinder:
             [
                 "pkg/__init__.py",
                 "examples/__init__.py",
-                "examples/file.py" "example/other_file.py",
+                "examples/file.py",
+                "example/other_file.py",
                 # Sub-packages should always be fine
                 "pkg/example/__init__.py",
                 "pkg/examples/__init__.py",


### PR DESCRIPTION
## Summary of changes

ISC001 Implicitly concatenated string literals on one line

ISC003 Explicitly concatenated string should be implicitly concatenated


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
