### PR TITLE
Avoid raising exception when license-files is defined outside of `pyproject.toml`

### DIFF
--- a/newsfragments/4899.bugfix.rst
+++ b/newsfragments/4899.bugfix.rst
@@ -1,0 +1,3 @@
+Avoided eagerly raising an exception when ``license-files`` is defined
+simultaneously inside and outside of ``pyproject.toml``.
+Instead we rely on the existing deprecation error.

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -90,7 +90,8 @@ def _apply_tool_table(dist: Distribution, config: dict, filename: StrPath):
         return  # short-circuit
 
     if "license-files" in tool_table:
-        if dist.metadata.license_files:
+        if "license-files" in config.get("project", {}):
+            # https://github.com/pypa/setuptools/pull/4837#discussion_r2004983349
             raise InvalidConfigError(
                 "'project.license-files' is defined already. "
                 "Remove 'tool.setuptools.license-files'."


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Instead we defer to the follow-up deprecation warning.

Rationale in https://github.com/pypa/setuptools/pull/4837#discussion_r2004983349

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
