### PR TITLE
Add warning for deprecated `project.license` as TOML table (PEP 639-related)

### DIFF
--- a/newsfragments/4840.feature.rst
+++ b/newsfragments/4840.feature.rst
@@ -1,0 +1,5 @@
+Deprecated ``project.license`` as a TOML table in
+``pyproject.toml``. Users are expected to move towards using
+``project.license-files`` and/or SPDX expressions (as strings) in
+``pyproject.license``.
+See :pep:`PEP 639 <639#deprecate-license-key-table-subkeys>`.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -203,6 +203,14 @@ def _license(dist: Distribution, val: str | dict, root_dir: StrPath | None):
     if isinstance(val, str):
         _set_config(dist, "license_expression", _static.Str(val))
     else:
+        pypa_guides = "guides/writing-pyproject-toml/#license"
+        SetuptoolsDeprecationWarning.emit(
+            "`project.license` as a TOML table is deprecated",
+            "Please use a simple string containing a SPDX expression for "
+            "`project.license`. You can also use `project.license-files`.",
+            see_url=f"https://packaging.python.org/en/latest/{pypa_guides}",
+            due_date=(2026, 2, 18),  # Introduced on 2025-02-18
+        )
         if "file" in val:
             # XXX: Is it completely safe to assume static?
             value = expand.read_files([val["file"]], root_dir)

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -387,9 +387,13 @@ class TestBuildMetaBackend:
         build_backend = self.get_build_backend()
         with tmpdir.as_cwd():
             path.build(files)
+            msgs = [
+                "'tool.setuptools.license-files' is deprecated in favor of 'project.license-files'",
+                "`project.license` as a TOML table is deprecated",
+            ]
             with warnings.catch_warnings():
-                msg = "'tool.setuptools.license-files' is deprecated in favor of 'project.license-files'"
-                warnings.filterwarnings("ignore", msg, SetuptoolsDeprecationWarning)
+                for msg in msgs:
+                    warnings.filterwarnings("ignore", msg, SetuptoolsDeprecationWarning)
                 sdist_path = build_backend.build_sdist("temp")
                 wheel_file = build_backend.build_wheel("temp")
 

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -708,12 +708,21 @@ class TestSdistTest:
             [project]
             name = "testing"
             readme = "USAGE.rst"
-            license = {file = "DOWHATYOUWANT"}
+            license-files = ["DOWHATYOUWANT"]
             dynamic = ["version"]
             [tool.setuptools.dynamic]
             version = {file = ["src/VERSION.txt"]}
             """,
         "pyproject.toml - directive with str instead of list": """
+            [project]
+            name = "testing"
+            readme = "USAGE.rst"
+            license-files = ["DOWHATYOUWANT"]
+            dynamic = ["version"]
+            [tool.setuptools.dynamic]
+            version = {file = "src/VERSION.txt"}
+            """,
+        "pyproject.toml - deprecated license table with file entry": """
             [project]
             name = "testing"
             readme = "USAGE.rst"
@@ -725,6 +734,9 @@ class TestSdistTest:
     }
 
     @pytest.mark.parametrize("config", _EXAMPLE_DIRECTIVES.keys())
+    @pytest.mark.filterwarnings(
+        "ignore:.project.license. as a TOML table is deprecated"
+    )
     def test_add_files_referenced_by_config_directives(self, source_dir, config):
         config_file, _, _ = config.partition(" - ")
         config_text = self._EXAMPLE_DIRECTIVES[config]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Alongside with https://github.com/pypa/setuptools/pull/4838, the objective of this PR is to introduce more deprecation warnings and prepare for an eventual feature removal in the spirit of PEP 639.

I am assuming that if a project is using `pyproject.toml` with `setuptools` it is relatively new and the maintainers are likely to be around.

Also the best is to introduce the warning as soon as possible, so that the clock starts ticking for the removal.

/cc @cdce8p 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
