### PR TITLE
Backport bugfix for wheel naming for Python 3.8

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 75.3.1
+current_version = 75.3.2
 commit = True
 tag = True
 

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,4 +1,9 @@
-v76.0.1
+v75.3.2
+=======
+
+- Fixed version error in changelog.
+
+v75.3.1
 =======
 
 Bugfixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ backend-path = ["."]
 
 [project]
 name = "setuptools"
-version = "75.3.1"
+version = "75.3.2"
 authors = [
 	{ name = "Python Packaging Authority", email = "distutils-sig@python.org" },
 ]


### PR DESCRIPTION
- **Merge pull request #4766 from di/fix/3777**
- **Repoint the news fragment.**
- **Bump version: 75.3.0 → 75.3.1**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4877

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
