### PR TITLE
No need for preview formatter rules

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -79,8 +79,5 @@ sections.delayed = ["distutils"]
 ignore-fully-untyped = true
 
 [format]
-# Enable preview to get hugged parenthesis unwrapping and other nice surprises
-# See https://github.com/jaraco/skeleton/pull/133#issuecomment-2239538373
-preview = true
 # https://docs.astral.sh/ruff/settings/#format_quote-style
 quote-style = "preserve"


### PR DESCRIPTION
## Summary of changes

The "`preserve`" quote style was stabilised as soon as ruff [0.2.2](https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md#022).

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
