### PR TITLE
[Docs] Add note about `setuptools` not defining the introduction of warnings as a breaking change

### DIFF
--- a/docs/userguide/interfaces.rst
+++ b/docs/userguide/interfaces.rst
@@ -50,6 +50,16 @@ reserve the right of speeding up the deprecation cycle and shortening deprecatio
 Note that these are exceptional circumstances and that the project will
 carefully attempt to find alternatives before resorting to unscheduled removals.
 
+.. important::
+   In the context of ``setuptools``, the introduction of :py:mod:`warnings`
+   (including deprecation warnings) is not considered a breaking change *per se*.
+   Instead it is considered a backwards compatible *communication action* that
+   precedes an upcoming breaking change. This is becauset code
+   containing warnings typically does not fail and can successfully terminate
+   execution, unless users explicitly opt into transforming those warnings
+   into errors (e.g., via Python's :external+python:ref:`-W option or
+   PYTHONWARNINGS environment variable <using-on-warnings>`).
+
 
 What to do when deprecation periods are undefined?
 --------------------------------------------------


### PR DESCRIPTION
Some users consider adding warnings as breaking change.
That is not a universal understanding, but I think it is useful to clarify Setuptools position on the docs.

Closes #5024. 

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
