### PR TITLE
Prevent deprecated license classifiers from being written to core metadata

### DIFF
--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -327,18 +327,18 @@ def test_license_expression_with_bad_classifier(tmp_path):
         "README",
         f"{text}\n    \"License :: OSI Approved :: MIT License\"\n]",
     )
-    msg = "License classifier are deprecated(?:.|\n)*'License :: OSI Approved :: MIT License'"
-    with pytest.raises(SetuptoolsDeprecationWarning, match=msg):
+    msg = "License classifier are deprecated"
+    with pytest.raises(SetuptoolsDeprecationWarning, match=msg) as exc:
         pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
+        assert "License :: OSI Approved :: MIT License" in str(exc.value)
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", SetuptoolsDeprecationWarning)
         dist = pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
-        # Check license classifier is still included
+        # Check 'License :: OSI Approved :: MIT License' is removed
         assert dist.metadata.get_classifiers() == [
             "Development Status :: 5 - Production/Stable",
             "Programming Language :: Python",
-            "License :: OSI Approved :: MIT License",
         ]
 
 


### PR DESCRIPTION
Follow up on the conversation in https://github.com/pypa/setuptools/pull/4706#discussion_r1958432361

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->


### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
