### PR TITLE
Ruff: lint pytest

### DIFF
--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -700,7 +700,7 @@ class TestParsing:
         (req,) = parse_requirements('foo >= 1.0, < 3')
 
     @pytest.mark.parametrize(
-        ['lower', 'upper'],
+        'lower, upper',
         [
             ('1.2-rc1', '1.2rc1'),
             ('0.4', '0.4.0'),
@@ -724,7 +724,7 @@ class TestParsing:
         """
 
     @pytest.mark.parametrize(
-        ['lower', 'upper'],
+        'lower, upper',
         [
             ('2.1', '2.1.1'),
             ('2a1', '2b0'),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,8 @@ check = [
 
 	# local
 
-	# workaround for businho/pytest-ruff#28
-	"ruff >= 0.5.2; sys_platform != 'cygwin'",
+	# changed defaults for PT001 and PT023 astral-sh/ruff#13292
+	"ruff >= 0.7.0; sys_platform != 'cygwin'",
 ]
 
 cover = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -20,6 +20,7 @@ extend-select = [
 	"I", # isort
 	"PERF", # Perflint
 	"PGH", # pygrep-hooks (blanket-* rules)
+	"PT", # flake8-pytest-style
 	"PYI", # flake8-pyi
 	"RUF10", # unused-noqa & redirected-noqa
 	"TRY", # tryceratops
@@ -28,6 +29,11 @@ extend-select = [
 ]
 ignore = [
 	"PERF203", # try-except-in-loop, micro-optimisation with many false-positive. Worth checking but don't block CI
+	"PT004", # deprecated https://github.com/astral-sh/ruff/issues/8796#issuecomment-2057143531
+	"PT005", # deprecated https://github.com/astral-sh/ruff/issues/8796#issuecomment-2057143531
+	"PT007", # temporarily disabled, TODO: configure and standardize to preference
+	"PT011", # temporarily disabled, TODO: tighten expected error 
+	"PT012", # pytest-raises-with-multiple-statements, avoid extra dummy methods for a few lines, sometimes we explicitly assert in case of no error
 	"TRY003", # raise-vanilla-args, avoid multitude of exception classes
 	"TRY301", # raise-within-try, it's handy
 	"UP015", # redundant-open-modes, explicit is preferred
@@ -74,6 +80,9 @@ sections.delayed = ["distutils"]
 
 [lint.flake8-annotations]
 ignore-fully-untyped = true
+
+[lint.flake8-pytest-style]
+parametrize-names-type = "csv"
 
 [format]
 # Enable preview to get hugged parenthesis unwrapping and other nice surprises

--- a/setuptools/command/install_lib.py
+++ b/setuptools/command/install_lib.py
@@ -101,7 +101,9 @@ class install_lib(orig.install_lib):
         preserve_symlinks: bool = False,  # type: ignore[override]
         level: object = 1,
     ) -> list[str]:
-        assert preserve_mode and preserve_times and not preserve_symlinks
+        assert preserve_mode
+        assert preserve_times
+        assert not preserve_symlinks
         exclude = self.get_exclusions()
 
         if not exclude:

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -209,7 +209,7 @@ def test_no_explicit_content_type_for_missing_extension(tmp_path):
 
 
 @pytest.mark.parametrize(
-    ('pyproject_text', 'expected_maintainers_meta_value'),
+    'pyproject_text, expected_maintainers_meta_value',
     (
         pytest.param(
             PEP621_EXAMPLE,

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -104,23 +104,22 @@ def venv_python(tmp_path):
 
 
 @pytest.fixture(autouse=True)
-def _prepare(tmp_path, venv_python, monkeypatch, request):
+def _prepare(tmp_path, venv_python, monkeypatch):
     download_path = os.getenv("DOWNLOAD_PATH", str(tmp_path))
     os.makedirs(download_path, exist_ok=True)
 
     # Environment vars used for building some of the packages
     monkeypatch.setenv("USE_MYPYC", "1")
 
-    def _debug_info():
-        # Let's provide the maximum amount of information possible in the case
-        # it is necessary to debug the tests directly from the CI logs.
-        print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
-        print("Temporary directory:")
-        map(print, tmp_path.glob("*"))
-        print("Virtual environment:")
-        run([venv_python, "-m", "pip", "freeze"])
+    yield
 
-    request.addfinalizer(_debug_info)
+    # Let's provide the maximum amount of information possible in the case
+    # it is necessary to debug the tests directly from the CI logs.
+    print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    print("Temporary directory:")
+    map(print, tmp_path.glob("*"))
+    print("Virtual environment:")
+    run([venv_python, "-m", "pip", "freeze"])
 
 
 @pytest.mark.parametrize('package, version', EXAMPLES)

--- a/setuptools/tests/test_bdist_egg.py
+++ b/setuptools/tests/test_bdist_egg.py
@@ -17,7 +17,7 @@ setup(py_modules=['hi'])
 """
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def setup_context(tmpdir):
     with (tmpdir / 'setup.py').open('w') as f:
         f.write(SETUP_PY)
@@ -28,7 +28,9 @@ def setup_context(tmpdir):
 
 
 class Test:
-    def test_bdist_egg(self, setup_context, user_override):
+    @pytest.mark.usefixtures("user_override")
+    @pytest.mark.usefixtures("setup_context")
+    def test_bdist_egg(self):
         dist = Distribution(
             dict(
                 script_name='setup.py',
@@ -50,7 +52,9 @@ class Test:
         os.environ.get('PYTHONDONTWRITEBYTECODE', False),
         reason="Byte code disabled",
     )
-    def test_exclude_source_files(self, setup_context, user_override):
+    @pytest.mark.usefixtures("user_override")
+    @pytest.mark.usefixtures("setup_context")
+    def test_exclude_source_files(self):
         dist = Distribution(
             dict(
                 script_name='setup.py',

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -407,14 +407,14 @@ class TestUserInstallTest:
         logging.basicConfig(level=logging.INFO, stream=sys.stderr)
         log.info('this should not break')
 
-    @pytest.fixture()
+    @pytest.fixture
     def foo_package(self, tmpdir):
         egg_file = tmpdir / 'foo-1.0.egg-info'
         with egg_file.open('w') as f:
             f.write('Name: foo\n')
         return str(tmpdir)
 
-    @pytest.fixture()
+    @pytest.fixture
     def install_target(self, tmpdir):
         target = str(tmpdir)
         with mock.patch('sys.path', sys.path + [target]):
@@ -472,6 +472,12 @@ def distutils_package():
         yield
 
 
+@pytest.mark.usefixtures("distutils_package")
+class TestDistutilsPackage:
+    def test_bdist_egg_available_on_distutils_pkg(self):
+        run_setup('setup.py', ['bdist_egg'])
+
+
 @pytest.fixture
 def mock_index():
     # set up a server which will simulate an alternate package index.
@@ -482,11 +488,6 @@ def mock_index():
         pytest.skip("could not find a valid port")
     p_index.start()
     return p_index
-
-
-class TestDistutilsPackage:
-    def test_bdist_egg_available_on_distutils_pkg(self, distutils_package):
-        run_setup('setup.py', ['bdist_egg'])
 
 
 class TestInstallRequires:

--- a/setuptools/tests/test_packageindex.py
+++ b/setuptools/tests/test_packageindex.py
@@ -1,4 +1,5 @@
 import http.client
+import re
 import urllib.error
 import urllib.request
 from inspect import cleandoc
@@ -24,11 +25,8 @@ class TestPackageIndex:
     def test_bad_url_bad_port(self):
         index = setuptools.package_index.PackageIndex()
         url = 'http://127.0.0.1:0/nonesuch/test_package_index'
-        try:
+        with pytest.raises(Exception, match=re.escape(url)):
             v = index.open_url(url)
-        except Exception as exc:
-            assert url in str(exc)
-        else:
             assert isinstance(v, urllib.error.HTTPError)
 
     def test_bad_url_typo(self):
@@ -37,15 +35,10 @@ class TestPackageIndex:
         # in its home URL
         index = setuptools.package_index.PackageIndex(hosts=('www.example.com',))
 
-        url = (
-            'url:%20https://svn.plone.org/svn'
-            '/collective/inquant.contentmirror.plone/trunk'
-        )
-        try:
+        url = 'url:%20https://svn.plone.org/svn/collective/inquant.contentmirror.plone/trunk'
+
+        with pytest.raises(Exception, match=re.escape(url)):
             v = index.open_url(url)
-        except Exception as exc:
-            assert url in str(exc)
-        else:
             assert isinstance(v, urllib.error.HTTPError)
 
     def test_bad_url_bad_status_line(self):
@@ -56,12 +49,8 @@ class TestPackageIndex:
 
         index.opener = _urlopen
         url = 'http://example.com'
-        try:
+        with pytest.raises(Exception, match=r'line'):
             index.open_url(url)
-        except Exception as exc:
-            assert 'line' in str(exc)
-        else:
-            raise AssertionError('Should have raise here!')
 
     def test_bad_url_double_scheme(self):
         """

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -21,7 +21,7 @@ from distutils.errors import DistutilsSetupError
 
 @pytest.fixture(autouse=True)
 def isolated_dir(tmpdir_cwd):
-    yield
+    return
 
 
 def makeSetup(**args):
@@ -257,7 +257,8 @@ def can_symlink(tmpdir):
     os.remove(link_fn)
 
 
-def test_findall_missing_symlink(tmpdir, can_symlink):
+@pytest.mark.usefixtures("can_symlink")
+def test_findall_missing_symlink(tmpdir):
     with tmpdir.as_cwd():
         os.symlink('foo', 'bar')
         found = list(setuptools.findall())

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -78,7 +78,7 @@ WHEEL_INFO_TESTS = (
 
 
 @pytest.mark.parametrize(
-    ('filename', 'info'), WHEEL_INFO_TESTS, ids=[t[0] for t in WHEEL_INFO_TESTS]
+    'filename, info', WHEEL_INFO_TESTS, ids=[t[0] for t in WHEEL_INFO_TESTS]
 )
 def test_wheel_info(filename, info):
     if inspect.isclass(info):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
In this PR I've enabled https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt linting in Ruff and configured to the current preferences.
<!-- Summary goes here -->


### Pull Request Checklist
- [x] Changes have tests (these are test changes, all existing tests should pass)
- [x] News fragment added in [`newsfragments/`]. (no user facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
