### PR TITLE
correct 'namespace' term to 'namespace-package' in quickstart doc

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -199,7 +199,7 @@ Package discovery
 -----------------
 For projects that follow a simple directory structure, ``setuptools`` should be
 able to automatically detect all :term:`packages <package>` and
-:term:`namespaces <namespace>`. However, complex projects might include
+:term:`namespaces <namespace-package>`. However, complex projects might include
 additional folders and supporting files that not necessarily should be
 distributed (or that can confuse ``setuptools`` auto discovery algorithm).
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The original reference pointed to python generic [namespace](https://docs.python.org/3.11/glossary.html#term-namespace),  in the python glossary, which is wrong. What it want to point to is [package namespace](https://docs.python.org/3.11/glossary.html#term-namespace-package).
I don't think it needs an entry in the changelog.

