### PR TITLE
pkg_resources ANN2 autofixes for fully untyped functions

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -172,7 +172,7 @@ def _sget_dict(val):
     return val.copy()
 
 
-def _sset_dict(key, ob, state):
+def _sset_dict(key, ob, state) -> None:
     ob.clear()
     ob.update(state)
 
@@ -181,7 +181,7 @@ def _sget_object(val):
     return val.__getstate__()
 
 
-def _sset_object(key, ob, state):
+def _sset_object(key, ob, state) -> None:
     ob.__setstate__(state)
 
 
@@ -1090,7 +1090,7 @@ class WorkingSet:
         for dist in self:
             callback(dist)
 
-    def _added_new(self, dist):
+    def _added_new(self, dist) -> None:
         for callback in self.callbacks:
             callback(dist)
 
@@ -1463,7 +1463,7 @@ class ResourceManager:
         return target_path
 
     @staticmethod
-    def _warn_unsafe_extraction_path(path):
+    def _warn_unsafe_extraction_path(path) -> None:
         """
         If the default extraction path is overridden and set to an insecure
         location, such as /tmp, it opens up an opportunity for an attacker to
@@ -1577,7 +1577,7 @@ def safe_version(version: str) -> str:
         return re.sub('[^A-Za-z0-9.]+', '-', version)
 
 
-def _forgiving_version(version):
+def _forgiving_version(version) -> str:
     """Fallback when ``safe_version`` is not safe enough
     >>> parse_version(_forgiving_version('0.23ubuntu1'))
     <Version('0.23.dev0+sanitized.ubuntu1')>
@@ -1779,7 +1779,7 @@ class NullProvider:
         return base
 
     @staticmethod
-    def _validate_resource_path(path):
+    def _validate_resource_path(path) -> None:
         """
         Validate the resource paths according to the docs.
         https://setuptools.pypa.io/en/latest/pkg_resources.html#basic-resource-access
@@ -1890,7 +1890,7 @@ class EggProvider(NullProvider):
         egg = next(eggs, None)
         egg and self._set_egg(egg)
 
-    def _set_egg(self, path: str):
+    def _set_egg(self, path: str) -> None:
         self.egg_name = os.path.basename(path)
         self.egg_info = os.path.join(path, 'EGG-INFO')
         self.egg_root = path
@@ -1918,7 +1918,7 @@ class DefaultProvider(EggProvider):
             return stream.read()
 
     @classmethod
-    def _register(cls):
+    def _register(cls) -> None:
         loader_names = (
             'SourceFileLoader',
             'SourcelessFileLoader',
@@ -2208,7 +2208,7 @@ class FileMetadata(EmptyProvider):
         self._warn_on_replacement(metadata)
         return metadata
 
-    def _warn_on_replacement(self, metadata):
+    def _warn_on_replacement(self, metadata) -> None:
         replacement_char = '�'
         if replacement_char in metadata:
             tmpl = "{self.path} could not be properly decoded in UTF-8"
@@ -2505,7 +2505,7 @@ def _handle_ns(packageName, path_item):
     return subpath
 
 
-def _rebuild_mod_path(orig_path, package_name, module: types.ModuleType):
+def _rebuild_mod_path(orig_path, package_name, module: types.ModuleType) -> None:
     """
     Rebuild module.__path__ ensuring that all entries are ordered
     corresponding to their sys.path order
@@ -2624,7 +2624,7 @@ def null_ns_handler(
     path_item: str | None,
     packageName: str | None,
     module: _ModuleLike | None,
-):
+) -> None:
     return None
 
 
@@ -2635,7 +2635,7 @@ register_namespace_handler(object, null_ns_handler)
 def normalize_path(filename: StrPath) -> str: ...
 @overload
 def normalize_path(filename: BytesPath) -> bytes: ...
-def normalize_path(filename: StrOrBytesPath):
+def normalize_path(filename: StrOrBytesPath) -> str | bytes:
     """Normalize a file/dir name for comparison purposes"""
     return os.path.normcase(os.path.realpath(os.path.normpath(_cygwin_patch(filename))))
 
@@ -2691,7 +2691,7 @@ def _is_unpacked_egg(path):
     )
 
 
-def _set_parent_ns(packageName):
+def _set_parent_ns(packageName) -> None:
     parts = packageName.split('.')
     name = parts.pop()
     if parts:
@@ -3336,7 +3336,7 @@ class Distribution:
                 " to sys.path" % (modname, fn, self.location),
             )
 
-    def has_version(self):
+    def has_version(self) -> bool:
         try:
             self.version
         except ValueError:
@@ -3552,7 +3552,7 @@ def ensure_directory(path: StrOrBytesPath) -> None:
     os.makedirs(dirname, exist_ok=True)
 
 
-def _bypass_ensure_directory(path):
+def _bypass_ensure_directory(path) -> None:
     """Sandbox-bypassing version of ensure_directory()"""
     if not WRITE_SUPPORT:
         raise OSError('"os.mkdir" not supported on this platform.')
@@ -3658,7 +3658,7 @@ def _call_aside(f, *args, **kwargs):
 
 
 @_call_aside
-def _initialize(g=globals()):
+def _initialize(g=globals()) -> None:
     "Set up global resource manager (deliberately not state-saved)"
     manager = ResourceManager()
     g['_manager'] = manager
@@ -3670,7 +3670,7 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_master_working_set() -> None:
     """
     Prepare the master working set and make the ``require()``
     API available.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

I commented `[lint.flake8-annotations] ignore-fully-untyped = true` in `ruff.toml` then ran `ruff check pkg_resources --select=ANN2 --fix --unsafe-fixes`.
I removed 3 `-> None` that were revealing hidden mypy issues to keep the changes here completely automated.

### Pull Request Checklist
- [x] Changes have tests (this increased the amount of type-checked code)
- [x] News fragment added in [`newsfragments/`]. (no public facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
