### PR TITLE
Remove `sandbox`'s Python 2 `builtins.file` support

### DIFF
--- a/newsfragments/4554.misc.rst
+++ b/newsfragments/4554.misc.rst
@@ -1,0 +1,1 @@
+Removed ``setputools.sandbox``'s Python 2 ``builtins.file`` support -- by :user:`Avasam`

--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -21,10 +21,6 @@ if sys.platform.startswith('java'):
     import org.python.modules.posix.PosixModule as _os
 else:
     _os = sys.modules[os.name]
-try:
-    _file = file  # type: ignore[name-defined] # Check for global variable
-except NameError:
-    _file = None
 _open = open
 
 
@@ -284,15 +280,11 @@ class AbstractSandbox(ABC):
 
     def __enter__(self):
         self._copy(self)
-        if _file:
-            builtins.file = self._file
         builtins.open = self._open
         self._active = True
 
     def __exit__(self, exc_type, exc_value, traceback):
         self._active = False
-        if _file:
-            builtins.file = _file
         builtins.open = _open
         self._copy(_os)
 
@@ -325,8 +317,6 @@ class AbstractSandbox(ABC):
 
         return wrap
 
-    if _file:
-        _file = _mk_single_path_wrapper('file', _file)
     _open = _mk_single_path_wrapper('open', _open)
     for __name in [
         "stat",
@@ -442,13 +432,6 @@ class DirectorySandbox(AbstractSandbox):
         from setuptools.sandbox import SandboxViolation
 
         raise SandboxViolation(operation, args, kw)
-
-    if _file:
-
-        def _file(self, path, mode='r', *args, **kw):
-            if mode not in ('r', 'rt', 'rb', 'rU', 'U') and not self._ok(path):
-                self._violation("file", path, mode, *args, **kw)
-            return _file(path, mode, *args, **kw)
 
     def _open(self, path, mode='r', *args, **kw):
         if mode not in ('r', 'rt', 'rb', 'rU', 'U') and not self._ok(path):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

If I'm not mistaken, this looks like support for Python 2's https://docs.python.org/2.7/library/functions.html#file that never got cleaned up. Where `_file` should always be `None` nowadays.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
