### PR TITLE
Using `dict` as an `OrderedDict` and allowed using `dict` as an ordered type in `setuptools.dist.check_requirements`

### DIFF
--- a/newsfragments/4575.feature.rst
+++ b/newsfragments/4575.feature.rst
@@ -1,0 +1,1 @@
+Allowed using `dict` as an ordered type in ``setuptools.dist.check_requirements`` -- by :user:`Avasam`

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -18,12 +18,11 @@ from jaraco.text import yield_lines
 from packaging.requirements import Requirement
 
 from .. import _reqs
+from .._reqs import _StrOrIter
 
 # dict can work as an ordered set
 _T = TypeVar("_T")
 _Ordered = Dict[_T, None]
-_ordered = dict
-_StrOrIter = _reqs._StrOrIter
 
 
 def _prepare(

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -2,7 +2,6 @@
 
 Create a distribution's .egg-info directory and contents"""
 
-import collections
 import functools
 import os
 import re
@@ -211,11 +210,9 @@ class egg_info(InfoCommon, Command):
         build tag. Install build keys in a deterministic order
         to avoid arbitrary reordering on subsequent builds.
         """
-        egg_info = collections.OrderedDict()
         # follow the order these keys would have been added
         # when PYTHONHASHSEED=0
-        egg_info['tag_build'] = self.tags()
-        egg_info['tag_date'] = 0
+        egg_info = dict(tag_build=self.tags(), tag_date=0)
         edit_config(filename, dict(egg_info=egg_info))
 
     def finalize_options(self):

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -310,7 +310,6 @@ def test_parity_with_metadata_from_pypa_wheel(tmp_path):
         python_requires=">=3.8",
         install_requires="""
         packaging==23.2
-        ordered-set==3.1.1
         more-itertools==8.8.0; extra == "other"
         jaraco.text==3.7.0
         importlib-resources==5.10.2; python_version<"3.8"

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -1,4 +1,3 @@
-import collections
 import os
 import re
 import urllib.parse
@@ -72,15 +71,10 @@ EXAMPLE_BASE_INFO = dict(
 
 
 def test_provides_extras_deterministic_order():
-    extras = collections.OrderedDict()
-    extras['a'] = ['foo']
-    extras['b'] = ['bar']
-    attrs = dict(extras_require=extras)
+    attrs = dict(extras_require=dict(a=['foo'], b=['bar']))
     dist = Distribution(attrs)
     assert list(dist.metadata.provides_extras) == ['a', 'b']
-    attrs['extras_require'] = collections.OrderedDict(
-        reversed(list(attrs['extras_require'].items()))
-    )
+    attrs['extras_require'] = dict(reversed(attrs['extras_require'].items()))
     dist = Distribution(attrs)
     assert list(dist.metadata.provides_extras) == ['b', 'a']
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Allows using `dict` as an ordered type in ``setuptools.dist.check_requirements``
https://github.com/pypa/setuptools/pull/4574 Gave me the idea for this PR

### Pull Request Checklist
- [x] Changes have tests (tests updated with new messages and dict)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
