### PR TITLE
Remove unused dependency on `coherent.licensed`

### DIFF
--- a/newsfragments/5003.feature.rst
+++ b/newsfragments/5003.feature.rst
@@ -1,0 +1,1 @@
+Removed no longer used build dependency on ``coherent.licensed``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
 	# "setuptools>=77",
 	# "setuptools_scm[toml]>=3.4.1",
 	# jaraco/skeleton#174
-	"coherent.licensed",
+	# "coherent.licensed",
 ]
 build-backend = "setuptools.build_meta"
 backend-path = ["."]


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

With the changes introduced in ae480ff7c2b40442dc97fff712312549a9ed76e6, the dependency on `coherent.licensed` is unused, so I think it would be good to remove it for clean-up purposes[^1].


The approach I took here was to simply comment out the line, because I notice that is the approach previously used in #4975, but I can also simply remove all the `requires` and put an empty array if that is preferred.


[^1]: The removal should speed up build and facilitate for downstream consumers building from git repos instead of sdists.
I understand that in the long run it would be nice to have a solution for the cycles, but for now because we are not using the dependency, there is not much point in keep it around.

Closes #5002 

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
