### PR TITLE
In config command, move to eager imports. Restore LinkError to ccompilers module.

### DIFF
--- a/newsfragments/4866.bugfix.rst
+++ b/newsfragments/4866.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ImportError in distutils when configuring for linking.

--- a/setuptools/_distutils/ccompiler.py
+++ b/setuptools/_distutils/ccompiler.py
@@ -1,6 +1,7 @@
 from .compilers.C import base
 from .compilers.C.base import (
     CompileError,
+    LinkError,
     gen_lib_options,
     gen_preprocess_options,
     get_default_compiler,
@@ -10,6 +11,7 @@ from .compilers.C.base import (
 
 __all__ = [
     'CompileError',
+    'LinkError',
     'gen_lib_options',
     'gen_preprocess_options',
     'get_default_compiler',

--- a/setuptools/_distutils/command/config.py
+++ b/setuptools/_distutils/command/config.py
@@ -17,6 +17,7 @@ import re
 from collections.abc import Sequence
 from distutils._log import log
 
+from ..ccompiler import CCompiler, CompileError, LinkError, new_compiler
 from ..core import Command
 from ..errors import DistutilsExecError
 from ..sysconfig import customize_compiler
@@ -90,8 +91,6 @@ class config(Command):
         """
         # We do this late, and only on-demand, because this is an expensive
         # import.
-        from ..ccompiler import CCompiler, new_compiler
-
         if not isinstance(self.compiler, CCompiler):
             self.compiler = new_compiler(
                 compiler=self.compiler, dry_run=self.dry_run, force=True
@@ -177,8 +176,6 @@ class config(Command):
         preprocessor succeeded, false if there were any errors.
         ('body' probably isn't of much use, but what the heck.)
         """
-        from ..ccompiler import CompileError
-
         self._check_compiler()
         ok = True
         try:
@@ -213,8 +210,6 @@ class config(Command):
         """Try to compile a source file built from 'body' and 'headers'.
         Return true on success, false otherwise.
         """
-        from ..ccompiler import CompileError
-
         self._check_compiler()
         try:
             self._compile(body, headers, include_dirs, lang)
@@ -239,8 +234,6 @@ class config(Command):
         'headers', to executable form.  Return true on success, false
         otherwise.
         """
-        from ..ccompiler import CompileError, LinkError
-
         self._check_compiler()
         try:
             self._link(body, headers, include_dirs, libraries, library_dirs, lang)


### PR DESCRIPTION
Closes pypa/setuptools#4866

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
