### PR TITLE
Avoid type issues with `_build_ext` being `Any`

### DIFF
--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -6,7 +6,7 @@ import sys
 from importlib.machinery import EXTENSION_SUFFIXES
 from importlib.util import cache_from_source as _compiled_file_name
 from pathlib import Path
-from typing import Iterator
+from typing import TYPE_CHECKING, Iterator
 
 from setuptools.dist import Distribution
 from setuptools.errors import BaseError
@@ -16,17 +16,19 @@ from distutils import log
 from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler, get_config_var
 
-try:
-    # Attempt to use Cython for building extensions, if available
-    from Cython.Distutils.build_ext import (  # type: ignore[import-not-found] # Cython not installed on CI tests
-        build_ext as _build_ext,
-    )
-
-    # Additionally, assert that the compiler module will load
-    # also. Ref #1229.
-    __import__('Cython.Compiler.Main')
-except ImportError:
+if TYPE_CHECKING:
+    # Cython not installed on CI tests, causing _build_ext to be `Any`
     from distutils.command.build_ext import build_ext as _build_ext
+else:
+    try:
+        # Attempt to use Cython for building extensions, if available
+        from Cython.Distutils.build_ext import build_ext as _build_ext
+
+        # Additionally, assert that the compiler module will load
+        # also. Ref #1229.
+        __import__('Cython.Compiler.Main')
+    except ImportError:
+        from distutils.command.build_ext import build_ext as _build_ext
 
 # make sure _config_vars is initialized
 get_config_var("LDSHARED")

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -183,12 +183,11 @@ class TestBuildExtInplace:
             "eggs.c": "#include missingheader.h\n",
             ".build": {"lib": {}, "tmp": {}},
         }
-        path.build(files)
+        path.build(files)  # type: ignore[arg-type] # jaraco/path#232
         extension = Extension('spam.eggs', ['eggs.c'], optional=optional)
         dist = Distribution(dict(ext_modules=[extension]))
         dist.script_name = 'setup.py'
         cmd = build_ext(dist)
-        # TODO: False-positive [attr-defined], raise upstream
         vars(cmd).update(build_lib=".build/lib", build_temp=".build/tmp", **opts)
         cmd.ensure_finalized()
         return cmd


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

When `Cython.Distutils.build_ext` is not installed, `_build_ext` is `Any` which trickles down issues. Like being an invalid type to subclass, missing attributes, always matching the first overload, etc.

### Pull Request Checklist
- [x] Changes have tests (static type tests)
- [x] News fragment added in [`newsfragments/`]. (not user facing yet)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
