### PR TITLE
Use `--force-reinstall` in integration test and skip wheel

### DIFF
--- a/newsfragments/4565.misc.rst
+++ b/newsfragments/4565.misc.rst
@@ -1,0 +1,3 @@
+Replace ``pip install -I`` with ``pip install --force-reinstall`` in
+integration tests. Additionally, remove ``wheel`` from virtual environment as
+it is no longer a build dependency.

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -137,7 +137,7 @@ def test_install_sdist(package, version, tmp_path, venv_python, setuptools_wheel
     # Use a virtualenv to simulate PEP 517 isolation
     # but install fresh setuptools wheel to ensure the version under development
     env = EXTRA_ENV_VARS.get(package, {})
-    run([*venv_pip, "install", "wheel", "-I", setuptools_wheel])
+    run([*venv_pip, "install", "--force-reinstall", setuptools_wheel])
     run([*venv_pip, "install", *INSTALL_OPTIONS, sdist], env)
 
     # Execute a simple script to make sure the package was installed correctly


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

In integration test:

- Replace `pip install -I` with `pip install --force-reinstall`
- Do not install `wheel` as it is no longer a build dependency (it also no longer gets automatically installed in the build env in regular workflows).

Closes #4564 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
