### PR TITLE
change VERSION to __version__ in the example

### DIFF
--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -192,7 +192,7 @@ corresponding entry is required in the ``tool.setuptools.dynamic`` table
    dynamic = ["version", "readme"]
    # ...
    [tool.setuptools.dynamic]
-   version = {attr = "my_package.VERSION"}
+   version = {attr = "my_package.__version__"}
    readme = {file = ["README.rst", "USAGE.rst"]}
 
 In the ``dynamic`` table, the ``attr`` directive [#directives]_ will read an

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -280,7 +280,7 @@ not installed yet. You may also need to manually add the project directory to
    directive for ``tool.setuptools.dynamic.version``.
 
 .. [#attr] ``attr`` is meant to be used when the module attribute is statically
-   specified (e.g. as a string, list or tuple). As a rule of thumb, the
+   specified (e.g. as a string). As a rule of thumb, the
    attribute should be able to be parsed with :func:`ast.literal_eval`, and
    should not be modified or re-assigned.
 

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -192,7 +192,7 @@ corresponding entry is required in the ``tool.setuptools.dynamic`` table
    dynamic = ["version", "readme"]
    # ...
    [tool.setuptools.dynamic]
-   version = {attr = "my_package.__version__"}
+   version = {attr = "my_package.__version__"}  # any module attribute compatible with ast.literal_eval
    readme = {file = ["README.rst", "USAGE.rst"]}
 
 In the ``dynamic`` table, the ``attr`` directive [#directives]_ will read an


### PR DESCRIPTION
## Summary of changes

In the example for dynamic specifying a version from a package attribute, change `VERSION` to `__version__`.

`__version__` is the most common convention, I think it's better to have the example reflect that.

See the discussion in:

https://github.com/pypa/packaging.python.org/pull/1580

and many other discussions -- 

