### PR TITLE
Restore the tests command and deprecate access to the module.

### DIFF
--- a/newsfragments/4520.feature.rst
+++ b/newsfragments/4520.feature.rst
@@ -1,0 +1,1 @@
+Restore the tests command and deprecate access to the module. (#4519)

--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -1,0 +1,42 @@
+from setuptools import Command
+from setuptools.warnings import SetuptoolsDeprecationWarning
+
+
+def __getattr__(name):
+    if name == 'test':
+        SetuptoolsDeprecationWarning.emit(
+            "The test command is disabled and references to it are deprecated.",
+            "Please remove any references to `setuptools.command.test` in all "
+            "supported versions of the affected package.",
+            due_date=(2024, 11, 15),
+            stacklevel=2,
+        )
+        return _test
+    raise AttributeError(name)
+
+
+class _test(Command):
+    """
+    Stub to warn when test command is referenced or used.
+    """
+
+    description = "stub for old test command (do not use)"
+
+    user_options = [
+        ('test-module=', 'm', "Run 'test_suite' in specified module"),
+        (
+            'test-suite=',
+            's',
+            "Run single test, case or suite (e.g. 'module.test_suite')",
+        ),
+        ('test-runner=', 'r', "Test runner to use"),
+    ]
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        raise RuntimeError("Support for the test command was removed in Setuptools 72")

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -54,6 +54,8 @@ EXAMPLES = [
     ("pyyaml", LATEST),  # cython + custom build_ext + custom distclass
     ("charset-normalizer", LATEST),  # uses mypyc, used by aiohttp
     ("protobuf", LATEST),
+    ("requests", LATEST),
+    ("celery", LATEST),
     # When adding packages to this list, make sure they expose a `__version__`
     # attribute, or modify the tests below
 ]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

As suggested by @hauntsaninja, add a deprecation warning to access of `setuptools.command.test` and raise an error when running the command.

This approach provides a gentler offboarding for projects still reliant on the presence of the module or the command. Currently, it gives 3 months for projects to cut new releases in response to the change. This deadline can be extended if deemed necessary.

Closes #4520; Closes #4519.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
