### PR TITLE
Fix failures of CI on macOS due to requirement normalisation inconsistency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ test = [
 
 	# local
 	"virtualenv>=13.0.0",
-	"wheel",
+	"wheel>=0.44.0",  # Consistent requirement normalisation in METADATA (see #4547)
 	"pip>=19.1", # For proper file:// URLs support.
 	"packaging>=23.2",
 	"jaraco.envs>=2.2",

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -437,10 +437,6 @@ class TestBuildMetaBackend:
         }
         assert license == "---- placeholder MIT license ----"
 
-        metadata = metadata.replace("(", "").replace(")", "").replace("'", '"')
-        # ^-- compatibility hack for pypa/wheel#552
-        #     + normalise all quotes to `"` to avoid inconsistency in #4547
-
         for line in (
             "Summary: This is a Python package",
             "License: MIT",

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 import pytest
 from jaraco import path
+from packaging.requirements import Requirement
 
 from .textwrap import DALS
 
@@ -445,8 +446,9 @@ class TestBuildMetaBackend:
             "License: MIT",
             "Classifier: Intended Audience :: Developers",
             "Requires-Dist: appdirs",
-            "Requires-Dist: tomli >=1 ; extra == \"all\"",
-            "Requires-Dist: importlib ; python_version == \"2.6\" and extra == \"all\"",
+            "Requires-Dist: " + str(Requirement('tomli>=1 ; extra == "all"')),
+            "Requires-Dist: "
+            + str(Requirement('importlib; python_version=="2.6" and extra =="all"')),
         ):
             assert line in metadata, (line, metadata)
 

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -448,7 +448,7 @@ class TestBuildMetaBackend:
             "Requires-Dist: tomli >=1 ; extra == \"all\"",
             "Requires-Dist: importlib ; python_version == \"2.6\" and extra == \"all\"",
         ):
-            assert line in metadata
+            assert line in metadata, (line, metadata)
 
         assert metadata.strip().endswith("This is a ``README``")
         assert epoints.strip() == "[console_scripts]\nfoo = foo.cli:main"

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -436,16 +436,17 @@ class TestBuildMetaBackend:
         }
         assert license == "---- placeholder MIT license ----"
 
-        metadata = metadata.replace("(", "").replace(")", "")
+        metadata = metadata.replace("(", "").replace(")", "").replace("'", '"')
         # ^-- compatibility hack for pypa/wheel#552
+        #     + normalise all quotes to `"` to avoid inconsistency in #4547
 
         for line in (
             "Summary: This is a Python package",
             "License: MIT",
             "Classifier: Intended Audience :: Developers",
             "Requires-Dist: appdirs",
-            "Requires-Dist: tomli >=1 ; extra == 'all'",
-            "Requires-Dist: importlib ; python_version == \"2.6\" and extra == 'all'",
+            "Requires-Dist: tomli >=1 ; extra == \"all\"",
+            "Requires-Dist: importlib ; python_version == \"2.6\" and extra == \"all\"",
         ):
             assert line in metadata
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->


It seems that the [error in `macOS`](https://github.com/pypa/setuptools/actions/runs/10302537702/job/28519161406#step:9:939) happens due to the normalisation of quotes in the Requirement string:

```python
assert "Requires-Dist: tomli >=1 ; extra == 'all'" in """
    Metadata-Version: 2.1
    Name: foo
    Version: 0.1
    Summary: This is a Python package
    License: MIT
    Project-URL: Homepage, http://github.com/
    Classifier: Development Status :: 5 - Production/Stable
    Classifier: Intended Audience :: Developers
    Description-Content-Type: text/x-rst
    License-File: LICENSE.txt
    Requires-Dist: appdirs
    Provides-Extra: all
    Requires-Dist: tomli>=1; extra == "all"
    Requires-Dist: pyscaffold<5,>=4; extra == "all"
    Requires-Dist: importlib; python_version == "2.6" and extra == "all"
    This is a ``README``
    """

## Summary of changes

```

Closes #4547

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
