### PR TITLE
setuptools ANN201 autofixes for fully untyped functions

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -3,8 +3,7 @@ import os
 import sys
 
 report_url = (
-    "https://github.com/pypa/setuptools/issues/new?"
-    "template=distutils-deprecation.yml"
+    "https://github.com/pypa/setuptools/issues/new?template=distutils-deprecation.yml"
 )
 
 

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -186,7 +186,7 @@ class Command(_Command):
             )
         return val
 
-    def ensure_string_list(self, option: str):
+    def ensure_string_list(self, option: str) -> None:
         r"""Ensure that 'option' is a list of strings.  If 'option' is
         currently a string, we split it either on /,\s*/ or /\s+/, so
         "foo bar baz", "foo,bar,baz", and "foo,   bar baz" all become

--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -31,7 +31,9 @@ def default_filter(src, dst):
     return dst
 
 
-def unpack_archive(filename, extract_dir, progress_filter=default_filter, drivers=None):
+def unpack_archive(
+    filename, extract_dir, progress_filter=default_filter, drivers=None
+) -> None:
     """Unpack `filename` to `extract_dir`, or raise ``UnrecognizedFormat``
 
     `progress_filter` is a function taking two arguments: a source path
@@ -63,7 +65,7 @@ def unpack_archive(filename, extract_dir, progress_filter=default_filter, driver
         raise UnrecognizedFormat("Not a recognized archive type: %s" % filename)
 
 
-def unpack_directory(filename, extract_dir, progress_filter=default_filter):
+def unpack_directory(filename, extract_dir, progress_filter=default_filter) -> None:
     """ "Unpack" a directory, using the same interface as for archives
 
     Raises ``UnrecognizedFormat`` if `filename` is not a directory
@@ -90,7 +92,7 @@ def unpack_directory(filename, extract_dir, progress_filter=default_filter):
             shutil.copystat(f, target)
 
 
-def unpack_zipfile(filename, extract_dir, progress_filter=default_filter):
+def unpack_zipfile(filename, extract_dir, progress_filter=default_filter) -> None:
     """Unpack zip `filename` to `extract_dir`
 
     Raises ``UnrecognizedFormat`` if `filename` is not a zipfile (as determined
@@ -185,7 +187,7 @@ def _iter_open_tar(tar_obj, extract_dir, progress_filter):
             yield member, final_dst
 
 
-def unpack_tarfile(filename, extract_dir, progress_filter=default_filter):
+def unpack_tarfile(filename, extract_dir, progress_filter=default_filter) -> bool:
     """Unpack tar/tar.gz/tar.bz2 `filename` to `extract_dir`
 
     Raises ``UnrecognizedFormat`` if `filename` is not a tarfile (as determined

--- a/setuptools/command/alias.py
+++ b/setuptools/command/alias.py
@@ -30,14 +30,14 @@ class alias(option_base):
         self.args = None
         self.remove = None
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         option_base.finalize_options(self)
         if self.remove and len(self.args) != 1:
             raise DistutilsOptionError(
                 "Must specify exactly one argument (the alias name) when using --remove"
             )
 
-    def run(self):
+    def run(self) -> None:
         aliases = self.distribution.get_option_dict('aliases')
 
         if not self.args:

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -50,7 +50,7 @@ def sorted_walk(dir):
         yield base, dirs, files
 
 
-def write_stub(resource, pyfile):
+def write_stub(resource, pyfile) -> None:
     _stub_template = textwrap.dedent(
         """
         def __bootstrap__():
@@ -101,7 +101,7 @@ class bdist_egg(Command):
         self.egg_output = None
         self.exclude_source_files = None
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         ei_cmd = self.ei_cmd = self.get_finalized_command("egg_info")
         self.egg_info = ei_cmd.egg_info
 
@@ -125,7 +125,7 @@ class bdist_egg(Command):
 
             self.egg_output = os.path.join(self.dist_dir, basename + '.egg')
 
-    def do_install_data(self):
+    def do_install_data(self) -> None:
         # Hack for packages that install data to install's --install-lib
         self.get_finalized_command('install').install_lib = self.bdist_dir
 
@@ -277,10 +277,10 @@ class bdist_egg(Command):
         log.warn("zip_safe flag not set; analyzing archive contents...")
         return analyze_egg(self.bdist_dir, self.stubs)
 
-    def gen_header(self):
+    def gen_header(self) -> str:
         return 'w'
 
-    def copy_metadata_to(self, target_dir):
+    def copy_metadata_to(self, target_dir) -> None:
         "Copy metadata (egg info) to the target_dir"
         # normalize the path (so that a forward-slash in egg_info will
         # match using startswith below)
@@ -353,7 +353,7 @@ def analyze_egg(egg_dir, stubs):
     return safe
 
 
-def write_safety_flag(egg_dir, safe):
+def write_safety_flag(egg_dir, safe) -> None:
     # Write or remove zip safety flag file(s)
     for flag, fn in safety_flags.items():
         fn = os.path.join(egg_dir, fn)
@@ -421,7 +421,7 @@ def iter_symbols(code):
             yield from iter_symbols(const)
 
 
-def can_scan():
+def can_scan() -> bool:
     if not sys.platform.startswith('java') and sys.platform != 'cli':
         # CPython, PyPy, etc.
         return True

--- a/setuptools/command/bdist_rpm.py
+++ b/setuptools/command/bdist_rpm.py
@@ -15,7 +15,7 @@ class bdist_rpm(orig.bdist_rpm):
 
     distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
-    def run(self):
+    def run(self) -> None:
         SetuptoolsDeprecationWarning.emit(
             "Deprecated command",
             """

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -85,15 +85,15 @@ class SubCommand(Protocol):
             ...
     """
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
         """(Required by the original :class:`setuptools.Command` interface)"""
         ...
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         """(Required by the original :class:`setuptools.Command` interface)"""
         ...
 
-    def run(self):
+    def run(self) -> None:
         """(Required by the original :class:`setuptools.Command` interface)"""
         ...
 

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -24,7 +24,7 @@ class build_clib(orig.build_clib):
 
     distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
-    def build_libraries(self, libraries):
+    def build_libraries(self, libraries) -> None:
         for lib_name, build_info in libraries:
             sources = build_info.get('sources')
             if sources is None or not isinstance(sources, (list, tuple)):

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -110,7 +110,7 @@ class build_ext(_build_ext):
         regular_file = os.path.join(self.build_lib, filename)
         return (inplace_file, regular_file)
 
-    def copy_extensions_to_source(self):
+    def copy_extensions_to_source(self) -> None:
         build_py = self.get_finalized_command('build_py')
         for ext in self.extensions:
             inplace_file, regular_file = self._get_inplace_equivalent(build_py, ext)
@@ -191,7 +191,7 @@ class build_ext(_build_ext):
         self.ext_map = {}
         self.editable_mode = False
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         _build_ext.finalize_options(self)
         self.extensions = self.extensions or []
         self.check_extensions_list(self.extensions)
@@ -254,7 +254,7 @@ class build_ext(_build_ext):
             return ext.export_symbols
         return _build_ext.get_export_symbols(self, ext)
 
-    def build_extension(self, ext):
+    def build_extension(self, ext) -> None:
         ext._convert_pyx_sources_to_lang()
         _compiler = self.compiler
         try:
@@ -344,7 +344,7 @@ class build_ext(_build_ext):
         if self.get_finalized_command('build_py').optimize:
             yield '.pyo'
 
-    def write_stub(self, output_dir, ext, compile=False):
+    def write_stub(self, output_dir, ext, compile=False) -> None:
         stub_file = os.path.join(output_dir, *ext._full_name.split('.')) + '.py'
         self._write_stub_file(stub_file, ext, compile)
 
@@ -415,7 +415,7 @@ if use_stubs or os.name == 'nt':
         extra_postargs=None,
         build_temp=None,
         target_lang=None,
-    ):
+    ) -> None:
         self.link(
             self.SHARED_LIBRARY,
             objects,
@@ -450,7 +450,7 @@ else:
         extra_postargs=None,
         build_temp=None,
         target_lang=None,
-    ):
+    ) -> None:
         # XXX we need to either disallow these attrs on Library instances,
         # or warn/abort here if set, or something...
         # libraries=None, library_dirs=None, runtime_library_dirs=None,

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -24,7 +24,7 @@ from distutils.util import convert_path
 _IMPLICIT_DATA_FILES = ('*.pyi', 'py.typed')
 
 
