### PR TITLE
Install all the files

### DIFF
--- a/newsfragments/4475.bugfix.rst
+++ b/newsfragments/4475.bugfix.rst
@@ -1,0 +1,1 @@
+Restored package data that went missing in 71.0. This change also incidentally causes tests to be installed once again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,9 +178,7 @@ PKG-INFO = "setuptools.command.egg_info:write_pkg_info"
 "dependency_links.txt" = "setuptools.command.egg_info:overwrite_arg"
 
 [tool.setuptools]
-# disabled as it causes tests to be included #2505
-# include_package_data = true
-include-package-data = false
+include-package-data = true
 
 [tool.setuptools.packages.find]
 include = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -194,10 +194,6 @@ exclude = [
 ]
 namespaces = true
 
-[tool.setuptools.package-data]
-# ensure that `setuptools/_vendor/jaraco/text/Lorem ipsum.txt` is installed
-"*" = ["*.txt"]
-
 [tool.distutils.sdist]
 formats = "zip"
 

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -12,7 +12,6 @@ import tarfile
 from inspect import cleandoc
 from pathlib import Path
 from unittest.mock import Mock
-from zipfile import ZipFile
 
 import pytest
 from ini2toml.api import LiteTranslator
@@ -421,11 +420,6 @@ class TestMeta:
         """Meta test to ensure tests can run from sdist"""
         with tarfile.open(setuptools_sdist) as tar:
             assert any(name.endswith(EXAMPLES_FILE) for name in tar.getnames())
-
-    def test_example_file_not_in_wheel(self, setuptools_wheel):
-        """Meta test to ensure auxiliary test files are not in wheel"""
-        with ZipFile(setuptools_wheel) as zipfile:
-            assert not any(name.endswith(EXAMPLES_FILE) for name in zipfile.namelist())
 
 
 class TestInteropCommandLineParsing:

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -301,6 +301,7 @@ def test_findall_missing_symlink(tmpdir, can_symlink):
         assert found == []
 
 
+@pytest.mark.xfail(reason="unable to exclude tests; #4475 #3260")
 def test_its_own_wheel_does_not_contain_tests(setuptools_wheel):
     with ZipFile(setuptools_wheel) as zipfile:
         contents = [f.replace(os.sep, '/') for f in zipfile.namelist()]

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -307,3 +307,10 @@ def test_its_own_wheel_does_not_contain_tests(setuptools_wheel):
 
     for member in contents:
         assert '/tests/' not in member
+
+
+def test_wheel_includes_cli_scripts(setuptools_wheel):
+    with ZipFile(setuptools_wheel) as zipfile:
+        contents = [f.replace(os.sep, '/') for f in zipfile.namelist()]
+
+    assert any('cli-64.exe' in member for member in contents)


### PR DESCRIPTION
- **Revert "Ensure that package data from vendored packages gets installed."**
- **Revert "Disable inclusion of package data as it causes 'tests' to be included as data. Fixes #2505."**
- **Add test asserting cli scripts are included in wheel.**
- **Remove test as it's redundant to the check in test_its_own_wheel_does_not_contain_tests.**
- **Mark the file as xfail for now.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4475

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
