### PR TITLE
docs: add keyword "changelog" to html file containing history/news/versions/releases/towncrier/updates

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -5,6 +5,9 @@
 History
 *******
 
+.. meta::
+   :keywords: changelog
+
 .. towncrier-draft-entries:: DRAFT, unreleased as on |today|
 
 .. include:: ../NEWS (links).rst


### PR DESCRIPTION
The history contains a log of changes. A changelog, you could say. Search engines and browser autocomplete-from-history features need a little help to reliable understand that this is the primary setuptools changelog, and the other pages just happen to reference it in a more prominent place, or are Nvidia-powered word salad entirely.

## Summary of changes

* Tell sphinx to add `<meta content="changelog" name="keywords" />` to history.html

### Pull Request Checklist
- [x] contains no program change
- [x] contains no changes worthy of adding visible log to changelog