### PR TITLE
docs(package-discovery): prioritise `pyproject.toml`

### DIFF
--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -5,8 +5,8 @@ Package Discovery and Namespace Packages
 ========================================
 
 .. note::
-    a full specification for the keywords supplied to ``setup.cfg`` or
-    ``setup.py`` can be found at :doc:`keywords reference </references/keywords>`
+    A full specification for the keywords supplied to ``setup.cfg`` or
+    ``setup.py`` can be found at :doc:`keywords reference </references/keywords>`.
 
 .. important::
     The examples provided here are only to demonstrate the functionality
@@ -45,7 +45,7 @@ Normally, you would specify the packages to be included manually in the followin
 
         setup(
             # ...
-            packages=['mypkg', 'mypkg.subpkg1', 'mypkg.subpkg2']
+            packages=["mypkg", "mypkg.subpkg1", "mypkg.subpkg2"]
         )
 
 
@@ -268,7 +268,7 @@ the provided tools for package discovery:
 
         [options]
         packages = find:
-        #or
+        # OR
         packages = find_namespace:
 
 .. tab:: setup.py
@@ -276,7 +276,7 @@ the provided tools for package discovery:
     .. code-block:: python
 
         from setuptools import find_packages
-        # or
+        # OR
         from setuptools import find_namespace_packages
 
 
@@ -327,7 +327,7 @@ in ``src`` that start with the name ``pkg`` and not ``additional``:
         [options]
         packages = find:
         package_dir =
-            =src
+            = src
 
         [options.packages.find]
         where = src
@@ -345,8 +345,8 @@ in ``src`` that start with the name ``pkg`` and not ``additional``:
         setup(
             # ...
             packages=find_packages(
-                where='src',
-                include=['pkg*'],  # alternatively: `exclude=['additional*']`
+                where="src",
+                include=["pkg*"],  # alternatively: `exclude=["additional*"]`
             ),
             package_dir={"": "src"}
             # ...
@@ -431,7 +431,7 @@ distribution, then you will need to specify:
 
         [options]
         package_dir =
-            =src
+            = src
         packages = find_namespace:
 
         [options.packages.find]
@@ -450,7 +450,7 @@ distribution, then you will need to specify:
 
         setup(
             # ...
-            packages=find_namespace_packages(where='src'),
+            packages=find_namespace_packages(where="src"),
             package_dir={"": "src"}
             # ...
         )
@@ -542,7 +542,7 @@ And the ``namespace_packages`` keyword in your ``setup.cfg`` or ``setup.py``:
 
         setup(
             # ...
-            namespace_packages=['timmins']
+            namespace_packages=["timmins"]
         )
 
 And your directory should look like this
@@ -568,7 +568,7 @@ file contains the following:
 
 .. code-block:: python
 
-    __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+    __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 The project layout remains the same and ``pyproject.toml/setup.cfg`` remains the same.
 

--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -19,6 +19,15 @@ support for namespace packages.
 
 Normally, you would specify the packages to be included manually in the following manner:
 
+.. tab:: pyproject.toml
+
+    .. code-block:: toml
+
+        # ...
+        [tool.setuptools]
+        packages = ["mypkg", "mypkg.subpkg1", "mypkg.subpkg2"]
+        # ...
+
 .. tab:: setup.cfg
 
     .. code-block:: ini
@@ -39,18 +48,29 @@ Normally, you would specify the packages to be included manually in the followin
             packages=['mypkg', 'mypkg.subpkg1', 'mypkg.subpkg2']
         )
 
+
+If your packages are not in the root of the repository or do not correspond
+exactly to the directory structure, you also need to configure ``package_dir``:
+
 .. tab:: pyproject.toml
 
     .. code-block:: toml
 
-        # ...
         [tool.setuptools]
-        packages = ["mypkg", "mypkg.subpkg1", "mypkg.subpkg2"]
         # ...
+        package-dir = {"" = "src"}
+            # directory containing all the packages (e.g.  src/mypkg1, src/mypkg2)
 
+        # OR
 
-If your packages are not in the root of the repository or do not correspond
-exactly to the directory structure, you also need to configure ``package_dir``:
+        [tool.setuptools.package-dir]
+        mypkg = "lib"
+        # mypkg.module corresponds to lib/module.py
+        "mypkg.subpkg1" = "lib1"
+        # mypkg.subpkg1.module1 corresponds to lib1/module1.py
+        "mypkg.subpkg2" = "lib2"
+        # mypkg.subpkg2.module2 corresponds to lib2/module2.py
+        # ...
 
 .. tab:: setup.cfg
 
@@ -92,26 +112,6 @@ exactly to the directory structure, you also need to configure ``package_dir``:
                 # ...
             }
         )
