### PR TITLE
interfaces.rst: Fix typo discovered by codespell

### DIFF
--- a/docs/userguide/interfaces.rst
+++ b/docs/userguide/interfaces.rst
@@ -147,7 +147,7 @@ you can still resort to restricting the version of Setuptools to be installed.
 This usually includes modifying ``[build-system] requires`` in ``pyproject.toml``
 and/or specifying ``pip`` :external+pip:ref:`Constraints Files` via
 the ``PIP_CONSTRAINT`` environment variable (or passing |build-constraint-uv|_).
-Please avoid however to pre-emptively add version constraints if not necessary,
+Please avoid however to preemptively add version constraints if not necessary,
 (you can read more about this in https://iscinumpy.dev/post/bound-version-constraints/).
 
 .. |build-constraint-uv| replace:: ``--build-constraint`` to ``uv``


### PR DESCRIPTION
## Fixing a typo causes GitHub Actions Windows tests fail!

Trivial change as a test to understand why Windows tests are failing on:
* #5033

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
