### PR TITLE
Temporarily disable deprecation "watchdog"

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ deps =
 	# Ideally all the dependencies should be set as "extras"
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
-	SETUPTOOLS_ENFORCE_DEPRECATION = {env:SETUPTOOLS_ENFORCE_DEPRECATION:1}
+	SETUPTOOLS_ENFORCE_DEPRECATION = {env:SETUPTOOLS_ENFORCE_DEPRECATION:0}  # TODO: return to 1 (temporarily disabled)
 commands =
 	pytest {posargs}
 usedevelop = True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

This temporarily stops the "watchdog" on deprecated features that have past the deadline, so to avoid the CI to failing on them.

(Once I or other maintainers have the time to remove the deprecated features properly the flag can be flipped again to 1 to re-enable the "watchdog")

(This is to be considered a temporary workaround until the proper removal procedure can be carried out).

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
