### PR TITLE
Apply ruff/flake8-logging rules (LOG)

### DIFF
--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -27,7 +27,8 @@ def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     import setuptools  # noqa: F401  # import setuptools to monkeypatch distutils
     import distutils  # <- load distutils after all the patches take place
 
-    logger = logging.Logger(__name__)
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.DEBUG)
     monkeypatch.setattr(logging, "root", logger)
     unset_log_level = logger.getEffectiveLevel()
     assert logging.getLevelName(unset_log_level) == "NOTSET"


### PR DESCRIPTION
## Summary of changes

```
LOG001 Use `logging.getLogger()` to instantiate loggers
```

From the [Logger Objects](https://docs.python.org/3/library/logging.html#logger-objects) documentation:
> Note that Loggers should _NEVER_ be instantiated directly, but always through the module-level function `logging.getLogger(name)`.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