-def make_writable(target):
+def make_writable(target) -> None:
     os.chmod(target, os.stat(target).st_mode | stat.S_IWRITE)
 
 
@@ -67,7 +67,7 @@ class build_py(orig.build_py):
             infile, outfile, preserve_mode, preserve_times, link, level
         )
 
-    def run(self):
+    def run(self) -> None:
         """Build modules, packages, and copy data files to build directory"""
         if not (self.py_modules or self.packages) or self.editable_mode:
             return
@@ -172,7 +172,7 @@ class build_py(orig.build_py):
                 srcfile = os.path.join(src_dir, filename)
                 yield (target, srcfile)
 
-    def build_package_data(self):
+    def build_package_data(self) -> None:
         """Copy data files into build directory"""
         for target, srcfile in self._get_package_data_output_mapping():
             self.mkpath(os.path.dirname(target))
@@ -239,7 +239,7 @@ class build_py(orig.build_py):
             if not os.path.isabs(file) or all(d not in norm_path for d in norm_dirs):
                 yield file
 
-    def get_data_files(self):
+    def get_data_files(self) -> None:
         pass  # Lazily compute data files in _get_data_files() function.
 
     def check_package(self, package, package_dir):

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -42,7 +42,7 @@ class develop(namespaces.DevelopInstaller, easy_install):
         self.setup_path = None
         self.always_copy_from = '.'  # always copy eggs installed in curdir
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         import pkg_resources
 
         ei = self.get_finalized_command("egg_info")
@@ -104,7 +104,7 @@ class develop(namespaces.DevelopInstaller, easy_install):
             )
         return path_to_setup
 
-    def install_for_development(self):
+    def install_for_development(self) -> None:
         self.run_command('egg_info')
 
         # Build extensions in-place
@@ -126,7 +126,7 @@ class develop(namespaces.DevelopInstaller, easy_install):
         # and handling requirements
         self.process_distribution(None, self.dist, not self.no_deps)
 
-    def uninstall_link(self):
+    def uninstall_link(self) -> None:
         if os.path.exists(self.egg_link):
             log.info("Removing %s (link to %s)", self.egg_link, self.egg_base)
 

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -48,7 +48,7 @@ class dist_info(Command):
         self.tag_build = None
         self.keep_egg_info = False
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         dist = self.distribution
         project_dir = dist.src_root or os.curdir
         self.output_dir = Path(self.output_dir or project_dir)
@@ -88,7 +88,7 @@ class dist_info(Command):
         else:
             yield
 
-    def run(self):
+    def run(self) -> None:
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.egg_info.run()
         egg_info_dir = self.egg_info.egg_info

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -34,7 +34,7 @@ import zipimport
 from collections.abc import Iterable
 from glob import glob
 from sysconfig import get_path
-from typing import TYPE_CHECKING, Callable, TypeVar
+from typing import TYPE_CHECKING, Callable, NoReturn, TypeVar
 
 from jaraco.text import yield_lines
 
@@ -212,7 +212,7 @@ class easy_install(Command):
             self, self.distribution.get_option_dict('easy_install')
         )
 
