### PR TITLE
Fix `no attribute 'join_path'` error in Windows test

### DIFF
--- a/newsfragments/4995.misc.rst
+++ b/newsfragments/4995.misc.rst
@@ -1,0 +1,1 @@
+Fixed ``no attribute 'join_path'`` error in Windows test

--- a/setuptools/tests/test_windows_wrappers.py
+++ b/setuptools/tests/test_windows_wrappers.py
@@ -48,7 +48,7 @@ class WrapperTester:
 
         # also copy cli.exe to the sample directory
         with (tmpdir / cls.wrapper_name).open('wb') as f:
-            w = resources.files('setuptools').join_path(cls.wrapper_source).read_bytes()
+            w = resources.files('setuptools').joinpath(cls.wrapper_source).read_bytes()
             f.write(w)
 
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Fix the error in https://github.com/pypa/setuptools/actions/runs/14977076299/job/42072003260?pr=4994#step:11:155

([test (3.13, windows-latest)](https://github.com/pypa/setuptools/actions/runs/14977076299/job/42072003260?pr=4994#logs))

<!-- issue number here -->

![image](https://github.com/user-attachments/assets/57c133fa-7fef-49b7-a6fc-60e472f5cdd3)


### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
