### PR TITLE
Remove `.tox` directory from setuptools own sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,3 +19,4 @@ include tox.ini
 include setuptools/tests/config/setupcfg_examples.txt
 include setuptools/config/*.schema.json
 global-exclude *.py[cod] __pycache__
+prune .tox

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -907,3 +907,12 @@ def run_sdist(monkeypatch, project):
     archive = next((project / "dist").glob("*.tar.gz"))
     with tarfile.open(str(archive)) as tar:
         return set(tar.getnames())
+
+
+def test_sanity_check_setuptools_own_sdist(setuptools_sdist):
+    with tarfile.open(setuptools_sdist) as tar:
+        files = tar.getnames()
+
+    # setuptools sdist should not include the .tox folder
+    tox_files = [name for name in files if ".tox" in name]
+    assert len(tox_files) == 0


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This solves the problem without changing the behaviour of setuptools itself, so it is a non controversial PR. I will submit a follow up PR with a more generic strategy that will prune the directory for everyone, not only setuptools.

Closes #4601

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
