### PR TITLE
Upgrade upload-artifact from deprecated v3 to v4

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -79,8 +79,8 @@ jobs:
           name: upstream
 
   linux:
-    # https://github.com/sagemath/sage/blob/develop/.github/workflows/docker.yml
-    uses: sagemath/sage/.github/workflows/docker.yml@develop
+    # https://github.com/sagemath/sage/blob/10.5/.github/workflows/docker.yml
+    uses: sagemath/sage/.github/workflows/docker.yml@10.5
     with:
       # Sage distribution packages to build
       targets: setuptools pyzmq


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This PR tries to fix the job failed at https://github.com/pypa/setuptools/actions/runs/13749067705/job/38447680927

see error output from github action logs

```bash
Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/
```


### Pull Request Checklist
- [ ] ~~Changes have tests~~
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
