### PR TITLE
Fix TypeError in VCRuntimeRedist

### DIFF
--- a/newsfragments/1902.bugfix.rst
+++ b/newsfragments/1902.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed TypeError in ``msvc.EnvironmentInfo.return_env`` when no runtime redistributables are installed.

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -1375,14 +1375,11 @@ class EnvironmentInfo:
         return [self.si.FSharpInstallDir]
 
     @property
-    def VCRuntimeRedist(self):
+    def VCRuntimeRedist(self) -> str | None:
         """
         Microsoft Visual C++ runtime redistributable dll.
 
-        Return
-        ------
-        str
-            path
+        Returns the first suitable path found or None.
         """
         vcruntime = 'vcruntime%d0.dll' % self.vc_ver
         arch_subdir = self.pi.target_dir(x64=True).strip('\\')

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -1469,7 +1469,7 @@ class EnvironmentInfo:
                 exists,
             ),
         )
-        if self.vs_ver >= 14 and isfile(self.VCRuntimeRedist):
+        if self.vs_ver >= 14 and self.VCRuntimeRedist:
             env['py_vcruntime_redist'] = self.VCRuntimeRedist
         return env
 

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -1406,11 +1406,11 @@ class EnvironmentInfo:
         )
 
         # vcruntime path
-        for prefix, crt_dir in itertools.product(prefixes, crt_dirs):
-            path = join(prefix, arch_subdir, crt_dir, vcruntime)
-            if isfile(path):
-                return path
-        return None
+        candidate_paths = (
+            join(prefix, arch_subdir, crt_dir, vcruntime)
+            for (prefix, crt_dir) in itertools.product(prefixes, crt_dirs)
+        )
+        return next(filter(isfile, candidate_paths), None)
 
     def return_env(self, exists=True):
         """


### PR DESCRIPTION
- **Prefer generator expression in VCRuntimeRedist**
- **In return_env, avoid checking `isfile`.**
- **Add type annotation for VCRuntimeRedist and update the docstring to reflect the behavior.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
