### PR TITLE
Consistently using `sys.version_info` as a `NamedTuple`

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -387,7 +387,7 @@ class UnknownExtra(ResolutionError):
 
 _provider_factories: dict[type[_ModuleLike], _ProviderFactoryType] = {}
 
-PY_MAJOR = '{}.{}'.format(*sys.version_info)
+PY_MAJOR = f'{sys.version_info.major}.{sys.version_info.minor}'
 EGG_DIST = 3
 BINARY_DIST = 2
 SOURCE_DIST = 1

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -119,7 +119,7 @@ class TestDistro:
         self.checkFooPkg(d)
 
         d = Distribution("/some/path")
-        assert d.py_version == '{}.{}'.format(*sys.version_info)
+        assert d.py_version == f'{sys.version_info.major}.{sys.version_info.minor}'
         assert d.platform is None
 
     def testDistroParse(self):

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -64,7 +64,7 @@ def _is_32bit_interpreter() -> bool:
 
 
 def python_tag() -> str:
-    return f"py{sys.version_info[0]}"
+    return f"py{sys.version_info.major}"
 
 
 def get_platform(archive_root: str | None) -> str:
@@ -483,7 +483,7 @@ class bdist_wheel(Command):
         # Add to 'Distribution.dist_files' so that the "upload" command works
         getattr(self.distribution, "dist_files", []).append((
             "bdist_wheel",
-            "{}.{}".format(*sys.version_info[:2]),  # like 3.7
+            f"{sys.version_info.major}.{sys.version_info.minor}",
             wheel_path,
         ))
 

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -234,10 +234,9 @@ class easy_install(Command):
         """
         Render the Setuptools version and installation details, then exit.
         """
-        ver = '{}.{}'.format(*sys.version_info)
+        ver = f'{sys.version_info.major}.{sys.version_info.minor}'
         dist = get_distribution('setuptools')
-        tmpl = 'setuptools {dist.version} from {dist.location} (Python {ver})'
-        print(tmpl.format(**locals()))
+        print(f'setuptools {dist.version} from {dist.location} (Python {ver})')
         raise SystemExit
 
     def finalize_options(self):  # noqa: C901  # is too complex (25)  # FIXME
@@ -1441,7 +1440,7 @@ def get_site_dirs():
                 os.path.join(
                     prefix,
                     "lib",
-                    "python{}.{}".format(*sys.version_info),
+                    f"python{sys.version_info.major}.{sys.version_info.minor}",
                     "site-packages",
                 ),
                 os.path.join(prefix, "lib", "site-python"),
@@ -1468,7 +1467,7 @@ def get_site_dirs():
             home,
             'Library',
             'Python',
-            '{}.{}'.format(*sys.version_info),
+            f'{sys.version_info.major}.{sys.version_info.minor}',
             'site-packages',
         )
         sitedirs.append(home_sp)

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -31,7 +31,7 @@ from distutils.errors import DistutilsInternalError
 from distutils.filelist import FileList as _FileList
 from distutils.util import convert_path
 
-PY_MAJOR = '{}.{}'.format(*sys.version_info)
+PY_MAJOR = f'{sys.version_info.major}.{sys.version_info.minor}'
 
 
 def translate_pattern(glob):  # noqa: C901  # is too complex (14)  # FIXME

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -64,10 +64,7 @@ __all__ = [
 
 _SOCKET_TIMEOUT = 15
 
-_tmpl = "setuptools/{setuptools.__version__} Python-urllib/{py_major}"
-user_agent = _tmpl.format(
-    py_major='{}.{}'.format(*sys.version_info), setuptools=setuptools
-)
+user_agent = f"setuptools/{setuptools.__version__} Python-urllib/{sys.version_info.major}.{sys.version_info.minor}"
 
 
 def parse_requirement_arg(spec):

--- a/setuptools/tests/test_easy_install.py
+++ b/setuptools/tests/test_easy_install.py
@@ -859,7 +859,9 @@ class TestSetupRequires:
         )
         dep_2_0_sdist = 'dep-2.0.tar.gz'
         dep_2_0_url = path_to_url(str(tmpdir / dep_2_0_sdist))
-        dep_2_0_python_requires = '!=' + '.'.join(map(str, sys.version_info[:2])) + '.*'
+        dep_2_0_python_requires = (
+            f'!={sys.version_info.major}.{sys.version_info.minor}.*'
+        )
         make_python_requires_sdist(
             str(tmpdir / dep_2_0_sdist), 'dep', '2.0', dep_2_0_python_requires
         )

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -261,11 +261,11 @@ class TestEggInfo:
         })
 
     mismatch_marker = "python_version<'{this_ver}'".format(
-        this_ver=sys.version_info[0],
+        this_ver=sys.version_info.major,
     )
     # Alternate equivalent syntax.
     mismatch_marker_alternate = 'python_version < "{this_ver}"'.format(
-        this_ver=sys.version_info[0],
+        this_ver=sys.version_info.major,
     )
     invalid_marker = "<=>++"
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Granted this may be a matter of preference, but I do believe it helps in clarity and "explicit > implicit".

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
