### PR TITLE
Bump min Python version for GHA (and fix spurious CI error)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,12 +63,6 @@ jobs:
         - platform: ubuntu-latest
           python: "3.10"
           distutils: stdlib
-        # Python 3.8, 3.9 are on macos-13 but not macos-latest (macos-14-arm64)
-        # https://github.com/actions/setup-python/issues/850
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        - {python: "3.8", platform: "macos-13"}
-        exclude:
-        - {python: "3.8", platform: "macos-latest"}
     runs-on: ${{ matrix.platform }}
     continue-on-error: ${{ matrix.python == '3.14' }}
     env:

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -42,8 +42,8 @@ jobs:
       # https://blog.jaraco.com/efficient-use-of-ci-resources/
       matrix:
         python:
-          - "3.8"
-          - "3.12"
+          - "3.9"
+          - "3.13"
         platform:
           - ubuntu-latest
     runs-on: ${{ matrix.platform }}

--- a/mypy.ini
+++ b/mypy.ini
@@ -20,7 +20,7 @@ disable_error_code =
 
 # CI should test for all versions, local development gets hints for oldest supported
 # But our testing setup doesn't allow passing CLI arguments, so local devs have to set this manually.
-# python_version = 3.8
+# python_version = 3.9
 
 exclude = (?x)(
 	# Avoid scanning Python files in generated folders

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -11,7 +11,7 @@
 		"setuptools/_distutils",
 	],
 	// Our testing setup doesn't allow passing CLI arguments, so local devs have to set this manually.
-	// "pythonVersion": "3.8",
+	// "pythonVersion": "3.9",
 	// For now we don't mind if mypy's `type: ignore` comments accidentally suppresses pyright issues
 	"enableTypeIgnoreComments": true,
 	"typeCheckingMode": "basic",

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 # include pyproject.toml for requires-python (workaround astral-sh/ruff#10299)
-include = "pyproject.toml"
+include = ["pyproject.toml"]
 
 exclude = [
 	"**/_vendor",

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -1407,6 +1407,10 @@ def test_use_correct_python_version_string(tmpdir, tmpdir_cwd, monkeypatch):
     assert cmd.config_vars['py_version_nodot'] == '310'
 
 
+@pytest.mark.xfail(
+    sys.platform == "darwin",
+    reason="https://github.com/pypa/setuptools/pull/4716#issuecomment-2447624418",
+)
 def test_editable_user_and_build_isolation(setup_context, monkeypatch, tmp_path):
     """`setup.py develop` should honor `--user` even under build isolation"""
 


### PR DESCRIPTION
Since https://github.com/pypa/setuptools/commit/e47994c81ce3e97502f761bdef60b20fe72bf02a we are having problems with 3.8.

This PR updates the versions to support the oldest and newest supported stable Python versions.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4717

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request


/cc @Avasam for `pyright` GHA.