### PR TITLE
ANN204 (missing return type for special methods) autofixes

### DIFF
--- a/_distutils_hack/__init__.py
+++ b/_distutils_hack/__init__.py
@@ -90,7 +90,7 @@ def do_override():
 
 
 class _TrivialRe:
-    def __init__(self, *patterns):
+    def __init__(self, *patterns) -> None:
         self._patterns = patterns
 
     def match(self, string):

--- a/pkg_resources/tests/test_resources.py
+++ b/pkg_resources/tests/test_resources.py
@@ -32,7 +32,7 @@ def pairwise(iterable):
 class Metadata(pkg_resources.EmptyProvider):
     """Mock object to return metadata as if from an on-disk distribution"""
 
-    def __init__(self, *pairs):
+    def __init__(self, *pairs) -> None:
         self.metadata = dict(pairs)
 
     def has_metadata(self, name) -> bool:

--- a/pkg_resources/tests/test_working_set.py
+++ b/pkg_resources/tests/test_working_set.py
@@ -56,7 +56,7 @@ def parse_distributions(s):
 
 
 class FakeInstaller:
-    def __init__(self, installable_dists):
+    def __init__(self, installable_dists) -> None:
         self._installable_dists = installable_dists
 
     def __call__(self, req):

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -60,7 +60,7 @@ def _install_setup_requires(attrs):
         fetch_build_eggs interface.
         """
 
-        def __init__(self, attrs: Mapping[str, object]):
+        def __init__(self, attrs: Mapping[str, object]) -> None:
             _incl = 'dependency_links', 'setup_requires'
             filtered = {k: attrs[k] for k in set(_incl) & set(attrs)}
             super().__init__(filtered)
@@ -167,7 +167,7 @@ class Command(_Command):
     command_consumes_arguments = False
     distribution: Distribution  # override distutils.dist.Distribution with setuptools.dist.Distribution
 
-    def __init__(self, dist: Distribution, **kw):
+    def __init__(self, dist: Distribution, **kw) -> None:
         """
         Construct the command for dist, updating
         vars(self) with any keyword parameters.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -72,7 +72,7 @@ LEGACY_EDITABLE = "legacy-editable" in SETUPTOOLS_ENABLE_FEATURES.replace("_", "
 
 
 class SetupRequirementsError(BaseException):
-    def __init__(self, specifiers):
+    def __init__(self, specifiers) -> None:
         self.specifiers = specifiers
 
 

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -185,7 +185,7 @@ class VersionlessRequirement:
     'foo'
     """
 
-    def __init__(self, dist):
+    def __init__(self, dist) -> None:
         self.__dist = dist
 
     def __getattr__(self, name: str):

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1612,7 +1612,7 @@ def get_exe_prefixes(exe_filename):
 class PthDistributions(Environment):
     """A .pth file with Distribution paths in it"""
 
-    def __init__(self, filename, sitedirs=()):
+    def __init__(self, filename, sitedirs=()) -> None:
         self.filename = filename
         self.sitedirs = list(map(normalize_path, sitedirs))
         self.basedir = normalize_path(os.path.dirname(self.filename))

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -392,7 +392,7 @@ class EditableStrategy(Protocol):
 
 
 class _StaticPth:
-    def __init__(self, dist: Distribution, name: str, path_entries: list[Path]):
+    def __init__(self, dist: Distribution, name: str, path_entries: list[Path]) -> None:
         self.dist = dist
         self.name = name
         self.path_entries = path_entries
@@ -436,7 +436,7 @@ class _LinkTree(_StaticPth):
         name: str,
         auxiliary_dir: StrPath,
         build_lib: StrPath,
-    ):
+    ) -> None:
         self.auxiliary_dir = Path(auxiliary_dir)
         self.build_lib = Path(build_lib).resolve()
         self._file = dist.get_command_obj("build_py").copy_file
@@ -496,7 +496,7 @@ class _LinkTree(_StaticPth):
 
 
 class _TopLevelFinder:
-    def __init__(self, dist: Distribution, name: str):
+    def __init__(self, dist: Distribution, name: str) -> None:
         self.dist = dist
         self.name = name
 

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -324,7 +324,9 @@ class egg_info(InfoCommon, Command):
 class FileList(_FileList):
     # Implementations of the various MANIFEST.in commands
 
-    def __init__(self, warn=None, debug_print=None, ignore_egg_info_dir: bool = False):
+    def __init__(
+        self, warn=None, debug_print=None, ignore_egg_info_dir: bool = False
+    ) -> None:
         super().__init__(warn, debug_print)
         self.ignore_egg_info_dir = ignore_egg_info_dir
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -52,7 +52,7 @@ _V_co = TypeVar("_V_co", covariant=True)
 class StaticModule:
     """Proxy to a module object that avoids executing arbitrary code."""
 
-    def __init__(self, name: str, spec: ModuleSpec):
+    def __init__(self, name: str, spec: ModuleSpec) -> None:
         module = ast.parse(pathlib.Path(spec.origin).read_bytes())  # type: ignore[arg-type] # Let it raise an error on None
         vars(self).update(locals())
         del self.self
@@ -383,7 +383,7 @@ class EnsurePackagesDiscovered:
     and those might not have been processed yet.
     """
 
-    def __init__(self, distribution: Distribution):
+    def __init__(self, distribution: Distribution) -> None:
         self._dist = distribution
         self._called = False
 
@@ -430,7 +430,7 @@ class LazyMappingProxy(Mapping[_K, _V_co]):
     'other value'
     """
 
-    def __init__(self, obtain_mapping_value: Callable[[], Mapping[_K, _V_co]]):
+    def __init__(self, obtain_mapping_value: Callable[[], Mapping[_K, _V_co]]) -> None:
         self._obtain = obtain_mapping_value
         self._value: Mapping[_K, _V_co] | None = None
 

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -176,7 +176,7 @@ class _ConfigExpander:
         root_dir: StrPath | None = None,
         ignore_option_errors: bool = False,
         dist: Distribution | None = None,
-    ):
+    ) -> None:
         self.config = config
         self.root_dir = root_dir or os.getcwd()
         self.project_cfg = config.get("project", {})
@@ -413,7 +413,7 @@ def _ignore_errors(ignore_option_errors: bool):
 class _EnsurePackagesDiscovered(_expand.EnsurePackagesDiscovered):
     def __init__(
         self, distribution: Distribution, project_cfg: dict, setuptools_cfg: dict
-    ):
+    ) -> None:
         super().__init__(distribution)
         self._project_cfg = project_cfg
         self._setuptools_cfg = setuptools_cfg

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -247,7 +247,7 @@ class ConfigHandler(Generic[Target]):
         options: AllCommandOptions,
         ignore_option_errors,
         ensure_discovered: expand.EnsurePackagesDiscovered,
-    ):
+    ) -> None:
         self.ignore_option_errors = ignore_option_errors
         self.target_obj: Target = target_obj
         self.sections = dict(self._section_options(options))
@@ -540,7 +540,7 @@ class ConfigMetadataHandler(ConfigHandler["DistributionMetadata"]):
         ensure_discovered: expand.EnsurePackagesDiscovered,
         package_dir: dict | None = None,
         root_dir: StrPath | None = os.curdir,
-    ):
+    ) -> None:
         super().__init__(target_obj, options, ignore_option_errors, ensure_discovered)
         self.package_dir = package_dir
         self.root_dir = root_dir
@@ -602,7 +602,7 @@ class ConfigOptionsHandler(ConfigHandler["Distribution"]):
         options: AllCommandOptions,
         ignore_option_errors: bool,
         ensure_discovered: expand.EnsurePackagesDiscovered,
-    ):
+    ) -> None:
         super().__init__(target_obj, options, ignore_option_errors, ensure_discovered)
         self.root_dir = target_obj.src_root
         self.package_dir: dict[str, str] = {}  # To be filled by `find_packages`

--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -28,7 +28,7 @@ class Require:
         homepage: str = '',
         attribute=None,
         format=None,
-    ):
+    ) -> None:
         if format is None and requested_version is not None:
             format = Version
 

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -71,7 +71,7 @@ class _Filter:
     the input matches at least one of the patterns.
     """
 
-    def __init__(self, *patterns: str):
+    def __init__(self, *patterns: str) -> None:
         self._patterns = dict.fromkeys(patterns)
 
     def __call__(self, item: str) -> bool:
@@ -300,7 +300,7 @@ class ConfigDiscovery:
     (from other metadata/options, the file system or conventions)
     """
 
-    def __init__(self, distribution: Distribution):
+    def __init__(self, distribution: Distribution) -> None:
         self.dist = distribution
         self._called = False
         self._disabled = False

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -147,7 +147,7 @@ class Extension(_Extension):
         *args,
         py_limited_api: bool = False,
         **kw,
-    ):
+    ) -> None:
         # The *args is needed for compatibility as calls may use positional
         # arguments. py_limited_api may be set only via keyword.
         self.py_limited_api = py_limited_api

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -50,7 +50,7 @@ class PlatformInfo:
 
     current_cpu = environ.get('processor_architecture', '').lower()
 
-    def __init__(self, arch):
+    def __init__(self, arch) -> None:
         self.arch = arch.lower().replace('x64', 'amd64')
 
     @property
@@ -176,7 +176,7 @@ class RegistryInfo:
         winreg.HKEY_CLASSES_ROOT,
     )
 
-    def __init__(self, platform_info):
+    def __init__(self, platform_info) -> None:
         self.pi = platform_info
 
     @property
@@ -366,7 +366,7 @@ class SystemInfo:
     ProgramFiles = environ.get('ProgramFiles', '')
     ProgramFilesx86 = environ.get('ProgramFiles(x86)', ProgramFiles)
 
-    def __init__(self, registry_info, vc_ver=None):
+    def __init__(self, registry_info, vc_ver=None) -> None:
         self.ri = registry_info
         self.pi = self.ri.pi
 
@@ -911,7 +911,7 @@ class EnvironmentInfo:
     # Variables and properties in this class use originals CamelCase variables
     # names from Microsoft source files for more easy comparison.
 
-    def __init__(self, arch, vc_ver=None, vc_min_ver=0):
+    def __init__(self, arch, vc_ver=None, vc_min_ver=0) -> None:
         self.pi = PlatformInfo(arch)
         self.ri = RegistryInfo(self.pi)
         self.si = SystemInfo(self.ri, vc_ver)

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -270,7 +270,7 @@ class HashChecker(ContentChecker):
         r'(?P<expected>[a-f0-9]+)'
     )
 
-    def __init__(self, hash_name, expected):
+    def __init__(self, hash_name, expected) -> None:
         self.hash_name = hash_name
         self.hash = hashlib.new(hash_name)
         self.expected = expected

--- a/setuptools/sandbox.py
+++ b/setuptools/sandbox.py
@@ -279,7 +279,7 @@ class AbstractSandbox:
 
     _active = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._attrs = [
             name
             for name in dir(_os)
@@ -442,7 +442,7 @@ class DirectorySandbox(AbstractSandbox):
     _exception_patterns: list[str | re.Pattern] = []
     "exempt writing to paths that match the pattern"
 
-    def __init__(self, sandbox, exceptions=_EXCEPTIONS):
+    def __init__(self, sandbox, exceptions=_EXCEPTIONS) -> None:
         self._sandbox = os.path.normcase(os.path.realpath(sandbox))
         self._prefix = os.path.join(self._sandbox, '')
         self._exceptions = [

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -76,7 +76,7 @@ def disable_info_traces():
 
 
 class Wheel:
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         match = WHEEL_NAME(os.path.basename(filename))
         if match is None:
             raise ValueError('invalid wheel name: %r' % filename)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Works towards step 6.2 of https://github.com/pypa/setuptools/issues/2345#issuecomment-1627561833
This will reduce changes from adding return types from typeshed

I commented out `ignore-fully-untyped` in `ruff.toml` then ran `ruff check --fix --unsafe-fixes --extend-exclude=setuptools/tests --select=ANN204`.
Then I removed 3 added return types that were revealing hidden mypy issues to keep the changes here completely automated.

### Pull Request Checklist
- [x] Changes have tests (this cuases more code to be statically checked by mypy)
- [x] News fragment added in [`newsfragments/`]. (no public facing changes)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
