### PR TITLE
Remove pkg_resources from wheel.

### DIFF
--- a/setuptools/_discovery.py
+++ b/setuptools/_discovery.py
@@ -1,0 +1,33 @@
+import functools
+import operator
+
+import packaging.requirements
+
+
+# from coherent.build.discovery
+def extras_from_dep(dep):
+    try:
+        markers = packaging.requirements.Requirement(dep).marker._markers
+    except AttributeError:
+        markers = ()
+    return set(
+        marker[2].value
+        for marker in markers
+        if isinstance(marker, tuple) and marker[0].value == 'extra'
+    )
+
+
+def extras_from_deps(deps):
+    """
+    >>> extras_from_deps(['requests'])
+    set()
+    >>> extras_from_deps(['pytest; extra == "test"'])
+    {'test'}
+    >>> sorted(extras_from_deps([
+    ...     'requests',
+    ...     'pytest; extra == "test"',
+    ...     'pytest-cov; extra == "test"',
+    ...     'sphinx; extra=="doc"']))
+    ['doc', 'test']
+    """
+    return functools.reduce(operator.or_, map(extras_from_dep, deps), set())

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -9,6 +9,7 @@ import posixpath
 import re
 import zipfile
 
+from packaging.requirements import Requirement
 from packaging.tags import sys_tags
 from packaging.utils import canonicalize_name
 from packaging.version import Version as parse_version
@@ -17,6 +18,8 @@ import setuptools
 from setuptools.archive_util import _unpack_zipfile_obj
 from setuptools.command.egg_info import _egg_basename, write_requirements
 
+from ._discovery import extras_from_deps
+from ._importlib import metadata
 from .unicode_utils import _read_utf8_with_fallback
 
 from distutils.util import get_platform
@@ -170,29 +173,45 @@ class Wheel:
 
     @staticmethod
     def _convert_requires(destination_eggdir, dist_info):
-        import pkg_resources
+        md = metadata.Distribution.at(dist_info).metadata
+        deps = md.get_all('Requires-Dist') or []
+        reqs = list(map(Requirement, deps))
 
-        dist = pkg_resources.Distribution.from_location(
-            destination_eggdir,
-            dist_info,
-            metadata=pkg_resources.PathMetadata(destination_eggdir, dist_info),
-        )
+        extras = extras_from_deps(deps)
 
         # Note: Evaluate and strip markers now,
         # as it's difficult to convert back from the syntax:
         # foobar; "linux" in sys_platform and extra == 'test'
         def raw_req(req):
+            req = Requirement(str(req))
             req.marker = None
             return str(req)
 
-        install_requires = list(map(raw_req, dist.requires()))
+        def eval(req, **env):
+            return not req.marker or req.marker.evaluate(env)
+
+        def for_extra(req):
+            try:
+                markers = req.marker._markers
+            except AttributeError:
+                markers = ()
+            return set(
+                marker[2].value
+                for marker in markers
+                if isinstance(marker, tuple) and marker[0].value == 'extra'
+            )
+
+        install_requires = list(
+            map(raw_req, filter(eval, itertools.filterfalse(for_extra, reqs)))
+        )
         extras_require = {
-            extra: [
-                req
-                for req in map(raw_req, dist.requires((extra,)))
-                if req not in install_requires
-            ]
-            for extra in dist.extras
+            extra: list(
+                map(
+                    raw_req,
+                    (req for req in reqs if for_extra(req) and eval(req, extra=extra)),
+                )
+            )
+            for extra in extras
         }
         return install_requires, extras_require
 


### PR DESCRIPTION
- **Extract a method for converting requires.**
- **Replace pkg_resources with importlib.metadata and packaging.requirements.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
