### PR TITLE
Fix `test_build_ext.py` on Python 3.9

### DIFF
--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import sys
 from importlib.util import cache_from_source as _compiled_file_name


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

https://github.com/pypa/setuptools/pull/4776#issuecomment-2565999938 CC @jaraco 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
