### PR TITLE
Test coverage config update for protocols

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,5 +18,6 @@ disable_warnings =
 show_missing = True
 exclude_also =
 	# jaraco/skeleton#97
-	@overload
+	# These are taken from https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion
+	class .*\bProtocol\):
 	if TYPE_CHECKING:

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -134,7 +134,7 @@ _AdapterT = TypeVar(
 
 # Use _typeshed.importlib.LoaderProtocol once available https://github.com/python/typeshed/pull/11890
 class _LoaderProtocol(Protocol):
-    def load_module(self, fullname: str, /) -> types.ModuleType: ...
+    def load_module(self, fullname: str, /) -> types.ModuleType: ... # test
 
 
 class _ZipLoaderModule(Protocol):
@@ -415,7 +415,7 @@ def register_loader_type(
 
 
 @overload
-def get_provider(moduleOrReq: str) -> IResourceProvider: ...
+def get_provider(moduleOrReq: str) -> IResourceProvider: ... # test
 @overload
 def get_provider(moduleOrReq: Requirement) -> Distribution: ...
 def get_provider(moduleOrReq: str | Requirement) -> IResourceProvider | Distribution:

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -134,7 +134,7 @@ _AdapterT = TypeVar(
 
 # Use _typeshed.importlib.LoaderProtocol once available https://github.com/python/typeshed/pull/11890
 class _LoaderProtocol(Protocol):
-    def load_module(self, fullname: str, /) -> types.ModuleType: ... # test
+    def load_module(self, fullname: str, /) -> types.ModuleType: ...  # test
 
 
 class _ZipLoaderModule(Protocol):
@@ -415,7 +415,7 @@ def register_loader_type(
 
 
 @overload
-def get_provider(moduleOrReq: str) -> IResourceProvider: ... # test
+def get_provider(moduleOrReq: str) -> IResourceProvider: ...  # test
 @overload
 def get_provider(moduleOrReq: Requirement) -> Distribution: ...
 def get_provider(moduleOrReq: str | Requirement) -> IResourceProvider | Distribution:

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -82,12 +82,15 @@ class SubCommand(Protocol):
 
     def initialize_options(self):
         """(Required by the original :class:`setuptools.Command` interface)"""
+        ...
 
     def finalize_options(self):
         """(Required by the original :class:`setuptools.Command` interface)"""
+        ...
 
     def run(self):
         """(Required by the original :class:`setuptools.Command` interface)"""
+        ...
 
     def get_source_files(self) -> list[str]:
         """
@@ -99,6 +102,7 @@ class SubCommand(Protocol):
         with all the files necessary to build the distribution.
         All files should be strings relative to the project root directory.
         """
+        ...
 
     def get_outputs(self) -> list[str]:
         """
@@ -112,6 +116,7 @@ class SubCommand(Protocol):
            in ``get_output_mapping()`` plus files that are generated during the build
            and don't correspond to any source file already present in the project.
         """
+        ...
 
     def get_output_mapping(self) -> dict[str, str]:
         """
@@ -122,3 +127,4 @@ class SubCommand(Protocol):
         Destination files should be strings in the form of
         ``"{build_lib}/destination/file/path"``.
         """
+        ...


### PR DESCRIPTION
Just a test to confirm whether
1. Single-line elipsis bodies are automatically excluded from coverage (making `@overload` redundant)
2. Excluding Protocols would resolve failing coverage for https://github.com/pypa/setuptools/pull/4192

If this works like I think it would, I'll PR to the skeleton.