### PR TITLE
Fallback to stdlib `distutils` if `setuptools._distutils` is missing

### DIFF
--- a/newsfragments/4441.bugfix.rst
+++ b/newsfragments/4441.bugfix.rst
@@ -1,0 +1,1 @@
+On Python 3.11 or below, fallback to stdlib `distutils` if ``setuptools._distutils`` is missing, even with ``SETUPTOOLS_USE_DISTUTILS=local``. -- by :user:`Avasam`

--- a/newsfragments/4441.bugfix.rst
+++ b/newsfragments/4441.bugfix.rst
@@ -1,1 +1,1 @@
-On Python 3.11 or below, fallback to stdlib `distutils` if ``setuptools._distutils`` is missing, even with ``SETUPTOOLS_USE_DISTUTILS=local``. -- by :user:`Avasam`
+Added a fallback to stdlib `distutils` if ``setuptools._distutils`` is missing on Python 3.11 or below, even with ``SETUPTOOLS_USE_DISTUTILS=local``. -- by :user:`Avasam`


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

If `setuptools._distutils` is missing and `SETUPTOOLS_USE_DISTUTILS` environment variable isn't set to `stdlib`, importing `setuptools` will fail.
This change fallsback to stdlib despite `SETUPTOOLS_USE_DISTUTILS=local` if `setuptools._distutils` is missing and shows a warning for Python 3.11 and below.

To test this, simply delete or rename `setuptools._distutils` (either with an editable install or directly in your site-packages) and set `SETUPTOOLS_USE_DISTUTILS` to nothing or `local`. I'd like to write a test for this and may need some pointers to get started since this test would include deleting files (or at least making an import inaccessible)

Before:
```py
>>> import setuptools
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "E:\Users\Avasam\Documents\Git\setuptools\setuptools\__init__.py", line 8, in <module>
    import _distutils_hack.override  # noqa: F401
  File "E:\Users\Avasam\Documents\Git\setuptools\_distutils_hack\override.py", line 1, in <module>
    __import__('_distutils_hack').do_override()
  File "E:\Users\Avasam\Documents\Git\setuptools\_distutils_hack\__init__.py", line 89, in do_override
    ensure_local_distutils()
  File "E:\Users\Avasam\Documents\Git\setuptools\_distutils_hack\__init__.py", line 76, in ensure_local_distutils
    assert '_distutils' in core.__file__, core.__file__
AssertionError: C:\Program Files\Python39\lib\distutils\core.py
```

After:
```py
>>> import setuptools
E:\Users\Avasam\Documents\Git\setuptools\_distutils_hack\__init__.py:66: UserWarning: environment variable SETUPTOOLS_USE_DISTUTILS is set to 'local' or None, but `setuptools._distutils` could not be imported. Falling back to stdlib distutils. This will lead to an error in Python 3.12 and above.
  warnings.warn(
```

Closes https://github.com/pypa/setuptools/issues/4439
The validity of this fix assumes that the user didn't themselves delete `setuptool._distutils` (messing up their own installation) and that distributing setuptools without `setuptools._distutils` and w/o setting an environment variable is a valid use-case. (sounds valid to me for vendor-stripped setuptools)

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
