### PR TITLE
Use brackets for the default value of option arguments

### DIFF
--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -176,7 +176,7 @@ class bdist_wheel(Command):
             "plat-name=",
             "p",
             "platform name to embed in generated filenames "
-            f"(default: {get_platform(None)})",
+            f"[default: {get_platform(None)}]",
         ),
         (
             "keep-temp",
@@ -189,7 +189,7 @@ class bdist_wheel(Command):
         (
             "relative",
             None,
-            "build the archive using relative paths (default: false)",
+            "build the archive using relative paths [default: false]",
         ),
         (
             "owner=",
@@ -201,18 +201,18 @@ class bdist_wheel(Command):
             "g",
             "Group name used when creating a tar file [default: current group]",
         ),
-        ("universal", None, "make a universal wheel (default: false)"),
+        ("universal", None, "make a universal wheel [default: false]"),
         (
             "compression=",
             None,
-            "zipfile compression (one of: {}) (default: 'deflated')".format(
+            "zipfile compression (one of: {}) [default: 'deflated']".format(
                 ", ".join(supported_compressions)
             ),
         ),
         (
             "python-tag=",
             None,
-            f"Python implementation compatibility tag (default: '{python_tag()}')",
+            f"Python implementation compatibility tag [default: '{python_tag()}']",
         ),
         (
             "build-number=",
@@ -224,7 +224,7 @@ class bdist_wheel(Command):
         (
             "py-limited-api=",
             None,
-            "Python tag (cp32|cp33|cpNN) for abi3 wheel tag (default: false)",
+            "Python tag (cp32|cp33|cpNN) for abi3 wheel tag [default: false]",
         ),
     ]
 

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -28,7 +28,7 @@ class dist_info(Command):
             'output-dir=',
             'o',
             "directory inside of which the .dist-info will be"
-            "created (default: top of the source tree)",
+            "created [default: top of the source tree]",
         ),
         ('tag-date', 'd', "Add date stamp (e.g. 20050528) to version number"),
         ('tag-build=', 'b', "Specify explicit tag to add to version number"),

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -172,7 +172,7 @@ class egg_info(InfoCommon, Command):
             'egg-base=',
             'e',
             "directory containing .egg-info directories"
-            " (default: top of the source tree)",
+            " [default: top of the source tree]",
         ),
         ('tag-date', 'd', "Add date stamp (e.g. 20050528) to version number"),
         ('tag-build=', 'b', "Specify explicit tag to add to version number"),


### PR DESCRIPTION
## Summary of changes

The goal is to standardize the format of the help text printed by commands. It is not easy to choose between brackets `[]` and parentheses `()`. I went for the [docopt](http://docopt.org/) style, which is the closest to a standard I could find:
> [...] and whether that argument has a default value ([default: 10]).

This change has already been applied to distutils (https://github.com/pypa/distutils/pull/262).

Closes  #4421

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
