### PR TITLE
Remove more reliance on pkg_resources

### DIFF
--- a/newsfragments/3085.feature.rst
+++ b/newsfragments/3085.feature.rst
@@ -1,0 +1,1 @@
+Replaced more references to pkg_resources with importlib equivalents.

--- a/pkg_resources/__init__.py
+++ b/pkg_resources/__init__.py
@@ -440,11 +440,7 @@ def _macos_arch(machine):
 
 
 def get_build_platform():
-    """Return this platform's string for platform-specific distributions
-
-    XXX Currently this is the same as ``distutils.util.get_platform()``, but it
-    needs some hacks for Linux and macOS.
-    """
+    """Return this platform's string for platform-specific distributions"""
     from sysconfig import get_platform
 
     plat = get_platform()

--- a/setuptools/_scripts.py
+++ b/setuptools/_scripts.py
@@ -11,9 +11,7 @@ import textwrap
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, TypedDict
 
-import pkg_resources
-
-from ._importlib import metadata
+from ._importlib import metadata, resources
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -331,12 +329,12 @@ def get_win_launcher(type):
             launcher_fn = launcher_fn.replace(".", "-64.")
     else:
         launcher_fn = launcher_fn.replace(".", "-32.")
-    return pkg_resources.resource_string('setuptools', launcher_fn)
+    return resources.files('setuptools').joinpath(launcher_fn).read_bytes()
 
 
 def load_launcher_manifest(name):
-    manifest = pkg_resources.resource_string(__name__, 'launcher manifest.xml')
-    return manifest.decode('utf-8') % vars()
+    res = resources.files(__name__).joinpath('launcher manifest.xml')
+    return res.read_text(encoding='utf-8') % vars()
 
 
 def _first_line_re():

--- a/setuptools/_scripts.py
+++ b/setuptools/_scripts.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, TypedDict
 
 import pkg_resources
 
+from ._importlib import metadata
+
 if TYPE_CHECKING:
     from typing_extensions import Self
 
@@ -167,6 +169,13 @@ class ScriptWriter:
         Yield write_script() argument tuples for a distribution's
         console_scripts and gui_scripts entry points.
         """
+
+        # If distribution is not an importlib.metadata.Distribution, assume
+        # it's a pkg_resources.Distribution and transform it.
+        if not hasattr(dist, 'entry_points'):
+            SetuptoolsWarning.emit("Unsupported distribution encountered.")
+            dist = metadata.Distribution.at(dist.egg_info)
+
         if header is None:
             header = cls.get_header()
         spec = f'{dist.name}=={dist.version}'

--- a/setuptools/_scripts.py
+++ b/setuptools/_scripts.py
@@ -169,13 +169,14 @@ class ScriptWriter:
         """
         if header is None:
             header = cls.get_header()
-        spec = str(dist.as_requirement())
+        spec = f'{dist.name}=={dist.version}'
         for type_ in 'console', 'gui':
-            group = type_ + '_scripts'
-            for name in dist.get_entry_map(group).keys():
-                cls._ensure_safe_name(name)
+            group = f'{type_}_scripts'
+            for ep in dist.entry_points.select(group=group):
+                name = ep.name
+                cls._ensure_safe_name(ep.name)
                 script_text = cls.template % locals()
-                args = cls._get_script_args(type_, name, header, script_text)
+                args = cls._get_script_args(type_, ep.name, header, script_text)
                 yield from args
 
     @staticmethod

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import itertools
 import os
 import sys
+import textwrap
 from collections.abc import Iterator
 from importlib.machinery import EXTENSION_SUFFIXES
 from importlib.util import cache_from_source as _compiled_file_name
@@ -72,10 +73,6 @@ elif os.name != 'nt':
         use_stubs = have_rtld = hasattr(dl, 'RTLD_NOW')
     except ImportError:
         pass
-
-
-def if_dl(s):
-    return s if have_rtld else ''
 
 
 def get_abi3_suffix():
