### PR TITLE
Make `command.build_ext.get_ext_filename` typesafe

### DIFF
--- a/newsfragments/4592.misc.rst
+++ b/newsfragments/4592.misc.rst
@@ -1,0 +1,1 @@
+If somehow the ``EXT_SUFFIX`` configuration variable and ``SETUPTOOLS_EXT_SUFFIX`` environment variables are both missing, ``setuptools.command.build_ext.pyget_ext_filename`` will now raise an `OSError` instead of a `TypeError` -- by :user:`Avasam`


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Extracted from https://github.com/pypa/setuptools/pull/4192/ . Fixes mypy and pyright errors when `get_ext_filename` is annotated

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
