### PR TITLE
Replace inappropriate international email test data with neutral example

### DIFF
--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -160,7 +160,7 @@ authors = [
   {name = "Tzu-Ping Chung"}
 ]
 maintainers = [
-  {name = "Степан Бандера", email = "криївка@оун-упа.укр"},
+  {name = "Ankit Ahlawat", email = "ankit@example.com"},
 ]
 """
 
@@ -261,7 +261,7 @@ def test_no_explicit_content_type_for_missing_extension(tmp_path):
         ),
         pytest.param(
             PEP621_INTERNATIONAL_EMAIL_EXAMPLE,
-            'Степан Бандера <криївка@оун-упа.укр>',
+            'Ankit Ahlawat <अंकित@उदाहरण.भारत>',
             marks=pytest.mark.xfail(
                 reason="CPython's `email.headerregistry.Address` only supports "
                 'RFC 5322, as of Nov 10, 2022 and latest Python 3.11.0',


### PR DESCRIPTION
Issue #5050

Bug Description:
The code contains inappropriate international email test data, including references to the Ukrainian nationalist Stepan Bandera and an email address containing a nationalist slogan. This content is unsuitable and should be replaced with neutral examples to maintain professionalism and inclusivity.