### PR TITLE
Downgrade hyphen and uppercase deprecation warning to info

### DIFF
--- a/newsfragments/4923.misc.rst
+++ b/newsfragments/4923.misc.rst
@@ -1,0 +1,1 @@
+This changes ``enforce_underscore`` and ``enforce_option_lowercase`` from deprecation warnings to information only.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -628,17 +628,16 @@ class Distribution(_Distribution):
 
         underscore_opt = opt.replace('-', '_')
         affected = f"(Affected: {self.metadata.name})." if self.metadata.name else ""
-        SetuptoolsDeprecationWarning.emit(
+        InformationOnly.emit(
             f"Invalid dash-separated key {opt!r} in {section!r} (setup.cfg), "
             f"please use the underscore name {underscore_opt!r} instead.",
             f"""
-            Usage of dash-separated {opt!r} will not be supported in future
-            versions. Please use the underscore name {underscore_opt!r} instead.
+            Usage of dash-separated {opt!r} is not supported by Python packaging
+            specifications. Please use the underscore name {underscore_opt!r} instead.
             {affected}
             """,
             see_docs="userguide/declarative_config.html",
-            due_date=(2026, 3, 3),
-            # Warning initially introduced in 3 Mar 2021
+            # Changed from warning to info after https://github.com/pypa/setuptools/issues/4910
         )
         return underscore_opt
 
@@ -648,17 +647,17 @@ class Distribution(_Distribution):
 
         lowercase_opt = opt.lower()
         affected = f"(Affected: {self.metadata.name})." if self.metadata.name else ""
-        SetuptoolsDeprecationWarning.emit(
+        InformationOnly.emit(
             f"Invalid uppercase key {opt!r} in {section!r} (setup.cfg), "
             f"please use lowercase {lowercase_opt!r} instead.",
             f"""
-            Usage of uppercase key {opt!r} in {section!r} will not be supported in
-            future versions. Please use lowercase {lowercase_opt!r} instead.
+            Usage of uppercase key {opt!r} in {section!r} is not supported
+            by Python packaging specifications. Please use lowercase {lowercase_opt!r}
+            instead.
             {affected}
             """,
             see_docs="userguide/declarative_config.html",
-            due_date=(2026, 3, 3),
-            # Warning initially introduced in 6 Mar 2021
+            # Changed from warning to info after https://github.com/pypa/setuptools/issues/4910
         )
         return lowercase_opt
 

--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -1,7 +1,6 @@
 import configparser
 import contextlib
 import inspect
-import re
 from pathlib import Path
 from unittest.mock import Mock, patch
 
@@ -420,49 +419,6 @@ class TestMetadata:
         with pytest.raises(UnicodeDecodeError):
             with get_dist(tmpdir):
                 pass
-
-    @pytest.mark.parametrize(
-        ("error_msg", "config", "invalid"),
-        [
-            (
-                "Invalid dash-separated key 'author-email' in 'metadata' (setup.cfg)",
-                DALS(
-                    """
-                    [metadata]
-                    author-email = test@test.com
-                    maintainer_email = foo@foo.com
-                    """
-                ),
-                {"author-email": "test@test.com"},
-            ),
-            (
-                "Invalid uppercase key 'Name' in 'metadata' (setup.cfg)",
-                DALS(
-                    """
-                    [metadata]
-                    Name = foo
-                    description = Some description
-                    """
-                ),
-                {"Name": "foo"},
-            ),
-        ],
-    )
-    def test_invalid_options_previously_deprecated(
-        self, tmpdir, error_msg, config, invalid
-    ):
-        # This test and related methods can be removed when no longer needed.
-        # Deprecation postponed due to push-back from the community in
-        # https://github.com/pypa/setuptools/issues/4910
-        fake_env(tmpdir, config)
-        with pytest.warns(SetuptoolsDeprecationWarning, match=re.escape(error_msg)):
-            dist = get_dist(tmpdir).__enter__()
-
-        tmpdir.join('setup.cfg').remove()
-
-        for field, value in invalid.items():
-            attr = field.replace("-", "_").lower()
-            assert getattr(dist.metadata, attr) == value
 
 
 class TestOptions:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
This changes `enforce_underscore` and `enforce_option_lowercase` from deprecation warnings to information only.
<!-- Summary goes here -->

Closes <!-- issue number here -->
https://github.com/pypa/setuptools/issues/4921

### Pull Request Checklist
~~- [] Changes have tests~~
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
