### PR TITLE
Add initial warnings regarding `license-files` glob patterns.

### DIFF
--- a/newsfragments/4838.feature.rst
+++ b/newsfragments/4838.feature.rst
@@ -1,3 +1,4 @@
 Added simple validation for given glob patterns in ``license-files``:
 a warning will be generated if no file is matched.
 Invalid glob patterns can raise an exception.
+-- thanks :user:`cdce8p` for contributions.

--- a/newsfragments/4838.feature.rst
+++ b/newsfragments/4838.feature.rst
@@ -1,0 +1,3 @@
+Added simple validation for given glob patterns in ``license-files``:
+a warning will be generated if no file is matched.
+Invalid glob patterns can raise an exception.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -484,6 +484,12 @@ class Distribution(_Distribution):
         ['LICENSE']
         >>> list(Distribution._expand_patterns(['pyproject.toml', 'LIC*']))
         ['pyproject.toml', 'LICENSE']
+        >>> list(Distribution._expand_patterns(['setuptools/**/pyprojecttoml.py']))
+        ['setuptools/config/pyprojecttoml.py']
+        >>> list(Distribution._expand_patterns(['../LICENSE']))
+        Traceback (most recent call last):
+        ...
+        setuptools.errors.InvalidConfigError: Pattern '../LICENSE' cannot contain '..'
         """
         return (
             path.replace(os.sep, "/")
@@ -494,14 +500,6 @@ class Distribution(_Distribution):
 
     @staticmethod
     def _find_pattern(pattern: str) -> Iterator[str]:
-        """
-        >>> list(Distribution._find_pattern("setuptools/**/pyprojecttoml.py"))
-        ['setuptools/config/pyprojecttoml.py']
-        >>> list(Distribution._find_pattern("../LICENSE"))
-        Traceback (most recent call last):
-        ...
-        setuptools.errors.InvalidConfigError: Pattern '../LICENSE' cannot contain '..'
-        """
         if ".." in pattern:  # XXX: Any other invalid character?
             raise InvalidConfigError(f"Pattern {pattern!r} cannot contain '..'")
         return iglob(pattern, recursive=True)

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 from collections.abc import Iterable, Iterator, MutableMapping, Sequence
-from glob import iglob
+from glob import glob
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
@@ -459,26 +459,16 @@ class Distribution(_Distribution):
             # See https://wheel.readthedocs.io/en/stable/user_guide.html
             # -> 'Including license files in the generated wheel file'
             patterns = ['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']
+            files = self._expand_patterns(patterns, enforce_match=False)
+        else:  # Patterns explicitly given by the user
+            files = self._expand_patterns(patterns, enforce_match=True)
 
-        self.metadata.license_files = list(
-            unique_everseen(self._expand_patterns(patterns)),
-        )
-
-        if license_files and not self.metadata.license_files:
-            # Pattern explicitly given but no file found
-            if not self.metadata.license_files:
-                SetuptoolsDeprecationWarning.emit(
-                    "Cannot find any license files for the given patterns.",
-                    f"The glob patterns {patterns!r} do not match any file.",
-                    due_date=(2026, 2, 20),
-                    # Warning introduced on 2025/02/18
-                    # PEP 639 requires us to error, but as a transition period
-                    # we will only issue a warning to give people time to prepare.
-                    # After the transition, this should raise an InvalidConfigError.
-                )
+        self.metadata.license_files = list(unique_everseen(files))
 
     @classmethod
-    def _expand_patterns(cls, patterns: list[str]) -> Iterator[str]:
+    def _expand_patterns(
+        cls, patterns: list[str], enforce_match: bool = True
+    ) -> Iterator[str]:
         """
         >>> list(Distribution._expand_patterns(['LICENSE']))
         ['LICENSE']
@@ -486,23 +476,61 @@ class Distribution(_Distribution):
         ['pyproject.toml', 'LICENSE']
         >>> list(Distribution._expand_patterns(['setuptools/**/pyprojecttoml.py']))
         ['setuptools/config/pyprojecttoml.py']
