### PR TITLE
Avoid adding an empty/incomplete `.egg-info` to `sys.path` while traversing `importlib.metadata.entry_points`

### DIFF
--- a/setuptools/_shutil.py
+++ b/setuptools/_shutil.py
@@ -39,3 +39,8 @@ def _auto_chmod(func: Callable[..., _T], arg: str, exc: BaseException) -> _T:
 
 def rmtree(path, ignore_errors=False, onexc=_auto_chmod):
     return py311.shutil_rmtree(path, ignore_errors, onexc)
+
+
+def rmdir(path, **opts):
+    if os.path.isdir(path):
+        rmtree(path, **opts)

--- a/setuptools/_shutil.py
+++ b/setuptools/_shutil.py
@@ -1,0 +1,41 @@
+"""Convenience layer on top of stdlib's shutil and os"""
+
+import os
+import stat
+from typing import Callable, TypeVar
+
+from .compat import py311
+
+from distutils import log
+
+try:
+    from os import chmod
+except ImportError:
+    # Jython compatibility
+    def chmod(*args: object, **kwargs: object) -> None:  # type: ignore[misc] # Mypy reuses the imported definition anyway
+        pass
+
+
+_T = TypeVar("_T")
+
+
+def attempt_chmod_verbose(path, mode):
+    log.debug("changing mode of %s to %o", path, mode)
+    try:
+        chmod(path, mode)
+    except OSError as e:
+        log.debug("chmod failed: %s", e)
+
+
+# Must match shutil._OnExcCallback
+def _auto_chmod(func: Callable[..., _T], arg: str, exc: BaseException) -> _T:
+    """shutils onexc callback to automatically call chmod for certain functions."""
+    # Only retry for scenarios known to have an issue
+    if func in [os.unlink, os.remove] and os.name == 'nt':
+        attempt_chmod_verbose(arg, stat.S_IWRITE)
+        return func(arg)
+    raise exc
+
+
+def rmtree(path, ignore_errors=False, onexc=_auto_chmod):
+    return py311.shutil_rmtree(path, ignore_errors, onexc)

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import cast
 
 from .. import _normalization
+from .._shutil import rmdir as _rm
 from .egg_info import egg_info as egg_info_cls
 
 from distutils import log
@@ -100,8 +101,3 @@ class dist_info(Command):
         # TODO: if bdist_wheel if merged into setuptools, just add "keep_egg_info" there
         with self._maybe_bkp_dir(egg_info_dir, self.keep_egg_info):
             bdist_wheel.egg2dist(egg_info_dir, self.dist_info_dir)
-
-
-def _rm(dir_name, **opts):
-    if os.path.isdir(dir_name):
-        shutil.rmtree(dir_name, **opts)

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -318,8 +318,7 @@ class egg_info(InfoCommon, Command):
             try:
                 # Unfortunately os.replace does not work for existing destination dirs,
                 # so we cannot have a single atomic operation
-                if os.path.isdir(self.egg_info):
-                    _shutil.rmtree(self.egg_info)
+                _shutil.rmdir(self.egg_info)
                 os.replace(staging, self.egg_info)
                 log.info(f"renaming {staging!r} to {self.egg_info!r}")
             except OSError as e:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

Related to the discussion in pypa/pyproject-hooks#206 (specifically https://github.com/pypa/pyproject-hooks/issues/206#issuecomment-2396492843).

## Summary of changes

- Approach generate the whole directory first in a staging area before moving it to the final location.

- 2220d40199352a5999a7ed0bd899f284d9ed27c9 and aa7e04f12a4fc7e193770d0f7130cfa105363356 are refactorings.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
