### PR TITLE
Offer direct guidance for replacing `bdist_wheel.universal`

### DIFF
--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -171,7 +171,12 @@ class bdist_wheel(Command):
             "g",
             "Group name used when creating a tar file [default: current group]",
         ),
-        ("universal", None, "*DEPRECATED* make a universal wheel [default: false]"),
+        (
+            "universal",
+            None,
+            "*DEPRECATED* make a universal wheel [default: false]\n\n'
+            'Set `python_tag = py2.py3` in `setup.cfg` instead.",
+        ),
         (
             "compression=",
             None,
@@ -267,6 +272,9 @@ class bdist_wheel(Command):
                 is being obviated.
                 Please discontinue using this option, or if you still need it,
                 file an issue with pypa/setuptools describing your use case.
+
+                The use of this setting can be replaced with `python_tag = py2.py3`
+                entry in `setup.cfg`.",
                 """,
                 due_date=(2025, 8, 30),  # Introduced in 2024-08-30
             )

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -274,7 +274,7 @@ class bdist_wheel(Command):
                 file an issue with pypa/setuptools describing your use case.
 
                 The use of this setting can be replaced with `python_tag = py2.py3`
-                entry in `setup.cfg`.",
+                entry in `setup.cfg`.
                 """,
                 due_date=(2025, 8, 30),  # Introduced in 2024-08-30
             )

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -174,8 +174,8 @@ class bdist_wheel(Command):
         (
             "universal",
             None,
-            "*DEPRECATED* make a universal wheel [default: false]\n\n'
-            'Set `python_tag = py2.py3` in `setup.cfg` instead.",
+            "*DEPRECATED* make a universal wheel [default: false]\n\n"
+            "Set `python_tag = py2.py3` in `setup.cfg` instead.",
         ),
         (
             "compression=",


### PR DESCRIPTION
This is a follow-up to #4617 which deprecated the `universal` flag of `bdist_wheel`. It originally offered people to complain in issues. I, however, think that it's useful to mention the non-deprecated alternative that will keep working past deprecation date. This is what this patch implements.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Ref #4617

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
