### PR TITLE
Mark new tests as `uses_network`

### DIFF
--- a/newsfragments/4982.misc.rst
+++ b/newsfragments/4982.misc.rst
@@ -1,0 +1,1 @@
+Mark more tests failing without Internet access as ``uses_network``.

--- a/setuptools/tests/integration/test_pbr.py
+++ b/setuptools/tests/integration/test_pbr.py
@@ -1,6 +1,9 @@
 import subprocess
 
+import pytest
 
+
+@pytest.mark.uses_network
 def test_pbr_integration(pbr_package, venv):
     """Ensure pbr packages install."""
     cmd = [

--- a/setuptools/tests/test_develop.py
+++ b/setuptools/tests/test_develop.py
@@ -70,6 +70,7 @@ class TestNamespaces:
         platform.python_implementation() == 'PyPy',
         reason="https://github.com/pypa/setuptools/issues/1202",
     )
+    @pytest.mark.uses_network
     def test_namespace_package_importable(self, tmpdir):
         """
         Installing two packages sharing the same namespace, one installed

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -1068,6 +1068,7 @@ def test_compat_install(tmp_path, venv):
     assert "cannot import name 'subpackage'" in out
 
 
+@pytest.mark.uses_network
 def test_pbr_integration(pbr_package, venv, editable_opts):
     """Ensure editable installs work with pbr, issue #3500"""
     cmd = [


### PR DESCRIPTION
## Summary of changes

Mark a few new tests that try to install stuff from PyPI via `pip` as `uses_network`.

To reproduce:

```
tox -e py313
sudo unshare -n sudo -u $USER sh -c '. .tox/py313/bin/activate && pytest -m "not uses_network"'
```

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
