### PR TITLE
Type all context manager dunders

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -217,10 +217,10 @@ def add_shim():
 
 
 class shim:
-    def __enter__(self):
+    def __enter__(self) -> None:
         insert_shim()
 
-    def __exit__(self, exc, value, tb):
+    def __exit__(self, exc: object, value: object, tb: object) -> None:
         _remove_shim()
 
 

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -23,6 +23,7 @@ from inspect import cleandoc
 from itertools import chain, starmap
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from types import TracebackType
 from typing import TYPE_CHECKING, Iterable, Iterator, Mapping, Protocol, TypeVar, cast
 
 from .. import Command, _normalization, _path, errors, namespaces
@@ -39,6 +40,8 @@ from .install import install as install_cls
 from .install_scripts import install_scripts as install_scripts_cls
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from .._vendor.wheel.wheelfile import WheelFile
 
 _P = TypeVar("_P", bound=StrPath)
@@ -379,9 +382,15 @@ class editable_wheel(Command):
 class EditableStrategy(Protocol):
     def __call__(self, wheel: WheelFile, files: list[str], mapping: dict[str, str]): ...
 
-    def __enter__(self): ...
+    def __enter__(self) -> Self: ...
 
-    def __exit__(self, _exc_type, _exc_value, _traceback): ...
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+        /,
+    ) -> object: ...
 
 
 class _StaticPth:
@@ -395,7 +404,7 @@ class _StaticPth:
         contents = _encode_pth(f"{entries}\n")
         wheel.writestr(f"__editable__.{self.name}.pth", contents)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         msg = f"""
         Editable install will be performed using .pth file to extend `sys.path` with:
         {list(map(os.fspath, self.path_entries))!r}
@@ -403,7 +412,13 @@ class _StaticPth:
         _logger.warning(msg + _LENIENT_WARNING)
         return self
 
-    def __exit__(self, _exc_type, _exc_value, _traceback): ...
+    def __exit__(
+        self,
+        _exc_type: object,
+        _exc_value: object,
+        _traceback: object,
+    ) -> None:
+        pass
 
 
 class _LinkTree(_StaticPth):
@@ -461,12 +476,17 @@ class _LinkTree(_StaticPth):
         for relative, src in mappings.items():
             self._create_file(relative, src, link=link_type)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         msg = "Strict editable install will be performed using a link tree.\n"
         _logger.warning(msg + _STRICT_WARNING)
         return self
 
-    def __exit__(self, _exc_type, _exc_value, _traceback):
+    def __exit__(
+        self,
+        _exc_type: object,
+        _exc_value: object,
+        _traceback: object,
+    ) -> None:
         msg = f"""\n
         Strict editable installation performed using the auxiliary directory:
             {self.auxiliary_dir}
@@ -522,12 +542,17 @@ class _TopLevelFinder:
         for file, content in self.get_implementation():
             wheel.writestr(file, content)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         msg = "Editable install will be performed using a meta path finder.\n"
         _logger.warning(msg + _LENIENT_WARNING)
         return self
 
-    def __exit__(self, _exc_type, _exc_value, _traceback):
+    def __exit__(
+        self,
+        _exc_type: object,
+        _exc_value: object,
+        _traceback: object,
+    ) -> None:
         msg = """\n
         Please be careful with folders in your working directory with the same
         name as your package as they may take precedence during imports.

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -30,7 +30,7 @@ from glob import iglob
 from importlib.machinery import ModuleSpec, all_suffixes
 from itertools import chain
 from pathlib import Path
-from types import ModuleType
+from types import ModuleType, TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, TypeVar
 
 from .._path import StrPath, same_path as _same_path
@@ -40,6 +40,8 @@ from ..warnings import SetuptoolsWarning
 from distutils.errors import DistutilsOptionError
 
 if TYPE_CHECKING:
+    from typing_extensions import Self
+
     from setuptools.dist import Distribution
 
 _K = TypeVar("_K")
@@ -385,10 +387,15 @@ class EnsurePackagesDiscovered:
             self._called = True
             self._dist.set_defaults(name=False)  # Skip name, we can still be parsing
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, _exc_type, _exc_value, _traceback):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         if self._called:
             self._dist.set_defaults.analyse_name()  # Now we can set a default name
 

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -15,6 +15,7 @@ import logging
 import os
 from contextlib import contextmanager
 from functools import partial
+from types import TracebackType
 from typing import TYPE_CHECKING, Any, Callable, Mapping
 
 from .._path import StrPath
@@ -430,7 +431,12 @@ class _EnsurePackagesDiscovered(_expand.EnsurePackagesDiscovered):
 
         return super().__enter__()
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         """When exiting the context, if values of ``packages``, ``py_modules`` and
         ``package_dir`` are missing in ``setuptools_cfg``, copy from ``dist``.
         """

--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -11,6 +11,8 @@ import re
 import sys
 import tempfile
 import textwrap
+from types import TracebackType
+from typing import TYPE_CHECKING
 
 import pkg_resources
 from pkg_resources import working_set
@@ -23,6 +25,9 @@ else:
     _os = sys.modules[os.name]
 _open = open
 
+
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 __all__ = [
     "AbstractSandbox",
@@ -118,10 +123,15 @@ class ExceptionSaver:
     later.
     """
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, type, exc, tb):
+    def __exit__(
+        self,
+        type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
         if not exc:
             return False
 
@@ -278,12 +288,17 @@ class AbstractSandbox:
         for name in self._attrs:
             setattr(os, name, getattr(source, name))
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         self._copy(self)
         builtins.open = self._open
         self._active = True
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(
+        self,
+        exc_type: object,
+        exc_value: object,
+        traceback: object,
+    ) -> None:
         self._active = False
         builtins.open = _open
         self._copy(_os)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Work towards #2345
Reduce changes in #4192 and #4504

I typed all `__enter__` and `__exit__` (didn't find any `__aenter__` or `__aexit__`)

Note here that `object` param type stands for "Unused even in subclass" and `object` return type in a protocol stands for "callable return value unused/unchecked". I can use `_typeshed.Unused` instead if that's clearer.

### Pull Request Checklist
- [x] Changes have tests (type checking)
- [x] News fragment added in [`newsfragments/`]. (not public facing yet)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
