### PR TITLE
Temporarily remove `requests` from integration tests

### DIFF
--- a/newsfragments/4909.misc.rst
+++ b/newsfragments/4909.misc.rst
@@ -1,0 +1,2 @@
+Temporarily remove ``requests`` from integration tests
+due to invalid ``setup.cfg``.

--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -54,7 +54,7 @@ EXAMPLES = [
     ("pyyaml", LATEST),  # cython + custom build_ext + custom distclass
     ("charset-normalizer", LATEST),  # uses mypyc, used by aiohttp
     ("protobuf", LATEST),
-    ("requests", LATEST),
+    # ("requests", LATEST),  # XXX: https://github.com/psf/requests/pull/6920
     ("celery", LATEST),
     # When adding packages to this list, make sure they expose a `__version__`
     # attribute, or modify the tests below


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Requests contain an invalid `setup.cfg` and will fail with the removal of deprecated support for dash-separated fields in `setup.cfg`.

This removes it from the integration tests until it is handled upstream: https://github.com/psf/requests/pull/6920.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
