### PR TITLE
BUG: fix a bug where calling `distutils.build_ext.finalize_options` more than once would raise an exception

### DIFF
--- a/newsfragments/5083.bugfix.rst
+++ b/newsfragments/5083.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug where calling ``build_ext.finalize_options`` more than once would
+raise an exception.

--- a/setuptools/_distutils/command/build_ext.py
+++ b/setuptools/_distutils/command/build_ext.py
@@ -276,10 +276,10 @@ class build_ext(Command):
         if self.undef:
             self.undef = self.undef.split(',')
 
-        if self.swig_opts is None:
-            self.swig_opts = []
-        else:
+        if isinstance(self.swig_opts, str):
             self.swig_opts = self.swig_opts.split(' ')
+        elif self.swig_opts is None:
+            self.swig_opts = []
 
         # Finally add the user include and library directories if requested
         if self.user:

--- a/setuptools/tests/test_build_ext.py
+++ b/setuptools/tests/test_build_ext.py
@@ -178,6 +178,17 @@ class TestBuildExt:
         assert example_stub.startswith(f"{build_lib}/mypkg/__pycache__/ext1")
         assert example_stub.endswith(".pyc")
 
+    def test_finalize_options_multiple_call(self):
+        """
+        Regression test. Check that calling build_ext.finalize_options
+        more than once doesn't raise an exception.
+        """
+        extension = Extension('spam.eggs', ['eggs.c'])
+        dist = Distribution(dict(ext_modules=[extension]))
+        cmd = build_ext(dist)
+        cmd.finalize_options()
+        cmd.finalize_options()
+
 
 class TestBuildExtInplace:
     def get_build_ext_cmd(self, optional: bool, **opts) -> build_ext:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This allows `build_ext.finalize_options` to be called more than once without crashing. This is helpful in h5py and yt where we cannot really finalize options of this class before needing side effects (which live in the `run` method, as recommended).

I'm opening as a draft and without a test for now because I'm running out of time but I'll make sure to add one before opening for review.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
