### PR TITLE
Remove `ABCMeta` metaclass, keep `abstractmethod`s

### DIFF
--- a/newsfragments/4579.bugfix.rst
+++ b/newsfragments/4579.bugfix.rst
@@ -1,0 +1,1 @@
+Remove `abc.ABCMeta` metaclass from abstract classes. `pypa/setuptools#4503 <https://github.com/pypa/setuptools/pull/4503>`_ had an unintended consequence of causing potential ``TypeError: metaclass conflict: the metaclass of a derived class must be a (non-strict) subclass of the metaclasses of all its bases`` -- by :user:`Avasam`

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -23,7 +23,6 @@ This module is deprecated. Users are directed to :mod:`importlib.resources`,
 from __future__ import annotations
 
 import sys
-from abc import ABC
 
 if sys.version_info < (3, 8):  # noqa: UP036 # Check for unsupported versions
     raise RuntimeError("Python 3.8 or later is required")
@@ -306,7 +305,7 @@ __all__ = [
 ]
 
 
-class ResolutionError(Exception, ABC):
+class ResolutionError(Exception):
     """Abstract base for dependency resolution errors"""
 
     def __repr__(self):

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -6,7 +6,7 @@ import functools
 import os
 import re
 import sys
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import TYPE_CHECKING, TypeVar, overload
 
 sys.path.extend(((vendor_path := os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setuptools', '_vendor')) not in sys.path) * [vendor_path])  # fmt: skip
@@ -120,7 +120,7 @@ else:
     _Command = monkey.get_unpatched(distutils.core.Command)
 
 
-class Command(_Command, ABC):
+class Command(_Command):
     """
     Setuptools internal actions are organized using a *command design pattern*.
     This means that each action (or group of closely related actions) executed during

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -1,6 +1,5 @@
 import configparser
 import os
-from abc import ABC
 
 from .. import Command
 from ..unicode_utils import _cfg_read_utf8_with_fallback
@@ -70,7 +69,7 @@ def edit_config(filename, settings, dry_run=False):
             opts.write(f)
 
 
-class option_base(Command, ABC):
+class option_base(Command):
     """Abstract base class for commands that mess with config files"""
 
     user_options = [

--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -11,7 +11,6 @@ import re
 import sys
 import tempfile
 import textwrap
-from abc import ABC
 
 import pkg_resources
 from pkg_resources import working_set
@@ -263,7 +262,7 @@ def run_setup(setup_script, args):
             # Normal exit, just return
 
 
-class AbstractSandbox(ABC):
+class AbstractSandbox:
     """Wrap 'os' module and 'open()' builtin for virtualizing setup scripts"""
 
     _active = False


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4579

#4503 had an unintended consequence of causing potential metaclass subclassing strictess issues. The goal was only to give additional information for static type-checking.

### Pull Request Checklist
- [ ] Changes have tests (not sure how this would be tested in a general manner, maybe banning `ABC`/`ABCMeta` with https://docs.astral.sh/ruff/settings/#lint_flake8-tidy-imports_banned-api ? )
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
