### PR TITLE
Move project-specific pins out of upstream.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,8 +39,7 @@ test = [
 	"pytest-cov",
 	"pytest-mypy",
 	"pytest-enabler >= 2.2",
-	# workaround for pypa/setuptools#3921
-	'pytest-ruff >= 0.3.2; sys_platform != "cygwin"',
+	"pytest-ruff >= 0.2.1",
 
 	# local
 	"virtualenv>=13.0.0",
@@ -65,6 +64,10 @@ test = [
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly
 	"importlib_metadata",
 	"pytest-subprocess",
+
+	# require newer pytest-ruff than upstream for pypa/setuptools#4368
+	# also exclude cygwin for pypa/setuptools#3921
+	'pytest-ruff >= 0.3.2; sys_platform != "cygwin"',
 
 	# workaround for pypa/setuptools#4333
 	"pyproject-hooks!=1.1",


### PR DESCRIPTION
- **Move workaround for #3921 to the local section, restoring upstream to match upstream.**
- **Exclude pytest-ruff (and thus ruff), which cannot build on cygwin.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
