### PR TITLE
Update `WorkingSet.find` to consider standardised `.dist-info` directory names.

### DIFF
--- a/newsfragments/4856.bugfix.rst
+++ b/newsfragments/4856.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``pkg_resources.require(...)`` to also consider standardised
+``dist-info`` directories.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -708,14 +708,15 @@ class WorkingSet:
         If there is no active distribution for the requested project, ``None``
         is returned.
         """
-        dist = self.by_key.get(req.key)
-
-        if dist is None:
-            canonical_key = self.normalized_to_canonical_keys.get(req.key)
-
-            if canonical_key is not None:
-                req.key = canonical_key
-                dist = self.by_key.get(canonical_key)
+        for candidate in (
+            req.key,
+            self.normalized_to_canonical_keys.get(req.key),
+            safe_name(req.key).replace(".", "-"),
+        ):
+            dist = self.by_key.get(candidate)
+            if dist:
+                req.key = candidate
+                break
 
         if dist is not None and dist not in req:
             # XXX add more info

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -708,11 +708,15 @@ class WorkingSet:
         If there is no active distribution for the requested project, ``None``
         is returned.
         """
-        for candidate in (
+        dist: Distribution | None = None
+
+        candidates = (
             req.key,
             self.normalized_to_canonical_keys.get(req.key),
             safe_name(req.key).replace(".", "-"),
-        ):
+        )
+
+        for candidate in filter(None, candidates):
             dist = self.by_key.get(candidate)
             if dist:
                 req.key = candidate

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -453,11 +453,11 @@ class TestWorkdirRequire:
             """,
         "pkg3_mod.egg-info/PKG-INFO": """
             Name: pkg3.mod
-            Version: 1.2.3
+            Version: 1.2.3.4
             """,
         "pkg4.mod.egg-info/PKG-INFO": """
             Name: pkg4.mod
-            Version: 0.42
+            Version: 0.42.1
             """,
     }
 
@@ -466,8 +466,8 @@ class TestWorkdirRequire:
         [
             ("pkg1.mod", "1.2.3", "pkg1.mod>=1"),
             ("pkg2.mod", "0.42", "pkg2.mod>=0.4"),
-            ("pkg3.mod", "1.2.3", "pkg3.mod<=2"),
-            ("pkg4.mod", "0.42", "pkg4.mod>0.2,<1"),
+            ("pkg3.mod", "1.2.3.4", "pkg3.mod<=2"),
+            ("pkg4.mod", "0.42.1", "pkg4.mod>0.2,<1"),
         ],
     )
     def test_require_normalised_name(self, tmp_path, monkeypatch, name, version, req):

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -477,5 +477,4 @@ class TestWorkdirRequire:
 
         [dist] = ws.require(req)
         assert dist.version == version
-        assert dist.project_name == name
         assert os.path.commonpath([dist.location, site_packages]) == site_packages

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -462,21 +462,24 @@ class TestWorkdirRequire:
     }
 
     @pytest.mark.parametrize(
-        ("name", "version", "req"),
+        ("version", "requirement"),
         [
-            ("pkg1.mod", "1.2.3", "pkg1.mod>=1"),
-            ("pkg2.mod", "0.42", "pkg2.mod>=0.4"),
-            ("pkg3.mod", "1.2.3.4", "pkg3.mod<=2"),
-            ("pkg4.mod", "0.42.1", "pkg4.mod>0.2,<1"),
+            ("1.2.3", "pkg1.mod>=1"),
+            ("0.42", "pkg2.mod>=0.4"),
+            ("1.2.3.4", "pkg3.mod<=2"),
+            ("0.42.1", "pkg4.mod>0.2,<1"),
         ],
     )
-    def test_require_normalised_name(self, tmp_path, monkeypatch, name, version, req):
+    def test_require_non_normalised_name(
+        self, tmp_path, monkeypatch, version, requirement
+    ):
         # https://github.com/pypa/setuptools/issues/4853
         site_packages = self.fake_site_packages(tmp_path, monkeypatch, self.FILES)
         ws = pkg_resources.WorkingSet([site_packages])
 
-        [dist] = ws.require(req)
-        assert dist.version == version
-        assert os.path.samefile(
-            os.path.commonpath([dist.location, site_packages]), site_packages
-        )
+        for req in [requirement, requirement.replace(".", "-")]:
+            [dist] = ws.require(req)
+            assert dist.version == version
+            assert os.path.samefile(
+                os.path.commonpath([dist.location, site_packages]), site_packages
+            )

--- a/pkg_resources/tests/test_pkg_resources.py
+++ b/pkg_resources/tests/test_pkg_resources.py
@@ -477,4 +477,6 @@ class TestWorkdirRequire:
 
         [dist] = ws.require(req)
         assert dist.version == version
-        assert os.path.commonpath([dist.location, site_packages]) == site_packages
+        assert os.path.samefile(
+            os.path.commonpath([dist.location, site_packages]), site_packages
+        )


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Alternative to https://github.com/pypa/setuptools/pull/4855

Closes #4853.

/cc @di: We wore working kind of in parallel on this. What are your thoughts? I don't have any strong preference regarding the 2 proposed approaches (either #4855 or #4856 are fine to me).

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
