### PR TITLE
Update mypy to 1.11

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -38,7 +38,8 @@ disable_error_code = import-not-found
 [mypy-distutils._modified,jaraco.*,trove_classifiers,wheel.*]
 ignore_missing_imports = True
 
-# Even when excluding generated modules, there might be problems: https://github.com/python/mypy/issues/11936#issuecomment-1466764006
+# Even when excluding a module, import issues can show up due to following import
+# https://github.com/python/mypy/issues/11936#issuecomment-1466764006
 [mypy-setuptools.config._validate_pyproject.*]
 follow_imports = silent
 # silent => ignore errors when following imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,10 @@ test = [
 	# for tools/finalize.py
 	'jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"',
 	"pytest-home >= 0.5",
-	"mypy==1.10.0", # pin mypy version so a new version doesn't suddenly cause the CI to fail
+	# pin mypy version so a new version doesn't suddenly cause the CI to fail,
+	# until types-setuptools is removed from typeshed.
+	# For help with static-typing issues, or mypy update, ping @Avasam 
+	"mypy==1.11",
 	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
 	"tomli",
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ test = [
 	# pin mypy version so a new version doesn't suddenly cause the CI to fail,
 	# until types-setuptools is removed from typeshed.
 	# For help with static-typing issues, or mypy update, ping @Avasam 
-	"mypy==1.11",
+	"mypy==1.11.*",
 	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
 	"tomli",
 	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -443,8 +443,7 @@ class _LinkTree(_StaticPth):
     ):
         self.auxiliary_dir = Path(auxiliary_dir)
         self.build_lib = Path(build_lib).resolve()
-        # TODO: Update typeshed distutils stubs to overload non-None return type by default
-        self._file = dist.get_command_obj("build_py").copy_file  # type: ignore[union-attr]
+        self._file = dist.get_command_obj("build_py").copy_file
         super().__init__(dist, name, [self.auxiliary_dir])
 
     def __call__(self, wheel: WheelFile, files: list[str], mapping: dict[str, str]):
@@ -462,9 +461,7 @@ class _LinkTree(_StaticPth):
         dest = self.auxiliary_dir / relative_output
         if not dest.parent.is_dir():
             dest.parent.mkdir(parents=True)
-        # TODO: Update typeshed distutils stubs so distutils.cmd.Command.copy_file, accepts PathLike
-        # same with methods used by copy_file
-        self._file(src_file, dest, link=link)  # type: ignore[arg-type]
+        self._file(src_file, dest, link=link)
 
     def _create_links(self, outputs, output_mapping):
         self.auxiliary_dir.mkdir(parents=True, exist_ok=True)

--- a/setuptools/command/install.py
+++ b/setuptools/command/install.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
+from collections.abc import Callable
 from distutils.errors import DistutilsArgError
 import inspect
 import glob
 import platform
 import distutils.command.install as orig
-from typing import cast
+from typing import Any, ClassVar, cast
 
 import setuptools
 from ..warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
@@ -29,7 +32,9 @@ class install(orig.install):
         'old-and-unmanageable',
         'single-version-externally-managed',
     ]
-    new_commands = [
+    # Type the same as distutils.command.install.install.sub_commands
+    # Must keep the second tuple item potentially None due to invariance
+    new_commands: ClassVar[list[tuple[str, Callable[[Any], bool] | None]]] = [
         ('install_egg_info', lambda self: True),
         ('install_scripts', lambda self: True),
     ]

--- a/setuptools/command/install_lib.py
+++ b/setuptools/command/install_lib.py
@@ -97,7 +97,7 @@ class install_lib(orig.install_lib):
         exclude = self.get_exclusions()
 
         if not exclude:
-            return orig.install_lib.copy_tree(self, infile, outfile)  # type: ignore[arg-type] # Fixed upstream
+            return orig.install_lib.copy_tree(self, infile, outfile)
 
         # Exclude namespace package __init__.py* files from the output
 

--- a/setuptools/command/upload_docs.py
+++ b/setuptools/command/upload_docs.py
@@ -50,7 +50,7 @@ class upload_docs(upload):
             and metadata.entry_points(group='distutils.commands', name='build_sphinx')
         )
 
-    sub_commands = [('build_sphinx', has_sphinx)]  # type: ignore[list-item] # TODO: Fix in typeshed distutils stubs
+    sub_commands = [('build_sphinx', has_sphinx)]
 
     def initialize_options(self):
         upload.initialize_options(self)

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -1,5 +1,7 @@
 """wheel tests"""
 
+from __future__ import annotations
+
 from distutils.sysconfig import get_config_var
 from distutils.util import get_platform
 import contextlib
@@ -11,6 +13,7 @@ import os
 import shutil
 import subprocess
 import sys
+from typing import Any
 import zipfile
 
 import pytest
@@ -176,7 +179,10 @@ class Record:
         return '%s(**%r)' % (self._id, self._fields)
 
 
-WHEEL_INSTALL_TESTS = (
+# Using Any to avoid possible type union issues later in test
+# making a TypedDict is not worth in a test and anonymous/inline TypedDict are experimental
+# https://github.com/python/mypy/issues/9884
+WHEEL_INSTALL_TESTS: tuple[dict[str, Any], ...] = (
     dict(
         id='basic',
         file_defs={'foo': {'__init__.py': ''}},
@@ -547,7 +553,7 @@ WHEEL_INSTALL_TESTS = (
 @pytest.mark.parametrize(
     'params',
     WHEEL_INSTALL_TESTS,
-    ids=list(params['id'] for params in WHEEL_INSTALL_TESTS),
+    ids=[params['id'] for params in WHEEL_INSTALL_TESTS],
 )
 def test_wheel_install(params):
     project_name = params.get('name', 'foo')


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
- Update mypy to 1.11
- Slightly relax version lock to allow automatic point releases
- Updated `follow_imports = silent` comment to be more generalized / future-proof
- As per https://github.com/pypa/setuptools/issues/4473#issuecomment-2234155911 , indicate myself as owner of the mypy pin, until the removal of `types-setuptools` from typeshed. Right now a CI failure is expected almost every version, especially as more annotations are added to setuptools, and fixes upstreamed to typeshed. Which would require a lock, then unlock PRs everytime (more churn than just locking and updating when ready), or non-obvious fixes (mainly due to distutils subtyping). Once `types-setuptools` is obsoleted, things should be more stable. @jaraco 
<!-- Summary goes here -->

Goes towards unblocking #4352
Closes #4432

### Pull Request Checklist
- [x] Changes have tests (these are test updates)
- [x] News fragment added in [`newsfragments/`]. (no user facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
