### PR TITLE
More fully sanitize the filename in PackageIndex._download_url

### DIFF
--- a/newsfragments/4946.bugfix.rst
+++ b/newsfragments/4946.bugfix.rst
@@ -1,0 +1,1 @@
+More fully sanitized the filename in PackageIndex._download.

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -854,8 +854,8 @@ class PackageIndex(Environment):
             '__downloaded__'
         )
 
-        if name.endswith('.egg.zip'):
-            name = name[:-4]  # strip the extra .zip before download
+        # strip any extra .zip before download
+        name = re.sub(r'\.egg\.zip$', '.egg', name)
 
         return os.path.join(tmpdir, name)
 

--- a/setuptools/package_index.py
+++ b/setuptools/package_index.py
@@ -807,9 +807,16 @@ class PackageIndex(Environment):
             else:
                 raise DistutilsError(f"Download error for {url}: {v}") from v
 
-    def _download_url(self, url, tmpdir):
-        # Determine download filename
-        #
+    @staticmethod
+    def _resolve_download_filename(url, tmpdir):
+        """
+        >>> du = PackageIndex._resolve_download_filename
+        >>> root = getfixture('tmp_path')
+        >>> url = 'https://files.pythonhosted.org/packages/a9/5a/0db.../setuptools-78.1.0.tar.gz'
+        >>> import pathlib
+        >>> str(pathlib.Path(du(url, root)).relative_to(root))
+        'setuptools-78.1.0.tar.gz'
+        """
         name, _fragment = egg_info_for_url(url)
         if name:
             while '..' in name:
@@ -820,8 +827,13 @@ class PackageIndex(Environment):
         if name.endswith('.egg.zip'):
             name = name[:-4]  # strip the extra .zip before download
 
-        filename = os.path.join(tmpdir, name)
+        return os.path.join(tmpdir, name)
 
+    def _download_url(self, url, tmpdir):
+        """
+        Determine the download filename.
+        """
+        filename = self._resolve_download_filename(url, tmpdir)
         return self._download_vcs(url, filename) or self._download_other(url, filename)
 
     @staticmethod


### PR DESCRIPTION
- **Extract _resolve_download_filename with test.**
- **Add a check to ensure the name resolves relative to the tmpdir.**
- **Extract _sanitize method for sanitizing the filename.**
- **Rely on re.sub to perform the decision in one expression.**
- **Add news fragment.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
