### PR TITLE
Override the executable in the editable_wheel command.

### DIFF
--- a/setuptools/_distutils/command/build_scripts.py
+++ b/setuptools/_distutils/command/build_scripts.py
@@ -106,7 +106,7 @@ class build_scripts(Command):
             log.info("copying and adjusting %s -> %s", script, self.build_dir)
             if not self.dry_run:
                 post_interp = shebang_match.group(1) or ''
-                shebang = f"#!python{post_interp}\n"
+                shebang = "#!" + self.executable + post_interp + "\n"
                 self._validate_shebang(shebang, f.encoding)
                 with open(outfile, "w", encoding=f.encoding) as outf:
                     outf.write(shebang)

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -36,6 +36,7 @@ from ..warnings import InformationOnly, SetuptoolsDeprecationWarning, Setuptools
 from .build import build as build_cls
 from .build_py import build_py as build_py_cls
 from .dist_info import dist_info as dist_info_cls
+from .distutils.commands import build_scripts as build_scripts_cls
 from .egg_info import egg_info as egg_info_cls
 from .install import install as install_cls
 from .install_scripts import install_scripts as install_scripts_cls
@@ -210,6 +211,11 @@ class editable_wheel(Command):
         install.install_scripts = build.build_scripts = scripts
         install.install_headers = headers
         install.install_data = data
+
+        # For portability, ensure scripts are built with #!python shebang
+        # pypa/setuptools#4863
+        build_scripts = cast(build_scripts_cls, dist.get_command_obj("build_scripts"))
+        build_scripts.executable = 'python'
 
         install_scripts = cast(
             install_scripts_cls, dist.get_command_obj("install_scripts")


### PR DESCRIPTION
- **Revert "Merge pull request pypa/distutils#332 from pypa/debt/unify-shebang"**
- **Remove support for special executable under a Python build.**
- **In build_editable, ensure that 'executable' is hard-coded to #!python for portability.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4934

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
