### PR TITLE
Add fake __getattribute__ to AbstractSandbox to let type-checkers know it has a bunch of dynamic methods

### DIFF
--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import textwrap
 from types import TracebackType
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 import pkg_resources
 from pkg_resources import working_set
@@ -405,6 +405,11 @@ class AbstractSandbox:
             self._remap_input(operation + '-from', src, *args, **kw),
             self._remap_input(operation + '-to', dst, *args, **kw),
         )
+
+    if TYPE_CHECKING:
+        # This is a catch-all for all the dynamically created attributes.
+        # This isn't public API anyway
+        def __getattribute__(self, name: str) -> Any: ...
 
 
 if hasattr(os, 'devnull'):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Follow-up to #4504, works towards #2345

Given that `AbstractSandbox` isn't even public API (afaik) and that the methods are created based on os availability, I figured simply marking it as "having dynamically created methods" was cleaner than trying to duplicate all the methods in a `TYPE_CHECKING` block like https://github.com/python/typeshed/pull/10058/files#diff-f3cbc40d076f82bceeedca2749a2d93fbb40a03e1bb4bc837de6e990823e381fR29-R56 (typeshed doesn't have any of these methods typed anyway)

This trades false-positives if trying to call one of these methods directly, for false-negatives if you try to call an `AbstractSandox` method that doesn't exist.

### Pull Request Checklist
- [x] Changes have tests (this reduces potential false-positives in type-checking tests)
- [x] News fragment added in [`newsfragments/`]. (this shouldn't affect runtime in any way)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
