### PR TITLE
Apply distutils fix for parsing linker parameters

### DIFF
--- a/newsfragments/+67050cd5.bugfix.rst
+++ b/newsfragments/+67050cd5.bugfix.rst
@@ -1,0 +1,1 @@
+Merge with pypa/distutils@24bd3179b including fix for pypa/distutils#355.

--- a/setuptools/_distutils/command/config.py
+++ b/setuptools/_distutils/command/config.py
@@ -89,8 +89,6 @@ class config(Command):
         """Check that 'self.compiler' really is a CCompiler object;
         if not, make it one.
         """
-        # We do this late, and only on-demand, because this is an expensive
-        # import.
         if not isinstance(self.compiler, CCompiler):
             self.compiler = new_compiler(
                 compiler=self.compiler, dry_run=self.dry_run, force=True

--- a/setuptools/_distutils/compilers/C/tests/test_unix.py
+++ b/setuptools/_distutils/compilers/C/tests/test_unix.py
@@ -245,6 +245,69 @@ class TestUnixCCompiler(support.TempdirManager):
         assert self.cc.linker_so[0] == 'my_cc'
 
     @pytest.mark.skipif('platform.system == "Windows"')
+    def test_cxx_commands_used_are_correct(self):
+        def gcv(v):
+            if v == 'LDSHARED':
+                return 'ccache gcc-4.2 -bundle -undefined dynamic_lookup'
+            elif v == 'LDCXXSHARED':
+                return 'ccache g++-4.2 -bundle -undefined dynamic_lookup'
+            elif v == 'CXX':
+                return 'ccache g++-4.2'
+            elif v == 'CC':
+                return 'ccache gcc-4.2'
+            return ''
+
+        def gcvs(*args, _orig=sysconfig.get_config_vars):
+            if args:
+                return list(map(sysconfig.get_config_var, args))
+            return _orig()  # pragma: no cover
+
+        sysconfig.get_config_var = gcv
+        sysconfig.get_config_vars = gcvs
+        with (
+            mock.patch.object(self.cc, 'spawn', return_value=None) as mock_spawn,
+            mock.patch.object(self.cc, '_need_link', return_value=True),
+            mock.patch.object(self.cc, 'mkpath', return_value=None),
+            EnvironmentVarGuard() as env,
+        ):
+            # override environment overrides in case they're specified by CI
+            del env['CXX']
+            del env['LDCXXSHARED']
+
+            sysconfig.customize_compiler(self.cc)
+            assert self.cc.linker_so_cxx[0:2] == ['ccache', 'g++-4.2']
+            assert self.cc.linker_exe_cxx[0:2] == ['ccache', 'g++-4.2']
+            self.cc.link(None, [], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = ['ccache', 'g++-4.2', '-bundle', '-undefined', 'dynamic_lookup']
+            assert call_args[:5] == expected
+
+            self.cc.link_executable([], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = ['ccache', 'g++-4.2', '-o', self.cc.executable_filename('a.out')]
+            assert call_args[:4] == expected
+
+            env['LDCXXSHARED'] = 'wrapper g++-4.2 -bundle -undefined dynamic_lookup'
+            env['CXX'] = 'wrapper g++-4.2'
+            sysconfig.customize_compiler(self.cc)
+            assert self.cc.linker_so_cxx[0:2] == ['wrapper', 'g++-4.2']
+            assert self.cc.linker_exe_cxx[0:2] == ['wrapper', 'g++-4.2']
+            self.cc.link(None, [], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = ['wrapper', 'g++-4.2', '-bundle', '-undefined', 'dynamic_lookup']
+            assert call_args[:5] == expected
+
+            self.cc.link_executable([], 'a.out', target_lang='c++')
+            call_args = mock_spawn.call_args[0][0]
+            expected = [
+                'wrapper',
+                'g++-4.2',
+                '-o',
+                self.cc.executable_filename('a.out'),
+            ]
+            assert call_args[:4] == expected
+
+    @pytest.mark.skipif('platform.system == "Windows"')
     @pytest.mark.usefixtures('disable_macos_customization')
     def test_cc_overrides_ldshared_for_cxx_correctly(self):
         """

--- a/setuptools/_distutils/compilers/C/unix.py
+++ b/setuptools/_distutils/compilers/C/unix.py
@@ -286,19 +286,18 @@ class Compiler(base.Compiler):
                 # building an executable or linker_so (with shared options)
                 # when building a shared library.
                 building_exe = target_desc == base.Compiler.EXECUTABLE
+                target_cxx = target_lang == "c++"
                 linker = (
-                    self.linker_exe
+                    (self.linker_exe_cxx if target_cxx else self.linker_exe)
                     if building_exe
-                    else (
-                        self.linker_so_cxx if target_lang == "c++" else self.linker_so
-                    )
+                    else (self.linker_so_cxx if target_cxx else self.linker_so)
                 )[:]
 
-                if target_lang == "c++" and self.compiler_cxx:
+                if target_cxx and self.compiler_cxx:
                     env, linker_ne = _split_env(linker)
                     aix, linker_na = _split_aix(linker_ne)
                     _, compiler_cxx_ne = _split_env(self.compiler_cxx)
-                    _, linker_exe_ne = _split_env(self.linker_exe)
+                    _, linker_exe_ne = _split_env(self.linker_exe_cxx)
 
                     params = _linker_params(linker_na, linker_exe_ne)
                     linker = env + aix + compiler_cxx_ne + params


### PR DESCRIPTION
- **Remove latent comment.**
- **Respect CXX when parsing linker parameters for UNIX c++ targets**
- **Add test for argument parsing for CXX targets on UNIX**
- **Fix new test case**
- **Add news fragment.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
