### PR TITLE
pkg_resources: Correctly handle normalized project names

### DIFF
--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2911,7 +2911,7 @@ class Distribution:
         platform: str | None = None,
         precedence: int = EGG_DIST,
     ) -> None:
-        self.project_name = safe_name(project_name or 'Unknown')
+        self.project_name = safe_name(project_name or 'Unknown').replace('.', '-')
         if version is not None:
             self._version = safe_version(version)
         self.py_version = py_version
@@ -3459,7 +3459,7 @@ class Requirement(packaging.requirements.Requirement):
         """DO NOT CALL THIS UNDOCUMENTED METHOD; use Requirement.parse()!"""
         super().__init__(requirement_string)
         self.unsafe_name = self.name
-        project_name = safe_name(self.name)
+        project_name = safe_name(self.name).replace('.', '-')
         self.project_name, self.key = project_name, project_name.lower()
         self.specs = [(spec.operator, spec.version) for spec in self.specifier]
         self.extras = tuple(map(safe_extra, self.extras))

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -3459,8 +3459,8 @@ class Requirement(packaging.requirements.Requirement):
         """DO NOT CALL THIS UNDOCUMENTED METHOD; use Requirement.parse()!"""
         super().__init__(requirement_string)
         self.unsafe_name = self.name
-        project_name = safe_name(self.name).replace('.', '-')
-        self.project_name, self.key = project_name, project_name.lower()
+        self.project_name = safe_name(self.name)
+        self.key = self.project_name.lower().replace('.', '-')
         self.specs = [(spec.operator, spec.version) for spec in self.specifier]
         self.extras = tuple(map(safe_extra, self.extras))
         self.hashCmp = (

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -2911,7 +2911,7 @@ class Distribution:
         platform: str | None = None,
         precedence: int = EGG_DIST,
     ) -> None:
-        self.project_name = safe_name(project_name or 'Unknown').replace('.', '-')
+        self.project_name = safe_name(project_name or 'Unknown')
         if version is not None:
             self._version = safe_version(version)
         self.py_version = py_version

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -453,11 +453,11 @@ class TestWorkdirRequire:
             """,
         "pkg3_mod.egg-info/PKG-INFO": """
             Name: pkg3.mod
-            Version: 1.2.3
+            Version: 1.2.3.4
             """,
         "pkg4.mod.egg-info/PKG-INFO": """
             Name: pkg4.mod
-            Version: 0.42
+            Version: 0.42.1
             """,
     }
 
@@ -466,8 +466,8 @@ class TestWorkdirRequire:
         [
             ("pkg1.mod", "1.2.3", "pkg1.mod>=1"),
             ("pkg2.mod", "0.42", "pkg2.mod>=0.4"),
-            ("pkg3.mod", "1.2.3", "pkg3.mod<=2"),
-            ("pkg4.mod", "0.42", "pkg4.mod>0.2,<1"),
+            ("pkg3.mod", "1.2.3.4", "pkg3.mod<=2"),
+            ("pkg4.mod", "0.42.1", "pkg4.mod>0.2,<1"),
         ],
     )
     def test_require_normalised_name(self, tmp_path, monkeypatch, name, version, req):

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -477,5 +477,4 @@ class TestWorkdirRequire:
 
         [dist] = ws.require(req)
         assert dist.version == version
-        assert dist.project_name == name
         assert os.path.commonpath([dist.location, site_packages]) == site_packages


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This fixes an issue where `pkg_resources.require` treats project names with periods differently than other project names. 

Before:
```
>>> import pkg_resources
<stdin>:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
>>> pkg_resources.require('zip-po')
[zip-po 0.0.0 (/home/di/.pyenv/versions/3.12.4/lib/python3.12/site-packages)]
>>> pkg_resources.require('zip_po')
[zip-po 0.0.0 (/home/di/.pyenv/versions/3.12.4/lib/python3.12/site-packages)]
>>> pkg_resources.require('zip.po')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/di/git/pypa/setuptools/pkg_resources/__init__.py", line 1061, in require
    needed = self.resolve(parse_requirements(requirements))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/di/git/pypa/setuptools/pkg_resources/__init__.py", line 888, in resolve
    dist = self._resolve_dist(
           ^^^^^^^^^^^^^^^^^^^
  File "/home/di/git/pypa/setuptools/pkg_resources/__init__.py", line 929, in _resolve_dist
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'zip.po' distribution was not found and is required by the application
```

After:
```
>>> import pkg_resources
<stdin>:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
>>> pkg_resources.require('zip-po')
[zip-po 0.0.0 (/home/di/.pyenv/versions/3.12.4/lib/python3.12/site-packages)]
>>> pkg_resources.require('zip_po')
[zip-po 0.0.0 (/home/di/.pyenv/versions/3.12.4/lib/python3.12/site-packages)]
>>> pkg_resources.require('zip.po')
[zip-po 0.0.0 (/home/di/.pyenv/versions/3.12.4/lib/python3.12/site-packages)]
```

The simplest fix would be a one-character update to `safe_name`, which currently does not normalize periods when producing a "safe" project name:

https://github.com/pypa/setuptools/blob/56c055b653f080544f490e198605974c71b6fe35/pkg_resources/__init__.py#L1551-L1556 

However, since this is a public API, changes here might be more disruptive, so I opted to change `pkg_resources` usage of `safe_name` internally instead.

Closes #4853.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
