### PR TITLE
Revert "Allow user to skip validation of pyproject.toml via env var"

### DIFF
--- a/newsfragments/4746.feature.rst
+++ b/newsfragments/4746.feature.rst
@@ -1,0 +1,2 @@
+Removed support for ``SETUPTOOLS_DANGEROUSLY_SKIP_PYPROJECT_VALIDATION``, as it
+is deemed prone to errors.

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -41,19 +41,6 @@ def load_file(filepath: StrPath) -> dict:
 
 
 def validate(config: dict, filepath: StrPath) -> bool:
-    skip = os.getenv("SETUPTOOLS_DANGEROUSLY_SKIP_PYPROJECT_VALIDATION", "false")
-    if skip.lower() == "true":  # https://github.com/pypa/setuptools/issues/4459
-        SetuptoolsWarning.emit(
-            "Skipping the validation of `pyproject.toml`.",
-            """
-            Please note that some setuptools functionalities rely on the validation of
-            `pyproject.toml` against misconfiguration to ensure proper operation.
-            By skipping the automatic checks, you taking responsibility for making sure
-            the file is valid. Otherwise unexpected behaviours may occur.
-            """,
-        )
-        return True
-
     from . import _validate_pyproject as validator
 
     trove_classifier = validator.FORMAT_FUNCTIONS.get("trove-classifier")

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -17,7 +17,6 @@ from setuptools.config.pyprojecttoml import (
 )
 from setuptools.dist import Distribution
 from setuptools.errors import OptionError
-from setuptools.warnings import SetuptoolsWarning
 
 import distutils.core
 
@@ -395,9 +394,3 @@ def test_warn_tools_typo(tmp_path):
 
     with pytest.warns(_ToolsTypoInMetadata):
         read_configuration(pyproject)
-
-
-def test_warn_skipping_validation(monkeypatch):
-    monkeypatch.setenv("SETUPTOOLS_DANGEROUSLY_SKIP_PYPROJECT_VALIDATION", "true")
-    with pytest.warns(SetuptoolsWarning, match="Skipping the validation"):
-        assert validate({"completely-wrong": "data"}, "pyproject.toml") is True


### PR DESCRIPTION
This reverts commit 913d50a130b3c92636978b1d0e0ace8c60c23a8e.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Related to the discussions in #4459. 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
