### PR TITLE
Attempt to comply with `sphinx` warning when building docs

### DIFF
--- a/newsfragments/4706.feature.rst
+++ b/newsfragments/4706.feature.rst
@@ -1,1 +1,1 @@
-Added initial support for license expression (:pep:`639#add-license-expression-field`). -- by :user:`cdce8p`
+Added initial support for license expression (:pep:`PEP 639 <639#add-license-expression-field>`). -- by :user:`cdce8p`

--- a/newsfragments/4706.feature.rst
+++ b/newsfragments/4706.feature.rst
@@ -1,1 +1,1 @@
-Added initial support for license expression (`PEP 639 <https://peps.python.org/pep-0639/#add-license-expression-field>`_). -- by :user:`cdce8p`
+Added initial support for license expression (:pep:`639#add-license-expression-field`). -- by :user:`cdce8p`

--- a/newsfragments/4728.feature.rst
+++ b/newsfragments/4728.feature.rst
@@ -1,1 +1,1 @@
-Store ``License-File``s in ``.dist-info/licenses`` subfolder and added support for recursive globs for ``license_files`` (`PEP 639 <https://peps.python.org/pep-0639/#add-license-expression-field>`_). -- by :user:`cdce8p`
+Store ``License-File``s in ``.dist-info/licenses`` subfolder and added support for recursive globs for ``license_files`` (:pep:`639#add-license-expression-field`). -- by :user:`cdce8p`

--- a/newsfragments/4728.feature.rst
+++ b/newsfragments/4728.feature.rst
@@ -1,1 +1,1 @@
-Store ``License-File``s in ``.dist-info/licenses`` subfolder and added support for recursive globs for ``license_files`` (:pep:`639#add-license-expression-field`). -- by :user:`cdce8p`
+Store ``License-File``s in ``.dist-info/licenses`` subfolder and added support for recursive globs for ``license_files`` (:pep:`PEP 639 <639#add-license-expression-field>`). -- by :user:`cdce8p`


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

It seems that `sphinx` do not like something in the docs:

![image](https://github.com/user-attachments/assets/1e49b1df-9de5-4b83-99a7-7b3a97e2c7e7)


This is an attempt to handle that.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
