### PR TITLE
Move `setuptools._path.StrPath` out of the `if TYPE_CHECKING` (Python 3.9+)

### DIFF
--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -10,10 +10,8 @@ from more_itertools import unique_everseen
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-    StrPath: TypeAlias = Union[str, os.PathLike[str]]  #  Same as _typeshed.StrPath
-else:
-    # Python 3.8 support
-    StrPath: TypeAlias = Union[str, os.PathLike]
+
+StrPath: TypeAlias = Union[str, os.PathLike[str]]  #  Same as _typeshed.StrPath
 
 
 def ensure_directory(path):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Implement @Avasam suggestions from https://github.com/pypa/setuptools/pull/4718#issuecomment-2448099867:

> You can move `setuptools._path.StrPat` out of the `TYPE_CHECKING` check

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
