### PR TITLE
Add comment explaining the origin of workaround for `_splituser`

### DIFF
--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -1104,6 +1104,7 @@ def open_with_auth(url, opener=urllib.request.urlopen):
 
 
 # copy of urllib.parse._splituser from Python 3.8
+# See https://github.com/python/cpython/issues/80072.
 def _splituser(host):
     """splituser('user[:passwd]@host[:port]')
     --> 'user[:passwd]', 'host[:port]'."""


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Implements @Avasam's suggestion in https://github.com/pypa/setuptools/pull/4718#issuecomment-2448304407.

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
