### PR TITLE
Raise `TypeError` in `easy_install.CommandSpec.from_param`

### DIFF
--- a/newsfragments/4548.feature.rst
+++ b/newsfragments/4548.feature.rst
@@ -1,0 +1,1 @@
+Changed the type of error raised by ``setuptools.command.easy_install.CommandSpec.from_param`` on unsupported argument from `AttributeError` to `TypeError` -- by :user:`Avasam`

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -2068,8 +2068,7 @@ class CommandSpec(list):
             return cls(param)
         if param is None:
             return cls.from_environment()
-        # AttributeError to keep backwards compatibility, this should really be a TypeError though
-        raise AttributeError(f"Argument has an unsupported type {type(param)}")
+        raise TypeError(f"Argument has an unsupported type {type(param)}")
 
     @classmethod
     def from_environment(cls):

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1332,6 +1332,16 @@ class TestCommandSpec:
         assert len(cmd) == 2
         assert '"' not in cmd.as_header()
 
+    def test_from_param_raises_expected_error(self) -> None:
+        """
+        from_param should raise its own TypeError when the argument's type is unsupported
+        """
+        with pytest.raises(TypeError) as exc_info:
+            ei.CommandSpec.from_param(object())  # type: ignore[arg-type] # We want a type error here
+        assert (
+            str(exc_info.value) == "Argument has an unsupported type <class 'object'>"
+        ), exc_info.value
+
 
 class TestWindowsScriptWriter:
     def test_header(self):


### PR DESCRIPTION
## Summary of changes

Follow-up to https://github.com/pypa/setuptools/pull/4505#discussion_r1709867572 
As mentioned in that comment, let's include this PR in a major update since, although an edge case, isn't backwards compatible.

Changed the type of error raised by `setuptools.command.easy_install.CommandSpec.from_param` on unsupported argument from `AttributeError` to `TypeError`.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