@@ -355,30 +352,34 @@ class build_ext(_build_ext):
             raise BaseError(stub_file + " already exists! Please delete.")
         if not self.dry_run:
             with open(stub_file, 'w', encoding="utf-8") as f:
-                content = '\n'.join([
-                    "def __bootstrap__():",
-                    "   global __bootstrap__, __file__, __loader__",
-                    "   import sys, os, pkg_resources, importlib.util" + if_dl(", dl"),
-                    "   __file__ = pkg_resources.resource_filename"
-                    f"(__name__,{os.path.basename(ext._file_name)!r})",
-                    "   del __bootstrap__",
-                    "   if '__loader__' in globals():",
-                    "       del __loader__",
-                    if_dl("   old_flags = sys.getdlopenflags()"),
-                    "   old_dir = os.getcwd()",
-                    "   try:",
-                    "     os.chdir(os.path.dirname(__file__))",
-                    if_dl("     sys.setdlopenflags(dl.RTLD_NOW)"),
-                    "     spec = importlib.util.spec_from_file_location(",
-                    "                __name__, __file__)",
-                    "     mod = importlib.util.module_from_spec(spec)",
-                    "     spec.loader.exec_module(mod)",
-                    "   finally:",
-                    if_dl("     sys.setdlopenflags(old_flags)"),
-                    "     os.chdir(old_dir)",
-                    "__bootstrap__()",
-                    "",  # terminal \n
-                ])
+                content = (
+                    textwrap.dedent(f"""
+                    def __bootstrap__():
+                       global __bootstrap__, __file__, __loader__
+                       import sys, os, pkg_resources, importlib.util
+                    #rtld   import dl
+                       __file__ = pkg_resources.resource_filename(__name__,
+                         {os.path.basename(ext._file_name)!r})
+                       del __bootstrap__
+                       if '__loader__' in globals():
+                           del __loader__
+                    #rtld   old_flags = sys.getdlopenflags()
+                       old_dir = os.getcwd()
+                       try:
+                         os.chdir(os.path.dirname(__file__))
+                    #rtld     sys.setdlopenflags(dl.RTLD_NOW)
+                         spec = importlib.util.spec_from_file_location(
+                                    __name__, __file__)
+                         mod = importlib.util.module_from_spec(spec)
+                         spec.loader.exec_module(mod)
+                       finally:
+                    #rtld     sys.setdlopenflags(old_flags)
+                         os.chdir(old_dir)
+                    __bootstrap__()
+                    """)
+                    .lstrip()
+                    .replace('#rtld', '#rtld' * (not have_rtld))
+                )
                 f.write(content)
         if compile:
             self._compile_and_remove_stub(stub_file)

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -356,25 +356,25 @@ class build_ext(_build_ext):
                     textwrap.dedent(f"""
                     def __bootstrap__():
                        global __bootstrap__, __file__, __loader__
-                       import sys, os, pkg_resources, importlib.util
+                       import sys, os, importlib.resources as irs, importlib.util
                     #rtld   import dl
-                       __file__ = pkg_resources.resource_filename(__name__,
-                         {os.path.basename(ext._file_name)!r})
-                       del __bootstrap__
-                       if '__loader__' in globals():
-                           del __loader__
-                    #rtld   old_flags = sys.getdlopenflags()
-                       old_dir = os.getcwd()
-                       try:
-                         os.chdir(os.path.dirname(__file__))
-                    #rtld     sys.setdlopenflags(dl.RTLD_NOW)
-                         spec = importlib.util.spec_from_file_location(
-                                    __name__, __file__)
-                         mod = importlib.util.module_from_spec(spec)
-                         spec.loader.exec_module(mod)
-                       finally:
-                    #rtld     sys.setdlopenflags(old_flags)
-                         os.chdir(old_dir)
+                       with irs.files(__name__).joinpath(
+                         {os.path.basename(ext._file_name)!r}) as __file__:
+                          del __bootstrap__
+                          if '__loader__' in globals():
+                              del __loader__
+                    #rtld      old_flags = sys.getdlopenflags()
+                          old_dir = os.getcwd()
+                          try:
+                            os.chdir(os.path.dirname(__file__))
+                    #rtld        sys.setdlopenflags(dl.RTLD_NOW)
+                            spec = importlib.util.spec_from_file_location(
+                                       __name__, __file__)
+                            mod = importlib.util.module_from_spec(spec)
+                            spec.loader.exec_module(mod)
+                          finally:
+                    #rtld        sys.setdlopenflags(old_flags)
+                            os.chdir(old_dir)
                     __bootstrap__()
                     """)
                     .lstrip()

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -655,8 +655,6 @@ def write_pkg_info(cmd, basename, filename) -> None:
         metadata.name, oldname = cmd.egg_name, metadata.name
 
         try:
