### PR TITLE
Update license of my_test_package to MIT

### DIFF
--- a/pkg_resources/tests/data/my-test-package_unpacked-egg/my_test_package-1.0-py3.7.egg/EGG-INFO/PKG-INFO
+++ b/pkg_resources/tests/data/my-test-package_unpacked-egg/my_test_package-1.0-py3.7.egg/EGG-INFO/PKG-INFO
@@ -5,6 +5,6 @@ Summary: UNKNOWN
 Home-page: UNKNOWN
 Author: UNKNOWN
 Author-email: UNKNOWN
-License: UNKNOWN
+License: MIT
 Description: UNKNOWN
 Platform: UNKNOWN


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

UNKNOWN license alerts Artifactory X-Ray scan so this file needs to by manually excluded from security scans. Adding MIT license will prevent from triggering warnings in scans such as X-Ray.

I'm skipping adding changes to newsfragments because it's not a change in the library itself and doesn't affect the way it works.

Closes [2709](https://github.com/pypa/setuptools/issues/2709)

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
