### PR TITLE
Omit ruff config from wheel distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,4 +19,3 @@ include tox.ini
 include setuptools/tests/config/setupcfg_examples.txt
 include setuptools/config/*.schema.json
 global-exclude *.py[cod] __pycache__
-global-exclude ruff.toml

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,3 +19,4 @@ include tox.ini
 include setuptools/tests/config/setupcfg_examples.txt
 include setuptools/config/*.schema.json
 global-exclude *.py[cod] __pycache__
+global-exclude ruff.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ exclude = [
 namespaces = true
 
 [tool.setuptools.exclude-package-data]
+# Remove ruff.toml when installing vendored packages (#4652)
 "*" = ["ruff.toml"]
 
 [tool.distutils.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,9 @@ exclude = [
 ]
 namespaces = true
 
+[tool.setuptools.exclude-package-data]
+"*" = ["ruff.toml"]
+
 [tool.distutils.sdist]
 formats = "zip"
 


### PR DESCRIPTION
https://github.com/pypa/setuptools/blob/main/setuptools/_vendor/ruff.toml is currently being included in wheels, which is probably unintended since it's only relevant to maintainers.