### PR TITLE
Reset the backports module when enabling vendored packages.

### DIFF
--- a/newsfragments/4476.bugfix.rst
+++ b/newsfragments/4476.bugfix.rst
@@ -1,0 +1,1 @@
+Reset the backports module when enabling vendored packages.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -75,6 +75,8 @@ from pkgutil import get_importer
 import _imp
 
 sys.path.extend(((vendor_path := os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setuptools', '_vendor')) not in sys.path) * [vendor_path])  # fmt: skip
+# workaround for #4476
+sys.modules.pop('backports', None)
 
 # capture these to bypass sandboxing
 from os import utime

--- a/ruff.toml
+++ b/ruff.toml
@@ -43,6 +43,11 @@ ignore = [
 	"ISC002",
 ]
 
+# Suppress nuisance warnings about E402 due to workaround for #4476
+[lint.per-file-ignores]
+"setuptools/__init__.py" = ["E402"]
+"pkg_resources/__init__.py" = ["E402"]
+
 [format]
 # Enable preview to get hugged parenthesis unwrapping
 preview = true

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -7,6 +7,8 @@ import sys
 from typing import TYPE_CHECKING
 
 sys.path.extend(((vendor_path := os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setuptools', '_vendor')) not in sys.path) * [vendor_path])  # fmt: skip
+# workaround for #4476
+sys.modules.pop('backports', None)
 
 import _distutils_hack.override  # noqa: F401
 import distutils.core


### PR DESCRIPTION
Closes #4476

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
