### PR TITLE
Enforce ruff/flake8-implicit-str-concat rules (ISC)

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2041,7 +2041,7 @@ class ZipProvider(EggProvider):
 
         if not WRITE_SUPPORT:
             raise OSError(
-                '"os.rename" and "os.unlink" are not supported ' 'on this platform'
+                '"os.rename" and "os.unlink" are not supported on this platform'
             )
         try:
             if not self.egg_name:

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -171,7 +171,7 @@ class TestResourceManager:
         lines = (
             'import pkg_resources',
             'import sys',
-            ('assert "setuptools" not in sys.modules, ' '"setuptools was imported"'),
+            ('assert "setuptools" not in sys.modules, "setuptools was imported"'),
         )
         cmd = [sys.executable, '-c', '; '.join(lines)]
         subprocess.check_call(cmd)
@@ -299,7 +299,7 @@ def test_distribution_version_missing_undetected_path():
 
     msg, dist = excinfo.value.args
     expected = (
-        "Missing 'Version:' header and/or PKG-INFO file at path: " '[could not detect]'
+        "Missing 'Version:' header and/or PKG-INFO file at path: [could not detect]"
     )
     assert msg == expected
 

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -257,7 +257,7 @@ class TestDistro:
             "/foo_dir/Foo-1.2.dist-info",
             metadata=Metadata((
                 "METADATA",
-                "Provides-Extra: baz\n" "Requires-Dist: quux; extra=='baz'",
+                "Provides-Extra: baz\nRequires-Dist: quux; extra=='baz'",
             )),
         )
         ad.add(Foo)

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -74,7 +74,7 @@ class bdist_egg(Command):
             'keep-temp',
             'k',
             "keep the pseudo-installation tree around after "
-            + "creating the distribution archive",
+            "creating the distribution archive",
         ),
         ('dist-dir=', 'd', "directory to put final built distributions in"),
         ('skip-build', None, "skip rebuilding everything (for testing/debugging)"),

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -363,16 +363,16 @@ class FileList(_FileList):
         }
         log_map = {
             'include': "warning: no files found matching '%s'",
-            'exclude': ("warning: no previously-included files found " "matching '%s'"),
+            'exclude': ("warning: no previously-included files found matching '%s'"),
             'global-include': (
-                "warning: no files found matching '%s' " "anywhere in distribution"
+                "warning: no files found matching '%s' anywhere in distribution"
             ),
             'global-exclude': (
                 "warning: no previously-included files matching "
                 "'%s' found anywhere in distribution"
             ),
             'recursive-include': (
-                "warning: no files found matching '%s' " "under directory '%s'"
+                "warning: no files found matching '%s' under directory '%s'"
             ),
             'recursive-exclude': (
                 "warning: no previously-included files matching "

--- a/setuptools/command/register.py
+++ b/setuptools/command/register.py
@@ -10,7 +10,7 @@ class register(orig.register):
     def run(self):
         msg = (
             "The register command has been removed, use twine to upload "
-            + "instead (https://pypi.org/p/twine)"
+            "instead (https://pypi.org/p/twine)"
         )
 
         self.announce("ERROR: " + msg, log.ERROR)

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -29,7 +29,7 @@ class sdist(orig.sdist):
         (
             'dist-dir=',
             'd',
-            "directory to put the source distribution archive(s) in " "[default: dist]",
+            "directory to put the source distribution archive(s) in [default: dist]",
         ),
         (
             'owner=',

--- a/setuptools/command/upload.py
+++ b/setuptools/command/upload.py
@@ -10,7 +10,7 @@ class upload(orig.upload):
     def run(self):
         msg = (
             "The upload command has been removed, use twine to upload "
-            + "instead (https://pypi.org/p/twine)"
+            "instead (https://pypi.org/p/twine)"
         )
 
         self.announce("ERROR: " + msg, log.ERROR)

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -158,9 +158,7 @@ def check_specifier(dist, attr, value):
     try:
         SpecifierSet(value)
     except (InvalidSpecifier, AttributeError) as error:
-        tmpl = (
-            "{attr!r} must be a string containing valid version specifiers; {error}"
-        )
+        tmpl = "{attr!r} must be a string containing valid version specifiers; {error}"
         raise DistutilsSetupError(tmpl.format(attr=attr, error=error)) from error
 
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -159,7 +159,7 @@ def check_specifier(dist, attr, value):
         SpecifierSet(value)
     except (InvalidSpecifier, AttributeError) as error:
         tmpl = (
-            "{attr!r} must be a string " "containing valid version specifiers; {error}"
+            "{attr!r} must be a string containing valid version specifiers; {error}"
         )
         raise DistutilsSetupError(tmpl.format(attr=attr, error=error)) from error
 

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -55,7 +55,7 @@ class Installer:
             "importlib.machinery.PathFinder.find_spec(%(pkg)r, "
             "[os.path.dirname(p)])))"
         ),
-        ("m = m or " "sys.modules.setdefault(%(pkg)r, types.ModuleType(%(pkg)r))"),
+        ("m = m or sys.modules.setdefault(%(pkg)r, types.ModuleType(%(pkg)r))"),
         "mp = (m or []) and m.__dict__.setdefault('__path__',[])",
         "(p not in mp) and mp.append(p)",
     )

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1137,7 +1137,7 @@ def local_open(url):
             files.append('<a href="{name}">{name}</a>'.format(name=f))
         else:
             tmpl = (
-                "<html><head><title>{url}</title>" "</head><body>{files}</body></html>"
+                "<html><head><title>{url}</title></head><body>{files}</body></html>"
             )
             body = tmpl.format(url=url, files='\n'.join(files))
         status, message = 200, "OK"

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1136,9 +1136,7 @@ def local_open(url):
                 f += '/'
             files.append('<a href="{name}">{name}</a>'.format(name=f))
         else:
-            tmpl = (
-                "<html><head><title>{url}</title></head><body>{files}</body></html>"
-            )
+            tmpl = "<html><head><title>{url}</title></head><body>{files}</body></html>"
             body = tmpl.format(url=url, files='\n'.join(files))
         status, message = 200, "OK"
     else:

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -84,7 +84,7 @@ class TestReadAttr:
             "pkg/__init__.py": "",
             "pkg/sub/__init__.py": "VERSION = '0.1.1'",
             "pkg/sub/mod.py": (
-                "VALUES = {'a': 0, 'b': {42}, 'c': (0, 1, 1)}\n" "raise SystemExit(1)"
+                "VALUES = {'a': 0, 'b': {42}, 'c': (0, 1, 1)}\nraise SystemExit(1)"
             ),
         }
         write_files(files, tmp_path)

