### PR TITLE
Prevent abi3 from being used with no-GIL interpreter

### DIFF
--- a/newsfragments/4420.bugfix.rst
+++ b/newsfragments/4420.bugfix.rst
@@ -1,0 +1,2 @@
+Raises an exception when ``py_limited_api`` is used in a build with
+``Py_GIL_DISABLED``. This is currently not supported (python/cpython#111506).

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -26,7 +26,6 @@ from wheel.metadata import pkginfo_to_metadata
 from wheel.wheelfile import WheelFile
 
 from .. import Command, __version__
-from ..warnings import SetuptoolsWarning
 from .egg_info import egg_info as egg_info_cls
 
 from distutils import log
@@ -297,13 +296,12 @@ class bdist_wheel(Command):
             raise ValueError(f"py-limited-api must match '{PY_LIMITED_API_PATTERN}'")
 
         if sysconfig.get_config_var("Py_GIL_DISABLED"):
-            SetuptoolsWarning.emit(
-                summary=f"Ignoring `py_limited_api={self.py_limited_api!r}`.",
-                details="`Py_LIMITED_API` is currently incompatible with "
-                f"`Py_GIL_DISABLED` ({sys.abiflags=!r}).",
-                see_url="https://github.com/python/cpython/issues/111506",
+            raise ValueError(
+                f"`py_limited_api={self.py_limited_api!r}` not supported. "
+                "`Py_LIMITED_API` is currently incompatible with "
+                f"`Py_GIL_DISABLED` ({sys.abiflags=!r}). "
+                "See https://github.com/python/cpython/issues/111506."
             )
-            self.py_limited_api = False
 
     @property
     def wheel_dist_name(self) -> str:

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -26,6 +26,7 @@ from wheel.metadata import pkginfo_to_metadata
 from wheel.wheelfile import WheelFile
 
 from .. import Command, __version__
+from ..warnings import SetuptoolsWarning
 from .egg_info import egg_info as egg_info_cls
 
 from distutils import log
@@ -278,6 +279,15 @@ class bdist_wheel(Command):
             PY_LIMITED_API_PATTERN, self.py_limited_api
         ):
             raise ValueError(f"py-limited-api must match '{PY_LIMITED_API_PATTERN}'")
+
+        if "t" in sys.abiflags:
+            SetuptoolsWarning.emit(
+                summary=f"Ignoring `py_limited_api={self.py_limited_api!r}`.",
+                details="`Py_LIMITED_API` is currently incompatible with "
+                f"`Py_GIL_DISABLED` ({sys.abiflags=!r}).",
+                see_url="https://github.com/python/cpython/issues/111506",
+            )
+            self.py_limited_api = False
 
         # Support legacy [wheel] section for setting universal
         wheel = self.distribution.get_option_dict("wheel")

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -280,7 +280,7 @@ class bdist_wheel(Command):
         ):
             raise ValueError(f"py-limited-api must match '{PY_LIMITED_API_PATTERN}'")
 
-        if "t" in sys.abiflags:
+        if sysconfig.get_config_var("Py_GIL_DISABLED"):
             SetuptoolsWarning.emit(
                 summary=f"Ignoring `py_limited_api={self.py_limited_api!r}`.",
                 details="`Py_LIMITED_API` is currently incompatible with "


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4420

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
