### PR TITLE
Fix typo: `pyproject.license` -> `project.license`

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -119,7 +119,7 @@ Deprecations and Removals
 - Deprecated ``project.license`` as a TOML table in
   ``pyproject.toml``\. Users are expected to move towards using
   ``project.license-files`` and/or SPDX expressions (as strings) in
-  ``pyproject.license``\.
+  ``project.license``\.
   See PEP :pep:`639 <639#deprecate-license-key-table-subkeys>`. (#4840)
 - Added simple validation for given glob patterns in ``license-files``\:
   a warning will be generated if no file is matched.


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Fix typo at https://setuptools.pypa.io/en/stable/history.html#v77-0-0

### Pull Request Checklist
- [n/a] Changes have tests
- [n/a] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request

---

Thank you for adding PEP 639 support!