--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -277,15 +277,11 @@ class TestMetadata:
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1'
 
-        config.write(
-            '[metadata]\nversion = attr: fake_package.subpkg_a.mod.VERSION\n'
-        )
+        config.write('[metadata]\nversion = attr: fake_package.subpkg_a.mod.VERSION\n')
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
-        config.write(
-            '[metadata]\nversion = attr: fake_package.subpkg_b.mod.VERSION\n'
-        )
+        config.write('[metadata]\nversion = attr: fake_package.subpkg_b.mod.VERSION\n')
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
@@ -446,9 +442,7 @@ class TestMetadata:
     def test_make_option_lowercase(self, tmpdir):
         # remove this test and the method make_option_lowercase() in setuptools.dist
         # when no longer needed
-        fake_env(
-            tmpdir, '[metadata]\nName = foo\ndescription = Some description\n'
-        )
+        fake_env(tmpdir, '[metadata]\nName = foo\ndescription = Some description\n')
         msg = "Usage of uppercase key 'Name' in 'metadata' will not be supported"
         with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
             with get_dist(tmpdir) as dist:

--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -35,7 +35,7 @@ def fake_env(
     tmpdir, setup_cfg, setup_py=None, encoding='ascii', package_path='fake_package'
 ):
     if setup_py is None:
-        setup_py = 'from setuptools import setup\n' 'setup()\n'
+        setup_py = 'from setuptools import setup\nsetup()\n'
 
     tmpdir.join('setup.py').write(setup_py)
     config = tmpdir.join('setup.cfg')
@@ -97,7 +97,7 @@ class TestConfigurationReader:
     def test_ignore_errors(self, tmpdir):
         _, config = fake_env(
             tmpdir,
-            '[metadata]\n' 'version = attr: none.VERSION\n' 'keywords = one, two\n',
+            '[metadata]\nversion = attr: none.VERSION\nkeywords = one, two\n',
         )
         with pytest.raises(ImportError):
             read_configuration('%s' % config)
@@ -171,7 +171,7 @@ class TestMetadata:
     def test_file_mixed(self, tmpdir):
         fake_env(
             tmpdir,
-            '[metadata]\n' 'long_description = file: README.rst, CHANGES.rst\n' '\n',
+            '[metadata]\nlong_description = file: README.rst, CHANGES.rst\n\n',
         )
 
         tmpdir.join('README.rst').write('readme contents\nline2')
@@ -179,14 +179,14 @@ class TestMetadata:
 
         with get_dist(tmpdir) as dist:
             assert dist.metadata.long_description == (
-                'readme contents\nline2\n' 'changelog contents\nand stuff'
+                'readme contents\nline2\nchangelog contents\nand stuff'
             )
 
     def test_file_sandboxed(self, tmpdir):
         tmpdir.ensure("README")
         project = tmpdir.join('depth1', 'depth2')
         project.ensure(dir=True)
