### PR TITLE
Fix 92989c2i / #4450

### DIFF
--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -124,6 +124,7 @@ def symlink_or_skip_test(src, dst):
         os.symlink(src, dst)
     except (OSError, NotImplementedError):
         pytest.skip("symlink not supported in OS")
+        return None
     return dst
 
 


### PR DESCRIPTION
## Summary of changes

Restore the previous functionality, where the function did not return explicitly in case of exceptions, and hence returned `None`.

Addresses https://github.com/pypa/setuptools/pull/4450#discussion_r1671240089.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
