### PR TITLE
Tiny nit fix: `master`->`main` in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,6 @@ Closes <!-- issue number here -->
   _(See [documentation][PR docs] for details)_
 
 
-[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
+[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
 [PR docs]:
 https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request


### PR DESCRIPTION
## Summary of changes

Tiny nit fix: `master`->`main` in PR template

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/master/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
