### PR TITLE
Set Ruff's pytest's parametrize-names-type to default (tuple)

### DIFF
--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -236,7 +236,7 @@ def make_distribution_no_version(tmpdir, basename):
 
 
 @pytest.mark.parametrize(
-    'suffix, expected_filename, expected_dist_type',
+    ("suffix", "expected_filename", "expected_dist_type"),
     [
         ('egg-info', 'PKG-INFO', EggInfoDistribution),
         ('dist-info', 'METADATA', DistInfoDistribution),
@@ -376,7 +376,7 @@ class TestDeepVersionLookupDistutils:
         assert dist.version == version
 
     @pytest.mark.parametrize(
-        'unnormalized, normalized',
+        ("unnormalized", "normalized"),
         [
             ('foo', 'foo'),
             ('foo/', 'foo'),
@@ -398,7 +398,7 @@ class TestDeepVersionLookupDistutils:
         reason='Testing case-insensitive filesystems.',
     )
     @pytest.mark.parametrize(
-        'unnormalized, normalized',
+        ("unnormalized", "normalized"),
         [
             ('MiXeD/CasE', 'mixed/case'),
         ],
@@ -414,7 +414,7 @@ class TestDeepVersionLookupDistutils:
         reason='Testing systems using backslashes as path separators.',
     )
     @pytest.mark.parametrize(
-        'unnormalized, expected',
+        ("unnormalized", "expected"),
         [
             ('forward/slash', 'forward\\slash'),
             ('forward/slash/', 'forward\\slash'),

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -700,7 +700,7 @@ class TestParsing:
         (req,) = parse_requirements('foo >= 1.0, < 3')
 
     @pytest.mark.parametrize(
-        'lower, upper',
+        ("lower", "upper"),
         [
             ('1.2-rc1', '1.2rc1'),
             ('0.4', '0.4.0'),
@@ -724,7 +724,7 @@ class TestParsing:
         """
 
     @pytest.mark.parametrize(
-        'lower, upper',
+        ("lower", "upper"),
         [
             ('2.1', '2.1.1'),
             ('2a1', '2b0'),

--- a/ruff.toml
+++ b/ruff.toml
@@ -81,9 +81,6 @@ sections.delayed = ["distutils"]
 [lint.flake8-annotations]
 ignore-fully-untyped = true
 
-[lint.flake8-pytest-style]
-parametrize-names-type = "csv"
-
 [format]
 # Enable preview to get hugged parenthesis unwrapping and other nice surprises
 # See https://github.com/jaraco/skeleton/pull/133#issuecomment-2239538373

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -183,7 +183,7 @@ def test_pep621_example(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "readme, ctype",
+    ("readme", "ctype"),
     [
         ("Readme.txt", "text/plain"),
         ("readme.md", "text/markdown"),
@@ -209,7 +209,7 @@ def test_no_explicit_content_type_for_missing_extension(tmp_path):
 
 
 @pytest.mark.parametrize(
-    'pyproject_text, expected_maintainers_meta_value',
+    ("pyproject_text", "expected_maintainers_meta_value"),
     (
         pytest.param(
             PEP621_EXAMPLE,
@@ -370,7 +370,7 @@ class TestPresetField:
         return file
 
     @pytest.mark.parametrize(
-        "attr, field, value",
+        ("attr", "field", "value"),
         [
             ("classifiers", "classifiers", ["Private :: Classifier"]),
             ("entry_points", "scripts", {"console_scripts": ["foobar=foobar:main"]}),
@@ -395,7 +395,7 @@ class TestPresetField:
         assert not dist_value
 
     @pytest.mark.parametrize(
-        "attr, field, value",
+        ("attr", "field", "value"),
         [
             ("install_requires", "dependencies", []),
             ("extras_require", "optional-dependencies", {}),
@@ -442,7 +442,8 @@ class TestPresetField:
         assert ':python_version < "3.7"' in reqs
 
     @pytest.mark.parametrize(
-        "field,group", [("scripts", "console_scripts"), ("gui-scripts", "gui_scripts")]
+        ("field", "group"),
+        [("scripts", "console_scripts"), ("gui-scripts", "gui_scripts")],
     )
     @pytest.mark.filterwarnings("error")
     def test_scripts_dont_require_dynamic_entry_points(self, tmp_path, field, group):

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -141,7 +141,7 @@ class TestReadAttr:
 
 
 @pytest.mark.parametrize(
-    'package_dir, file, module, return_value',
+    ("package_dir", "file", "module", "return_value"),
     [
         ({"": "src"}, "src/pkg/main.py", "pkg.main", 42),
         ({"pkg": "lib"}, "lib/main.py", "pkg.main", 13),
@@ -158,7 +158,7 @@ def test_resolve_class(monkeypatch, tmp_path, package_dir, file, module, return_
 
 
 @pytest.mark.parametrize(
-    'args, pkgs',
+    ("args", "pkgs"),
     [
         ({"where": ["."], "namespaces": False}, {"pkg", "other"}),
         ({"where": [".", "dir1"], "namespaces": False}, {"pkg", "other", "dir2"}),
@@ -192,7 +192,7 @@ def test_find_packages(tmp_path, args, pkgs):
 
 
 @pytest.mark.parametrize(
-    "files, where, expected_package_dir",
+    ("files", "where", "expected_package_dir"),
     [
         (["pkg1/__init__.py", "pkg1/other.py"], ["."], {}),
         (["pkg1/__init__.py", "pkg2/__init__.py"], ["."], {}),

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -149,7 +149,7 @@ def test_read_configuration(tmp_path):
 
 
 @pytest.mark.parametrize(
-    "pkg_root, opts",
+    ("pkg_root", "opts"),
     [
         (".", {}),
         ("src", {}),
@@ -308,7 +308,7 @@ def test_ignore_unrelated_config(tmp_path, example):
 
 
 @pytest.mark.parametrize(
-    "example, error_msg",
+    ("example", "error_msg"),
     [
         (
             """

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -122,7 +122,7 @@ def _prepare(tmp_path, venv_python, monkeypatch):
     run([venv_python, "-m", "pip", "freeze"])
 
 
-@pytest.mark.parametrize('package, version', EXAMPLES)
+@pytest.mark.parametrize(("package", "version"), EXAMPLES)
 @pytest.mark.uses_network
 def test_install_sdist(package, version, tmp_path, venv_python, setuptools_wheel):
     venv_pip = (venv_python, "-m", "pip")

--- a/setuptools/tests/test_bdist_wheel.py
+++ b/setuptools/tests/test_bdist_wheel.py
@@ -322,7 +322,7 @@ def test_licenses_deprecated(dummy_dist, monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "config_file, config",
+    ("config_file", "config"),
     [
         ("setup.cfg", "[metadata]\nlicense_files=licenses/*\n  LICENSE"),
         ("setup.cfg", "[metadata]\nlicense_files=licenses/*, LICENSE"),
@@ -434,7 +434,7 @@ def test_build_from_readonly_tree(dummy_dist, monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "option, compress_type",
+    ("option", "compress_type"),
     list(bdist_wheel.supported_compressions.items()),
     ids=list(bdist_wheel.supported_compressions),
 )
@@ -589,7 +589,7 @@ def test_data_dir_with_tag_build(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    "reported,expected",
+    ("reported", "expected"),
     [("linux-x86_64", "linux_i686"), ("linux-aarch64", "linux_armv7l")],
 )
 @pytest.mark.skipif(

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -737,7 +737,7 @@ class TestBuildMetaBackend:
         self._assert_link_tree(next(Path("build").glob("__editable__.*")))
 
     @pytest.mark.parametrize(
-        'setup_literal, requirements',
+        ("setup_literal", "requirements"),
         [
             ("'foo'", ['foo']),
             ("['foo']", ['foo']),

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -161,7 +161,7 @@ class TestDiscoverPackagesAndPyModules:
     }
 
     @pytest.mark.parametrize(
-        "config_file, param, circumstance",
+        ("config_file", "param", "circumstance"),
         product(
             ["setup.cfg", "setup.py", "pyproject.toml"],
             ["packages", "py_modules"],
@@ -191,7 +191,7 @@ class TestDiscoverPackagesAndPyModules:
         assert getattr(dist, other) is None
 
     @pytest.mark.parametrize(
-        "extra_files, pkgs",
+        ("extra_files", "pkgs"),
         [
             (["venv/bin/simulate_venv"], {"pkg"}),
             (["pkg-stubs/__init__.pyi"], {"pkg", "pkg-stubs"}),
@@ -284,7 +284,7 @@ class TestNoConfig:
 
 class TestWithAttrDirective:
     @pytest.mark.parametrize(
-        "folder, opts",
+        ("folder", "opts"),
         [
             ("src", {}),
             ("lib", {"packages": "find:", "packages.find": {"where": "lib"}}),
@@ -446,7 +446,7 @@ class TestWithPackageData:
     """
 
     @pytest.mark.parametrize(
-        "src_root, files",
+        ("src_root", "files"),
         [
             (".", {"setup.cfg": DALS(EXAMPLE_SETUPCFG)}),
             (".", {"pyproject.toml": DALS(EXAMPLE_PYPROJECT)}),

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -23,7 +23,7 @@ EXAMPLE_BASE_INFO = dict(
 
 
 @pytest.mark.parametrize(
-    'content, result',
+    ("content", "result"),
     (
         pytest.param(
             "Just a single line",
@@ -154,7 +154,7 @@ def __read_test_cases():
     ]
 
 
-@pytest.mark.parametrize('name,attrs', __read_test_cases())
+@pytest.mark.parametrize(("name", "attrs"), __read_test_cases())
 def test_read_metadata(name, attrs):
     dist = Distribution(attrs)
     metadata_out = dist.metadata
@@ -263,7 +263,7 @@ def __maintainer_test_cases():
     ]
 
 
-@pytest.mark.parametrize('name,attrs', __maintainer_test_cases())
+@pytest.mark.parametrize(("name", "attrs"), __maintainer_test_cases())
 def test_maintainer_author(name, attrs, tmpdir):
     tested_keys = {
         'author': 'Author',

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -129,7 +129,7 @@ CHECK_PACKAGE_DATA_TESTS = (
 )
 
 
-@pytest.mark.parametrize('package_data, expected_message', CHECK_PACKAGE_DATA_TESTS)
+@pytest.mark.parametrize(('package_data', 'expected_message'), CHECK_PACKAGE_DATA_TESTS)
 def test_check_package_data(package_data, expected_message):
     if expected_message is None:
         assert check_package_data(None, 'package_data', package_data) is None
@@ -156,7 +156,7 @@ def test_metadata_name():
 
 
 @pytest.mark.parametrize(
-    "dist_name, py_module",
+    ('dist_name', 'py_module'),
     [
         ("my.pkg", "my_pkg"),
         ("my-pkg", "my_pkg"),
@@ -187,7 +187,7 @@ def test_dist_default_py_modules(tmp_path, dist_name, py_module):
 
 
 @pytest.mark.parametrize(
-    "dist_name, package_dir, package_files, packages",
+    ('dist_name', 'package_dir', 'package_files', 'packages'),
     [
         ("my.pkg", None, ["my_pkg/__init__.py", "my_pkg/mod.py"], ["my_pkg"]),
         ("my-pkg", None, ["my_pkg/__init__.py", "my_pkg/mod.py"], ["my_pkg"]),
@@ -241,7 +241,7 @@ def test_dist_default_packages(
 
 
 @pytest.mark.parametrize(
-    "dist_name, package_dir, package_files",
+    ('dist_name', 'package_dir', 'package_files'),
     [
         ("my.pkg.nested", None, ["my/pkg/nested/__init__.py"]),
         ("my.pkg", None, ["my/pkg/__init__.py", "my/pkg/file.py"]),

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -169,7 +169,7 @@ class TestWheelCompatibility:
 
     @pytest.mark.parametrize("name", "my-proj my_proj my.proj My.Proj".split())
     @pytest.mark.parametrize("version", ["0.42.13"])
-    @pytest.mark.parametrize("suffix, cfg", EGG_INFO_OPTS)
+    @pytest.mark.parametrize(("suffix", "cfg"), EGG_INFO_OPTS)
     def test_dist_info_is_the_same_as_in_wheel(
         self, name, version, tmp_path, suffix, cfg
     ):

--- a/setuptools/tests/test_distutils_adoption.py
+++ b/setuptools/tests/test_distutils_adoption.py
@@ -116,7 +116,7 @@ print("success")
 
 @pytest.mark.usefixtures("tmpdir_cwd")
 @pytest.mark.parametrize(
-    "distutils_version, imported_module",
+    ('distutils_version', 'imported_module'),
     [
         pytest.param("stdlib", "dir_util", marks=skip_without_stdlib_distutils),
         pytest.param("stdlib", "file_util", marks=skip_without_stdlib_distutils),
@@ -175,7 +175,7 @@ else:
 
 @pytest.mark.usefixtures("tmpdir_cwd")
 @pytest.mark.parametrize(
-    "distutils_version, imported_module",
+    ('distutils_version', 'imported_module'),
     [
         ("local", "distutils"),
         # Unfortunately we still get ._distutils.errors.DistutilsError with SETUPTOOLS_USE_DISTUTILS=stdlib

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -543,7 +543,7 @@ class TestEggInfo:
         assert 'Provides-Extra:' not in pkg_info_text
 
     @pytest.mark.parametrize(
-        "files, license_in_sources",
+        ('files', 'license_in_sources'),
         [
             (
                 {
@@ -627,7 +627,7 @@ class TestEggInfo:
             assert 'INVALID_LICENSE' not in sources_text
 
     @pytest.mark.parametrize(
-        "files, incl_licenses, excl_licenses",
+        ('files', 'incl_licenses', 'excl_licenses'),
         [
             (
                 {
@@ -839,7 +839,7 @@ class TestEggInfo:
             assert sources_lines.count(lf) == 0
 
     @pytest.mark.parametrize(
-        "files, incl_licenses, excl_licenses",
+        ('files', 'incl_licenses', 'excl_licenses'),
         [
             (
                 {

--- a/setuptools/tests/test_glob.py
+++ b/setuptools/tests/test_glob.py
@@ -5,7 +5,7 @@ from setuptools.glob import glob
 
 
 @pytest.mark.parametrize(
-    'tree, pattern, matches',
+    ('tree', 'pattern', 'matches'),
     (
         ('', b'', []),
         ('', '', []),

--- a/setuptools/tests/test_logging.py
+++ b/setuptools/tests/test_logging.py
@@ -19,7 +19,7 @@ setup(
 
 
 @pytest.mark.parametrize(
-    "flag, expected_level", [("--dry-run", "INFO"), ("--verbose", "DEBUG")]
+    ('flag', 'expected_level'), [("--dry-run", "INFO"), ("--verbose", "DEBUG")]
 )
 def test_verbosity_level(tmp_path, monkeypatch, flag, expected_level):
     """Make sure the correct verbosity level is set (issue #3038)"""

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -78,7 +78,7 @@ WHEEL_INFO_TESTS = (
 
 
 @pytest.mark.parametrize(
-    'filename, info', WHEEL_INFO_TESTS, ids=[t[0] for t in WHEEL_INFO_TESTS]
+    ('filename', 'info'), WHEEL_INFO_TESTS, ids=[t[0] for t in WHEEL_INFO_TESTS]
 )
 def test_wheel_info(filename, info):
     if inspect.isclass(info):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Follow-up to https://github.com/pypa/setuptools/pull/4557#discussion_r1824409142
1. Remove the `ruff.lint.flake8-pytest-style.parametrize-names-type` config from `ruff.toml`
2. Run `ruff check --fix --unsafe-fixes`
3. Run `ruff format`

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
