### PR TITLE
Add guidance on core dependencies

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -7,7 +7,7 @@ Installation
 
 You can install the latest version of ``setuptools`` using :pypi:`pip`::
 
-    pip install --upgrade setuptools
+    pip install --upgrade setuptools[core]
 
 Most of the times, however, you don't have to...
 
@@ -55,6 +55,16 @@ containing a ``build-system`` section similar to the example below:
 
 This section declares what are your build system dependencies, and which
 library will be used to actually do the packaging.
+
+.. note::
+
+   Package maintainers might be tempted to use ``setuptools[core]`` as the
+   requirement, given the guidance above. Avoid doing so, as the extra
+   is currently considered an internal implementation detail and is likely
+   to go away in the future and the Setuptools team will not support
+   compatibility for problems arising from packages published with this
+   extra declared. Vendored packages will satisfy the dependencies in
+   the most common isolated build scenarios.
 
 .. note::
 


### PR DESCRIPTION
In an attempt to lessen the burden of #4483, guide users installing setuptools to install the required dependencies.

This docs update attempts to honor the intent of https://github.com/pypa/setuptools/pull/4457#discussion_r1668814513, namely to expose the dependencies for incidental use but discourage it for use in `build-requires`.


<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Ref #4483

### Pull Request Checklist
- [ ] ~~Changes have tests~~
- [ ] ~~News fragment added in [`newsfragments/`].~~
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
