### PR TITLE
Sync with distutils@30b7331

### DIFF
--- a/newsfragments/+61911d95.bugfix.rst
+++ b/newsfragments/+61911d95.bugfix.rst
@@ -1,0 +1,1 @@
+Synced with pypa/distutils@30b7331 including fix for modified check on empty sources (pypa/distutils#284).

--- a/setuptools/_distutils/_modified.py
+++ b/setuptools/_distutils/_modified.py
@@ -63,7 +63,7 @@ def newer_group(sources, target, missing='error'):
         return missing == 'newer' and not os.path.exists(source)
 
     ignored = os.path.exists if missing == 'ignore' else None
-    return any(
+    return not os.path.exists(target) or any(
         missing_as_newer(source) or _newer(source, target)
         for source in filter(ignored, sources)
     )

--- a/setuptools/_distutils/dist.py
+++ b/setuptools/_distutils/dist.py
@@ -658,7 +658,7 @@ Common commands: (see '--help-commands' for more)
             )
             print()
 
-        for command in self.commands:
+        for command in commands:
             if isinstance(command, type) and issubclass(command, Command):
                 klass = command
             else:

--- a/setuptools/_distutils/tests/test_modified.py
+++ b/setuptools/_distutils/tests/test_modified.py
@@ -117,3 +117,10 @@ def test_newer_pairwise_group(groups_target):
     newer = newer_pairwise_group([groups_target.newer], [groups_target.target])
     assert older == ([], [])
     assert newer == ([groups_target.newer], [groups_target.target])
+
+
+def test_newer_group_no_sources_no_target(tmp_path):
+    """
+    Consider no sources and no target "newer".
+    """
+    assert newer_group([], str(tmp_path / 'does-not-exist'))


### PR DESCRIPTION
- **Let _show_help() use commands instead of self.commands**
- **Enforce flake8-bugbear (B) and isort (I) ruff rules**
- **Add test capturing missed expectation.**
- **Ensure a missing target is still indicated as 'sources are newer' even when there are no sources.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Style changes plus pypa/distutils#276 and pypa/distutils#284.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
