### PR TITLE
Ensured all methods in `setuptools.modified` raise a consistant `distutils.error.DistutilsError` type

### DIFF
--- a/newsfragments/4567.bugfix.rst
+++ b/newsfragments/4567.bugfix.rst
@@ -1,0 +1,1 @@
+Ensured all methods in ``setuptools.modified`` raise a consistant ``distutils.errors.DistutilsError`` type -- by :user:`Avasam`

--- a/newsfragments/4567.bugfix.rst
+++ b/newsfragments/4567.bugfix.rst
@@ -1,1 +1,4 @@
-Ensured all methods in ``setuptools.modified`` raise a consistant ``distutils.errors.DistutilsError`` type -- by :user:`Avasam`
+Ensured methods in ``setuptools.modified`` preferably raise a consistent
+``distutils.errors.DistutilsError`` type
+(except in the deprecated use case of ``SETUPTOOLS_USE_DISTUTILS=stdlib``)
+-- by :user:`Avasam`

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -1,16 +1,9 @@
 from ..dist import Distribution
+from ..modified import newer_pairwise_group
 
 import distutils.command.build_clib as orig
 from distutils import log
 from distutils.errors import DistutilsSetupError
-
-try:
-    from distutils._modified import (  # pyright: ignore[reportMissingImports]
-        newer_pairwise_group,
-    )
-except ImportError:
-    # fallback for SETUPTOOLS_USE_DISTUTILS=stdlib
-    from .._distutils._modified import newer_pairwise_group
 
 
 class build_clib(orig.build_clib):

--- a/setuptools/modified.py
+++ b/setuptools/modified.py
@@ -1,8 +1,18 @@
-from ._distutils._modified import (
-    newer,
-    newer_group,
-    newer_pairwise,
-    newer_pairwise_group,
-)
+try:
+    # Ensure a DistutilsError raised by these methods is the same as distutils.errors.DistutilsError
+    from distutils._modified import (
+        newer,
+        newer_group,
+        newer_pairwise,
+        newer_pairwise_group,
+    )
+except ImportError:
+    # fallback for SETUPTOOLS_USE_DISTUTILS=stdlib, because _modified never existed in stdlib
+    from ._distutils._modified import (
+        newer,
+        newer_group,
+        newer_pairwise,
+        newer_pairwise_group,
+    )
 
 __all__ = ['newer', 'newer_pairwise', 'newer_group', 'newer_pairwise_group']

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -114,6 +114,7 @@ print("success")
 """
 
 
+@pytest.mark.usefixtures("tmpdir_cwd")
 @pytest.mark.parametrize(
     "distutils_version, imported_module",
     [
@@ -125,9 +126,7 @@ print("success")
         ("local", "archive_util"),
     ],
 )
-def test_modules_are_not_duplicated_on_import(
-    distutils_version, imported_module, tmpdir_cwd, venv
-):
+def test_modules_are_not_duplicated_on_import(distutils_version, imported_module, venv):
     env = dict(SETUPTOOLS_USE_DISTUTILS=distutils_version)
     script = ENSURE_IMPORTS_ARE_NOT_DUPLICATED.format(imported_module=imported_module)
     cmd = ['python', '-c', script]
@@ -145,6 +144,7 @@ print("success")
 """
 
 
+@pytest.mark.usefixtures("tmpdir_cwd")
 @pytest.mark.parametrize(
     "distutils_version",
     [
@@ -152,8 +152,37 @@ print("success")
         pytest.param("stdlib", marks=skip_without_stdlib_distutils),
     ],
 )
-def test_log_module_is_not_duplicated_on_import(distutils_version, tmpdir_cwd, venv):
+def test_log_module_is_not_duplicated_on_import(distutils_version, venv):
     env = dict(SETUPTOOLS_USE_DISTUTILS=distutils_version)
     cmd = ['python', '-c', ENSURE_LOG_IMPORT_IS_NOT_DUPLICATED]
+    output = venv.run(cmd, env=win_sr(env), **_TEXT_KWARGS).strip()
+    assert output == "success"
+
+
+ENSURE_CONSISTENT_ERROR_FROM_MODIFIED_PY = r"""
+from setuptools.modified import newer
+from distutils.errors import DistutilsError
+
+# Can't use pytest.raises in this context
+try:
+    newer("", "")
+except DistutilsError:
+    print("success")
+else:
+    raise AssertionError("Expected to raise")
+"""
+
+
+@pytest.mark.usefixtures("tmpdir_cwd")
+@pytest.mark.parametrize(
+    "distutils_version",
+    [
+        "local",
+        pytest.param("stdlib", marks=skip_without_stdlib_distutils),
+    ],
+)
+def test_consistent_error_from_modified_py(distutils_version, venv):
+    env = dict(SETUPTOOLS_USE_DISTUTILS=distutils_version)
+    cmd = ['python', '-c', ENSURE_CONSISTENT_ERROR_FROM_MODIFIED_PY]
     output = venv.run(cmd, env=win_sr(env), **_TEXT_KWARGS).strip()
     assert output == "success"

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -180,7 +180,9 @@ else:
         ("local", "distutils"),
         # Unfortunately we still get ._distutils.errors.DistutilsError with SETUPTOOLS_USE_DISTUTILS=stdlib
         # But that's a deprecated use-case we don't mind not fully supporting in newer code
-        pytest.param("stdlib", "setuptools._distutils", marks=skip_without_stdlib_distutils),
+        pytest.param(
+            "stdlib", "setuptools._distutils", marks=skip_without_stdlib_distutils
+        ),
     ],
 )
 def test_consistent_error_from_modified_py(distutils_version, imported_module, venv):

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -175,12 +175,12 @@ else:
 
 @pytest.mark.usefixtures("tmpdir_cwd")
 @pytest.mark.parametrize(
-    "distutils_version",
+    "distutils_version, imported_module",
     [
         ("local", "distutils"),
         # Unfortunately we still get ._distutils.errors.DistutilsError with SETUPTOOLS_USE_DISTUTILS=stdlib
         # But that's a deprecated use-case we don't mind not fully supporting in newer code
-        (pytest.param("stdlib", marks=skip_without_stdlib_distutils), "._distutils"),
+        pytest.param("stdlib", "._distutils", marks=skip_without_stdlib_distutils),
     ],
 )
 def test_consistent_error_from_modified_py(distutils_version, imported_module, venv):

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -180,7 +180,7 @@ else:
         ("local", "distutils"),
         # Unfortunately we still get ._distutils.errors.DistutilsError with SETUPTOOLS_USE_DISTUTILS=stdlib
         # But that's a deprecated use-case we don't mind not fully supporting in newer code
-        pytest.param("stdlib", "._distutils", marks=skip_without_stdlib_distutils),
+        pytest.param("stdlib", "setuptools._distutils", marks=skip_without_stdlib_distutils),
     ],
 )
 def test_consistent_error_from_modified_py(distutils_version, imported_module, venv):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The following code should now work as expected in all cases:
```py
from setuptools.modified import newer_pairwise_group
from distutils.error import DistutilsError

try:
    newer_pairwise_group(...)
except DistutilsError:
    pass
```

I'm not entirely certain my test is correct. Hopefully it should be.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