-
-.. tab:: pyproject.toml
-
-    .. code-block:: toml
-
-        [tool.setuptools]
-        # ...
-        package-dir = {"" = "src"}
-            # directory containing all the packages (e.g.  src/mypkg1, src/mypkg2)
-
-        # OR
-
-        [tool.setuptools.package-dir]
-        mypkg = "lib"
-        # mypkg.module corresponds to lib/module.py
-        "mypkg.subpkg1" = "lib1"
-        # mypkg.subpkg1.module1 corresponds to lib1/module1.py
-        "mypkg.subpkg2" = "lib2"
-        # mypkg.subpkg2.module2 corresponds to lib2/module2.py
-        # ...
 
 This can get tiresome really quickly. To speed things up, you can rely on
 setuptools automatic discovery, or use the provided tools, as explained in
@@ -252,6 +252,16 @@ reserved names such as ``tasks``, ``example`` or ``docs``, or you want to
 *exclude* nested packages that would be otherwise included), you can use
 the provided tools for package discovery:
 
+.. tab:: pyproject.toml
+
+    .. code-block:: toml
+
+        # ...
+        [tool.setuptools.packages]
+        find = {}  # Scanning implicit namespaces is active by default
+        # OR
+        find = {namespaces = false}  # Disable implicit namespaces
+
 .. tab:: setup.cfg
 
     .. code-block:: ini
@@ -268,16 +278,6 @@ the provided tools for package discovery:
         from setuptools import find_packages
         # or
         from setuptools import find_namespace_packages
-
-.. tab:: pyproject.toml
-
-    .. code-block:: toml
-
-        # ...
-        [tool.setuptools.packages]
-        find = {}  # Scanning implicit namespaces is active by default
-        # OR
-        find = {namespaces = false}  # Disable implicit namespaces
 
 
 Finding simple packages
@@ -302,6 +302,23 @@ it, consider the following directory::
 
 To have setuptools to automatically include packages found
 in ``src`` that start with the name ``pkg`` and not ``additional``:
+
+.. tab:: pyproject.toml
+
+    .. code-block:: toml
+
+        [tool.setuptools.packages.find]
+        where = ["src"]
+        include = ["pkg*"]  # alternatively: `exclude = ["additional*"]`
+        namespaces = false
+
+    .. note::
+        When using ``tool.setuptools.packages.find`` in ``pyproject.toml``,
+        setuptools will consider :pep:`implicit namespaces <420>` by default when
+        scanning your project directory.
+        To avoid ``pkg.namespace`` from being added to your package list
+        you can set ``namespaces = false``. This will prevent any folder
+        without an ``__init__.py`` file from being scanned.
 
 .. tab:: setup.cfg
 
@@ -340,23 +357,6 @@ in ``src`` that start with the name ``pkg`` and not ``additional``:
         ``pkg`` does not contain an ``__init__.py`` file, therefore
         ``pkg.namespace`` is ignored by ``find_packages()``
         (see ``find_namespace_packages()`` below).
-
-.. tab:: pyproject.toml
-
-    .. code-block:: toml
-
-        [tool.setuptools.packages.find]
-        where = ["src"]
-        include = ["pkg*"]  # alternatively: `exclude = ["additional*"]`
-        namespaces = false
-
-    .. note::
-        When using ``tool.setuptools.packages.find`` in ``pyproject.toml``,
-        setuptools will consider :pep:`implicit namespaces <420>` by default when
-        scanning your project directory.
-        To avoid ``pkg.namespace`` from being added to your package list
-        you can set ``namespaces = false``. This will prevent any folder
-        without an ``__init__.py`` file from being scanned.
 
 .. important::
    ``include`` and ``exclude`` accept strings representing :mod:`glob` patterns.
@@ -414,6 +414,17 @@ by creating a project directory organized as follows::
 If you want the ``timmins.foo`` to be automatically included in the
 distribution, then you will need to specify:
 
+.. tab:: pyproject.toml
+
+    .. code-block:: toml
+
+        [tool.setuptools.packages.find]
+        where = ["src"]
+
+    When using ``tool.setuptools.packages.find`` in ``pyproject.toml``,
+    setuptools will consider :pep:`implicit namespaces <420>` by default when
+    scanning your project directory.
+
 .. tab:: setup.cfg
 
     .. code-block:: ini
@@ -448,17 +459,6 @@ distribution, then you will need to specify:
     ``__init__.py`` file will be ignored.
     On the other hand, ``find_namespace_packages()`` will scan all
     directories.
-
-.. tab:: pyproject.toml
-
-    .. code-block:: toml
-
-        [tool.setuptools.packages.find]
-        where = ["src"]
-
-    When using ``tool.setuptools.packages.find`` in ``pyproject.toml``,
-    setuptools will consider :pep:`implicit namespaces <420>` by default when
-    scanning your project directory.
 
 After installing the package distribution, ``timmins.foo`` would become
 available to your interpreter.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

"Package Discovery" page is the only one where `pyproject.toml` examples appear last, so this updates the examples to have them first instead.

Second commit is unrelated, but I found some inconsistencies and thought it could be an opportunity to fix them.

As this is a minor change, I'm not sure if a news entry should be added.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
