### PR TITLE
Allow user to skip validation of `pyproject.toml` via env var

### DIFF
--- a/newsfragments/4611.feature.rst
+++ b/newsfragments/4611.feature.rst
@@ -1,0 +1,7 @@
+Added support for the environment variable
+``SETUPTOOLS_DANGEROUSLY_SKIP_PYPROJECT_VALIDATION=true``, allowing users to bypass
+the validation of ``pyproject.toml``.
+This option should be used only as a last resort when resolving dependency
+issues, as it may lead to improper functioning.
+Users who enable this setting are responsible for ensuring that ``pyproject.toml``
+complies with setuptools requirements.

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -41,6 +41,19 @@ def load_file(filepath: StrPath) -> dict:
 
 
 def validate(config: dict, filepath: StrPath) -> bool:
+    skip = os.getenv("SETUPTOOLS_DANGEROUSLY_SKIP_PYPROJECT_VALIDATION", "false")
+    if skip.lower() == "true":  # https://github.com/pypa/setuptools/issues/4459
+        SetuptoolsWarning.emit(
+            "Skipping the validation of `pyproject.toml`.",
+            """
+            Please note that some setuptools functionalities rely on the validation of
+            `pyproject.toml` against misconfiguration to ensure proper operation.
+            By skipping the automatic checks, you taking responsibility for making sure
+            the file is valid. Otherwise unexpected behaviours may occur.
+            """,
+        )
+        return True
+
     from . import _validate_pyproject as validator
 
     trove_classifier = validator.FORMAT_FUNCTIONS.get("trove-classifier")

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -17,6 +17,7 @@ from setuptools.config.pyprojecttoml import (
 )
 from setuptools.dist import Distribution
 from setuptools.errors import OptionError
+from setuptools.warnings import SetuptoolsWarning
 
 import distutils.core
 
@@ -394,3 +395,9 @@ def test_warn_tools_typo(tmp_path):
 
     with pytest.warns(_ToolsTypoInMetadata):
         read_configuration(pyproject)
+
+
+def test_warn_skipping_validation(monkeypatch):
+    monkeypatch.setenv("SETUPTOOLS_DANGEROUSLY_SKIP_PYPROJECT_VALIDATION", "true")
+    with pytest.warns(SetuptoolsWarning, match="Skipping the validation"):
+        assert validate({"completely-wrong": "data"}, "pyproject.toml") is True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4459 using the approach mentioned in https://github.com/pypa/setuptools/issues/4459#issuecomment-2269491725.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
