### PR TITLE
Validate license-files glob patterns

### DIFF
--- a/newsfragments/4841.feature.rst
+++ b/newsfragments/4841.feature.rst
@@ -1,0 +1,3 @@
+Added validation for given glob patterns in ``license-files``.
+Raise an exception if it is invalid or doesn't match any
+license files.

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -372,6 +372,9 @@ class TestParityWithMetadataFromPyPaWheel:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(expand, "read_attr", Mock(return_value="0.42"))
         monkeypatch.setattr(expand, "read_files", Mock(return_value="hello world"))
+        monkeypatch.setattr(
+            Distribution, "_validate_and_expand_pattern", Mock(return_value=[])
+        )
         if request.param is None:
             yield self.base_example()
         else:

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -844,6 +844,10 @@ class TestEggInfo:
             pypath=os.pathsep.join([env.paths['lib'], str(tmpdir_cwd)]),
         )
         egg_info_dir = os.path.join('.', 'foo.egg-info')
+        if "INVALID_LICENSE" in excl_licenses:
+            # Invalid license file patterns raise InvalidConfigError
+            assert not Path(egg_info_dir, "SOURCES.txt").is_file()
+            return
 
         sources_text = Path(egg_info_dir, "SOURCES.txt").read_text(encoding="utf-8")
         sources_lines = [line.strip() for line in sources_text.splitlines()]


### PR DESCRIPTION
Alternative approach to #4838.

Validate each pattern and raise an exception if it is invalid or a pattern doesn't match any license files.
This will also apply to existing configs with `license-files` in `setup.cfg` and `tools.setuptools.license-files`, however I don't think that's an issue as these are almost always real problems and easy to fix.

Ref: #4829