### PR TITLE
[Investigation] Reduce the amount of patching in `setuptools.build_meta`

### DIFF
--- a/bootstrap.egg-info/entry_points.txt
+++ b/bootstrap.egg-info/entry_points.txt
@@ -1,5 +1,6 @@
 [distutils.commands]
 egg_info = setuptools.command.egg_info:egg_info
+dist_info = setuptools.command.dist_info:dist_info
 build_py = setuptools.command.build_py:build_py
 sdist = setuptools.command.sdist:sdist
 editable_wheel = setuptools.command.editable_wheel:editable_wheel

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -55,7 +55,7 @@ def _expand_setupcfg(attrs: dict[str, Any]) -> Distribution:
 
     dist = Distribution(attrs)
     dist.set_defaults._disable()
-    if os.path.exists("setup.cfg"):
+    if os.path.exists("setup.cfg"):  # Assumes no other config contains setup_requires
         _apply(dist, "setup.cfg", ignore_option_errors=True)
     return dist
 

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -21,6 +21,7 @@ sys.modules.pop('backports', None)
 import _distutils_hack.override  # noqa: F401
 
 from . import logging, monkey
+from .compat import py310
 from .depends import Require
 from .discovery import PackageFinder, PEP420PackageFinder
 from .dist import Distribution
@@ -80,10 +81,7 @@ def _fetch_build_eggs(dist: Distribution):
         please contact that package's maintainers or distributors.
         """
         if "InvalidVersion" in ex.__class__.__name__:
-            if hasattr(ex, "add_note"):
-                ex.add_note(msg)  # PEP 678
-            else:
-                dist.announce(f"\n{msg}\n")
+            py310.add_note(ex, msg)
         raise
 
 

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -11,7 +11,6 @@ import functools
 import os
 import sys
 from abc import abstractmethod
-from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 sys.path.extend(((vendor_path := os.path.join(os.path.dirname(os.path.dirname(__file__)), 'setuptools', '_vendor')) not in sys.path) * [vendor_path])  # fmt: skip
@@ -50,7 +49,7 @@ find_packages = PackageFinder.find
 find_namespace_packages = PEP420PackageFinder.find
 
 
-def _expand_setupcfg(attrs: MutableMapping[str, Any]) -> Distribution:
+def _expand_setupcfg(attrs: dict[str, Any]) -> Distribution:
     """Bare minimum setup.cfg parsing so that we can extract setup_requires"""
     from setuptools.config.setupcfg import _apply
 
@@ -61,7 +60,7 @@ def _expand_setupcfg(attrs: MutableMapping[str, Any]) -> Distribution:
     return dist
 
 
-def _install_setup_requires(attrs: MutableMapping[str, Any]) -> None:
+def _install_setup_requires(attrs: dict[str, Any]) -> None:
     dist = _expand_setupcfg(attrs)
     if dist.setup_requires:
         _fetch_build_eggs(dist)

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -499,3 +499,20 @@ build_editable = _BACKEND.build_editable
 
 # The legacy backend
 __legacy__ = _BuildMetaLegacyBackend()
+
+
+def __getattr__(name):
+    if name == "SetupRequirementsError":
+        SetuptoolsDeprecationWarning.emit(
+            "SetupRequirementsError is no longer part of the public API.",
+            "Please do not import SetupRequirementsError.",
+            due_date=(2026, 5, 12),
+        )
+
+        class SetupRequirementsError(BaseException):
+            def __init__(self, specifiers) -> None:
+                self.specifiers = specifiers
+
+        return SetupRequirementsError
+
+    raise AttributeError(name)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This started as an exercise in https://github.com/pypa/setuptools/pull/4973#issuecomment-2873210026

The idea is to avoid all the patching involved in making `setuptools.build_meta` compatible with `setup.py`.
Currently `no_install_setup_requires` is patching the distribution class that is already patched by `setuptools.monkey`. It looks very fragile.

(Granted, this PR replaces patching with magic argv flags + a bunch of `if-statements`, but that can be slightly better?)

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
