### PR TITLE
Add optional Distribution parameter to walk_revctrl file finder

### DIFF
--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -582,7 +582,7 @@ class manifest_maker(sdist):
         sdist.add_defaults(self)
         self.filelist.append(self.template)
         self.filelist.append(self.manifest)
-        rcfiles = list(walk_revctrl())
+        rcfiles = list(walk_revctrl(distribution=self.distribution))
         if rcfiles:
             self.filelist.extend(rcfiles)
         elif os.path.exists(self.manifest):


### PR DESCRIPTION

i made a first draft using claude - the tests need some simplification for the unit part and im looking for suggestions on a integration test thats not excessive

----

File finder entry points for SCM-based files can now optionally receive the Distribution object to make more informed decisions about which files to include. This maintains full backward compatibility with existing entry points that only accept dirname.

Changes:
- Add optional distribution parameter to walk_revctrl function
- Create _call_finder_with_distribution_support helper function with signature inspection to detect entry point capabilities
- Update manifest_maker.add_defaults() to pass distribution object
- Add comprehensive unit tests covering all scenarios including backward compatibility and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
