### PR TITLE
Merge bugfixes from distutils

### DIFF
--- a/newsfragments/+f0b61194.bugfix.rst
+++ b/newsfragments/+f0b61194.bugfix.rst
@@ -1,0 +1,1 @@
+Merge with pypa/distutils@251797602, including fix for dirutil.mkpath handling in pypa/distutils#304.

--- a/setuptools/_distutils/dir_util.py
+++ b/setuptools/_distutils/dir_util.py
@@ -32,8 +32,9 @@ class SkipRepeatAbsolutePaths(set):
         def wrapper(path, *args, **kwargs):
             if path.absolute() in self:
                 return
+            result = func(path, *args, **kwargs)
             self.add(path.absolute())
-            return func(path, *args, **kwargs)
+            return result
 
         return wrapper
 
@@ -44,7 +45,7 @@ wrapper = SkipRepeatAbsolutePaths().wrap
 
 @functools.singledispatch
 @wrapper
-def mkpath(name: pathlib.Path, mode=0o777, verbose=True, dry_run=False):
+def mkpath(name: pathlib.Path, mode=0o777, verbose=True, dry_run=False) -> None:
     """Create a directory and any missing ancestor directories.
 
     If the directory already exists (or if 'name' is the empty string, which
@@ -52,20 +53,14 @@ def mkpath(name: pathlib.Path, mode=0o777, verbose=True, dry_run=False):
     Raise DistutilsFileError if unable to create some directory along the way
     (eg. some sub-path exists, but is a file rather than a directory).
     If 'verbose' is true, log the directory created.
-    Return the list of directories actually created.
     """
     if verbose and not name.is_dir():
         log.info("creating %s", name)
-
-    ancestry = itertools.chain((name,), name.parents)
-    missing = (path for path in ancestry if not path.is_dir())
 
     try:
         dry_run or name.mkdir(mode=mode, parents=True, exist_ok=True)
     except OSError as exc:
         raise DistutilsFileError(f"could not create '{name}': {exc.args[-1]}")
-
-    return list(map(str, missing))
 
 
 @mkpath.register


### PR DESCRIPTION
- **Restore expectation that mkpath returns a list of the items it created.**
- **Remove support for returning the directories created in mkpath, unused.**
- **Add test capturing missed expectation.**
- **Correct the order of operations to ensure that failed attempts aren't cached and are thus retried on subsequent operations.**
- **Add news fragment.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
