### PR TITLE
[CI] Set `PIP_PREFER_BINARY` in tox as a workaround for problems in macOS

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ deps =
 setenv =
 	PYTHONWARNDEFAULTENCODING = 1
 	SETUPTOOLS_ENFORCE_DEPRECATION = {env:SETUPTOOLS_ENFORCE_DEPRECATION:0}  # TODO: return to 1 (temporarily disabled)
+	PIP_PREFER_BINARY = 1  # Workaround for #5105
 commands =
 	pytest {posargs}
 usedevelop = True


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #5105

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
