### PR TITLE
Add URL with detailed rationale/clarifications in deprecation warning

### DIFF
--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -635,8 +635,11 @@ class Distribution(_Distribution):
             Usage of dash-separated {opt!r} will not be supported in future
             versions. Please use the underscore name {underscore_opt!r} instead.
             {affected}
+
+            Available configuration options are listed in:
+            https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
             """,
-            see_docs="userguide/declarative_config.html",
+            see_url="https://github.com/pypa/setuptools/discussions/5011",
             due_date=(2026, 3, 3),
             # Warning initially introduced in 3 Mar 2021
         )
@@ -655,8 +658,11 @@ class Distribution(_Distribution):
             Usage of uppercase key {opt!r} in {section!r} will not be supported in
             future versions. Please use lowercase {lowercase_opt!r} instead.
             {affected}
+
+            Available configuration options are listed in:
+            https://setuptools.pypa.io/en/latest/userguide/declarative_config.html
             """,
-            see_docs="userguide/declarative_config.html",
+            see_url="https://github.com/pypa/setuptools/discussions/5011",
             due_date=(2026, 3, 3),
             # Warning initially introduced in 6 Mar 2021
         )


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

The intention of the change is to provide detailed explanation for the deprecations by linking against https://github.com/pypa/setuptools/discussions/5011.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
