### PR TITLE
`_Finder.find` - fix docstring markdown rendering

### DIFF
--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -95,22 +95,22 @@ class _Finder:
         include: Iterable[str] = ('*',),
     ) -> list[str]:
         """Return a list of all Python items (packages or modules, depending on
-        the finder implementation) found within directory 'where'.
+        the finder implementation) found within directory ``where``.
 
-        'where' is the root directory which will be searched.
+        ``where`` is the root directory which will be searched.
         It should be supplied as a "cross-platform" (i.e. URL-style) path;
         it will be converted to the appropriate local path syntax.
 
-        'exclude' is a sequence of names to exclude; '*' can be used
+        ``exclude`` is a sequence of names to exclude; ``*`` can be used
         as a wildcard in the names.
-        When finding packages, 'foo.*' will exclude all subpackages of 'foo'
-        (but not 'foo' itself).
+        When finding packages, ``foo.*`` will exclude all subpackages of ``foo``
+        (but not ``foo`` itself).
 
-        'include' is a sequence of names to include.
+        ``include`` is a sequence of names to include.
         If it's specified, only the named items will be included.
         If it's not specified, all found items will be included.
-        'include' can contain shell style wildcard patterns just like
-        'exclude'.
+        ``include`` can contain shell style wildcard patterns just like
+        ``exclude``.
         """
 
         exclude = exclude or cls.DEFAULT_EXCLUDE


### PR DESCRIPTION
`*` was rendered as cursive in tooltips. Used double backticks - the way it's done in other docstrings of the same file.

Before:
<img width="793" height="211" alt="image" src="https://github.com/user-attachments/assets/affb2097-6b5d-4119-98da-cff10ffb347c" />

After:
<img width="757" height="216" alt="image" src="https://github.com/user-attachments/assets/0c04f894-67e4-4bd6-a231-55f7a99205ba" />

