### PR TITLE
Workaround for `bdist_wheel.dist_info_dir` problems

### DIFF
--- a/newsfragments/4684.bugfix.rst
+++ b/newsfragments/4684.bugfix.rst
@@ -1,0 +1,2 @@
+Add workaround for ``bdist_wheel --dist-info-dir`` errors
+when customisation does not inherit from setuptools.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -417,17 +417,27 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         config_settings: _ConfigSettings = None,
         metadata_directory: StrPath | None = None,
     ):
-        cmd = ['bdist_wheel']
-        if metadata_directory:
-            cmd.extend(['--dist-info-dir', metadata_directory])
-        with suppress_known_deprecation():
-            return self._build_with_temp_dir(
-                cmd,
-                '.whl',
-                wheel_directory,
-                config_settings,
-                self._arbitrary_args(config_settings),
-            )
+        def _build(cmd: list[str]):
+            with suppress_known_deprecation():
+                return self._build_with_temp_dir(
+                    cmd,
+                    '.whl',
+                    wheel_directory,
+                    config_settings,
+                    self._arbitrary_args(config_settings),
+                )
+
+        if metadata_directory is None:
+            return _build(['bdist_wheel'])
+
+        try:
+            return _build(['bdist_wheel', '--dist-info-dir', metadata_directory])
+        except SystemExit as ex:
+            # pypa/setuptools#4683
+            if "--dist-info-dir" not in str(ex):
+                raise
+            _IncompatibleBdistWheel.emit()
+            return _build(['bdist_wheel'])
 
     def build_sdist(
         self, sdist_directory: StrPath, config_settings: _ConfigSettings = None
@@ -512,6 +522,17 @@ class _BuildMetaLegacyBackend(_BuildMetaBackend):
             # within the hook after run_setup is called.
             sys.path[:] = sys_path
             sys.argv[0] = sys_argv_0
+
+
+class _IncompatibleBdistWheel(SetuptoolsDeprecationWarning):
+    _SUMMARY = "wheel.bdist_wheel is deprecated, please import it from setuptools"
+    _DETAILS = """
+    Ensure that any custom bdist_wheel implementation is a subclass of
+    setuptools.command.bdist_wheel.bdist_wheel.
+    """
+    _DUE_DATE = (2025, 10, 15)
+    # Initially introduced in 2024/10/15, but maybe too disruptive to be enforced?
+    _SEE_URL = "https://github.com/pypa/wheel/pull/631"
 
 
 # The primary backend

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -432,7 +432,7 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
 
         try:
             return _build(['bdist_wheel', '--dist-info-dir', metadata_directory])
-        except SystemExit as ex:
+        except SystemExit as ex:  # pragma: nocover
             # pypa/setuptools#4683
             if "--dist-info-dir" not in str(ex):
                 raise

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -434,7 +434,7 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
             return _build(['bdist_wheel', '--dist-info-dir', metadata_directory])
         except SystemExit as ex:  # pragma: nocover
             # pypa/setuptools#4683
-            if "--dist-info-dir" not in str(ex):
+            if "--dist-info-dir not recognized" not in str(ex):
                 raise
             _IncompatibleBdistWheel.emit()
             return _build(['bdist_wheel'])


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This is a workaround identified in https://github.com/pypa/setuptools/pull/4647#issuecomment-2395672359

We should be able to see the integration tests failing or passing for PyYAML in https://github.com/pypa/setuptools/actions/runs/11353165220

Closes #4683 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
