### PR TITLE
Reduce Ruff configs that duplicates upstream after skeleton merge

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -10,13 +10,13 @@ exclude = [
 [lint]
 extend-select = [
 	# upstream
- 
+
 	"C901", # complex-structure
 	"I", # isort
 	"PERF401", # manual-list-comprehension
 	"W", # pycodestyle Warning
- 
- 	# Ensure modern type annotation syntax and best practices
+
+	# Ensure modern type annotation syntax and best practices
 	# Not including those covered by type-checkers or exclusive to Python 3.11+
 	"FA", # flake8-future-annotations
 	"F404", # late-future-import
@@ -30,13 +30,9 @@ extend-select = [
 
 	# local
 	"ANN2", # missing-return-type-*
-	"F", # Pyflakes
-	"F404", # late-future-import
-	"FA", # flake8-future-annotations
 	"PERF", # Perflint
 	"PGH", # pygrep-hooks (blanket-* rules)
 	"PT", # flake8-pytest-style
-	"PYI", # flake8-pyi
 	"RUF10", # unused-noqa & redirected-noqa
 	"TRY", # tryceratops
 	"UP", # pyupgrade
@@ -44,7 +40,7 @@ extend-select = [
 ]
 ignore = [
 	# upstream
- 
+
 	# Typeshed rejects complex or non-literal defaults for maintenance and testing reasons,
 	# irrelevant to this project.
 	"PYI011", # typed-argument-default-in-stub
@@ -64,8 +60,8 @@ ignore = [
 	"ISC001",
 	"ISC002",
 
- 	# local
- 	"PERF203", # try-except-in-loop, micro-optimisation with many false-positive. Worth checking but don't block CI
+	# local
+	"PERF203", # try-except-in-loop, micro-optimisation with many false-positive. Worth checking but don't block CI
 	"PT007", # temporarily disabled, TODO: configure and standardize to preference
 	"PT011", # temporarily disabled, TODO: tighten expected error 
 	"PT012", # pytest-raises-with-multiple-statements, avoid extra dummy methods for a few lines, sometimes we explicitly assert in case of no error


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

These configs are now repeated with skeleton upstream and can be removed.

### Pull Request Checklist
- [N/A] Changes have tests
- [N/A] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