-            # write unescaped data to PKG-INFO, so older pkg_resources
-            # can still parse it
             metadata.write_pkg_info(cmd.egg_info)
         finally:
             metadata.name, metadata.version = oldname, oldver

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -32,17 +32,11 @@ class install_scripts(orig.install_scripts):
 
     def _install_ep_scripts(self):
         # Delay import side-effects
-        from pkg_resources import Distribution, PathMetadata
-
         from .. import _scripts
+        from .._importlib import metadata
 
         ei_cmd = self.get_finalized_command("egg_info")
-        dist = Distribution(
-            ei_cmd.egg_base,
-            PathMetadata(ei_cmd.egg_base, ei_cmd.egg_info),
-            ei_cmd.egg_name,
-            ei_cmd.egg_version,
-        )
+        dist = metadata.Distribution.at(path=ei_cmd.egg_info)
         bs_cmd = self.get_finalized_command('build_scripts')
         exec_param = getattr(bs_cmd, 'executable', None)
         writer = _scripts.ScriptWriter

--- a/setuptools/tests/contexts.py
+++ b/setuptools/tests/contexts.py
@@ -75,20 +75,6 @@ def save_user_site_setting():
 
 
 @contextlib.contextmanager
-def save_pkg_resources_state():
-    import pkg_resources
-
-    pr_state = pkg_resources.__getstate__()
-    # also save sys.path
-    sys_path = sys.path[:]
-    try:
-        yield pr_state, sys_path
-    finally:
-        sys.path[:] = sys_path
-        pkg_resources.__setstate__(pr_state)
-
-
-@contextlib.contextmanager
 def suppress_exceptions(*excs):
     try:
         yield

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -9,8 +9,6 @@ from functools import partial
 
 import pytest
 
-import pkg_resources
-from setuptools._importlib import metadata as md
 from setuptools.archive_util import unpack_archive
 
 from .textwrap import DALS
@@ -19,50 +17,6 @@ read = partial(pathlib.Path.read_text, encoding="utf-8")
 
 
 class TestDistInfo:
