### PR TITLE
Fix ModuleNotFoundError for _distutils/util.py:byte_compile

### DIFF
--- a/setuptools/_distutils/util.py
+++ b/setuptools/_distutils/util.py
@@ -414,6 +414,7 @@ def byte_compile(  # noqa: C901
             with script:
                 script.write(
                     """\
+import setuptools
 from distutils.util import byte_compile
 files = [
 """


### PR DESCRIPTION
## Summary of changes
Solve `ModuleNotfoundError 'No module named 'distutils'` for function `_distutils/util.py:byte_compile.` By adding `import setuptools` to the script in `byte_complie`, `distutils` will be available.

The python package `thrift` is broken for python 3.12 in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/a0812b380b9d17e9dd02b677e4052bf446b97cbe/pkgs/development/python-modules/thrift/default.nix#L12), since `distutils` was removed in python 3.12. The [thrift](https://github.com/apache/thrift/blob/master/lib/py/setup.py) python package use setuptools/distutils to build. 

The build process use the function ` _distutils/util.py:byte_compile`, that run a python script in a subprocess. Problem is that we get error:

```
       >   File "/build/tmpgob9mq6_.py", line 1, in <module>
       >     from distutils.util import byte_compile
       > ModuleNotFoundError: No module named 'distutils'
```
 when it try to build. Problem is that in the subprocess the `setuptool` is not imported and therefore are `distutils` not available.  
 
 This PR solve the problem by import setuptools first in the script. 