### PR TITLE
Prevent accidental warning from deprecated entrypoint in `pypa/wheel#631`

### DIFF
--- a/newsfragments/4559.misc.rst
+++ b/newsfragments/4559.misc.rst
@@ -1,0 +1,2 @@
+Prevent deprecation warning from ``pypa/wheel#631`` to accidentally
+trigger when validating ``pyproject.toml``.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -278,6 +278,7 @@ def _valid_command_options(cmdclass: Mapping = EMPTY) -> dict[str, set[str]]:
 def _load_ep(ep: metadata.EntryPoint) -> tuple[str, type] | None:
     if ep.value.startswith("wheel.bdist_wheel"):
         # Ignore deprecated entrypoint from wheel and avoid warning pypa/wheel#631
+        # TODO: remove check when `bdist_wheel` has been fully removed from pypa/wheel
         return None
 
     # Ignore all the errors

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -276,6 +276,10 @@ def _valid_command_options(cmdclass: Mapping = EMPTY) -> dict[str, set[str]]:
 
 
 def _load_ep(ep: metadata.EntryPoint) -> tuple[str, type] | None:
+    if ep.value.startswith("wheel.bdist_wheel"):
+        # Ignore deprecated entrypoint from wheel and avoid warning pypa/wheel#631
+        return None
+
     # Ignore all the errors
     try:
         return (ep.name, ep.load())


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Ignore deprecated entrypoint from wheel and avoid warning pypa/wheel#631 when validating experimental options from `pyproject.toml`.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