-    metadata_base = DALS(
-        """
-        Metadata-Version: 1.2
-        Requires-Dist: splort (==4)
-        Provides-Extra: baz
-        Requires-Dist: quux (>=1.1); extra == 'baz'
-        """
-    )
-
-    @classmethod
-    def build_metadata(cls, **kwargs):
-        lines = ('{key}: {value}\n'.format(**locals()) for key, value in kwargs.items())
-        return cls.metadata_base + ''.join(lines)
-
-    @pytest.fixture
-    def metadata(self, tmpdir):
-        dist_info_name = 'UnversionedDistribution.dist-info'
-        unversioned = tmpdir / dist_info_name
-        unversioned.mkdir()
-        filename = unversioned / 'METADATA'
-        content = self.build_metadata(
-            Name='UnversionedDistribution',
-            Version='0.3',
-        )
-        filename.write_text(content, encoding='utf-8')
-
-        return str(tmpdir)
-
-    def test_version(self, metadata):
-        (dist,) = md.Distribution.discover(path=[metadata])
-        assert dist.version == '0.3'
-
-    def test_conditional_dependencies(self, metadata):
-        specs = 'splort==4', 'quux>=1.1'
-        requires = list(map(pkg_resources.Requirement.parse, specs))
-
-        for d in pkg_resources.find_distributions(metadata):
-            assert d.requires() == requires[:1]
-            assert d.requires(extras=('baz',)) == [
-                requires[0],
-                pkg_resources.Requirement.parse('quux>=1.1;extra=="baz"'),
-            ]
-            assert d.extras == ['baz']
-
     def test_invalid_version(self, tmp_path):
         """
         Supplying an invalid version crashes dist_info.

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -10,6 +10,7 @@ from functools import partial
 import pytest
 
 import pkg_resources
+from setuptools._importlib import metadata as md
 from setuptools.archive_util import unpack_archive
 
 from .textwrap import DALS
@@ -34,15 +35,6 @@ class TestDistInfo:
 
     @pytest.fixture
     def metadata(self, tmpdir):
-        dist_info_name = 'VersionedDistribution-2.718.dist-info'
-        versioned = tmpdir / dist_info_name
-        versioned.mkdir()
-        filename = versioned / 'METADATA'
-        content = self.build_metadata(
-            Name='VersionedDistribution',
-        )
-        filename.write_text(content, encoding='utf-8')
-
         dist_info_name = 'UnversionedDistribution.dist-info'
         unversioned = tmpdir / dist_info_name
         unversioned.mkdir()
@@ -55,18 +47,9 @@ class TestDistInfo:
 
         return str(tmpdir)
 
-    def test_distinfo(self, metadata):
-        dists = dict(
-            (d.project_name, d) for d in pkg_resources.find_distributions(metadata)
-        )
-
-        assert len(dists) == 2, dists
-
-        unversioned = dists['UnversionedDistribution']
-        versioned = dists['VersionedDistribution']
-
-        assert versioned.version == '2.718'  # from filename
-        assert unversioned.version == '0.3'  # from METADATA
+    def test_version(self, metadata):
+        (dist,) = md.Distribution.discover(path=[metadata])
+        assert dist.version == '0.3'
 
     def test_conditional_dependencies(self, metadata):
         specs = 'splort==4', 'quux>=1.1'

--- a/setuptools/tests/test_windows_wrappers.py
+++ b/setuptools/tests/test_windows_wrappers.py
@@ -20,7 +20,7 @@ import textwrap
 
 import pytest
 
-import pkg_resources
+from setuptools._importlib import resources
 
 pytestmark = pytest.mark.skipif(sys.platform != 'win32', reason="Windows only")
 
@@ -48,7 +48,7 @@ class WrapperTester:
 
         # also copy cli.exe to the sample directory
         with (tmpdir / cls.wrapper_name).open('wb') as f:
-            w = pkg_resources.resource_string('setuptools', cls.wrapper_source)
+            w = resources.files('setuptools').join_path(cls.wrapper_source).read_bytes()
             f.write(w)
 
 


### PR DESCRIPTION
## Summary of changes

Removes the remaining references to pkg_resources in the Setuptools codebase.

All that remains in the setuptools package relying on pkg_resources are tests for pkg_resources-style namespace packages.

- **Remove comment referring to pkg_resources.**
- **In bdist_egg, remove reliance on pkg_resources.**
- **Convert stub into a single string for easier human parsing.**
- **In build_ext, remove reliance on pkg_resources.**
- **Converted install_scripts and _scripts to prefer importlib.metadata over pkg_resources.**
- **Add a compatibility shim and warning for legacy use on ScriptWriter.get_args**
- **Prefer importlib.resources in _scripts.**
- **Remove unused context manager.**
- **Adapt test_distinfo to test_version and migrate to use importlib.metadata.**
- **Removed test_version and test_conditional_dependencies, as these tests were only exercising expectations about pkg_resources and not dist_info.**
- **Prefer importlib.resources in test_windows_wrappers.**
- **Add news fragment.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->


<!-- Summary goes here -->

Ref #3085

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
