### PR TITLE
Type str/repr dunders

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -308,7 +308,7 @@ __all__ = [
 class ResolutionError(Exception):
     """Abstract base for dependency resolution errors"""
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self.__class__.__name__ + repr(self.args)
 
 
@@ -384,7 +384,7 @@ class DistributionNotFound(ResolutionError):
     def report(self):
         return self._template.format(**locals())
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.report()
 
 
@@ -2717,7 +2717,7 @@ class EntryPoint:
         self.extras = tuple(extras)
         self.dist = dist
 
-    def __str__(self):
+    def __str__(self) -> str:
         s = "%s = %s" % (self.name, self.module_name)
         if self.attrs:
             s += ':' + '.'.join(self.attrs)
@@ -2725,7 +2725,7 @@ class EntryPoint:
             s += ' [%s]' % ','.join(self.extras)
         return s
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "EntryPoint.parse(%r)" % str(self)
 
     @overload
@@ -3149,13 +3149,13 @@ class Distribution:
             filename += '-' + self.platform
         return filename
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.location:
             return "%s (%s)" % (self, self.location)
         else:
             return str(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         try:
             version = getattr(self, 'version', None)
         except ValueError:
@@ -3500,7 +3500,7 @@ class Requirement(packaging.requirements.Requirement):
     def __hash__(self):
         return self.__hash
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "Requirement.parse(%r)" % str(self)
 
     @staticmethod

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1014,7 +1014,7 @@ class Credential:
         yield self.username
         yield self.password
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '%(username)s:%(password)s' % vars(self)
 
 

--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -509,6 +509,6 @@ class SandboxViolation(DistutilsError):
         """
     ).lstrip()
 
-    def __str__(self):
+    def __str__(self) -> str:
         cmd, args, kwargs = self.args
         return self.tmpl.format(**locals())

--- a/setuptools/tests/test_sandbox.py
+++ b/setuptools/tests/test_sandbox.py
@@ -75,7 +75,7 @@ class TestExceptionSaver:
         class CantPickleThis(Exception):
             "This Exception is unpickleable because it's not in globals"
 
-            def __repr__(self):
+            def __repr__(self) -> str:
                 return 'CantPickleThis%r' % (self.args,)
 
         with setuptools.sandbox.ExceptionSaver() as saved_exc:

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -175,7 +175,7 @@ class Record:
         self._id = id
         self._fields = kwargs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '%s(**%r)' % (self._id, self._fields)
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Work towards #2345 

I typed all `__str__` and `__repr__`

Note here that `object` param type stands for "Unused even in subclass" and `object` return type in a protocol stands for "callable return value unused/unchecked". I can use `_typeshed.Unused` instead if that's clearer.

### Pull Request Checklist
- [x] Changes have tests (type checking)
- [x] News fragment added in [`newsfragments/`]. (not public facing yet)
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
