### PR TITLE
Hotfix for Directory not empty errors

### DIFF
--- a/newsfragments/4998.bugfix.1.rst
+++ b/newsfragments/4998.bugfix.1.rst
@@ -1,0 +1,1 @@
+In installer, when discovering egg dists, let metadata discovery search each egg.

--- a/newsfragments/4998.bugfix.rst
+++ b/newsfragments/4998.bugfix.rst
@@ -1,0 +1,1 @@
+Only attempt to fetch eggs for unsatisfied requirements.

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -92,9 +92,7 @@ def _fetch_build_egg_no_warn(dist, req):  # noqa: C901  # is too complex (16)  #
     if dist.dependency_links:
         find_links.extend(dist.dependency_links)
     eggs_dir = os.path.realpath(dist.get_egg_cache_dir())
-    cached_dists = metadata.Distribution.discover(
-        path=glob.glob(f'{eggs_dir}/*.egg/EGG-INFO')
-    )
+    cached_dists = metadata.Distribution.discover(path=glob.glob(f'{eggs_dir}/*.egg'))
     for egg_dist in cached_dists:
         if _dist_matches_req(egg_dist, req):
             return egg_dist


### PR DESCRIPTION
- **Only attempt to fetch eggs for unsatisfied requirements.**
- **In installer, when discovering egg dists, let metadata discovery search each egg.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #4998

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
