### PR TITLE
easy_install.get_win_launcher: Default to pythonw.exe in GUI mode

### DIFF
--- a/launcher.c
+++ b/launcher.c
@@ -291,8 +291,8 @@ int run(int argc, char **argv, int is_gui) {
     *ptr-- = '\0';
 
     if (strncmp(python, "#!", 2)) {
-        /* default to python.exe if no #! header */
-        strcpy(python, "#!python.exe");
+        /* default to python[w].exe if no #! header */
+        strcpy(python, is_gui ? "#!pythonw.exe" : "#!python.exe");
     }
 
     parsedargs = parse_argv(python+2, &parsedargc);


### PR DESCRIPTION
## Summary of changes

When creating a launcher script where no explicit python binary is defined, `pythonw.exe` should be used in Windows when in GUI mode.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
