### PR TITLE
Exclude coverage for older Python version checks

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -20,3 +20,6 @@ exclude_also =
 	# jaraco/skeleton#97
 	@overload
 	if TYPE_CHECKING:
+	# Coverage is only run on the latest Python version
+	# these will never be considered covered and we aim for 100% coverage
+	if sys\.version_info <

--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -2,10 +2,10 @@ import os
 import sys
 from typing import Union
 
-if sys.version_info >= (3, 9):
-    StrPath = Union[str, os.PathLike[str]]  #  Same as _typeshed.StrPath
-else:
+if sys.version_info < (3, 9):
     StrPath = Union[str, os.PathLike]
+else:
+    StrPath = Union[str, os.PathLike[str]]  #  Same as _typeshed.StrPath
 
 
 def ensure_directory(path):

--- a/setuptools/compat/py310.py
+++ b/setuptools/compat/py310.py
@@ -4,7 +4,7 @@ import sys
 __all__ = ['tomllib']
 
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:  # pragma: no cover
+if sys.version_info < (3, 11):
     from setuptools.extern import tomli as tomllib
+else:
+    import tomllib


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Something I noticed from coverage failing for 1 line in https://github.com/pypa/setuptools/pull/4436 . The rationale is explained in config comment:
> Coverage is only run on the latest Python version, these will never be considered covered and we aim for 100% coverage

![image](https://github.com/pypa/setuptools/assets/1350584/b7b162ad-1a0e-4bb1-90cc-14eb928eb9b7)

### Pull Request Checklist
- [x] Changes have tests (diffcov should pass for this PR)
- [x] News fragment added in [`newsfragments/`]. (not public facing)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
