### PR TITLE
Apply ruff/flake8-raise rules (RSE)

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2808,7 +2808,7 @@ class EntryPoint:
             return ()
         req = Requirement.parse('x' + extras_spec)
         if req.specs:
-            raise ValueError()
+            raise ValueError
         return req.extras
 
     @classmethod

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -237,7 +237,7 @@ class easy_install(Command):
         dist = get_distribution('setuptools')
         tmpl = 'setuptools {dist.version} from {dist.location} (Python {ver})'
         print(tmpl.format(**locals()))
-        raise SystemExit()
+        raise SystemExit
 
     def finalize_options(self):  # noqa: C901  # is too complex (25)  # FIXME
         self.version and self._render_version()

--- a/setuptools/tests/test_sandbox.py
+++ b/setuptools/tests/test_sandbox.py
@@ -100,7 +100,7 @@ class TestExceptionSaver:
         with pytest.raises(setuptools.sandbox.UnpickleableException) as caught:
             with setuptools.sandbox.save_modules():
                 setuptools.sandbox.hide_setuptools()
-                raise ExceptionUnderTest()
+                raise ExceptionUnderTest
 
         (msg,) = caught.value.args
         assert msg == 'ExceptionUnderTest()'


### PR DESCRIPTION
## Summary of changes

```
RSE102 Unnecessary parentheses on raised exception
```

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
