### PR TITLE
Restore "delayed" aspect of existing import of `pkg_resources` in `setuptools/installer.py`

### DIFF
--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -6,8 +6,7 @@ import subprocess
 import sys
 import tempfile
 from functools import partial
-
-from pkg_resources import Distribution
+from typing import TYPE_CHECKING
 
 from . import _reqs
 from ._reqs import _StrOrIter
@@ -16,6 +15,9 @@ from .wheel import Wheel
 
 from distutils import log
 from distutils.errors import DistutilsError
+
+if TYPE_CHECKING:
+    from pkg_resources import Distribution
 
 
 def _fixup_find_links(find_links):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

In `setuptools/installer` accidentally the import of `pkg_resources` was made eager when sorting out type annotations. This PR restores the previous behaviour (introduced in https://github.com/pypa/setuptools/pull/3792).

Fix https://github.com/pypa/setuptools/commit/f160c700762fcf0eef7a75ff4aa58ba262473c60#r156839662

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