-        >>> list(Distribution._expand_patterns(['../LICENSE']))
-        Traceback (most recent call last):
-        ...
-        setuptools.errors.InvalidConfigError: Pattern '../LICENSE' cannot contain '..'
         """
         return (
             path.replace(os.sep, "/")
             for pattern in patterns
-            for path in sorted(cls._find_pattern(pattern))
+            for path in sorted(cls._find_pattern(pattern, enforce_match))
             if not path.endswith('~') and os.path.isfile(path)
         )
 
     @staticmethod
-    def _find_pattern(pattern: str) -> Iterator[str]:
-        if ".." in pattern:  # XXX: Any other invalid character?
+    def _find_pattern(pattern: str, enforce_match: bool = True) -> list[str]:
+        r"""
+        >>> Distribution._find_pattern("LICENSE")
+        ['LICENSE']
+        >>> Distribution._find_pattern("/LICENSE.MIT")
+        Traceback (most recent call last):
+        ...
+        setuptools.errors.InvalidConfigError: Pattern '/LICENSE.MIT' should be relative...
+        >>> Distribution._find_pattern("../LICENSE.MIT")
+        Traceback (most recent call last):
+        ...
+        setuptools.errors.InvalidConfigError: ...Pattern '../LICENSE.MIT' cannot contain '..'
+        >>> Distribution._find_pattern("LICEN{CSE*")
+        Traceback (most recent call last):
+        ...
+        setuptools.warnings.SetuptoolsDeprecationWarning: ...Pattern 'LICEN{CSE*' contains invalid characters...
+        """
+        if ".." in pattern:
             raise InvalidConfigError(f"Pattern {pattern!r} cannot contain '..'")
-        return iglob(pattern, recursive=True)
+        if pattern.startswith((os.sep, "/")) or ":\\" in pattern:
+            raise InvalidConfigError(
+                f"Pattern {pattern!r} should be relative and must not start with '/'"
+            )
+        if re.match(r'^[\w\-\.\/\*\?\[\]]+$', pattern) is None:
+            pypa_guides = "specifications/pyproject-toml/#license-files"
+            SetuptoolsDeprecationWarning.emit(
+                "Please provide a valid glob pattern.",
+                "Pattern {pattern!r} contains invalid characters.",
+                pattern=pattern,
+                see_url=f"https://packaging.python.org/en/latest/{pypa_guides}",
+                due_date=(2025, 2, 20),  # Introduced in 2024-02-20
+            )
+
+        found = glob(pattern, recursive=True)
+
+        if enforce_match and not found:
+            SetuptoolsDeprecationWarning.emit(
+                "Cannot find any files for the given pattern.",
+                "Pattern {pattern!r} did not match any files.",
+                pattern=pattern,
+                due_date=(2025, 2, 20),  # Introduced in 2024-02-20
+                # PEP 639 requires us to error, but as a transition period
+                # we will only issue a warning to give people time to prepare.
+                # After the transition, this should raise an InvalidConfigError.
+            )
+        return found
 
     # FIXME: 'Distribution._parse_config_files' is too complex (14)
     def _parse_config_files(self, filenames=None):  # noqa: C901

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -515,7 +515,7 @@ class Distribution(_Distribution):
                 "Pattern {pattern!r} contains invalid characters.",
                 pattern=pattern,
                 see_url=f"https://packaging.python.org/en/latest/{pypa_guides}",
-                due_date=(2025, 2, 20),  # Introduced in 2024-02-20
+                due_date=(2026, 2, 20),  # Introduced in 2025-02-20
             )
 
         found = glob(pattern, recursive=True)
@@ -525,7 +525,7 @@ class Distribution(_Distribution):
                 "Cannot find any files for the given pattern.",
                 "Pattern {pattern!r} did not match any files.",
                 pattern=pattern,
-                due_date=(2025, 2, 20),  # Introduced in 2024-02-20
+                due_date=(2026, 2, 20),  # Introduced in 2025-02-20
                 # PEP 639 requires us to error, but as a transition period
                 # we will only issue a warning to give people time to prepare.
                 # After the transition, this should raise an InvalidConfigError.

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -465,7 +465,7 @@ class TestLicenseFiles:
         pyproject = self.base_pyproject_license_pep639(tmp_path)
         assert list(tmp_path.glob("_FILE*")) == []  # sanity check
 
-        msg = "Cannot find any license files for the given patterns."
+        msg = "Cannot find any files for the given pattern.*"
         with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
             pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
 

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -461,6 +461,14 @@ class TestLicenseFiles:
         assert (tmp_path / "LICENSE.txt").exists()  # from base example
         assert set(dist.metadata.license_files) == {*license_files, "LICENSE.txt"}
 
+    def test_missing_patterns(self, tmp_path):
+        pyproject = self.base_pyproject_license_pep639(tmp_path)
+        assert list(tmp_path.glob("_FILE*")) == []  # sanity check
+
+        msg = "Cannot find any license files for the given patterns."
+        with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
+            pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
+
     def test_deprecated_file_expands_to_text(self, tmp_path):
         """Make sure the old example with ``license = {text = ...}`` works"""
 

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -373,6 +373,9 @@ class TestParityWithMetadataFromPyPaWheel:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(expand, "read_attr", Mock(return_value="0.42"))
         monkeypatch.setattr(expand, "read_files", Mock(return_value="hello world"))
+        monkeypatch.setattr(
+            Distribution, "_finalize_license_files", Mock(return_value=None)
+        )
         if request.param is None:
             yield self.base_example()
         else:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

>  The PEP specifies that tools should reject any patterns which contain not-approved chars.
 Furthermore, it should be an error if a pattern doesn't match any files.

Ref: https://github.com/pypa/setuptools/pull/4829#issuecomment-2663706134

This by no means introduces an exhaustive check, just the low hanging fruits.

I intentionally do not analyse each pattern individually here to avoid wreaking too much havoc (imagine e.g. project templates that adds a very general catch all list of patterns in `setup.cfg`).

Regarding the `glob` patterns, I am keeping loose for the time being, would like to avoid adding a regex for each pattern if possible, but open to it...

/cc @cdce8p 

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
