### PR TITLE
Allow path objects for data-files

### DIFF
--- a/newsfragments/4494.feature.rst
+++ b/newsfragments/4494.feature.rst
@@ -1,0 +1,1 @@
+Added support for `Path` objects for generating data_files -- by :user:`InvincibleRMC`

--- a/setuptools/_distutils/command/install_data.py
+++ b/setuptools/_distutils/command/install_data.py
@@ -6,6 +6,7 @@ platform-independent data files."""
 # contributed by Bastian Kleineidam
 
 import os
+from pathlib import Path
 
 from ..core import Command
 from ..util import change_root, convert_path
@@ -49,6 +50,16 @@ class install_data(Command):
             if isinstance(f, str):
                 # it's a simple file, so copy it
                 f = convert_path(f)
+                if self.warn_dir:
+                    self.warn(
+                        "setup script did not provide a directory for "
+                        f"'{f}' -- installing right in '{self.install_dir}'"
+                    )
+                (out, _) = self.copy_file(f, self.install_dir)
+                self.outfiles.append(out)
+            elif isinstance(f, Path):
+                # it's a simple file, so copy it
+                f = convert_path(str(f))
                 if self.warn_dir:
                     self.warn(
                         "setup script did not provide a directory for "

--- a/setuptools/_distutils/tests/test_install_data.py
+++ b/setuptools/_distutils/tests/test_install_data.py
@@ -1,6 +1,7 @@
 """Tests for distutils.command.install_data."""
 
 import os
+from pathlib import Path
 from distutils.command.install_data import install_data
 from distutils.tests import support
 
@@ -18,22 +19,27 @@ class TestInstallData(
 
         # data_files can contain
         #  - simple files
+        #  - a Path object
         #  - a tuple with a path, and a list of file
         one = os.path.join(pkg_dir, 'one')
         self.write_file(one, 'xxx')
         inst2 = os.path.join(pkg_dir, 'inst2')
         two = os.path.join(pkg_dir, 'two')
         self.write_file(two, 'xxx')
+        three = Path(pkg_dir) / 'three'
+        self.write_file(three, 'xxx')
 
-        cmd.data_files = [one, (inst2, [two])]
-        assert cmd.get_inputs() == [one, (inst2, [two])]
+        cmd.data_files = [one, (inst2, [two]), three]
+        assert cmd.get_inputs() == [one, (inst2, [two]), three]
 
         # let's run the command
         cmd.ensure_finalized()
         cmd.run()
 
         # let's check the result
-        assert len(cmd.get_outputs()) == 2
+        assert len(cmd.get_outputs()) == 3
+        rthree = os.path.split(one)[-1]
+        assert os.path.exists(os.path.join(inst, rthree))
         rtwo = os.path.split(two)[-1]
         assert os.path.exists(os.path.join(inst2, rtwo))
         rone = os.path.split(one)[-1]
@@ -46,21 +52,23 @@ class TestInstallData(
         cmd.run()
 
         # let's check the result
-        assert len(cmd.get_outputs()) == 2
+        assert len(cmd.get_outputs()) == 3
+        assert os.path.exists(os.path.join(inst, rthree))
         assert os.path.exists(os.path.join(inst2, rtwo))
         assert os.path.exists(os.path.join(inst, rone))
         cmd.outfiles = []
 
         # now using root and empty dir
         cmd.root = os.path.join(pkg_dir, 'root')
-        inst4 = os.path.join(pkg_dir, 'inst4')
-        three = os.path.join(cmd.install_dir, 'three')
-        self.write_file(three, 'xx')
-        cmd.data_files = [one, (inst2, [two]), ('inst3', [three]), (inst4, [])]
+        inst5 = os.path.join(pkg_dir, 'inst5')
+        four = os.path.join(cmd.install_dir, 'four')
+        self.write_file(four, 'xx')
+        cmd.data_files = [one, (inst2, [two]), ('inst5', [four]), (inst5, [])]
         cmd.ensure_finalized()
         cmd.run()
 
         # let's check the result
-        assert len(cmd.get_outputs()) == 4
+        assert len(cmd.get_outputs()) == 5
+        assert os.path.exists(os.path.join(inst, rthree))
         assert os.path.exists(os.path.join(inst2, rtwo))
         assert os.path.exists(os.path.join(inst, rone))


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Adds support for `Path` objects to generate data_files from setup().

<!-- Summary goes here -->

Closes #4494 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
