### PR TITLE
Drop test dependency on `path` package

### DIFF
--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -5,7 +5,6 @@ from inspect import cleandoc
 import jaraco.path
 import pytest
 import tomli_w
-from path import Path
 
 import setuptools  # noqa: F401 # force distutils.core to be patched
 from setuptools.config.pyprojecttoml import (
@@ -363,7 +362,7 @@ def test_include_package_data_in_setuppy(tmp_path):
     }
     jaraco.path.build(files, prefix=tmp_path)
 
-    with Path(tmp_path):
+    with jaraco.path.DirectoryStack().context(tmp_path):
         dist = distutils.core.run_setup("setup.py", {}, stop_after="config")
 
     assert dist.get_name() == "myproj"

--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import path
 import pytest
 
 from . import contexts, environment
@@ -119,7 +118,7 @@ def setuptools_wheel(tmp_path_factory, request):
 def venv(tmp_path, setuptools_wheel):
     """Virtual env with the version of setuptools under test installed"""
     env = environment.VirtualEnv()
-    env.root = path.Path(tmp_path / 'venv')
+    env.root = Path(tmp_path / 'venv')
     env.create_opts = ['--no-setuptools', '--wheel=bundle']
     # TODO: Use `--no-wheel` when setuptools implements its own bdist_wheel
     env.req = str(setuptools_wheel)
@@ -141,7 +140,7 @@ def venv(tmp_path, setuptools_wheel):
 def venv_without_setuptools(tmp_path):
     """Virtual env without any version of setuptools installed"""
     env = environment.VirtualEnv()
-    env.root = path.Path(tmp_path / 'venv_without_setuptools')
+    env.root = Path(tmp_path / 'venv_without_setuptools')
     env.create_opts = ['--no-setuptools', '--no-wheel']
     env.ensure_env()
     return env
@@ -151,7 +150,7 @@ def venv_without_setuptools(tmp_path):
 def bare_venv(tmp_path):
     """Virtual env without any common packages installed"""
     env = environment.VirtualEnv()
-    env.root = path.Path(tmp_path / 'bare_venv')
+    env.root = Path(tmp_path / 'bare_venv')
     env.create_opts = ['--no-setuptools', '--no-pip', '--no-wheel', '--no-seed']
     env.ensure_env()
     return env

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -2,11 +2,11 @@ import os
 import sys
 from configparser import ConfigParser
 from itertools import product
+from pathlib import Path
 from typing import cast
 
 import jaraco.path
 import pytest
-from path import Path
 
 import setuptools  # noqa: F401 # force distutils.core to be patched
 from setuptools.command.sdist import sdist
@@ -307,7 +307,7 @@ class TestWithAttrDirective:
         assert dist.package_dir
         package_path = find_package_path("pkg", dist.package_dir, tmp_path)
         assert os.path.exists(package_path)
-        assert folder in Path(package_path).parts()
+        assert folder in Path(package_path).parts
 
         _run_build(tmp_path, "--sdist")
         dist_file = tmp_path / "dist/pkg-42.tar.gz"
@@ -618,7 +618,7 @@ def _get_dist(dist_path, attrs):
 
     script = dist_path / 'setup.py'
     if script.exists():
-        with Path(dist_path):
+        with jaraco.path.DirectoryStack().context(dist_path):
             dist = cast(
                 Distribution,
                 distutils.core.run_setup("setup.py", {}, stop_after="init"),
@@ -628,7 +628,7 @@ def _get_dist(dist_path, attrs):
 
     dist.src_root = root
     dist.script_name = "setup.py"
-    with Path(dist_path):
+    with jaraco.path.DirectoryStack().context(dist_path):
         dist.parse_config_files()
 
     dist.set_defaults()
@@ -641,7 +641,7 @@ def _run_sdist_programatically(dist_path, attrs):
     cmd.ensure_finalized()
     assert cmd.distribution.packages or cmd.distribution.py_modules
 
-    with quiet(), Path(dist_path):
+    with quiet(), jaraco.path.DirectoryStack().context(dist_path):
         cmd.run()
 
     return dist, cmd

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -14,10 +14,8 @@ from typing import Any
 from unittest.mock import Mock
 from uuid import uuid4
 
-import jaraco.envs
 import jaraco.path
 import pytest
-from path import Path as _Path
 
 from setuptools._importlib import resources as importlib_resources
 from setuptools.command.editable_wheel import (
@@ -565,6 +563,8 @@ class TestFinderTemplate:
             self.install_finder(code)
             mod1 = import_module("different_name.my_module")
             mod2 = import_module("different_name.subpkg.my_module2")
+            assert mod1.__file__ is not None
+            assert mod2.__file__ is not None
 
             expected = str((tmp_path / "src/my_package/my_module.py").resolve())
             assert str(Path(mod1.__file__).resolve()) == expected
@@ -972,7 +972,7 @@ class TestLinkTree:
     def test_generated_tree(self, tmp_path):
         jaraco.path.build(self.FILES, prefix=tmp_path)
 
-        with _Path(tmp_path):
+        with jaraco.path.DirectoryStack().context(tmp_path):
             name = "mypkg-3.14159"
             dist = Distribution({"script_name": "%PEP 517%"})
             dist.parse_config_files()

--- a/tools/vendored.py
+++ b/tools/vendored.py
@@ -1,9 +1,9 @@
 import functools
 import re
 import subprocess
+from pathlib import Path
 
 import jaraco.packaging.metadata
-from path import Path
 
 
 def remove_all(paths):

--- a/tox.ini
+++ b/tox.ini
@@ -72,7 +72,6 @@ commands =
 [testenv:vendor]
 skip_install = True
 deps =
-	path
 	jaraco.packaging
 	# workaround for pypa/pyproject-hooks#192
 	pyproject-hooks!=1.1


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

As far as I can tell, `pathlib`+`jaraco.path` should be sufficient, and it's only used in tests. There may be issues with vendored deps, let's see what the CI says.

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests (these are the test changes)
- [x] News fragment added in [`newsfragments/`]. (no public changes, tests only)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
