### PR TITLE
Restore License Classifier

### DIFF
--- a/newsfragments/4957.bugfix.rst
+++ b/newsfragments/4957.bugfix.rst
@@ -1,0 +1,1 @@
+Restored license declaration to classifiers -- by :user:`WilliamRoyNelson`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ readme = "README.rst"
 classifiers = [
 	"Development Status :: 5 - Production/Stable",
 	"Intended Audience :: Developers",
+	"License :: OSI Approved :: MIT License",
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3 :: Only",
 	"Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
## Summary of changes

Partially reverts
https://github.com/pypa/setuptools/commit/4e1e89392de5cb405e7844cdc8b20fc2755dbaba

Which removed all license declarations from the project without adding a proper SPDX identifier.
https://github.com/pypa/setuptools/pull/4901 has a discussion on what the new license declaration should be, but until that's resolved, this restores the old license declaration so that automated tools do not reject setuptools as having no license.

Closes https://github.com/pypa/setuptools/issues/4956

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
