### PR TITLE
Remove `strip_trailing_zero` arg from `canonicalize_version` call

### DIFF
--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -282,5 +282,5 @@ def _distribution_fullname(name: str, version: str) -> str:
     """
     return "{}-{}".format(
         canonicalize_name(name).replace('-', '_'),
-        canonicalize_version(version, strip_trailing_zero=False),
+        canonicalize_version(version),
     )


### PR DESCRIPTION
…`_core_metadata._distribution_fullname`

A comment above suggests that the `get_fullname` function really isn't needed, but it got called in a project I was building anyway. This fixes it.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
