### PR TITLE
Automatic updates from Ruff for Python 3.9+

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -50,22 +50,17 @@ import types
 import warnings
 import zipfile
 import zipimport
+from collections.abc import Iterable, Iterator, Mapping, MutableSequence
 from pkgutil import get_importer
 from typing import (
     TYPE_CHECKING,
     Any,
     BinaryIO,
     Callable,
-    Dict,
-    Iterable,
-    Iterator,
     Literal,
-    Mapping,
-    MutableSequence,
     NamedTuple,
     NoReturn,
     Protocol,
-    Tuple,
     TypeVar,
     Union,
     overload,
@@ -424,7 +419,7 @@ def get_provider(moduleOrReq: str | Requirement) -> IResourceProvider | Distribu
     return _find_adapter(_provider_factories, loader)(module)
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _macos_vers():
     version = platform.mac_ver()[0]
     # fallback for MacPorts
@@ -1120,7 +1115,7 @@ class WorkingSet:
         self.callbacks = callbacks[:]
 
 
-class _ReqExtras(Dict["Requirement", Tuple[str, ...]]):
+class _ReqExtras(dict["Requirement", tuple[str, ...]]):
     """
     Map each requirement to the extras that demanded it.
     """
@@ -1952,7 +1947,7 @@ class EmptyProvider(NullProvider):
 empty_provider = EmptyProvider()
 
 
-class ZipManifests(Dict[str, "MemoizedZipManifests.manifest_mod"]):
+class ZipManifests(dict[str, "MemoizedZipManifests.manifest_mod"]):
     """
     zip manifest builder
     """
@@ -2662,7 +2657,7 @@ if TYPE_CHECKING:
 
 else:
 
-    @functools.lru_cache(maxsize=None)
+    @functools.cache
     def _normalize_cached(filename):
         return normalize_path(filename)
 

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from functools import lru_cache
-from typing import TYPE_CHECKING, Callable, Iterable, Iterator, TypeVar, Union, overload
+from typing import TYPE_CHECKING, Callable, TypeVar, Union, overload
 
 import jaraco.text as text
 from packaging.requirements import Requirement

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -37,8 +37,9 @@ import sys
 import tempfile
 import tokenize
 import warnings
+from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterable, Iterator, List, Mapping, Union
+from typing import TYPE_CHECKING, Union
 
 import setuptools
 
@@ -146,7 +147,7 @@ def suppress_known_deprecation():
         yield
 
 
-_ConfigSettings: TypeAlias = Union[Mapping[str, Union[str, List[str], None]], None]
+_ConfigSettings: TypeAlias = Union[Mapping[str, Union[str, list[str], None]], None]
 """
 Currently the user can run::
 

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -11,8 +11,9 @@ from __future__ import annotations
 
 import io
 from collections import defaultdict
+from collections.abc import Mapping
 from itertools import filterfalse
-from typing import Dict, Mapping, TypeVar
+from typing import TypeVar
 
 from jaraco.text import yield_lines
 from packaging.requirements import Requirement
@@ -22,7 +23,7 @@ from .._reqs import _StrOrIter
 
 # dict can work as an ordered set
 _T = TypeVar("_T")
-_Ordered = Dict[_T, None]
+_Ordered = dict[_T, None]
 
 
 def _prepare(

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -14,11 +14,12 @@ import struct
 import sys
 import sysconfig
 import warnings
+from collections.abc import Iterable, Sequence
 from email.generator import BytesGenerator, Generator
 from email.policy import EmailPolicy
 from glob import iglob
 from shutil import rmtree
-from typing import TYPE_CHECKING, Callable, Iterable, Literal, Sequence, cast
+from typing import TYPE_CHECKING, Callable, Literal, cast
 from zipfile import ZIP_DEFLATED, ZIP_STORED
 
 from packaging import tags, version as _packaging_version

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import itertools
 import os
 import sys
+from collections.abc import Iterator
 from importlib.machinery import EXTENSION_SUFFIXES
 from importlib.util import cache_from_source as _compiled_file_name
 from pathlib import Path
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 from setuptools.dist import Distribution
 from setuptools.errors import BaseError

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -5,10 +5,10 @@ import itertools
 import os
 import stat
 import textwrap
+from collections.abc import Iterable, Iterator
 from functools import partial
 from glob import glob
 from pathlib import Path
-from typing import Iterable, Iterator
 
 from more_itertools import unique_everseen
 

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -17,6 +17,7 @@ import logging
 import os
 import shutil
 import traceback
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import suppress
 from enum import Enum
 from inspect import cleandoc
@@ -24,7 +25,7 @@ from itertools import chain, starmap
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import TracebackType
-from typing import TYPE_CHECKING, Iterable, Iterator, Mapping, Protocol, TypeVar, cast
+from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
 from .. import Command, _normalization, _path, errors, namespaces
 from .._path import StrPath

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -12,12 +12,13 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from email.headerregistry import Address
 from functools import partial, reduce
 from inspect import cleandoc
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Callable, Dict, Mapping, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
 
 from .._path import StrPath
 from ..errors import RemovedConfigError
@@ -34,7 +35,7 @@ if TYPE_CHECKING:
 
 
 EMPTY: Mapping = MappingProxyType({})  # Immutable dict-like
-_ProjectReadmeValue: TypeAlias = Union[str, Dict[str, str]]
+_ProjectReadmeValue: TypeAlias = Union[str, dict[str, str]]
 _Correspondence: TypeAlias = Callable[["Distribution", Any, Union[StrPath, None]], None]
 _T = TypeVar("_T")
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -25,13 +25,14 @@ import importlib
 import os
 import pathlib
 import sys
+from collections.abc import Iterable, Iterator, Mapping
 from configparser import ConfigParser
 from glob import iglob
 from importlib.machinery import ModuleSpec, all_suffixes
 from itertools import chain
 from pathlib import Path
 from types import ModuleType, TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from .._path import StrPath, same_path as _same_path
 from ..discovery import find_package_path

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from contextlib import contextmanager
 from functools import partial
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Mapping
+from typing import TYPE_CHECKING, Any, Callable
 
 from .._path import StrPath
 from ..errors import FileError, InvalidConfigError

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -15,21 +15,9 @@ import contextlib
 import functools
 import os
 from collections import defaultdict
+from collections.abc import Iterable, Iterator
 from functools import partial, wraps
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Generic,
-    Iterable,
-    Iterator,
-    List,
-    Tuple,
-    TypeVar,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, TypeVar, cast
 
 from packaging.markers import default_environment as marker_env
 from packaging.requirements import InvalidRequirement, Requirement
@@ -48,13 +36,13 @@ if TYPE_CHECKING:
 
     from distutils.dist import DistributionMetadata
 
-SingleCommandOptions: TypeAlias = Dict[str, Tuple[str, Any]]
+SingleCommandOptions: TypeAlias = dict[str, tuple[str, Any]]
 """Dict that associate the name of the options of a particular command to a
 tuple. The first element of the tuple indicates the origin of the option value
 (e.g. the name of the configuration file where it was read from),
 while the second element of the tuple is the option value itself
 """
-AllCommandOptions: TypeAlias = Dict[str, SingleCommandOptions]
+AllCommandOptions: TypeAlias = dict[str, SingleCommandOptions]
 """cmd name => its options"""
 Target = TypeVar("Target", "Distribution", "DistributionMetadata")
 
@@ -114,7 +102,7 @@ def _apply(
 
     try:
         # TODO: Temporary cast until mypy 1.12 is released with upstream fixes from typeshed
-        _Distribution.parse_config_files(dist, filenames=cast(List[str], filenames))
+        _Distribution.parse_config_files(dist, filenames=cast(list[str], filenames))
         handlers = parse_configuration(
             dist, dist.command_options, ignore_option_errors=ignore_option_errors
         )

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -41,11 +41,11 @@ from __future__ import annotations
 
 import itertools
 import os
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from fnmatch import fnmatchcase
 from glob import glob
 from pathlib import Path
-from typing import TYPE_CHECKING, ClassVar, Iterable, Mapping
+from typing import TYPE_CHECKING, ClassVar
 
 import _distutils_hack.override  # noqa: F401
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -6,19 +6,10 @@ import numbers
 import os
 import re
 import sys
-from collections.abc import Iterable
+from collections.abc import Iterable, MutableMapping, Sequence
 from glob import iglob
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    List,
-    MutableMapping,
-    Sequence,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Union
 
 from more_itertools import partition, unique_everseen
 from packaging.markers import InvalidMarker, Marker
@@ -66,10 +57,10 @@ Supported iterable types that are known to be:
 - not imply a nested type (like `dict`)
 for use with `isinstance`.
 """
-_Sequence: TypeAlias = Union[Tuple[str, ...], List[str]]
+_Sequence: TypeAlias = Union[tuple[str, ...], list[str]]
 # This is how stringifying _Sequence would look in Python 3.10
 _sequence_type_repr = "tuple[str, ...] | list[str]"
-_OrderedStrSequence: TypeAlias = Union[str, Dict[str, Any], Sequence[str]]
+_OrderedStrSequence: TypeAlias = Union[str, dict[str, Any], Sequence[str]]
 """
 :meta private:
 Avoid single-use iterable. Disallow sets.

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -8,7 +8,7 @@ import inspect
 import platform
 import sys
 import types
-from typing import Type, TypeVar, cast, overload
+from typing import TypeVar, cast, overload
 
 import distutils.filelist
 
@@ -58,7 +58,7 @@ def get_unpatched_class(cls: type[_T]) -> type[_T]:
     first.
     """
     external_bases = (
-        cast(Type[_T], cls)
+        cast(type[_T], cls)
         for cls in _get_mro(cls)
         if not cls.__module__.startswith('setuptools')
     )

--- a/setuptools/warnings.py
+++ b/setuptools/warnings.py
@@ -12,12 +12,12 @@ import warnings
 from datetime import date
 from inspect import cleandoc
 from textwrap import indent
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-_DueDate: TypeAlias = Tuple[int, int, int]  # time tuple
+_DueDate: TypeAlias = tuple[int, int, int]  # time tuple
 _INDENT = 8 * " "
 _TEMPLATE = f"""{80 * '*'}\n{{details}}\n{80 * '*'}"""
 

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -31,7 +31,7 @@ WHEEL_NAME = re.compile(
 NAMESPACE_PACKAGE_INIT = "__import__('pkg_resources').declare_namespace(__name__)\n"
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def _get_supported_tags():
     # We calculate the supported tags only once, otherwise calling
     # this method on thousands of wheels takes seconds instead of

--- a/tools/generate_validation_code.py
+++ b/tools/generate_validation_code.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import itertools
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 
 def generate_pyproject_validation(dest: Path, schemas: Iterable[Path]) -> bool:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Implement @Avasam suggestions from https://github.com/pypa/setuptools/pull/4718#issuecomment-2448099867:

> - functools.lru_cache(maxsize=None) can be replaced by functools.cache
> - Callable, Generator, Iterator, Iterable, Sequence, Mapping, MutableMapping should be imported from collections.abc instead of typing
> - Type, Dict, List, Tuple should be replaced by their builtin variant
> 



The procedure used for the changes is:

1. Modify `ruff.toml` as suggested in https://github.com/pypa/setuptools/pull/4718#issuecomment-2448099867
2. Run `ruff check --fix --unsafe-fixes`
3. Manually add the missing fixes
4. Manually check all files and add improvements as necessary
5. `git restore ruff.toml` (I am leaving this decision for `skeleton` for the time being)
6. `git restore setuptools/_importlib.py` (Already covered in #4718)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
