### PR TITLE
Disable and revert `unpacked-list-comprehension (UP027)`

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -12,18 +12,19 @@ extend-select = [
 
 	# local
 	"ANN2", # missing-return-type-*
-	"FA", # flake8-future-annotations
 	"F404", # late-future-import
+	"FA", # flake8-future-annotations
 	"I", # isort
 	"PYI", # flake8-pyi
+	"TRY", # tryceratops
 	"UP", # pyupgrade
-	"TRY",
 	"YTT", # flake8-2020
 ]
 ignore = [
 	"TRY003", # raise-vanilla-args, avoid multitude of exception classes
 	"TRY301", # raise-within-try, it's handy
 	"UP015", # redundant-open-modes, explicit is preferred
+	"UP027", # unpacked-list-comprehension, is actually slower for cases relevant to unpacking, set for deprecation: https://github.com/astral-sh/ruff/issues/12754
 	"UP030", # temporarily disabled
 	"UP031", # temporarily disabled
 	"UP032", # temporarily disabled

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -561,10 +561,7 @@ class PackageIndex(Environment):
         if self[requirement.key]:  # we've seen at least one distro
             meth, msg = self.info, "Couldn't retrieve index page for %r"
         else:  # no distros seen for this name, might be misspelled
-            meth, msg = (
-                self.warn,
-                "Couldn't find index page for %r (maybe misspelled?)",
-            )
+            meth, msg = self.warn, "Couldn't find index page for %r (maybe misspelled?)"
         meth(msg, requirement.unsafe_name)
         self.scan_all()
 

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -283,9 +283,9 @@ class TestEggInfo:
                 else:
                     install_cmd_kwargs = {}
                 name = name_kwargs[0].strip()
-                setup_py_requires, setup_cfg_requires, expected_requires = (
+                setup_py_requires, setup_cfg_requires, expected_requires = [
                     DALS(a).format(**format_dict) for a in test_params
-                )
+                ]
                 for id_, requires, use_cfg in (
                     (name, setup_py_requires, False),
                     (name + '_in_setup_cfg', setup_cfg_requires, True),


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

In https://github.com/astral-sh/ruff/issues/12754 it was found that the original pyupgrade rule `unpacked-list-comprehension (UP027)` is based on lacks justification and is actually slower in cases relevant to unpacking (ie: small sizes). The rule is deprecated in https://github.com/astral-sh/ruff/pull/12843 for Ruff 0.6

This PR disables the rule now before there's any usage of it. I also searched for `,.*? = \(` to find any code that would've triggered it and revert.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
