### PR TITLE
Ignore newlines when processing keywords/platforms

### DIFF
--- a/newsfragments/4887.bugfix.rst
+++ b/newsfragments/4887.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed handling of keywords following the old specification with spaces instead of commas and containing newlines.

--- a/setuptools/_distutils/dist.py
+++ b/setuptools/_distutils/dist.py
@@ -644,6 +644,7 @@ Common commands: (see '--help-commands' for more)
             if value is None:
                 continue
             if isinstance(value, str):
+                value = value.replace("\n", " ")
                 value = [elm.strip() for elm in value.split(',')]
                 setattr(self.metadata, attr, value)
 

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -164,6 +164,30 @@ def __read_test_cases():
                 version=sic('1.0.0a'),
             ),
         ),
+        (
+            'Keywords with commas',
+            params(
+                keywords='one, two, three',
+            ),
+        ),
+        (
+            'Keywords with spaces',
+            params(
+                keywords='one two three',
+            ),
+        ),
+        (
+            'Keywords with commas multiline',
+            params(
+                keywords='one, two,\nthree, four\n',
+            ),
+        ),
+        (
+            'Keywords with spaces multiline',
+            params(
+                keywords='one two\nthree four\n',
+            ),
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary of changes

Newlines in `keywords` or `platforms` can break
the produced metadata in PKG-INFO or METADATA files.

Fixes: https://github.com/pypa/setuptools/issues/4887

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].