### PR TITLE
Remove trailing / from `interspinx_mapping` to avoid verbose logs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -191,7 +191,7 @@ nitpick_ignore += [
 # Allow linking objects on other Sphinx sites seamlessly:
 intersphinx_mapping.update(
     # python=('https://docs.python.org/3', None),
-    python=('https://docs.python.org/3.11/', None),
+    python=('https://docs.python.org/3.11', None),
     # ^-- Python 3.11 is required because it still contains `distutils`.
     #     Just leaving it as `3` would imply 3.12+, but that causes an
     #     error with the cross references to distutils functions.
@@ -237,9 +237,9 @@ favicons = [
 intersphinx_mapping.update({
     'pip': ('https://pip.pypa.io/en/latest', None),
     'build': ('https://build.pypa.io/en/latest', None),
-    'PyPUG': ('https://packaging.python.org/en/latest/', None),
-    'packaging': ('https://packaging.pypa.io/en/latest/', None),
-    'twine': ('https://twine.readthedocs.io/en/stable/', None),
+    'PyPUG': ('https://packaging.python.org/en/latest', None),
+    'packaging': ('https://packaging.pypa.io/en/latest', None),
+    'twine': ('https://twine.readthedocs.io/en/stable', None),
     'importlib-resources': (
         'https://importlib-resources.readthedocs.io/en/latest',
         None,


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

As per https://github.com/pypa/setuptools/pull/4643#issuecomment-2359893642, it seems that `sphinx` simply append a `/` even if it already exists when creating intersphinx links, and that result in some redirection notifications when building the docs.

This PR removes the trailing `/`, so that these verbose notifications are no longer present.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
