### PR TITLE
Ran autofixes for `missing-return-type-special-method (ANN204)` with `ignore-fully-untyped = false`

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -66,13 +66,12 @@ ignore = [
 	"UP038", # Using `X | Y` in `isinstance` call is slower and more verbose https://github.com/astral-sh/ruff/issues/7871
 	# Only enforcing return type annotations for public functions
 	"ANN202", # missing-return-type-private-function
-	"ANN204", # missing-return-type-special-method
 ]
 
 [lint.per-file-ignores]
 # Suppress nuisance warnings about module-import-not-at-top-of-file (E402) due to workaround for #4476
 "setuptools/__init__.py" = ["E402"]
-"pkg_resources/__init__.py" = ["E402"]
+"pkg_resources/__init__.py" = ["E402", "ANN204"]
 
 [lint.isort]
 combine-as-imports = true

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -9,6 +9,7 @@ from collections.abc import Iterable, Iterator
 from functools import partial
 from glob import glob
 from pathlib import Path
+from typing import Any
 
 from more_itertools import unique_everseen
 
@@ -81,7 +82,8 @@ class build_py(orig.build_py):
         # output files are.
         self.byte_compile(orig.build_py.get_outputs(self, include_bytecode=False))
 
-    def __getattr__(self, attr: str):
+    # Should return "list[tuple[str, str, str, list[str]]] | Any" but can't do without typed distutils on Python 3.12+
+    def __getattr__(self, attr: str) -> Any:
         "lazily compute data files"
         if attr == 'data_files':
             self.data_files = self._get_data_files()
@@ -381,8 +383,8 @@ class _IncludePackageDataAbuse:
         # _DUE_DATE: still not defined as this is particularly controversial.
         # Warning initially introduced in May 2022. See issue #3340 for discussion.
 
-    def __init__(self):
-        self._already_warned = set()
+    def __init__(self) -> None:
+        self._already_warned = set[str]()
 
     def is_module(self, file):
         return file.endswith(".py") and file[: -len(".py")].isidentifier()

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -406,7 +406,9 @@ class _StaticPth:
         self.name = name
         self.path_entries = path_entries
 
-    def __call__(self, wheel: WheelFile, files: list[str], mapping: Mapping[str, str]):
+    def __call__(
+        self, wheel: WheelFile, files: list[str], mapping: Mapping[str, str]
+    ) -> None:
         entries = "\n".join(str(p.resolve()) for p in self.path_entries)
         contents = _encode_pth(f"{entries}\n")
         wheel.writestr(f"__editable__.{self.name}.pth", contents)
@@ -451,7 +453,9 @@ class _LinkTree(_StaticPth):
         self._file = dist.get_command_obj("build_py").copy_file
         super().__init__(dist, name, [self.auxiliary_dir])
 
-    def __call__(self, wheel: WheelFile, files: list[str], mapping: Mapping[str, str]):
+    def __call__(
+        self, wheel: WheelFile, files: list[str], mapping: Mapping[str, str]
+    ) -> None:
         self._create_links(files, mapping)
         super().__call__(wheel, files, mapping)
 
@@ -545,7 +549,9 @@ class _TopLevelFinder:
         content = _encode_pth(f"import {finder}; {finder}.install()")
         yield (f"__editable__.{self.name}.pth", content)
 
-    def __call__(self, wheel: WheelFile, files: list[str], mapping: Mapping[str, str]):
+    def __call__(
+        self, wheel: WheelFile, files: list[str], mapping: Mapping[str, str]
+    ) -> None:
         for file, content in self.get_implementation():
             wheel.writestr(file, content)
 

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -65,7 +65,7 @@ class StaticModule:
             elif isinstance(statement, ast.AnnAssign) and statement.value:
                 yield (statement.target, statement.value)
 
-    def __getattr__(self, attr: str):
+    def __getattr__(self, attr: str) -> Any:
         """Attempt to load an attribute "statically", via :func:`ast.literal_eval`."""
         try:
             return next(

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -335,7 +335,7 @@ class ConfigDiscovery:
 
     def __call__(
         self, force: bool = False, name: bool = True, ignore_ext_modules: bool = False
-    ):
+    ) -> None:
         """Automatically discover missing configuration fields
         and modifies the given ``distribution`` object in-place.
 

--- a/setuptools/tests/integration/helpers.py
+++ b/setuptools/tests/integration/helpers.py
@@ -5,11 +5,14 @@ with setuptools, and ``run`` will always try to be as verbose as possible to
 facilitate debugging.
 """
 
+from __future__ import annotations
+
 import os
 import subprocess
 import tarfile
+from collections.abc import Iterator
 from pathlib import Path
-from zipfile import ZipFile
+from zipfile import ZipFile, ZipInfo
 
 
 def run(cmd, env=None):
@@ -35,16 +38,16 @@ def run(cmd, env=None):
 class Archive:
     """Compatibility layer for ZipFile/Info and TarFile/Info"""
 
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         self._filename = filename
         if filename.endswith("tar.gz"):
-            self._obj = tarfile.open(filename, "r:gz")
+            self._obj: tarfile.TarFile | ZipFile = tarfile.open(filename, "r:gz")
         elif filename.endswith("zip"):
             self._obj = ZipFile(filename)
         else:
             raise ValueError(f"{filename} doesn't seem to be a zip or tar.gz")
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[ZipInfo] | Iterator[tarfile.TarInfo]:
         if hasattr(self._obj, "infolist"):
             return iter(self._obj.infolist())
         return iter(self._obj)

--- a/setuptools/tests/test_bdist_wheel.py
+++ b/setuptools/tests/test_bdist_wheel.py
@@ -295,7 +295,7 @@ def test_preserve_unicode_metadata(monkeypatch, tmp_path):
     class simpler_bdist_wheel(bdist_wheel):
         """Avoid messing with setuptools/distutils internals"""
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.skipif(
 
 
 class BuildBackendBase:
-    def __init__(self, cwd='.', env=None, backend_name='setuptools.build_meta'):
+    def __init__(self, cwd='.', env=None, backend_name='setuptools.build_meta') -> None:
         self.cwd = cwd
         self.env = env or {}
         self.backend_name = backend_name
@@ -44,7 +44,7 @@ class BuildBackendBase:
 class BuildBackend(BuildBackendBase):
     """PEP 517 Build Backend"""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.pool = futures.ProcessPoolExecutor(max_workers=1)
 
@@ -77,12 +77,12 @@ class BuildBackend(BuildBackendBase):
 
 
 class BuildBackendCaller(BuildBackendBase):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
 
         (self.backend_name, _, self.backend_obj) = self.backend_name.partition(':')
 
-    def __call__(self, name, *args, **kw):
+    def __call__(self, name, *args, **kw) -> Any:
         """Handles arbitrary function invocations on the build backend."""
         os.chdir(self.cwd)
         os.environ.update(self.env)

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -168,7 +168,7 @@ def _check_wheel_install(
 
 
 class Record:
-    def __init__(self, id, **kwargs):
+    def __init__(self, id, **kwargs) -> None:
         self._id = id
         self._fields = kwargs
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

I set `[lint.flake8-annotations] ignore-fully-untyped = false` then ran `ruff check --select=ANN204 --fix --unsafe-fixes`

## Summary of changes

Step 6.3 of https://github.com/pypa/setuptools/issues/2345#issuecomment-1627561833
Some slight overlaps with https://github.com/pypa/setuptools/pull/4744

### Pull Request Checklist
- [x] Changes have tests (this adds static tests)
- [x] News fragment added in [`newsfragments/`]. (not user facing)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
