### PR TITLE
Remove almost identical copies of methods already defined in `distutils`

### DIFF
--- a/newsfragments/4996.misc.rst
+++ b/newsfragments/4996.misc.rst
@@ -1,0 +1,2 @@
+Remove code duplication for ``_ensure_stringlike`` and ``ensure_string_list``
+in ``setuptools/__init__.py`` (already exists in ``distutils/cmd.py``).

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import functools
 import os
-import re
 import sys
 from abc import abstractmethod
 from collections.abc import Mapping
@@ -30,7 +29,6 @@ from .version import __version__ as __version__
 from .warnings import SetuptoolsDeprecationWarning
 
 import distutils.core
-from distutils.errors import DistutilsOptionError
 
 __all__ = [
     'setup',
@@ -174,42 +172,6 @@ class Command(_Command):
         """
         super().__init__(dist)
         vars(self).update(kw)
-
-    def _ensure_stringlike(self, option, what, default=None):
-        val = getattr(self, option)
-        if val is None:
-            setattr(self, option, default)
-            return default
-        elif not isinstance(val, str):
-            raise DistutilsOptionError(f"'{option}' must be a {what} (got `{val}`)")
-        return val
-
-    def ensure_string_list(self, option: str) -> None:
-        r"""Ensure that 'option' is a list of strings.  If 'option' is
-        currently a string, we split it either on /,\s*/ or /\s+/, so
-        "foo bar baz", "foo,bar,baz", and "foo,   bar baz" all become
-        ["foo", "bar", "baz"].
-
-        ..
-           TODO: This method seems to be similar to the one in ``distutils.cmd``
-           Probably it is just here for backward compatibility with old Python versions?
-
-        :meta private:
-        """
-        val = getattr(self, option)
-        if val is None:
-            return
-        elif isinstance(val, str):
-            setattr(self, option, re.split(r',\s*|\s+', val))
-        else:
-            if isinstance(val, list):
-                ok = all(isinstance(v, str) for v in val)
-            else:
-                ok = False
-            if not ok:
-                raise DistutilsOptionError(
-                    f"'{option}' must be a list of strings (got {val!r})"
-                )
 
     @overload
     def reinitialize_command(


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

There are [2 methods](https://github.com/pypa/setuptools/blob/v80.5.0/setuptools/__init__.py#L178-L212) defined for `setuptools.Command` that just look like copies of the ones defined in `distutils.cmd.Command` (except for formatting, rust auto-fixes). They seem to have been introduced in #1180.

https://www.diffchecker.com/w6na9oHI/

I am struggling to see the reason why we need to re-define them, unless the code was there just for backward compatibility with old Python versions (i.e. fixes were backported into `distutils`).

I can see however that this code exists since before Python 3.6...
It definetelly exists in the stdlib in 3.9 (minimum version supported by setuptools):

https://github.com/python/cpython/blob/3.9/Lib/distutils/cmd.py#L207-L215

https://github.com/python/cpython/blob/3.9/Lib/distutils/cmd.py#L223-L242

This PR tries to remove this code duplication.
If there is a reason for the duplication we should see regression tests failing. 

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
