### PR TITLE
Avoid iterating over entry-points while an empty `.egg-info` exists in `sys.path`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           rm -rf dist
           # workaround for pypa/setuptools#4333
-          pipx run --pip-args 'pyproject-hooks<1.1' build
+          pipx run --pip-args 'pyproject-hooks!=1.1' build
           echo "PRE_BUILT_SETUPTOOLS_SDIST=$(ls dist/*.tar.gz)" >> $GITHUB_ENV
           echo "PRE_BUILT_SETUPTOOLS_WHEEL=$(ls dist/*.whl)" >> $GITHUB_ENV
           rm -rf setuptools.egg-info  # Avoid interfering with the other tests

--- a/newsfragments/4680.bugfix.rst
+++ b/newsfragments/4680.bugfix.rst
@@ -1,0 +1,4 @@
+Changed ``egg_info`` command to avoid adding an empty ``.egg-info`` while
+iterating over entry-points is available in ``sys.path``.
+This avoids triggering integration problems with ``importlib.metadata``/``importlib_metadata``
+(reference: pypa/pyproject-hooks#206).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
 	"pytest-subprocess",
 
 	# workaround for pypa/pyproject-hooks#206
-	"pyproject-hooks<1.1",  # TODO: fix problem with egg-info, see #4670
+	"pyproject-hooks!=1.1",
 
 	"jaraco.test",
 ]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Alternative to https://github.com/pypa/setuptools/pull/4670

This is a much more minimal and surgical change than the originally proposed in #4670, so less controversial (which hopefully minimises the risks in merging it).

Note however that without the other changes in #4670, setuptools will keep to "temporarily" add empty `.egg-info` directories in `sys.path`... What this PR does is to simply avoid iterating over entry-points while the directory is empty.

Closes #4670

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
