### PR TITLE
Defer import error for `packaging.licenses` in environments with `packaging<24.2`

### DIFF
--- a/newsfragments/4898.bugfix.rst
+++ b/newsfragments/4898.bugfix.rst
@@ -1,0 +1,4 @@
+Better error messages for ``packaging.licenses`` import errors in environments with ``packaging<24.2``\.
+The import statement was also deferred to spare users that are not using
+license expressions.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,6 @@ core = [
 
 	# for distutils
 	"jaraco.functools >= 4",
-	"packaging",
 	"more_itertools",
 ]
 

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -4,6 +4,7 @@ and core metadata
 """
 
 import re
+from typing import TYPE_CHECKING
 
 import packaging
 
@@ -155,14 +156,16 @@ try:
         canonicalize_license_expression as _canonicalize_license_expression,
     )
 except ImportError:
+    if not TYPE_CHECKING:
+        # XXX: pyright is still upset even with # pyright: ignore[reportAssignmentType]
 
-    def _canonicalize_license_expression(expression: str) -> str:  # type: ignore[misc]  # pyright: ignore[reportAssignmentType]
-        # Defer import error to affect only users that actually use it
-        # https://github.com/pypa/setuptools/issues/4894
-        raise ImportError(
-            "Cannot import `packaging.licenses`."
-            """
-            Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.
-            Please make sure you have a suitable version installed.
-            """
-        )
+        def _canonicalize_license_expression(expression: str) -> str:
+            # Defer import error to affect only users that actually use it
+            # https://github.com/pypa/setuptools/issues/4894
+            raise ImportError(
+                "Cannot import `packaging.licenses`."
+                """
+                Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.
+                Please make sure you have a suitable version installed.
+                """
+            )

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -151,21 +151,29 @@ def safer_best_effort_version(value: str) -> str:
     return filename_component(best_effort_version(value))
 
 
+def _missing_canonicalize_license_expression(expression: str) -> str:
+    """
+    Defer import error to affect only users that actually use it
+    https://github.com/pypa/setuptools/issues/4894
+    >>> _missing_canonicalize_license_expression("a OR b")
+    Traceback (most recent call last):
+    ...
+    ImportError: ...Cannot import `packaging.licenses`...
+    """
+    raise ImportError(
+        "Cannot import `packaging.licenses`."
+        """
+        Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.
+        Please make sure you have a suitable version installed.
+        """
+    )
+
+
 try:
     from packaging.licenses import (
         canonicalize_license_expression as _canonicalize_license_expression,
     )
-except ImportError:
+except ImportError:  # pragma: nocover
     if not TYPE_CHECKING:
         # XXX: pyright is still upset even with # pyright: ignore[reportAssignmentType]
-
-        def _canonicalize_license_expression(expression: str) -> str:
-            # Defer import error to affect only users that actually use it
-            # https://github.com/pypa/setuptools/issues/4894
-            raise ImportError(
-                "Cannot import `packaging.licenses`."
-                """
-                Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.
-                Please make sure you have a suitable version installed.
-                """
-            )
+        _canonicalize_license_expression = _missing_canonicalize_license_expression

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -156,7 +156,7 @@ try:
     )
 except ImportError:
 
-    def _canonicalize_license_expression(expression: str) -> str:
+    def _canonicalize_license_expression(expression: str) -> str:  # type: ignore[misc]  # pyright: ignore[reportAssignmentType]
         # Defer import error to affect only users that actually use it
         # https://github.com/pypa/setuptools/issues/4894
         raise ImportError(

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -148,3 +148,21 @@ def safer_best_effort_version(value: str) -> str:
     # See bdist_wheel.safer_verion
     # TODO: Replace with only safe_version in the future (no need for best effort)
     return filename_component(best_effort_version(value))
+
+
+try:
+    from packaging.licenses import (
+        canonicalize_license_expression as _canonicalize_license_expression,
+    )
+except ImportError:
+
+    def _canonicalize_license_expression(expression: str) -> str:
+        # Defer import error to affect only users that actually use it
+        # https://github.com/pypa/setuptools/issues/4894
+        raise ImportError(
+            "Cannot import `packaging.licenses`."
+            """
+            Setuptools>=77.0.0 requires "packaging>=24.2" to work properly.
+            Please make sure you have a suitable version installed.
+            """
+        )

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Union
 
 from more_itertools import partition, unique_everseen
-from packaging.licenses import canonicalize_license_expression
 from packaging.markers import InvalidMarker, Marker
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import Version
@@ -24,6 +23,7 @@ from . import (
     command as _,  # noqa: F401 # imported for side-effects
 )
 from ._importlib import metadata
+from ._normalization import _canonicalize_license_expression
 from ._path import StrPath
 from ._reqs import _StrOrIter
 from .config import pyprojecttoml, setupcfg
@@ -423,7 +423,7 @@ class Distribution(_Distribution):
         license_expr = self.metadata.license_expression
         if license_expr:
             str_ = _static.Str if _static.is_static(license_expr) else str
-            normalized = str_(canonicalize_license_expression(license_expr))
+            normalized = str_(_canonicalize_license_expression(license_expr))
             if license_expr != normalized:
                 InformationOnly.emit(f"Normalizing '{license_expr}' to '{normalized}'")
                 self.metadata.license_expression = normalized


### PR DESCRIPTION

## Summary of changes

Motivated by a well-known limitation of the vendoring system.

Closes #4894

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
