### PR TITLE
Exclude top-level `.tox|.nox|.venv` from sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,4 +19,3 @@ include tox.ini
 include setuptools/tests/config/setupcfg_examples.txt
 include setuptools/config/*.schema.json
 global-exclude *.py[cod] __pycache__
-prune .tox

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -606,16 +606,6 @@ class manifest_maker(sdist):
             log.debug("adding file referenced by config '%s'", rf)
         self.filelist.extend(referenced)
 
-    def prune_file_list(self):
-        build = self.get_finalized_command('build')
-        base_dir = self.distribution.get_fullname()
-        self.filelist.prune(build.build_base)
-        self.filelist.prune(base_dir)
-        sep = re.escape(os.sep)
-        self.filelist.exclude_pattern(
-            r'(^|' + sep + r')(RCS|CVS|\.svn)' + sep, is_regex=True
-        )
-
     def _safe_data_files(self, build_py):
         """
         The parent class implementation of this method

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import os
+import re
 from itertools import chain
 
 from .._importlib import metadata
@@ -155,6 +156,12 @@ class sdist(orig.sdist):
             super()._add_defaults_data_files()
         except TypeError:
             log.warn("data_files contains unexpected objects")
+
+    def prune_file_list(self):
+        super().prune_file_list()
+        # Prevent accidental inclusion of test-related cache dirs at the project root
+        sep = re.escape(os.sep)
+        self.filelist.exclude_pattern(r"^(\.tox|\.nox|\.venv)" + sep, is_regex=True)
 
     def check_readme(self):
         for f in self.READMES:

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -458,7 +458,7 @@ class TestSdistTest:
 
         cmd = self.setup_with_extension()
         self.assert_package_data_in_manifest(cmd)
-        manifest = cmd.filelist.files
+        manifest = {f.replace(os.sep, '/') for f in cmd.filelist.files}
         for path in excluded:
             assert os.path.exists(path)
             assert path not in manifest, (path, manifest)

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -429,12 +429,19 @@ class TestSdistTest:
     def test_exclude_dev_only_cache_folders(self, source_dir):
         included = {
             # Emulate problem in https://github.com/pypa/setuptools/issues/4601
-            "MANIFEST.in": "global-include LICEN[CS]E* COPYING* NOTICE* AUTHORS*",
+            "MANIFEST.in": (
+                "global-include LICEN[CS]E* COPYING* NOTICE* AUTHORS*\n"
+                "global-include *.txt\n"
+            ),
             # For the sake of being conservative and limiting unforeseen side-effects
-            # we just exclude dev-only cache folders at the root of the repository
+            # we just exclude dev-only cache folders at the root of the repository:
             "test/.venv/lib/python3.9/site-packages/bar-2.dist-info/AUTHORS.rst": "",
             "src/.nox/py/lib/python3.12/site-packages/bar-2.dist-info/COPYING.txt": "",
             "doc/.tox/default/lib/python3.11/site-packages/foo-4.dist-info/LICENSE": "",
+            # Let's test against false positives with similarly named files:
+            ".venv-requirements.txt": "",
+            ".tox-coveragerc.txt": "",
+            ".noxy/coveragerc.txt": "",
         }
 
         excluded = {
@@ -454,10 +461,10 @@ class TestSdistTest:
         manifest = cmd.filelist.files
         for path in excluded:
             assert os.path.exists(path)
-            assert path not in manifest
+            assert path not in manifest, (path, manifest)
         for path in included:
             assert os.path.exists(path)
-            assert path in manifest
+            assert path in manifest, (path, manifest)
 
     @fail_on_ascii
     def test_manifest_is_written_with_utf8_encoding(self):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This is a follow up on #4602: instead of doing an ad-hoc exclusion rule for setuptools' own `MANIFEST.in`, this PR proposes to always ["prune"](https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#using-manifest-in) the `.tox`, `.nox` and `.venv` top-level directories.

This is done by extending the `sdist.prune_file_list` method from distutils using the same technique that the original method already uses to exclude directories like `.git` or `.svn`.

I am only excluding top-level `.tox|.nox|.venv` directories to be conservative and minimise Hyrum's law [unexpected consequences](https://xkcd.com/1172/).

This PR also removes the custom implementation on `setuptools.command.egg_info:manifest_maker.prune_file_list` and instead let the class just access the  parent's class implementation via inheritance:
  - By comparing the [removed lines](https://github.com/pypa/setuptools/blob/v73.0.1/setuptools/command/egg_info.py#L609-L617) with the [distutils' implementation](https://github.com/pypa/setuptools/blob/v73.0.1/setuptools//_distutils/command/sdist.py#L391-L404), I can see that manifest_maker is basically re-implementing the functionality.
  - I double checked that the implementation is present in [CPython 3.8](https://github.com/python/cpython/blob/v3.8.0/Lib/distutils/command/sdist.py#L353-L375), so `SETUPTOOLS_USE_DISTUTILS=stdlib` should not affect this particular aspect.

Finally, it is important to notice that once the implementation of `sdist` prunes these directories, the user cannot add them back via `MANIFEST.in`. But I think that is OK.

I did a [quick search on Github](https://github.com/search?q=path%3AMANIFEST.in+%2F%5C.venv%7C%5C.tox%7C%5C.nox%2F&type=code&p=5), and it seems that most of the users are trying to exclude the directories (on a quick/not-thorough inspection I did not see anyone intentionally including them).

<!-- Summary goes here -->

Closes #4601

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
