### PR TITLE
Redundant abstractmethod run in `setuptools.command.setopt.option_base`

### DIFF
--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -1,4 +1,4 @@
-from abc import ABC, abstractmethod
+from abc import ABC
 from distutils.util import convert_path
 from distutils import log
 from distutils.errors import DistutilsOptionError
@@ -103,10 +103,6 @@ class option_base(Command, ABC):
                 "Must specify only one configuration file option", filenames
             )
         (self.filename,) = filenames
-
-    @abstractmethod
-    def run(self) -> None:
-        raise NotImplementedError
 
 
 class setopt(option_base):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

@abravalheri I noticed this abstractmethod was redundant (doesn't break anything) by marking the class as `ABC` after https://github.com/pypa/setuptools/pull/4503 was merged

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
