### PR TITLE
Python 3 is the default nowadays

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -146,8 +146,6 @@ jobs:
           fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
       - name: Install tox
         run: python -m pip install tox
       - name: Eval ${{ matrix.job }}
@@ -270,8 +268,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: Setup Python
         uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
       - name: Install tox
         run: python -m pip install tox
       - name: Run


### PR DESCRIPTION
## Summary of changes

`python-version: 3.x` is implicit.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