-        fake_env(project, '[metadata]\n' 'long_description = file: ../../README\n')
+        fake_env(project, '[metadata]\nlong_description = file: ../../README\n')
 
         with get_dist(project, parse=False) as dist:
             with pytest.raises(DistutilsOptionError):
@@ -253,7 +253,7 @@ class TestMetadata:
 
     def test_version(self, tmpdir):
         package_dir, config = fake_env(
-            tmpdir, '[metadata]\n' 'version = attr: fake_package.VERSION\n'
+            tmpdir, '[metadata]\nversion = attr: fake_package.VERSION\n'
         )
 
         sub_a = package_dir.mkdir('subpkg_a')
@@ -263,35 +263,35 @@ class TestMetadata:
         sub_b = package_dir.mkdir('subpkg_b')
         sub_b.join('__init__.py').write('')
         sub_b.join('mod.py').write(
-            'import third_party_module\n' 'VERSION = (2016, 11, 26)'
+            'import third_party_module\nVERSION = (2016, 11, 26)'
         )
 
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1.2.3'
 
-        config.write('[metadata]\n' 'version = attr: fake_package.get_version\n')
+        config.write('[metadata]\nversion = attr: fake_package.get_version\n')
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '3.4.5.dev'
 
-        config.write('[metadata]\n' 'version = attr: fake_package.VERSION_MAJOR\n')
+        config.write('[metadata]\nversion = attr: fake_package.VERSION_MAJOR\n')
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '1'
 
         config.write(
-            '[metadata]\n' 'version = attr: fake_package.subpkg_a.mod.VERSION\n'
+            '[metadata]\nversion = attr: fake_package.subpkg_a.mod.VERSION\n'
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
         config.write(
-            '[metadata]\n' 'version = attr: fake_package.subpkg_b.mod.VERSION\n'
+            '[metadata]\nversion = attr: fake_package.subpkg_b.mod.VERSION\n'
         )
         with get_dist(tmpdir) as dist:
             assert dist.metadata.version == '2016.11.26'
 
     def test_version_file(self, tmpdir):
         _, config = fake_env(
-            tmpdir, '[metadata]\n' 'version = file: fake_package/version.txt\n'
+            tmpdir, '[metadata]\nversion = file: fake_package/version.txt\n'
         )
         tmpdir.join('fake_package', 'version.txt').write('1.2.3\n')
 
@@ -346,12 +346,12 @@ class TestMetadata:
             assert dist.metadata.version == '1.2.3'
 
     def test_unknown_meta_item(self, tmpdir):
-        fake_env(tmpdir, '[metadata]\n' 'name = fake_name\n' 'unknown = some\n')
+        fake_env(tmpdir, '[metadata]\nname = fake_name\nunknown = some\n')
         with get_dist(tmpdir, parse=False) as dist:
             dist.parse_config_files()  # Skip unknown.
 
     def test_usupported_section(self, tmpdir):
-        fake_env(tmpdir, '[metadata.some]\n' 'key = val\n')
+        fake_env(tmpdir, '[metadata.some]\nkey = val\n')
         with get_dist(tmpdir, parse=False) as dist:
             with pytest.raises(DistutilsOptionError):
                 dist.parse_config_files()
@@ -364,7 +364,7 @@ class TestMetadata:
         ])
 
         # From file.
-        _, config = fake_env(tmpdir, '[metadata]\n' 'classifiers = file: classifiers\n')
+        _, config = fake_env(tmpdir, '[metadata]\nclassifiers = file: classifiers\n')
 
         tmpdir.join('classifiers').write(
             'Framework :: Django\n'
@@ -387,25 +387,25 @@ class TestMetadata:
             assert set(dist.metadata.classifiers) == expected
 
     def test_interpolation(self, tmpdir):
-        fake_env(tmpdir, '[metadata]\n' 'description = %(message)s\n')
+        fake_env(tmpdir, '[metadata]\ndescription = %(message)s\n')
         with pytest.raises(configparser.InterpolationMissingOptionError):
             with get_dist(tmpdir):
                 pass
 
     def test_non_ascii_1(self, tmpdir):
-        fake_env(tmpdir, '[metadata]\n' 'description = éàïôñ\n', encoding='utf-8')
+        fake_env(tmpdir, '[metadata]\ndescription = éàïôñ\n', encoding='utf-8')
         with get_dist(tmpdir):
             pass
 
     def test_non_ascii_3(self, tmpdir):
-        fake_env(tmpdir, '\n' '# -*- coding: invalid\n')
+        fake_env(tmpdir, '\n# -*- coding: invalid\n')
         with get_dist(tmpdir):
             pass
 
     def test_non_ascii_4(self, tmpdir):
         fake_env(
             tmpdir,
-            '# -*- coding: utf-8\n' '[metadata]\n' 'description = éàïôñ\n',
+            '# -*- coding: utf-8\n[metadata]\ndescription = éàïôñ\n',
             encoding='utf-8',
         )
         with get_dist(tmpdir) as dist:
@@ -447,7 +447,7 @@ class TestMetadata:
         # remove this test and the method make_option_lowercase() in setuptools.dist
         # when no longer needed
         fake_env(
-            tmpdir, '[metadata]\n' 'Name = foo\n' 'description = Some description\n'
+            tmpdir, '[metadata]\nName = foo\ndescription = Some description\n'
         )
         msg = "Usage of uppercase key 'Name' in 'metadata' will not be supported"
         with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
@@ -561,7 +561,7 @@ class TestOptions:
             assert dist.tests_require == ['mock==0.7.2', 'pytest']
 
     def test_package_dir_fail(self, tmpdir):
-        fake_env(tmpdir, '[options]\n' 'package_dir = a b\n')
+        fake_env(tmpdir, '[options]\npackage_dir = a b\n')
         with get_dist(tmpdir, parse=False) as dist:
             with pytest.raises(DistutilsOptionError):
                 dist.parse_config_files()
@@ -589,13 +589,13 @@ class TestOptions:
             }
 
     def test_packages(self, tmpdir):
