### PR TITLE
Compile code in run_setup

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -314,7 +314,9 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         __name__ = '__main__'
 
         with _open_setup_script(__file__) as f:
-            code = f.read().replace(r'\r\n', r'\n')
+            source = f.read().replace(r'\r\n', r'\n')
+    
+        code = compile(source, __file__, 'exec')
 
         try:
             exec(code, locals())


### PR DESCRIPTION
## Summary of changes

Closes #4815

`exec(code, locals())` in gets a code string and then calls `compile` internally. This PR adds an explicit compile step (as it is already the case in many other places in the codebase) which enables better filename and code hints in the printed traceback (see issue above).

Old:

```
...
  File "/Users/marcin/.pyenv/versions/3.12.3/envs/default/lib/python3.12/site-packages/setuptools/build_meta.py", line 522, in run_setup
    super().run_setup(setup_script=setup_script)
  File "/Users/marcin/.pyenv/versions/3.12.3/envs/default/lib/python3.12/site-packages/setuptools/build_meta.py", line 320, in run_setup
    exec(code, locals())
  File "<string>", line 14, in <module>
  File "<string>", line 12, in baz
  File "<string>", line 9, in bar
  File "<string>", line 6, in foo
BadPackageError: This package is bad
[end of output]
...
```

New:

```
...
  File "~/.local/lib/python3.14/site-packages/setuptools/build_meta.py", line 525, in run_setup
    super().run_setup(setup_script=setup_script)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/lib/python3.14/site-packages/setuptools/build_meta.py", line 323, in run_setup
    exec(source, locals())
    ~~~~^^^^^^^^^^^^^^^^^^
  File "~/.../bad_package/setup.py", line 14, in <module>
    baz()
    ~~~^^
  File "~/.../bad_package/setup.py", line 12, in baz
    bar()
    ~~~^^
  File "~/.../bad_package/setup.py", line 9, in bar
    foo()
    ~~~^^
  File "~/.../bad_package/setup.py", line 6, in foo
    raise BadPackageError("This package is bad")
BadPackageError: This package is bad
[end of output]
...
```


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
