### PR TITLE
Explicit pass the Python path to pipx in CI step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,15 +90,16 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: setuptools/tests/config
         run: python -m downloads.preload setupcfg_examples.txt
+      - name: Adjust env vars
+        shell: bash
+        run: |
+          echo 'PIPX_DEFAULT_PYTHON=${{ steps.python-install.outputs.python-path }}' >> $GITHUB_ENV
       - name: Pre-build distributions for test
         shell: bash
         run: |
           rm -rf dist
           # workaround for pypa/setuptools#4333
-          pipx run \
-            --python ${{ steps.python-install.outputs.python-path }} \
-            --pip-args 'pyproject-hooks!=1.1' \
-            build
+          pipx run --pip-args 'pyproject-hooks!=1.1' build
           echo "PRE_BUILT_SETUPTOOLS_SDIST=$(ls dist/*.tar.gz)" >> $GITHUB_ENV
           echo "PRE_BUILT_SETUPTOOLS_WHEEL=$(ls dist/*.whl)" >> $GITHUB_ENV
           rm -rf setuptools.egg-info  # Avoid interfering with the other tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,10 @@ jobs:
         run: |
           rm -rf dist
           # workaround for pypa/setuptools#4333
-          pipx run --pip-args 'pyproject-hooks!=1.1' build
+          pipx run \
+            --python ${{ steps.python-install.outputs.python-path }} \
+            --pip-args 'pyproject-hooks!=1.1' \
+            build
           echo "PRE_BUILT_SETUPTOOLS_SDIST=$(ls dist/*.tar.gz)" >> $GITHUB_ENV
           echo "PRE_BUILT_SETUPTOOLS_WHEEL=$(ls dist/*.whl)" >> $GITHUB_ENV
           rm -rf setuptools.egg-info  # Avoid interfering with the other tests


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

I identified some recent problems in the CI:

```
creating virtual environment...
installing build...
* Creating isolated environment: venv+pip...
* Getting build dependencies for sdist...
/home/runner/work/setuptools/setuptools/_distutils_hack/__init__.py:53: UserWarning: Reliance on distutils from stdlib is deprecated. Users must rely on setuptools to provide the distutils module. Avoid importing distutils or import setuptools first, and avoid setting SETUPTOOLS_USE_DISTUTILS=stdlib. Register concerns at https://github.com/pypa/setuptools/issues/new?template=distutils-deprecation.yml
  warnings.warn(

Traceback (most recent call last):
  File "/opt/pipx/.cache/98ab2ca9c43e098/lib/python3.12/site-packages/pyproject_hooks/_impl.py", line 402, in _call_hook
    raise BackendUnavailable(
pyproject_hooks._impl.BackendUnavailable: Cannot import 'setuptools.build_meta'

ERROR Backend 'setuptools.build_meta' is not available.
Error: Process completed with exit code 1.
```

https://github.com/pypa/setuptools/actions/runs/12672452318/job/35316523998

Curiously the trace shows `lib/python3.12/site-packages/pyproject_hooks/...`, but the python that should have been used is Python 10. So there might be a problem with `pipx` picking up the wrong version of Python...

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
