### PR TITLE
Ruff: enable all pyflakes and perf rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -7,20 +7,22 @@ exclude = [
 [lint]
 extend-select = [
 	"C901",
-	"PERF401",
 	"W",
 
 	# local
 	"ANN2", # missing-return-type-*
+	"F", # Pyflakes
 	"F404", # late-future-import
 	"FA", # flake8-future-annotations
 	"I", # isort
+	"PERF", # Perflint
 	"PYI", # flake8-pyi
 	"TRY", # tryceratops
 	"UP", # pyupgrade
 	"YTT", # flake8-2020
 ]
 ignore = [
+	"PERF203", # try-except-in-loop, micro-optimisation with many false-positive. Worth checking but don't block CI
 	"TRY003", # raise-vanilla-args, avoid multitude of exception classes
 	"TRY301", # raise-within-try, it's handy
 	"UP015", # redundant-open-modes, explicit is preferred

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -2187,7 +2187,7 @@ class ScriptWriter:
         spec = str(dist.as_requirement())
         for type_ in 'console', 'gui':
             group = type_ + '_scripts'
-            for name, ep in dist.get_entry_map(group).items():
+            for name in dist.get_entry_map(group).keys():
                 cls._ensure_safe_name(name)
                 script_text = cls.template % locals()
                 args = cls._get_script_args(type_, name, header, script_text)

--- a/setuptools/tests/test_manifest.py
+++ b/setuptools/tests/test_manifest.py
@@ -485,14 +485,8 @@ class TestFileListTest(TempDirTestCase):
             'prune',
             'blarg',
         ):
-            try:
+            with pytest.raises(DistutilsTemplateError):
                 file_list.process_template_line(action)
-            except DistutilsTemplateError:
-                pass
-            except Exception:
-                assert False, "Incorrect error thrown"
-            else:
-                assert False, "Should have thrown an error"
 
     def test_include(self, caplog):
         caplog.set_level(logging.DEBUG)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Setuptools conforms to all the Ruff-implemented Pyflakes and Perflint rules except `PERF203` and a single instance of `PERF102`. So we can be less picky about their selection.

`PERF203` is worth looking at, but is often a micro-optimisation with false-positives, let's not block the CI on that. I applied it on some tests.

### Pull Request Checklist
- [x] Changes have tests (these are new static tests)
- [x] News fragment added in [`newsfragments/`]. (no public-facing change)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
