### PR TITLE
Type sequence checks in setuptools/dist.py

### DIFF
--- a/newsfragments/4578.bugfix.rst
+++ b/newsfragments/4578.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a `TypeError` when a ``Distribution``'s old included attribute was a `tuple` -- by :user:`Avasam`

--- a/newsfragments/4578.feature.rst
+++ b/newsfragments/4578.feature.rst
@@ -1,0 +1,1 @@
+Made errors when parsing ``Distribution`` data more explicit about the expected type (``tuple[str, ...] | list[str]``) -- by :user:`Avasam`

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -140,8 +140,7 @@ def _check_marker(marker):
 def assert_bool(dist, attr, value):
     """Verify that value is True, False, 0, or 1"""
     if bool(value) != value:
-        tmpl = "{attr!r} must be a boolean value (got {value!r})"
-        raise DistutilsSetupError(tmpl.format(attr=attr, value=value))
+        raise DistutilsSetupError(f"{attr!r} must be a boolean value (got {value!r})")
 
 
 def invalid_unless_false(dist, attr, value):
@@ -163,11 +162,11 @@ def check_requirements(dist, attr: str, value: _StrOrIter) -> None:
         if isinstance(value, (dict, set)):
             raise TypeError("Unordered types are not allowed")
     except (TypeError, ValueError) as error:
-        tmpl = (
+        msg = (
             f"{attr!r} must be a string or iterable of strings "
             f"containing valid project/version requirement specifiers; {error}"
         )
-        raise DistutilsSetupError(tmpl) from error
+        raise DistutilsSetupError(msg) from error
 
 
 def check_specifier(dist, attr, value):
@@ -175,8 +174,8 @@ def check_specifier(dist, attr, value):
     try:
         SpecifierSet(value)
     except (InvalidSpecifier, AttributeError) as error:
-        tmpl = "{attr!r} must be a string containing valid version specifiers; {error}"
-        raise DistutilsSetupError(tmpl.format(attr=attr, error=error)) from error
+        msg = f"{attr!r} must be a string containing valid version specifiers; {error}"
+        raise DistutilsSetupError(msg) from error
 
 
 def check_entry_points(dist, attr, value):

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -118,8 +118,8 @@ CHECK_PACKAGE_DATA_TESTS = (
             'hello': '*.msg',
         },
         (
-            "\"values of 'package_data' dict\" "
-            "must be a list of strings (got '*.msg')"
+            "\"values of 'package_data' dict\" must be of type <tuple[str, ...] | list[str]>"
+            " (got '*.msg')"
         ),
     ),
     # Invalid value type (generators are single use)
@@ -128,8 +128,8 @@ CHECK_PACKAGE_DATA_TESTS = (
             'hello': (x for x in "generator"),
         },
         (
-            "\"values of 'package_data' dict\" must be a list of strings "
-            "(got <generator object"
+            "\"values of 'package_data' dict\" must be of type <tuple[str, ...] | list[str]>"
+            " (got <generator object"
         ),
     ),
 )


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Split from https://github.com/pypa/setuptools/pull/4575

Fixes a `TypeError` when a ``Distribution``'s old included attribute was a `tuple`.

Note that I'm purposefully avoiding using `Iterable`, `Sequence` or `Container` because `str` matches all those. And I didn't wanna complicate the checks to allow "any iterable except str" (maybe in a future PR)


### Pull Request Checklist
- [x] Changes have tests (tests updated with new messages and dict)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
