### PR TITLE
[CI] Constraint transient test dependency on `pyobjc`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ test = [
 	"tomli-w>=1.0.0",
 	"pytest-timeout",
 	'pytest-perf; sys_platform != "cygwin"', # workaround for jaraco/inflect#195, pydantic/pydantic-core#773 (see #3986)
+	'pyobjc<12; sys_platform == "darwin" and python_version <= "3.9"', # workaround for #5105
 	# for tools/finalize.py
 	'jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"',
 	"pytest-home >= 0.5",


### PR DESCRIPTION
... to avoid problems when installing `pyobjc-framework-Metal` on macOS for Python 3.9 (wheels not available).

Workaround for #5105. A different approach was already tested in https://github.com/pypa/setuptools/pull/5106, but it fails.
That seems to indicate that trying to coerce installers to use binaries in general causes other test errors.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #5105

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
