### PR TITLE
Ensure `_apply_pyproject` sets field on `dist.metadata` object not on `dist`

### DIFF
--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -423,6 +423,7 @@ SETUPTOOLS_PATCHES = {
     "provides_extras",
     "license_file",
     "license_files",
+    "license_expression",
 }
 
 _PREPROCESS = {


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Not sure why the tests where not failing, but I think this is the way we ensure `dist.metadata.license_expression` gets set instead of `dist.license_expression`.

(I guess the test `hasattr(dist.metadata, field)` is true? Is it always true? If not when it is false?)


### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
