### PR TITLE
Rename arguments on _EditableFinder and _EditableNamespaceFinder

### DIFF
--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -805,7 +805,7 @@ PATH_PLACEHOLDER = {name!r} + ".__path_hook__"
 
 class _EditableFinder:  # MetaPathFinder
     @classmethod
-    def find_spec(cls, fullname: str, _path=None, _target=None) -> ModuleSpec | None:
+    def find_spec(cls, fullname: str, path=None, target=None) -> ModuleSpec | None:  # type: ignore
         # Top-level packages and modules (we know these exist in the FS)
         if fullname in MAPPING:
             pkg_path = MAPPING[fullname]
@@ -851,7 +851,7 @@ class _EditableNamespaceFinder:  # PathEntryFinder
         return [*paths, PATH_PLACEHOLDER]
 
     @classmethod
-    def find_spec(cls, fullname: str, _target=None) -> ModuleSpec | None:
+    def find_spec(cls, fullname: str, target=None) -> ModuleSpec | None:  # type: ignore
         if fullname in NAMESPACES:
             spec = ModuleSpec(fullname, None, is_package=True)
             spec.submodule_search_locations = cls._paths(fullname)


### PR DESCRIPTION
This commit rename the `find_spec` arguments in _EditableFinder and _EditableNamespaceFinder to be compliant of the standard `importlib.abc.MetaPathFinder` interface.

https://docs.python.org/3/library/importlib.html#importlib.machinery.PathFinder.find_spec https://github.com/abravalheri/typeshed/blob/eecac02ef7fdbe82b9dc57fa3ca4bb9d341116d7/stdlib/_typeshed/importlib.pyi

The `find_module` arguments were not renamed because the method `find_module` is deprecated starting from Pyhton3.10 and has been removed in Pyhton3.12

https://docs.python.org/3/reference/import.html#the-meta-path

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