-        fake_env(tmpdir, '[options]\n' 'packages = find:\n')
+        fake_env(tmpdir, '[options]\npackages = find:\n')
 
         with get_dist(tmpdir) as dist:
             assert dist.packages == ['fake_package']
 
     def test_find_directive(self, tmpdir):
-        dir_package, config = fake_env(tmpdir, '[options]\n' 'packages = find:\n')
+        dir_package, config = fake_env(tmpdir, '[options]\npackages = find:\n')
 
         dir_sub_one, _ = make_package_dir('sub_one', dir_package)
         dir_sub_two, _ = make_package_dir('sub_two', dir_package)
@@ -633,7 +633,7 @@ class TestOptions:
 
     def test_find_namespace_directive(self, tmpdir):
         dir_package, config = fake_env(
-            tmpdir, '[options]\n' 'packages = find_namespace:\n'
+            tmpdir, '[options]\npackages = find_namespace:\n'
         )
 
         dir_sub_one, _ = make_package_dir('sub_one', dir_package)
@@ -754,7 +754,7 @@ class TestOptions:
         assert len(recwarn) == num_warnings
 
     def test_dash_preserved_extras_require(self, tmpdir):
-        fake_env(tmpdir, '[options.extras_require]\n' 'foo-a = foo\n' 'foo_b = test\n')
+        fake_env(tmpdir, '[options.extras_require]\nfoo-a = foo\nfoo_b = test\n')
 
         with get_dist(tmpdir) as dist:
             assert dist.extras_require == {'foo-a': ['foo'], 'foo_b': ['test']}
@@ -785,7 +785,7 @@ class TestOptions:
         tmpdir.join('entry_points').write(expected)
 
         # From file.
-        config.write('[options]\n' 'entry_points = file: entry_points\n')
+        config.write('[options]\nentry_points = file: entry_points\n')
 
         with get_dist(tmpdir) as dist:
             assert dist.entry_points == expected
@@ -904,7 +904,7 @@ class TestOptions:
         module_path = Path(tmpdir, "src/custom_build.py")  # auto discovery for src
         module_path.parent.mkdir(parents=True, exist_ok=True)
         module_path.write_text(
-            "from distutils.core import Command\n" "class CustomCmd(Command): pass\n",
+            "from distutils.core import Command\nclass CustomCmd(Command): pass\n",
             encoding="utf-8",
         )
 

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -310,7 +310,7 @@ class TestEggInfo:
                         )
                     )
             return pytest.mark.parametrize(
-                'requires,use_setup_cfg,' 'expected_requires,install_cmd_kwargs',
+                'requires,use_setup_cfg,expected_requires,install_cmd_kwargs',
                 argvalues,
                 ids=idlist,
             )

--- a/setuptools/tests/test_integration.py
+++ b/setuptools/tests/test_integration.py
@@ -16,7 +16,7 @@ from setuptools.dist import Distribution
 
 
 pytestmark = pytest.mark.skipif(
-    'platform.python_implementation() == "PyPy" and ' 'platform.system() == "Windows"',
+    'platform.python_implementation() == "PyPy" and platform.system() == "Windows"',
     reason="pypa/setuptools#2496",
 )
 


### PR DESCRIPTION
## Summary of changes

```
ISC001 Implicitly concatenated string literals on one line
ISC003 Explicitly concatenated string should be implicitly concatenated
```

The list of [Conflicting lint rules](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules) includes `ISC001` and `ISC002`. This is why I don't add them in `ruff.toml`, for now.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
