### PR TITLE
Add Python version specifiers to [core] dependencies

### DIFF
--- a/newsfragments/4492.misc.rst
+++ b/newsfragments/4492.misc.rst
@@ -1,0 +1,1 @@
+Now backports in ``core`` dependencies are installed only on Python versions requiring them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,9 @@ core = [
 	"ordered-set>=3.1.1",
 	"more_itertools>=8.8",
 	"jaraco.text>=3.7",
-	"importlib_resources>=5.10.2",
-	"importlib_metadata>=6",
-	"tomli>=2.0.1",
+	"importlib_resources>=5.10.2; python_version < '3.9'",
+	"importlib_metadata>=6; python_version < '3.10'",
+	"tomli>=2.0.1; python_version < '3.11'",
 	"wheel>=0.43.0",
 
 	# pkg_resources


### PR DESCRIPTION

## Summary of changes

Add Python version specifiers to importlib_metadata, importlib_resources and tomli dependencies, to require them only on Python versions on which they are actually used.

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
