### PR TITLE
Ignore ruff/tryceratops rule TRY003

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -18,6 +18,7 @@ extend-select = [
 	"YTT", # flake8-2020
 ]
 ignore = [
+	"TRY003", # raise-vanilla-args, avoid multitude of exception classes
 	"TRY301", # raise-within-try, it's handy
 	"UP015", # redundant-open-modes, explicit is preferred
 	"UP030", # temporarily disabled


### PR DESCRIPTION
## Summary of changes

```
TRY003 Avoid specifying long messages outside the exception class
```

Applying this rule would mean creating lots of specialised exception classes. Not sure this would improve readability and maintainability in this context.

Addresses https://github.com/pypa/setuptools/pull/4450#issuecomment-2200583235.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
