### PR TITLE
Fix error message string formatting

### DIFF
--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -285,7 +285,7 @@ class bdist_wheel(Command):
             raise ValueError(
                 f"`py_limited_api={self.py_limited_api!r}` not supported. "
                 "`Py_LIMITED_API` is currently incompatible with "
-                "`Py_GIL_DISABLED`."
+                "`Py_GIL_DISABLED`. "
                 "See https://github.com/python/cpython/issues/111506."
             )
 


### PR DESCRIPTION
I hit this error in the wild and noticed it had a typo.