### PR TITLE
Made `setuptools.package_index.Credential` a `NamedTuple`

### DIFF
--- a/newsfragments/4585.feature.rst
+++ b/newsfragments/4585.feature.rst
@@ -1,0 +1,1 @@
+Made ``setuptools.package_index.Credential`` a `typing.NamedTuple` -- by :user:`Avasam`

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -18,6 +18,7 @@ import urllib.parse
 import urllib.request
 from fnmatch import translate
 from functools import wraps
+from typing import NamedTuple
 
 from more_itertools import unique_everseen
 
@@ -1001,21 +1002,20 @@ def _encode_auth(auth):
     return encoded.replace('\n', '')
 
 
-class Credential:
+class Credential(NamedTuple):
     """
-    A username/password pair. Use like a namedtuple.
+    A username/password pair.
+
+    Displayed separated by `:`.
+    >>> str(Credential('username', 'password'))
+    'username:password'
     """
 
-    def __init__(self, username, password):
-        self.username = username
-        self.password = password
+    username: str
+    password: str
 
-    def __iter__(self):
-        yield self.username
-        yield self.password
-
-    def __str__(self):
-        return '%(username)s:%(password)s' % vars(self)
+    def __str__(self) -> str:
+        return f'{self.username}:{self.password}'
 
 
 class PyPIConfig(configparser.RawConfigParser):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Docstring said "like a namedtuple", but I don't see why it can't be simplified to a `NamedTuple`

Contributes to #2345 and my batches of dunder typing (this was the only untyped `__iter__` outside tests)

One potential difference is the repr:
`'<setuptools.package_index.Credential object at 0x000001D0C827AD90>'`
`Credential(username='a', password='b')`
(but `__str__` already printed the values)


### Pull Request Checklist
- [x] Changes have tests (added doctest for __str__, direct access is already tested)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
