### PR TITLE
Bump declared platformdirs dependency to >= 4.2.2

### DIFF
--- a/newsfragments/4560.misc.rst
+++ b/newsfragments/4560.misc.rst
@@ -1,0 +1,1 @@
+Bumped declared ``platformdirs`` dependency to ``>= 4.2.2`` to help platforms lacking `ctypes` support install setuptools seamlessly -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ core = [
 	"wheel>=0.43.0",
 
 	# pkg_resources
-	"platformdirs >= 2.6.2",
+	"platformdirs >= 4.2.2", # Made ctypes optional (see #4461)
 
 	# for distutils
 	"jaraco.collections",


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4461
The vendored version was already 4.2.2, so this change is only to help platforms lacking `ctypes` support install setuptools seamlessly.

### Pull Request Checklist
- [x] Changes have tests (existing tests should pass)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
