### PR TITLE
Move static-checkers-only dependencies into their dedicated extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,14 +54,6 @@ test = [
 	# for tools/finalize.py
 	'jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"',
 	"pytest-home >= 0.5",
-	# pin mypy version so a new version doesn't suddenly cause the CI to fail,
-	# until types-setuptools is removed from typeshed.
-	# For help with static-typing issues, or mypy update, ping @Avasam 
-	"mypy==1.11.*",
-	# No Python 3.11 dependencies require tomli, but needed for type-checking since we import it directly
-	"tomli",
-	# No Python 3.12 dependencies require importlib_metadata, but needed for type-checking since we import it directly
-	"importlib_metadata",
 	"pytest-subprocess",
 
 	# workaround for pypa/setuptools#4333
@@ -134,6 +126,11 @@ type = [
 	"pytest-mypy",
 
 	# local
+
+	# pin mypy version so a new version doesn't suddenly cause the CI to fail,
+	# until types-setuptools is removed from typeshed.
+	# For help with static-typing issues, or mypy update, ping @Avasam 
+	"mypy==1.11.*",
 ]
 
 

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -202,13 +202,12 @@ def build_deps(package, sdist_file):
     "Manually" install them, since pip will not install build
     deps with `--no-build-isolation`.
     """
-    import tomli as toml
-
     # delay importing, since pytest discovery phase may hit this file from a
     # testenv without tomli
+    from setuptools.compat.py310 import tomllib
 
     archive = Archive(sdist_file)
-    info = toml.loads(_read_pyproject(archive))
+    info = tomllib.loads(_read_pyproject(archive))
     deps = info.get("build-system", {}).get("requires", [])
     deps += EXTRA_BUILD_DEPS.get(package, [])
     # Remove setuptools from requirements (and deduplicate)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

https://github.com/pypa/setuptools/commit/0588af036a2b38318c99b39a3549d587b6eb1b4b added extras specific for type-checking and "checkers" (lint+format). I think other dependencies that are only specified for these tests should also be moved there ?

### Pull Request Checklist
- [x] Changes have tests (config change only, tests should pass as-is)
- [x] News fragment added in [`newsfragments/`]. (not user facing)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
