### PR TITLE
Override distribution attribute type in all distutils-based commands

### DIFF
--- a/setuptools/command/bdist_rpm.py
+++ b/setuptools/command/bdist_rpm.py
@@ -1,3 +1,4 @@
+from ..dist import Distribution
 from ..warnings import SetuptoolsDeprecationWarning
 
 import distutils.command.bdist_rpm as orig
@@ -11,6 +12,8 @@ class bdist_rpm(orig.bdist_rpm):
     2. Always run 'install' using --single-version-externally-managed to
        disable eggs in RPM distributions.
     """
+
+    distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
     def run(self):
         SetuptoolsDeprecationWarning.emit(

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from ..dist import Distribution
+
 from distutils.command.build import build as _build
 
 _ORIGINAL_SUBCOMMANDS = {"build_py", "build_clib", "build_ext", "build_scripts"}
 
 
 class build(_build):
+    distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
+
     # copy to avoid sharing the object with parent class
     sub_commands = _build.sub_commands[:]
 

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -1,3 +1,5 @@
+from ..dist import Distribution
+
 import distutils.command.build_clib as orig
 from distutils import log
 from distutils.errors import DistutilsSetupError
@@ -24,6 +26,8 @@ class build_clib(orig.build_clib):
         * cflags   - specify a list of additional flags to pass to
                      the compiler.
     """
+
+    distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
     def build_libraries(self, libraries):
         for lib_name, build_info in libraries:

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -18,7 +18,6 @@ from setuptools import Command
 from setuptools.command import bdist_egg
 from setuptools.command.sdist import sdist, walk_revctrl
 from setuptools.command.setopt import edit_config
-from setuptools.dist import Distribution
 from setuptools.glob import glob
 
 from .. import _entry_points, _normalization
@@ -522,7 +521,6 @@ class FileList(_FileList):
 
 
 class manifest_maker(sdist):
-    distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
     template = "MANIFEST.in"
 
     def initialize_options(self):

--- a/setuptools/command/register.py
+++ b/setuptools/command/register.py
@@ -1,11 +1,15 @@
 from setuptools.errors import RemovedCommandError
 
+from ..dist import Distribution
+
 import distutils.command.register as orig
 from distutils import log
 
 
 class register(orig.register):
     """Formerly used to register packages on PyPI."""
+
+    distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
     def run(self):
         msg = (


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

This was already done here and there for various commands as needed as they came up from type-checking more code. Figured I may as well go ahead and make it complete.

### Pull Request Checklist
- [x] Changes have tests (existing type-checking tests)
- [x] News fragment added in [`newsfragments/`]. (not user facing yet)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
