### PR TITLE
Changed the import of `ctypes.wintypes` from `__import__` to a regular `import` statement

### DIFF
--- a/newsfragments/4534.misc.rst
+++ b/newsfragments/4534.misc.rst
@@ -1,0 +1,1 @@
+Changed the import of ``ctypes.wintypes`` from ``__import__`` to a regular ``import`` statement -- by :user:`Avasam`

--- a/setuptools/windows_support.py
+++ b/setuptools/windows_support.py
@@ -8,7 +8,7 @@ def windows_only(func):
 
 
 @windows_only
-def hide_file(path):
+def hide_file(path: str) -> None:
     """
     Set the hidden attribute on a file or directory.
 
@@ -17,8 +17,8 @@ def hide_file(path):
     `path` must be text.
     """
     import ctypes
+    import ctypes.wintypes
 
-    __import__('ctypes.wintypes')
     SetFileAttributes = ctypes.windll.kernel32.SetFileAttributesW
     SetFileAttributes.argtypes = ctypes.wintypes.LPWSTR, ctypes.wintypes.DWORD
     SetFileAttributes.restype = ctypes.wintypes.BOOL


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The issue https://github.com/python/cpython/issues/61140 referenced in https://github.com/pypa/setuptools/commit/1fab75aaec4ada030ca2777e26edbf5eb76d9802, has been resolved in Python 3.8.7 https://docs.python.org/3.8/whatsnew/changelog.html#python-3-8-7-release-candidate-1

Even then, the decoractor added in https://github.com/pypa/setuptools/commit/81b4d929152eb7119f89a06294e2b656d36c3484 ensures that this wouldn't be run on non-windows machines anyway.
<!-- Summary goes here -->

Resolves a few mypy `attr-defined` and pyright `reportAttributeAccessIssue` for #2345 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