-    def delete_blockers(self, blockers):
+    def delete_blockers(self, blockers) -> None:
         extant_blockers = (
             filename
             for filename in blockers
@@ -407,12 +407,12 @@ class easy_install(Command):
                 val = subst_vars(val, self.config_vars)
                 setattr(self, attr, val)
 
-    def expand_basedirs(self):
+    def expand_basedirs(self) -> None:
         """Calls `os.path.expanduser` on install_base, install_platbase and
         root."""
         self._expand_attrs(['install_base', 'install_platbase', 'root'])
 
-    def expand_dirs(self):
+    def expand_dirs(self) -> None:
         """Calls `os.path.expanduser` on install dirs."""
         dirs = [
             'install_purelib',
@@ -424,7 +424,7 @@ class easy_install(Command):
         ]
         self._expand_attrs(dirs)
 
-    def run(self, show_deprecation: bool = True):
+    def run(self, show_deprecation: bool = True) -> None:
         if show_deprecation:
             self.announce(
                 "WARNING: The easy_install command is deprecated "
@@ -464,10 +464,10 @@ class easy_install(Command):
             pid = random.randint(0, sys.maxsize)
         return os.path.join(self.install_dir, "test-easy-install-%s" % pid)
 
-    def warn_deprecated_options(self):
+    def warn_deprecated_options(self) -> None:
         pass
 
-    def check_site_dir(self):  # is too complex (12)  # FIXME
+    def check_site_dir(self) -> None:  # is too complex (12)  # FIXME
         """Verify that self.install_dir is .pth-capable dir, if needed"""
 
         instdir = normalize_path(self.install_dir)
@@ -554,7 +554,7 @@ class easy_install(Command):
         """
     ).lstrip()
 
-    def cant_write_to_target(self):
+    def cant_write_to_target(self) -> NoReturn:
         msg = self.__cant_write_msg % (
             sys.exc_info()[1],
             self.install_dir,
@@ -626,7 +626,7 @@ class easy_install(Command):
             log.warn("TEST FAILED: %s does NOT support .pth files", instdir)
         return False
 
-    def install_egg_scripts(self, dist):
+    def install_egg_scripts(self, dist) -> None:
         """Write all the scripts for `dist`, unless scripts are excluded"""
         if not self.exclude_scripts and dist.metadata_isdir('scripts'):
             for script_name in dist.metadata_listdir('scripts'):
@@ -639,7 +639,7 @@ class easy_install(Command):
                 )
         self.install_wrapper_scripts(dist)
 
-    def add_output(self, path):
+    def add_output(self, path) -> None:
         if os.path.isdir(path):
             for base, dirs, files in os.walk(path):
                 for filename in files:
@@ -647,14 +647,14 @@ class easy_install(Command):
         else:
             self.outputs.append(path)
 
-    def not_editable(self, spec):
+    def not_editable(self, spec) -> None:
         if self.editable:
             raise DistutilsArgError(
                 "Invalid argument %r: you can't use filenames or URLs "
                 "with --editable (except via the --find-links option)." % (spec,)
             )
 
-    def check_editable(self, spec):
+    def check_editable(self, spec) -> None:
         if not self.editable:
             return
 
@@ -760,7 +760,7 @@ class easy_install(Command):
         dist,
         deps: bool = True,
         *info,
-    ):
+    ) -> None:
         self.update_pth(dist)
         self.package_index.add(dist)
         if dist in self.local_index[dist.key]:
@@ -798,7 +798,7 @@ class easy_install(Command):
                     self.easy_install(dist.as_requirement())
         log.info("Finished processing dependencies for %s", requirement)
 
-    def should_unzip(self, dist):
+    def should_unzip(self, dist) -> bool:
         if self.zip_ok is not None:
             return not self.zip_ok
         if dist.has_metadata('not-zip-safe'):
@@ -828,13 +828,13 @@ class easy_install(Command):
         shutil.move(setup_base, dst)
         return dst
 
-    def install_wrapper_scripts(self, dist):
+    def install_wrapper_scripts(self, dist) -> None:
         if self.exclude_scripts:
             return
         for args in ScriptWriter.best().get_args(dist):
             self.write_script(*args)
 
-    def install_script(self, dist, script_name, script_text, dev_path=None):
+    def install_script(self, dist, script_name, script_text, dev_path=None) -> None:
         """Generate a legacy script wrapper and install it"""
         spec = str(dist.as_requirement())
         is_script = is_python_script(script_text, script_name)
@@ -859,7 +859,7 @@ class easy_install(Command):
         raw_bytes = resource_string('setuptools', name)
         return raw_bytes.decode('utf-8')
 
-    def write_script(self, script_name, contents, mode: str = "t", blockers=()):
+    def write_script(self, script_name, contents, mode: str = "t", blockers=()) -> None:
         """Write an executable file to the scripts directory"""
         self.delete_blockers(  # clean up old .py/.pyw w/o a script
             [os.path.join(self.script_dir, x) for x in blockers]
@@ -1042,7 +1042,7 @@ class easy_install(Command):
         return self.install_egg(egg_path, tmpdir)
 
     # FIXME: 'easy_install.exe_to_egg' is too complex (12)
-    def exe_to_egg(self, dist_filename, egg_tmp):  # noqa: C901
+    def exe_to_egg(self, dist_filename, egg_tmp) -> None:  # noqa: C901
         """Extract a bdist_wininst to the directories an egg would use"""
         # Check for .pth file and set up prefix translations
         prefixes = get_exe_prefixes(dist_filename)
@@ -1174,7 +1174,7 @@ class easy_install(Command):
         python = sys.executable
         return '\n' + self.__editable_msg % locals()
 
-    def run_setup(self, setup_script, setup_base, args):
+    def run_setup(self, setup_script, setup_base, args) -> None:
         sys.modules.setdefault('distutils.command.bdist_egg', bdist_egg)
         sys.modules.setdefault('distutils.command.egg_info', egg_info)
 
@@ -1243,7 +1243,7 @@ class easy_install(Command):
         cfg_filename = os.path.join(base, 'setup.cfg')
         setopt.edit_config(cfg_filename, settings)
 
-    def update_pth(self, dist):  # noqa: C901  # is too complex (11)  # FIXME
+    def update_pth(self, dist) -> None:  # noqa: C901  # is too complex (11)  # FIXME
         if self.pth_file is None:
             return
 
@@ -1292,7 +1292,7 @@ class easy_install(Command):
         log.debug("Unpacking %s to %s", src, dst)
         return dst  # only unpack-and-compile skips files for dry run
 
-    def unpack_and_compile(self, egg_path, destination):
+    def unpack_and_compile(self, egg_path, destination) -> None:
         to_compile = []
         to_chmod = []
 
@@ -1311,7 +1311,7 @@ class easy_install(Command):
                 mode = ((os.stat(f)[stat.ST_MODE]) | 0o555) & 0o7755
                 chmod(f, mode)
 
-    def byte_compile(self, to_compile):
+    def byte_compile(self, to_compile) -> None:
         if sys.dont_write_bytecode:
             return
 
@@ -1366,7 +1366,7 @@ class easy_install(Command):
         """
     ).strip()
 
-    def create_home_path(self):
+    def create_home_path(self) -> None:
         """Create directories under ~."""
         if not self.user:
             return
@@ -1656,7 +1656,7 @@ class PthDistributions(Environment):
             return self._load_raw()
         return [], False
 
-    def save(self):
+    def save(self) -> None:
         """Write changed .pth file back to disk"""
         # first reload the file
         last_paths, last_dirty = self._load()
@@ -1710,7 +1710,7 @@ class PthDistributions(Environment):
     def _wrap_lines(lines):
         return lines
 
-    def add(self, dist):
+    def add(self, dist) -> None:
         """Add `dist` to the distribution map"""
         new_path = dist.location not in self.paths and (
             dist.location not in self.sitedirs
@@ -1723,7 +1723,7 @@ class PthDistributions(Environment):
             self.dirty = True
         super().add(dist)
 
-    def remove(self, dist):
+    def remove(self, dist) -> None:
         """Remove `dist` from the distribution map"""
         while dist.location in self.paths:
             self.paths.remove(dist.location)

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -119,13 +119,13 @@ class editable_wheel(Command):
         self.project_dir = None
         self.mode = None
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         dist = self.distribution
         self.project_dir = dist.src_root or os.curdir
         self.package_dir = dist.package_dir or {}
         self.dist_dir = Path(self.dist_dir or os.path.join(self.project_dir, "dist"))
 
-    def run(self):
+    def run(self) -> None:
         try:
             self.dist_dir.mkdir(exist_ok=True)
             self._ensure_dist_info()

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -195,7 +195,7 @@ class egg_info(InfoCommon, Command):
     # allow the 'tag_svn_revision' to be detected and
     # set, supporting sdists built on older Setuptools.
     @property
-    def tag_svn_revision(self):
+    def tag_svn_revision(self) -> None:
         pass
 
     @tag_svn_revision.setter
@@ -204,7 +204,7 @@ class egg_info(InfoCommon, Command):
 
     ####################################
 
-    def save_version_info(self, filename):
+    def save_version_info(self, filename) -> None:
         """
         Materialize the value of date into the
         build tag. Install build keys in a deterministic order
@@ -215,7 +215,7 @@ class egg_info(InfoCommon, Command):
         egg_info = dict(tag_build=self.tags(), tag_date=0)
         edit_config(filename, dict(egg_info=egg_info))
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         # Note: we need to capture the current value returned
         # by `self.tagged_version()`, so we can later update
         # `self.distribution.metadata.version` without
@@ -252,7 +252,7 @@ class egg_info(InfoCommon, Command):
         """Compute filename of the output egg. Private API."""
         return _egg_basename(self.egg_name, self.egg_version, py_version, platform)
 
-    def write_or_delete_file(self, what, filename, data, force: bool = False):
+    def write_or_delete_file(self, what, filename, data, force: bool = False) -> None:
         """Write `data` to `filename` or delete if empty
 
         If `data` is non-empty, this routine is the same as ``write_file()``.
@@ -270,7 +270,7 @@ class egg_info(InfoCommon, Command):
             else:
                 self.delete_file(filename)
 
-    def write_file(self, what, filename, data):
+    def write_file(self, what, filename, data) -> None:
         """Write `data` to `filename` (if not a dry run) after announcing it
 
         `what` is used in a log message to identify what is being written
@@ -283,13 +283,13 @@ class egg_info(InfoCommon, Command):
             f.write(data)
             f.close()
 
-    def delete_file(self, filename):
+    def delete_file(self, filename) -> None:
         """Delete `filename` (if not a dry run) after announcing it"""
         log.info("deleting %s", filename)
         if not self.dry_run:
             os.unlink(filename)
 
-    def run(self):
+    def run(self) -> None:
         # Pre-load to avoid iterating over entry-points while an empty .egg-info
         # exists in sys.path. See pypa/pyproject-hooks#206
         writers = list(metadata.entry_points(group='egg_info.writers'))
@@ -311,7 +311,7 @@ class egg_info(InfoCommon, Command):
 
         self.find_sources()
 
-    def find_sources(self):
+    def find_sources(self) -> None:
         """Generate SOURCES.txt manifest file"""
         manifest_filename = os.path.join(self.egg_info, "SOURCES.txt")
         mm = manifest_maker(self.distribution)
@@ -472,7 +472,7 @@ class FileList(_FileList):
         match = translate_pattern(os.path.join('**', pattern))
         return self._remove_files(match.match)
 
-    def append(self, item):
+    def append(self, item) -> None:
         if item.endswith('\r'):  # Fix older sdists built on Windows
             item = item[:-1]
         path = convert_path(item)
@@ -480,7 +480,7 @@ class FileList(_FileList):
         if self._safe_path(path):
             self.files.append(path)
 
-    def extend(self, paths):
+    def extend(self, paths) -> None:
         self.files.extend(filter(self._safe_path, paths))
 
     def _repair(self):
@@ -524,17 +524,17 @@ class FileList(_FileList):
 class manifest_maker(sdist):
     template = "MANIFEST.in"
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
         self.use_defaults = True
         self.prune = True
         self.manifest_only = True
         self.force_manifest = True
         self.ignore_egg_info_dir = False
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         pass
 
-    def run(self):
+    def run(self) -> None:
         self.filelist = FileList(ignore_egg_info_dir=self.ignore_egg_info_dir)
         if not os.path.exists(self.manifest):
             self.write_manifest()  # it must exist so it'll get in the list
@@ -552,7 +552,7 @@ class manifest_maker(sdist):
         path = unicode_utils.filesys_decode(path)
         return path.replace(os.sep, '/')
 
-    def write_manifest(self):
+    def write_manifest(self) -> None:
         """
         Write the file list in 'self.filelist' to the manifest file
         named by 'self.manifest'.
@@ -564,7 +564,7 @@ class manifest_maker(sdist):
         msg = "writing manifest file '%s'" % self.manifest
         self.execute(write_file, (self.manifest, files), msg)
 
-    def warn(self, msg):
+    def warn(self, msg) -> None:
         if not self._should_suppress_warning(msg):
             sdist.warn(self, msg)
 
@@ -575,7 +575,7 @@ class manifest_maker(sdist):
         """
         return re.match(r"standard file .*not found", msg)
 
-    def add_defaults(self):
+    def add_defaults(self) -> None:
         sdist.add_defaults(self)
         self.filelist.append(self.template)
         self.filelist.append(self.manifest)
@@ -593,7 +593,7 @@ class manifest_maker(sdist):
         ei_cmd = self.get_finalized_command('egg_info')
         self.filelist.graft(ei_cmd.egg_info)
 
-    def add_license_files(self):
+    def add_license_files(self) -> None:
         license_files = self.distribution.metadata.license_files or []
         for lf in license_files:
             log.info("adding license file '%s'", lf)
@@ -632,7 +632,7 @@ class manifest_maker(sdist):
         return build_py.get_data_files()
 
 
-def write_file(filename, contents):
+def write_file(filename, contents) -> None:
     """Create a file with the specified name and write 'contents' (a
     sequence of strings without line terminators) to it.
     """
@@ -645,7 +645,7 @@ def write_file(filename, contents):
         f.write(contents)
 
 
-def write_pkg_info(cmd, basename, filename):
+def write_pkg_info(cmd, basename, filename) -> None:
     log.info("writing %s", filename)
     if not cmd.dry_run:
         metadata = cmd.distribution.metadata
@@ -664,7 +664,7 @@ def write_pkg_info(cmd, basename, filename):
         bdist_egg.write_safety_flag(cmd.egg_info, safe)
 
 
-def warn_depends_obsolete(cmd, basename, filename):
+def warn_depends_obsolete(cmd, basename, filename) -> None:
     """
     Unused: left to avoid errors when updating (from source) from <= 67.8.
     Old installations have a .dist-info directory with the entry-point
@@ -679,18 +679,18 @@ write_requirements = _requirestxt.write_requirements
 write_setup_requirements = _requirestxt.write_setup_requirements
 
 
-def write_toplevel_names(cmd, basename, filename):
+def write_toplevel_names(cmd, basename, filename) -> None:
     pkgs = dict.fromkeys([
         k.split('.', 1)[0] for k in cmd.distribution.iter_distribution_names()
     ])
     cmd.write_file("top-level names", filename, '\n'.join(sorted(pkgs)) + '\n')
 
 
-def overwrite_arg(cmd, basename, filename):
+def overwrite_arg(cmd, basename, filename) -> None:
     write_arg(cmd, basename, filename, True)
 
 
-def write_arg(cmd, basename, filename, force: bool = False):
+def write_arg(cmd, basename, filename, force: bool = False) -> None:
     argname = os.path.splitext(basename)[0]
     value = getattr(cmd.distribution, argname, None)
     if value is not None:
@@ -698,7 +698,7 @@ def write_arg(cmd, basename, filename, force: bool = False):
     cmd.write_or_delete_file(argname, filename, value, force)
 
 
-def write_entries(cmd, basename, filename):
+def write_entries(cmd, basename, filename) -> None:
     eps = _entry_points.load(cmd.distribution.entry_points)
     defn = _entry_points.render(eps)
     cmd.write_or_delete_file('entry points', filename, defn, True)

--- a/setuptools/command/install.py
+++ b/setuptools/command/install.py
@@ -63,7 +63,7 @@ class install(orig.install):
         self.old_and_unmanageable = None
         self.single_version_externally_managed = None
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         super().finalize_options()
         if self.root:
             self.single_version_externally_managed = True
@@ -130,7 +130,7 @@ class install(orig.install):
 
         return False
 
-    def do_egg_install(self):
+    def do_egg_install(self) -> None:
         easy_install = self.distribution.get_command_class('easy_install')
 
         cmd = easy_install(

--- a/setuptools/command/install_egg_info.py
+++ b/setuptools/command/install_egg_info.py
@@ -28,7 +28,7 @@ class install_egg_info(namespaces.Installer, Command):
         self.target = os.path.join(self.install_dir, basename)
         self.outputs = []
 
-    def run(self):
+    def run(self) -> None:
         self.run_command('egg_info')
         if os.path.isdir(self.target) and not os.path.islink(self.target):
             dir_util.remove_tree(self.target, dry_run=self.dry_run)
@@ -42,7 +42,7 @@ class install_egg_info(namespaces.Installer, Command):
     def get_outputs(self):
         return self.outputs
 
-    def copytree(self):
+    def copytree(self) -> None:
         # Copy the .egg-info tree to site-packages
         def skimmer(src, dst):
             # filter out source-control directories; note that 'src' is always

--- a/setuptools/command/install_lib.py
+++ b/setuptools/command/install_lib.py
@@ -15,7 +15,7 @@ class install_lib(orig.install_lib):
 
     distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
-    def run(self):
+    def run(self) -> None:
         self.build()
         outfiles = self.install()
         if outfiles is not None:

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -15,7 +15,7 @@ class install_scripts(orig.install_scripts):
 
     distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
         orig.install_scripts.initialize_options(self)
         self.no_ep = False
 
@@ -56,7 +56,7 @@ class install_scripts(orig.install_scripts):
         for args in writer.get_args(dist, cmd.as_header()):
             self.write_script(*args)
 
-    def write_script(self, script_name, contents, mode: str = "t", *ignored):
+    def write_script(self, script_name, contents, mode: str = "t", *ignored) -> None:
         """Write an executable file to the scripts directory"""
         from setuptools.command.easy_install import chmod, current_umask
 

--- a/setuptools/command/rotate.py
+++ b/setuptools/command/rotate.py
@@ -28,7 +28,7 @@ class rotate(Command):
         self.dist_dir = None
         self.keep = None
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         if self.match is None:
             raise DistutilsOptionError(
                 "Must specify one or more (comma-separated) match patterns "
@@ -44,7 +44,7 @@ class rotate(Command):
             self.match = [convert_path(p.strip()) for p in self.match.split(',')]
         self.set_undefined_options('bdist', ('dist_dir', 'dist_dir'))
 
-    def run(self):
+    def run(self) -> None:
         self.run_command("egg_info")
         from glob import glob
 

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -55,7 +55,7 @@ class sdist(orig.sdist):
     README_EXTENSIONS = ['', '.rst', '.txt', '.md']
     READMES = tuple('README{0}'.format(ext) for ext in README_EXTENSIONS)
 
-    def run(self):
+    def run(self) -> None:
         self.run_command('egg_info')
         ei_cmd = self.get_finalized_command('egg_info')
         self.filelist = ei_cmd.filelist
@@ -74,10 +74,10 @@ class sdist(orig.sdist):
             if data not in dist_files:
                 dist_files.append(data)
 
-    def initialize_options(self):
+    def initialize_options(self) -> None:
         orig.sdist.initialize_options(self)
 
-    def make_distribution(self):
+    def make_distribution(self) -> None:
         """
         Workaround for #516
         """
@@ -105,7 +105,7 @@ class sdist(orig.sdist):
             if orig_val is not NoValue:
                 os.link = orig_val
 
-    def add_defaults(self):
+    def add_defaults(self) -> None:
         super().add_defaults()
         self._add_defaults_build_sub_commands()
 
@@ -158,13 +158,13 @@ class sdist(orig.sdist):
         except TypeError:
             log.warn("data_files contains unexpected objects")
 
-    def prune_file_list(self):
+    def prune_file_list(self) -> None:
         super().prune_file_list()
         # Prevent accidental inclusion of test-related cache dirs at the project root
         sep = re.escape(os.sep)
         self.filelist.exclude_pattern(r"^(\.tox|\.nox|\.venv)" + sep, is_regex=True)
 
-    def check_readme(self):
+    def check_readme(self) -> None:
         for f in self.READMES:
             if os.path.exists(f):
                 return
@@ -173,7 +173,7 @@ class sdist(orig.sdist):
                 "standard file not found: should have one of " + ', '.join(self.READMES)
             )
 
-    def make_release_tree(self, base_dir, files):
+    def make_release_tree(self, base_dir, files) -> None:
         orig.sdist.make_release_tree(self, base_dir, files)
 
         # Save any egg_info command line options used to create this sdist

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -126,14 +126,14 @@ class setopt(option_base):
         self.set_value = None
         self.remove = None
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         option_base.finalize_options(self)
         if self.command is None or self.option is None:
             raise DistutilsOptionError("Must specify --command *and* --option")
         if self.set_value is None and not self.remove:
             raise DistutilsOptionError("Must specify --set-value or --remove")
 
-    def run(self):
+    def run(self) -> None:
         edit_config(
             self.filename,
             {self.command: {self.option.replace('-', '_'): self.set_value}},

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -477,7 +477,7 @@ class ConfigHandler(Generic[Target]):
         parser = (lambda _, v: values_parser(v)) if values_parser else (lambda _, v: v)
         return cls._parse_section_to_dict_with_key(section_options, parser)
 
-    def parse_section(self, section_options):
+    def parse_section(self, section_options) -> None:
         """Parses configuration file section.
 
         :param dict section_options:
@@ -713,7 +713,7 @@ class ConfigOptionsHandler(ConfigHandler["Distribution"]):
 
         return find_kwargs
 
-    def parse_section_entry_points(self, section_options):
+    def parse_section_entry_points(self, section_options) -> None:
         """Parses `entry_points` configuration file section.
 
         :param dict section_options:
@@ -725,21 +725,21 @@ class ConfigOptionsHandler(ConfigHandler["Distribution"]):
         package_data = self._parse_section_to_dict(section_options, self._parse_list)
         return expand.canonic_package_data(package_data)
 
-    def parse_section_package_data(self, section_options):
+    def parse_section_package_data(self, section_options) -> None:
         """Parses `package_data` configuration file section.
 
         :param dict section_options:
         """
         self['package_data'] = self._parse_package_data(section_options)
 
-    def parse_section_exclude_package_data(self, section_options):
+    def parse_section_exclude_package_data(self, section_options) -> None:
         """Parses `exclude_package_data` configuration file section.
 
         :param dict section_options:
         """
         self['exclude_package_data'] = self._parse_package_data(section_options)
 
-    def parse_section_extras_require(self, section_options):
+    def parse_section_extras_require(self, section_options) -> None:
         """Parses `extras_require` configuration file section.
 
         :param dict section_options:
@@ -751,7 +751,7 @@ class ConfigOptionsHandler(ConfigHandler["Distribution"]):
 
         self['extras_require'] = parsed
 
-    def parse_section_data_files(self, section_options):
+    def parse_section_data_files(self, section_options) -> None:
         """Parses `data_files` configuration file section.
 
         :param dict section_options:

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -479,7 +479,7 @@ class ConfigDiscovery:
             """
             raise PackageDiscoveryError(cleandoc(msg))
 
-    def analyse_name(self):
+    def analyse_name(self) -> None:
         """The packages/modules are the essential contribution of the author.
         Therefore the name of the distribution can be derived from them.
         """

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -640,7 +640,7 @@ class Distribution(_Distribution):
         self,
         filenames: Iterable[StrPath] | None = None,
         ignore_option_errors: bool = False,
-    ):
+    ) -> None:
         """Parses configuration files from various levels
         and loads configuration.
         """
@@ -663,7 +663,7 @@ class Distribution(_Distribution):
 
         return _fetch_build_eggs(self, requires)
 
-    def finalize_options(self):
+    def finalize_options(self) -> None:
         """
         Allow plugins to apply arbitrary operations to the
         distribution. Each hook may optionally define a 'order'
@@ -760,7 +760,7 @@ class Distribution(_Distribution):
                 self.cmdclass[ep.name] = cmdclass
         return _Distribution.get_command_list(self)
 
-    def include(self, **attrs):
+    def include(self, **attrs) -> None:
         """Add items to distribution that are named in keyword arguments
 
         For example, 'dist.include(py_modules=["x"])' would add 'x' to
@@ -782,7 +782,7 @@ class Distribution(_Distribution):
             else:
                 self._include_misc(k, v)
 
-    def exclude_package(self, package: str):
+    def exclude_package(self, package: str) -> None:
         """Remove packages, modules, and extensions in named package"""
 
         pfx = package + '.'
@@ -803,7 +803,7 @@ class Distribution(_Distribution):
                 if p.name != package and not p.name.startswith(pfx)
             ]
 
-    def has_contents_for(self, package: str):
+    def has_contents_for(self, package: str) -> bool:
         """Return true if 'exclude_package(package)' would do something"""
 
         pfx = package + '.'
@@ -852,7 +852,7 @@ class Distribution(_Distribution):
             new = [item for item in value if item not in old]
             setattr(self, name, list(old) + new)
 
-    def exclude(self, **attrs):
+    def exclude(self, **attrs) -> None:
         """Remove items from distribution that are named in keyword arguments
 
         For example, 'dist.exclude(py_modules=["x"])' would remove 'x' from
@@ -991,7 +991,7 @@ class Distribution(_Distribution):
         finally:
             sys.stdout.reconfigure(encoding=encoding)
 
-    def run_command(self, command):
+    def run_command(self, command) -> None:
         self.set_defaults()
         # Postpone defaults until all explicit configuration is considered
         # (setup() args, config files, command line and plugins)

--- a/setuptools/launch.py
+++ b/setuptools/launch.py
@@ -10,7 +10,7 @@ import sys
 import tokenize
 
 
-def run():
+def run() -> None:
     """
     Run the script in sys.argv[1] as if it had
     been invoked naturally.

--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -11,7 +11,7 @@ def _not_warning(record):
     return record.levelno < logging.WARNING
 
 
-def configure():
+def configure() -> None:
     """
     Configure logging to emit warning and above to stderr
     and everything else to stdout. This behavior is provided

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -84,7 +84,7 @@ class PlatformInfo:
         """
         return self.current_cpu == 'x86'
 
-    def current_dir(self, hidex86=False, x64=False):
+    def current_dir(self, hidex86=False, x64=False) -> str:
         """
         Current platform specific subfolder.
 
@@ -108,7 +108,7 @@ class PlatformInfo:
             else r'\%s' % self.current_cpu
         )
 
-    def target_dir(self, hidex86=False, x64=False):
+    def target_dir(self, hidex86=False, x64=False) -> str:
         r"""
         Target platform specific subfolder.
 
@@ -177,7 +177,7 @@ class RegistryInfo:
         self.pi = platform_info
 
     @property
-    def visualstudio(self):
+    def visualstudio(self) -> str:
         """
         Microsoft Visual Studio root registry key.
 
@@ -225,7 +225,7 @@ class RegistryInfo:
         return os.path.join(self.sxs, 'VS7')
 
     @property
-    def vc_for_python(self):
+    def vc_for_python(self) -> str:
         """
         Microsoft Visual C++ for Python registry key.
 
@@ -237,7 +237,7 @@ class RegistryInfo:
         return r'DevDiv\VCForPython'
 
     @property
-    def microsoft_sdk(self):
+    def microsoft_sdk(self) -> str:
         """
         Microsoft SDK registry key.
 
@@ -273,7 +273,7 @@ class RegistryInfo:
         return os.path.join(self.microsoft_sdk, 'NETFXSDK')
 
     @property
-    def windows_kits_roots(self):
+    def windows_kits_roots(self) -> str:
         """
         Microsoft Windows Kits Roots registry key.
 

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -11,7 +11,7 @@ flatten = itertools.chain.from_iterable
 class Installer:
     nspkg_ext = '-nspkg.pth'
 
-    def install_namespaces(self):
+    def install_namespaces(self) -> None:
         nsp = self._get_all_ns_packages()
         if not nsp:
             return
@@ -30,7 +30,7 @@ class Installer:
             # See: python/cpython#77102
             f.writelines(lines)
 
-    def uninstall_namespaces(self):
+    def uninstall_namespaces(self) -> None:
         filename = self._get_nspkg_file()
         if not os.path.exists(filename):
             return

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -306,7 +306,7 @@ class PackageIndex(Environment):
         verify_ssl: bool = True,
         *args,
         **kw,
-    ):
+    ) -> None:
         super().__init__(*args, **kw)
         self.index_url = index_url + "/"[: not index_url.endswith('/')]
         self.scanned_urls: dict = {}
@@ -325,7 +325,7 @@ class PackageIndex(Environment):
         return super().add(dist)
 
     # FIXME: 'PackageIndex.process_url' is too complex (14)
-    def process_url(self, url, retrieve: bool = False):  # noqa: C901
+    def process_url(self, url, retrieve: bool = False) -> None:  # noqa: C901
         """Evaluate a URL as a possible download, and maybe retrieve it"""
         if url in self.scanned_urls and not retrieve:
             return
@@ -378,7 +378,7 @@ class PackageIndex(Environment):
         if url.startswith(self.index_url) and getattr(f, 'code', None) != 404:
             page = self.process_index(url, page)
 
-    def process_filename(self, fn, nested: bool = False):
+    def process_filename(self, fn, nested: bool = False) -> None:
         # process filenames or directories
         if not os.path.exists(fn):
             self.warn("Not found: %s", fn)
@@ -394,7 +394,7 @@ class PackageIndex(Environment):
             self.debug("Found: %s", fn)
             list(map(self.add, dists))
 
-    def url_ok(self, url, fatal: bool = False):
+    def url_ok(self, url, fatal: bool = False) -> bool:
         s = URL_SCHEME(url)
         is_file = s and s.group(1).lower() == 'file'
         if is_file or self.allows(urllib.parse.urlparse(url)[1]):
@@ -410,7 +410,7 @@ class PackageIndex(Environment):
             self.warn(msg, url)
             return False
 
-    def scan_egg_links(self, search_path):
+    def scan_egg_links(self, search_path) -> None:
         dirs = filter(os.path.isdir, search_path)
         egg_links = (
             (path, entry)
@@ -420,7 +420,7 @@ class PackageIndex(Environment):
         )
         list(itertools.starmap(self.scan_egg_link, egg_links))
 
-    def scan_egg_link(self, path, entry):
+    def scan_egg_link(self, path, entry) -> None:
         content = _read_utf8_with_fallback(os.path.join(path, entry))
         # filter non-empty lines
         lines = list(filter(None, map(str.strip, content.splitlines())))
@@ -481,21 +481,21 @@ class PackageIndex(Environment):
             lambda m: '<a href="%s#md5=%s">%s</a>' % m.group(1, 3, 2), page
         )
 
-    def need_version_info(self, url):
+    def need_version_info(self, url) -> None:
         self.scan_all(
             "Page at %s links to .py file(s) without version info; an index "
             "scan is required.",
             url,
         )
 
-    def scan_all(self, msg=None, *args):
+    def scan_all(self, msg=None, *args) -> None:
         if self.index_url not in self.fetched_urls:
             if msg:
                 self.warn(msg, *args)
             self.info("Scanning index of all packages (this may take a while)")
         self.scan_url(self.index_url)
 
-    def find_packages(self, requirement):
+    def find_packages(self, requirement) -> None:
         self.scan_url(self.index_url + requirement.unsafe_name + '/')
 
         if not self.package_pages.get(requirement.key):
@@ -519,7 +519,7 @@ class PackageIndex(Environment):
             self.debug("%s does not match %s", requirement, dist)
         return super().obtain(requirement, installer)
 
-    def check_hash(self, checker, filename, tfp):
+    def check_hash(self, checker, filename, tfp) -> None:
         """
         checker is a ContentChecker
         """
@@ -533,7 +533,7 @@ class PackageIndex(Environment):
                 % (checker.hash.name, os.path.basename(filename))
             )
 
-    def add_find_links(self, urls):
+    def add_find_links(self, urls) -> None:
         """Add `urls` to the list that will be prescanned for searches"""
         for url in urls:
             if (
@@ -554,7 +554,7 @@ class PackageIndex(Environment):
             list(map(self.scan_url, self.to_scan))
         self.to_scan = None  # from now on, go ahead and process immediately
 
-    def not_found_in_index(self, requirement):
+    def not_found_in_index(self, requirement) -> None:
         if self[requirement.key]:  # we've seen at least one distro
             meth, msg = self.info, "Couldn't retrieve index page for %r"
         else:  # no distros seen for this name, might be misspelled
@@ -777,7 +777,7 @@ class PackageIndex(Environment):
             if fp:
                 fp.close()
 
-    def reporthook(self, url, filename, blocknum, blksize, size):
+    def reporthook(self, url, filename, blocknum, blksize, size) -> None:
         pass  # no-op
 
     # FIXME:
@@ -884,7 +884,7 @@ class PackageIndex(Environment):
         self.url_ok(url, True)
         return self._attempt_download(url, filename)
 
-    def scan_url(self, url):
+    def scan_url(self, url) -> None:
         self.process_url(url, True)
 
     def _attempt_download(self, url, filename):
@@ -930,13 +930,13 @@ class PackageIndex(Environment):
 
         return resolved, rev
 
-    def debug(self, msg, *args):
+    def debug(self, msg, *args) -> None:
         log.debug(msg, *args)
 
-    def info(self, msg, *args):
+    def info(self, msg, *args) -> None:
         log.info(msg, *args)
 
-    def warn(self, msg, *args):
+    def warn(self, msg, *args) -> None:
         log.warn(msg, *args)
 
 

--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -453,7 +453,7 @@ class DirectorySandbox(AbstractSandbox):
             self._violation("open", path, mode, *args, **kw)
         return _open(path, mode, *args, **kw)
 
-    def tmpnam(self):
+    def tmpnam(self) -> None:
         self._violation("tmpnam")
 
     def _ok(self, path):

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -39,7 +39,7 @@ def _get_supported_tags():
     return {(t.interpreter, t.abi, t.platform) for t in sys_tags()}
 
 
-def unpack(src_dir, dst_dir):
+def unpack(src_dir, dst_dir) -> None:
     """Move everything under `src_dir` to `dst_dir`, and delete the former."""
     for dirpath, dirnames, filenames in os.walk(src_dir):
         subdir = os.path.relpath(dirpath, src_dir)
@@ -116,7 +116,7 @@ class Wheel:
                 return dirname
         raise ValueError("unsupported wheel format. .dist-info not found")
 
-    def install_as_egg(self, destination_eggdir):
+    def install_as_egg(self, destination_eggdir) -> None:
         """Install wheel as an egg directory."""
         with zipfile.ZipFile(self.filename) as zf:
             self._install_as_egg(destination_eggdir, zf)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

I commented `[lint.per-file-ignores] "setuptools/**" = ["ANN2"]` and `[lint.flake8-annotations] ignore-fully-untyped = true` in `ruff.toml` then ran `ruff check setuptools --select=ANN201 --fix --unsafe-fixes`.
I removed the added return types that were revealing hidden mypy issues (often `initialize_options`) to keep the changes here completely automated.

This has some overlap with #4709, but they can be merged in either order.

### Pull Request Checklist
- [x] Changes have tests (this increased the amount of type-checked code)
- [x] News fragment added in [`newsfragments/`]. (no public facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
