### PR TITLE
Fix "residual" invalid dynamic behaviour of `optional-dependencies`

### DIFF
--- a/newsfragments/4696.bugfix.rst
+++ b/newsfragments/4696.bugfix.rst
@@ -1,0 +1,4 @@
+Fix clashes for ``optional-dependencies`` in ``pyproject.toml`` and
+``extra_requires`` in ``setup.cfg/setup.py``.
+As per PEP 621, ``optional-dependencies`` has to be honoured and dynamic
+behaviour is not allowed.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -217,8 +217,10 @@ def _dependencies(dist: Distribution, val: list, _root_dir):
 
 
 def _optional_dependencies(dist: Distribution, val: dict, _root_dir):
-    existing = getattr(dist, "extras_require", None) or {}
-    dist.extras_require = {**existing, **val}
+    if getattr(dist, "extras_require", None):
+        msg = "`extras_require` overwritten in `pyproject.toml` (optional-dependencies)"
+        SetuptoolsWarning.emit(msg)
+    dist.extras_require = val
 
 
 def _ext_modules(dist: Distribution, val: list[dict]) -> list[Extension]:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This is reminiscent of https://github.com/pypa/setuptools/pull/3306.
It is another situation where PEP 621 does not allow mixing dynamic and static configurations.

Without explicitly listing `optional-dependencies` in `dynamic` users cannot rely on `setup.py` to specify `extras_require` -- in turn, when `optional-dependencies` *is present* in `dynamic`, then it cannot be listed as an static configuration.

Therefore, the only valid situation according to PEP 621, is that static `optional-dependencies` are honoured exactly as provided, without modifications (this means ignoring any `extras_require` previously set)..

<!-- Summary goes here -->

Closes https://github.com/pypa/setuptools/issues/3300

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
