### PR TITLE
Restore support for pathlib paths in build_base

### DIFF
--- a/newsfragments/4615.bugfix.rst
+++ b/newsfragments/4615.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed TypeError in sdist filelist processing by adding support for pathlib Paths for the build_base.

--- a/setuptools/_distutils/_msvccompiler.py
+++ b/setuptools/_distutils/_msvccompiler.py
@@ -159,7 +159,7 @@ def _get_vc_env(plat_spec):
             stderr=subprocess.STDOUT,
         ).decode('utf-16le', errors='replace')
     except subprocess.CalledProcessError as exc:
-        log.error(exc.output)
+        log.error(exc.output)  # noqa: RUF100, TRY400
         raise DistutilsPlatformError(f"Error executing {exc.cmd}")
 
     env = {

--- a/setuptools/_distutils/command/sdist.py
+++ b/setuptools/_distutils/command/sdist.py
@@ -391,7 +391,7 @@ class sdist(Command):
         build = self.get_finalized_command('build')
         base_dir = self.distribution.get_fullname()
 
-        self.filelist.exclude_pattern(None, prefix=build.build_base)
+        self.filelist.exclude_pattern(None, prefix=os.fspath(build.build_base))
         self.filelist.exclude_pattern(None, prefix=base_dir)
 
         if sys.platform == 'win32':

--- a/setuptools/_distutils/tests/test_msvccompiler.py
+++ b/setuptools/_distutils/tests/test_msvccompiler.py
@@ -14,22 +14,19 @@ needs_winreg = pytest.mark.skipif('not hasattr(_msvccompiler, "winreg")')
 
 
 class Testmsvccompiler(support.TempdirManager):
-    def test_no_compiler(self):
+    def test_no_compiler(self, monkeypatch):
         # makes sure query_vcvarsall raises
         # a DistutilsPlatformError if the compiler
         # is not found
         def _find_vcvarsall(plat_spec):
             return None, None
 
-        old_find_vcvarsall = _msvccompiler._find_vcvarsall
-        _msvccompiler._find_vcvarsall = _find_vcvarsall
-        try:
-            with pytest.raises(DistutilsPlatformError):
-                _msvccompiler._get_vc_env(
-                    'wont find this version',
-                )
-        finally:
-            _msvccompiler._find_vcvarsall = old_find_vcvarsall
+        monkeypatch.setattr(_msvccompiler, '_find_vcvarsall', _find_vcvarsall)
+
+        with pytest.raises(DistutilsPlatformError):
+            _msvccompiler._get_vc_env(
+                'wont find this version',
+            )
 
     @needs_winreg
     def test_get_vc_env_unicode(self):

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -4,6 +4,7 @@ import contextlib
 import io
 import logging
 import os
+import pathlib
 import sys
 import tarfile
 import tempfile
@@ -821,6 +822,21 @@ class TestSdistTest:
             cmd.run()
         manifest = cmd.filelist.files
         assert '.myfile~' in manifest
+
+    @pytest.mark.xfail(reason="4615")
+    def test_build_base_pathlib(self, source_dir):
+        """
+        Ensure if build_base is a pathlib.Path, the build still succeeds.
+        """
+        dist = Distribution({
+            **SETUP_ATTRS,
+            "script_name": "setup.py",
+            "options": {"build": {"build_base": pathlib.Path('build')}},
+        })
+        cmd = sdist(dist)
+        cmd.ensure_finalized()
+        with quiet():
+            cmd.run()
 
 
 def test_default_revctrl():

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -823,7 +823,6 @@ class TestSdistTest:
         manifest = cmd.filelist.files
         assert '.myfile~' in manifest
 
-    @pytest.mark.xfail(reason="4615")
     def test_build_base_pathlib(self, source_dir):
         """
         Ensure if build_base is a pathlib.Path, the build still succeeds.

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -823,6 +823,7 @@ class TestSdistTest:
         manifest = cmd.filelist.files
         assert '.myfile~' in manifest
 
+    @pytest.mark.skipif("os.environ.get('SETUPTOOLS_USE_DISTUTILS') == 'stdlib'")
     def test_build_base_pathlib(self, source_dir):
         """
         Ensure if build_base is a pathlib.Path, the build still succeeds.


### PR DESCRIPTION
- **In sdist.prune_file_list, support build.build_base as a pathlib.Path.**
- **Add test capturing missed expectation.**
- **Enable the test**
- **Add news fragment.**

Merges incidental changes in distutils:

- **Use monkeypatch to monkeypatch.**
- **Disable TRY400 so it doesn't cause problems in other branches. Disable RUF100 to prevent it from failing in this branch. Ref pypa/distutils#292**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4615

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
