### PR TITLE
Remove pkg_resources usage from installer (and more)

### DIFF
--- a/newsfragments/4997.feature.rst
+++ b/newsfragments/4997.feature.rst
@@ -1,0 +1,1 @@
+Removed usage of pkg_resources from installer. Set an official deadline on the installer deprecation to 2025-10-31.

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -36,7 +36,6 @@ def safe_name(component: str) -> str:
     >>> safe_name("hello_world")
     'hello_world'
     """
-    # See pkg_resources.safe_name
     return _UNSAFE_NAME_CHARS.sub("-", component)
 
 
@@ -81,7 +80,6 @@ def best_effort_version(version: str) -> str:
     >>> best_effort_version("42.+?1")
     '42.dev0+sanitized.1'
     """
-    # See pkg_resources._forgiving_version
     try:
         return safe_version(version)
     except packaging.version.InvalidVersion:

--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -39,11 +39,20 @@ def same_path(p1: StrPath, p2: StrPath) -> bool:
     return normpath(p1) == normpath(p2)
 
 
+def _cygwin_patch(filename: StrPath):  # pragma: nocover
+    """
+    Contrary to POSIX 2008, on Cygwin, getcwd (3) contains
+    symlink components. Using
+    os.path.abspath() works around this limitation. A fix in os.getcwd()
+    would probably better, in Cygwin even more so, except
+    that this seems to be by design...
+    """
+    return os.path.abspath(filename) if sys.platform == 'cygwin' else filename
+
+
 def normpath(filename: StrPath) -> str:
     """Normalize a file/dir name for comparison purposes."""
-    # See pkg_resources.normalize_path for notes about cygwin
-    file = os.path.abspath(filename) if sys.platform == 'cygwin' else filename
-    return os.path.normcase(os.path.realpath(os.path.normpath(file)))
+    return os.path.normcase(os.path.realpath(os.path.normpath(_cygwin_patch(filename))))
 
 
 @contextlib.contextmanager

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -37,6 +37,6 @@ def parse(strs: _StrOrIter) -> Iterator[Requirement]: ...
 def parse(strs: _StrOrIter, parser: Callable[[str], _T]) -> Iterator[_T]: ...
 def parse(strs: _StrOrIter, parser: Callable[[str], _T] = parse_req) -> Iterator[_T]:  # type: ignore[assignment]
     """
-    Replacement for ``pkg_resources.parse_requirements`` that uses ``packaging``.
+    Parse requirements.
     """
     return map(parser, parse_strings(strs))

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -46,8 +46,6 @@ from distutils.util import strtobool
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
-    from pkg_resources import Distribution as _pkg_resources_Distribution
-
 
 __all__ = ['Distribution']
 
@@ -761,9 +759,7 @@ class Distribution(_Distribution):
         self._finalize_license_expression()
         self._finalize_license_files()
 
-    def fetch_build_eggs(
-        self, requires: _StrOrIter
-    ) -> list[_pkg_resources_Distribution]:
+    def fetch_build_eggs(self, requires: _StrOrIter) -> list[metadata.Distribution]:
         """Resolve pre-setup requirements"""
         from .installer import _fetch_build_eggs
 

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -9,8 +9,8 @@ import tempfile
 import packaging.requirements
 import packaging.utils
 
+from . import _reqs
 from ._importlib import metadata
-from ._reqs import _StrOrIter
 from .warnings import SetuptoolsDeprecationWarning
 from .wheel import Wheel
 
@@ -35,11 +35,9 @@ def fetch_build_egg(dist, req):
     return _fetch_build_egg_no_warn(dist, req)
 
 
-def _fetch_build_eggs(dist, requires: _StrOrIter) -> list[metadata.Distribution]:
+def _fetch_build_eggs(dist, requires: _reqs._StrOrIter) -> list[metadata.Distribution]:
     _DeprecatedInstaller.emit(stacklevel=3)
     _warn_wheel_not_available(dist)
-
-    from . import _reqs
 
     needed_reqs = (
         req for req in _reqs.parse(requires) if not req.marker or req.marker.evaluate()

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -10,6 +10,7 @@ from functools import partial
 from pkg_resources import Distribution
 
 from . import _reqs
+from ._importlib import metadata
 from ._reqs import _StrOrIter
 from .warnings import SetuptoolsDeprecationWarning
 from .wheel import Wheel
@@ -133,11 +134,9 @@ def strip_marker(req):
 
 
 def _warn_wheel_not_available(dist):
-    import pkg_resources  # Delay import to avoid unnecessary side-effects
-
     try:
-        pkg_resources.get_distribution('wheel')
-    except pkg_resources.DistributionNotFound:
+        metadata.distribution('wheel')
+    except metadata.PackageNotFoundError:
         dist.announce('WARNING: The wheel package is not available.', log.WARN)
 
 

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -147,4 +147,4 @@ class _DeprecatedInstaller(SetuptoolsDeprecationWarning):
     Requirements should be satisfied by a PEP 517 installer.
     If you are using pip, you can try `pip install --use-pep517`.
     """
-    # _DUE_DATE not decided yet
+    _DUE_DATE = 2025, 10, 31

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -56,7 +56,7 @@ def test_dist_fetch_build_egg(tmpdir):
         dist = Distribution()
         dist.parse_config_files()
         resolved_dists = [dist.fetch_build_egg(r) for r in reqs]
-    assert [dist.key for dist in resolved_dists if dist] == reqs
+    assert [dist.name for dist in resolved_dists if dist] == reqs
 
 
 EXAMPLE_BASE_INFO = dict(


### PR DESCRIPTION
- **Remove comments referring to pkg_resources and inline a compatibility behavior with its explanation.**
- **Set the due date for installer removal (same as easy_install and package_index).**
- **Rely on importlib.metadata to detect presence of wheel.**
- **Replace pkg_resources with packaging.requirements.**
- **Migrated installer to avoid pkg_resources.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Ref #3085 

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
