### PR TITLE
CI: Require Python >= 3.13.5

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
       matrix:
         python:
         - "3.9"
-        - ">=3.13.5"
+        - ">=3.13.5"  # temporary bound until it becomes the default, python/cpython#135151
         platform:
         - ubuntu-latest
         - macos-latest


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Some Windows jobs are failing because it's Python 3.13.4, which incorrectly tries to link to the threaded version. See https://github.com/python/cpython/issues/135151.

This has been fixed in [last week's 3.13.5 release](https://discuss.python.org/t/python-3-13-5-is-now-available-yes-really/95211), but it's not necessarily in the default CI images yet, so let's specify `>= 3.13.5` to ensure the new one is always installed on-demand.

This can be reverted at some point in the future.

Closes #5037.

### Pull Request Checklist
- [x] Changes have tests
- [n/a] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
