### PR TITLE
Removed support for the 'legacy-editable' feature.

### DIFF
--- a/docs/userguide/development_mode.rst
+++ b/docs/userguide/development_mode.rst
@@ -197,13 +197,6 @@ works (still within the context of :pep:`660`).
    Users are encouraged to try out the new editable installation techniques
    and make the necessary adaptations.
 
-.. note::
-   Newer versions of ``pip`` no longer run the fallback command
-   ``python setup.py develop`` when the ``pyproject.toml`` file is present.
-   This means that setting the environment variable
-   ``SETUPTOOLS_ENABLE_FEATURES="legacy-editable"``
-   will have no effect when installing a package with ``pip``.
-
 
 How editable installations work
 -------------------------------

--- a/newsfragments/917.removal.rst
+++ b/newsfragments/917.removal.rst
@@ -1,0 +1,1 @@
+Removed support for 'legacy-editable' installs.

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -67,9 +67,6 @@ __all__ = [
     'SetupRequirementsError',
 ]
 
-SETUPTOOLS_ENABLE_FEATURES = os.getenv("SETUPTOOLS_ENABLE_FEATURES", "").lower()
-LEGACY_EDITABLE = "legacy-editable" in SETUPTOOLS_ENABLE_FEATURES.replace("_", "-")
-
 
 class SetupRequirementsError(BaseException):
     def __init__(self, specifiers) -> None:
@@ -457,37 +454,30 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         assert len(dist_info_candidates) <= 1
         return str(dist_info_candidates[0]) if dist_info_candidates else None
 
-    if not LEGACY_EDITABLE:
-        # PEP660 hooks:
-        # build_editable
-        # get_requires_for_build_editable
-        # prepare_metadata_for_build_editable
-        def build_editable(
-            self,
-            wheel_directory: StrPath,
-            config_settings: _ConfigSettings = None,
-            metadata_directory: StrPath | None = None,
-        ):
-            # XXX can or should we hide our editable_wheel command normally?
-            info_dir = self._get_dist_info_dir(metadata_directory)
-            opts = ["--dist-info-dir", info_dir] if info_dir else []
-            cmd = ["editable_wheel", *opts, *self._editable_args(config_settings)]
-            with suppress_known_deprecation():
-                return self._build_with_temp_dir(
-                    cmd, ".whl", wheel_directory, config_settings
-                )
-
-        def get_requires_for_build_editable(
-            self, config_settings: _ConfigSettings = None
-        ):
-            return self.get_requires_for_build_wheel(config_settings)
-
-        def prepare_metadata_for_build_editable(
-            self, metadata_directory: StrPath, config_settings: _ConfigSettings = None
-        ):
-            return self.prepare_metadata_for_build_wheel(
-                metadata_directory, config_settings
+    def build_editable(
+        self,
+        wheel_directory: StrPath,
+        config_settings: _ConfigSettings = None,
+        metadata_directory: StrPath | None = None,
+    ):
+        # XXX can or should we hide our editable_wheel command normally?
+        info_dir = self._get_dist_info_dir(metadata_directory)
+        opts = ["--dist-info-dir", info_dir] if info_dir else []
+        cmd = ["editable_wheel", *opts, *self._editable_args(config_settings)]
+        with suppress_known_deprecation():
+            return self._build_with_temp_dir(
+                cmd, ".whl", wheel_directory, config_settings
             )
+
+    def get_requires_for_build_editable(self, config_settings: _ConfigSettings = None):
+        return self.get_requires_for_build_wheel(config_settings)
+
+    def prepare_metadata_for_build_editable(
+        self, metadata_directory: StrPath, config_settings: _ConfigSettings = None
+    ):
+        return self.prepare_metadata_for_build_wheel(
+            metadata_directory, config_settings
+        )
 
 
 class _BuildMetaLegacyBackend(_BuildMetaBackend):
@@ -549,11 +539,9 @@ get_requires_for_build_sdist = _BACKEND.get_requires_for_build_sdist
 prepare_metadata_for_build_wheel = _BACKEND.prepare_metadata_for_build_wheel
 build_wheel = _BACKEND.build_wheel
 build_sdist = _BACKEND.build_sdist
-
-if not LEGACY_EDITABLE:
-    get_requires_for_build_editable = _BACKEND.get_requires_for_build_editable
-    prepare_metadata_for_build_editable = _BACKEND.prepare_metadata_for_build_editable
-    build_editable = _BACKEND.build_editable
+get_requires_for_build_editable = _BACKEND.get_requires_for_build_editable
+prepare_metadata_for_build_editable = _BACKEND.prepare_metadata_for_build_editable
+build_editable = _BACKEND.build_editable
 
 
 # The legacy backend

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -936,30 +936,6 @@ class TestBuildMetaLegacyBackend(TestBuildMetaBackend):
         build_backend.build_sdist("temp")
 
 
-def test_legacy_editable_install(venv, tmpdir, tmpdir_cwd):
-    pyproject = """
-    [build-system]
-    requires = ["setuptools"]
-    build-backend = "setuptools.build_meta"
-    [project]
-    name = "myproj"
-    version = "42"
-    """
-    path.build({"pyproject.toml": DALS(pyproject), "mymod.py": ""})
-
-    # First: sanity check
-    cmd = ["pip", "install", "--no-build-isolation", "-e", "."]
-    output = venv.run(cmd, cwd=tmpdir).lower()
-    assert "running setup.py develop for myproj" not in output
-    assert "created wheel for myproj" in output
-
-    # Then: real test
-    env = {**os.environ, "SETUPTOOLS_ENABLE_FEATURES": "legacy-editable"}
-    cmd = ["pip", "install", "--no-build-isolation", "-e", "."]
-    output = venv.run(cmd, cwd=tmpdir, env=env).lower()
-    assert "running setup.py develop for myproj" in output
-
-
 @pytest.mark.filterwarnings("ignore::setuptools.SetuptoolsDeprecationWarning")
 def test_sys_exit_0_in_setuppy(monkeypatch, tmp_path):
     """Setuptools should be resilient to setup.py with ``sys.exit(0)`` (#3973)."""


### PR DESCRIPTION
According to [the docs](https://github.com/pypa/setuptools/blob/8e4868a036b7fae3208d16cb4e5fe6d63c3752df/docs/userguide/development_mode.rst#legacy-behavior), pip no longer relies on this feature and that notice has been there for over two years.

Removal of this feature is required to eliminate reliance on the `develop` command, which is required to eliminate reliance on the `easy_install` command (#917).

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
