### PR TITLE
Bump jaraco.test to py.typed version 5.5 in test extra

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -41,15 +41,18 @@ disable_error_code = import-not-found
 #     - support for `SETUPTOOLS_USE_DISTUTILS=stdlib` is dropped (#3625)
 #       for setuptools to import `_distutils` directly
 #     - or non-stdlib distutils typings are exposed
+[mypy-distutils.*]
+ignore_missing_imports = True
+#  - wheel: does not intend on exposing a programmatic API https://github.com/pypa/wheel/pull/610#issuecomment-2081687671
+[mypy-wheel.*]
+ignore_missing_imports = True
 # - The following are not marked as py.typed:
 #  - jaraco.develop: https://github.com/jaraco/jaraco.develop/issues/22
 #  - jaraco.envs: https://github.com/jaraco/jaraco.envs/issues/7
 #  - jaraco.packaging: https://github.com/jaraco/jaraco.packaging/issues/20
 #  - jaraco.path: https://github.com/jaraco/jaraco.path/issues/2
-#  - jaraco.test: https://github.com/jaraco/jaraco.test/issues/7
 #  - jaraco.text: https://github.com/jaraco/jaraco.text/issues/17
-#  - wheel: does not intend on exposing a programmatic API https://github.com/pypa/wheel/pull/610#issuecomment-2081687671
-[mypy-distutils.*,jaraco.develop,jaraco.envs,jaraco.packaging.*,jaraco.path,jaraco.test.*,jaraco.text,wheel.*]
+[mypy-jaraco.develop,jaraco.envs,jaraco.packaging.*,jaraco.path,jaraco.text]
 ignore_missing_imports = True
 
 # Even when excluding a module, import issues can show up due to following import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ test = [
 	# workaround for pypa/setuptools#4333
 	"pyproject-hooks!=1.1",
 
-	"jaraco.test",
+	"jaraco.test>=5.5", # py.typed
 ]
 
 doc = [


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Works towards #2345
I split out wheel and distutils sections in mypy config since those are not actionable.

### Pull Request Checklist
- [ ] Changes have tests (merge https://github.com/pypa/setuptools/pull/4604 to re-enable tests)
- [ ] News fragment added in [`newsfragments/`]. (not public facing)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
