### PR TITLE
Fix issue with absolute path with Python 3.13 on Windows

### DIFF
--- a/newsfragments/4669.bugfix.rst
+++ b/newsfragments/4669.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue with Python 3.13 on Windows where specifying the absolute path to an extension module source file would cause the build files to be written to the directory containing the source file.

--- a/setuptools/_distutils/ccompiler.py
+++ b/setuptools/_distutils/ccompiler.py
@@ -989,7 +989,8 @@ int main (int argc, char **argv) {{
         # Chop off the drive
         no_drive = os.path.splitdrive(base)[1]
         # If abs, chop off leading /
-        return no_drive[os.path.isabs(no_drive) :]
+        is_abs = os.path.isabs(no_drive) or sys.platform == 'win32' and (no_drive.startswith('/') or no_drive.startswith('\\'))
+        return no_drive[is_abs:]
 
     def shared_object_filename(self, basename, strip_dir=False, output_dir=''):
         assert output_dir is not None


### PR DESCRIPTION
Fix #4669

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix an issue with Python 3.13 on Windows where specifying the absolute path to an extension module source file would cause the build files to be written to the directory containing the source file.

Closes #4669

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

I tested this change manually by using the `setup.py` and `simpleext.c` files in the bug report and executing `py -3.13 setup.py build_ext`. Before this change, the build files were written to the directory containing these files. After this change, the build files were instead written to `build/temp.win-amd64-cpython-313`. I am not sure whether there is an easy way to add an automated test for this.

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
