### PR TITLE
[CI] Use local `setuptools` wheel for build dependency when testing from custom index

### DIFF
--- a/setuptools/tests/fixtures.py
+++ b/setuptools/tests/fixtures.py
@@ -187,30 +187,44 @@ def make_sdist(dist_path, files):
             dist.addfile(file_info, fileobj=file_bytes)
 
 
-def make_trivial_sdist(dist_path, distname, version):
+def make_trivial_sdist(dist_path, distname, version, setuptools_wheel=None):
     """
     Create a simple sdist tarball at dist_path, containing just a simple
     setup.py.
-    """
 
-    make_sdist(
-        dist_path,
-        [
-            (
-                'setup.py',
-                DALS(
-                    f"""\
-             import setuptools
-             setuptools.setup(
-                 name={distname!r},
-                 version={version!r}
-             )
-         """
-                ),
+    If ``setuptools_wheel`` is passed, a ``pyproject.toml`` file will also
+    be generated and the passed value will be used as location for
+    setuptools (as build dependency).
+    """
+    files = [
+        (
+            'setup.py',
+            DALS(
+                f"""\
+                 import setuptools
+                 setuptools.setup(
+                     name={distname!r},
+                     version={version!r}
+                 )
+                 """
             ),
-            ('setup.cfg', ''),
-        ],
-    )
+        ),
+        ('setup.cfg', ''),
+    ]
+
+    if setuptools_wheel:
+        files.append((
+            "pyproject.toml",
+            DALS(
+                f"""\
+                [build-system]
+                requires = ["setuptools @ {setuptools_wheel.as_uri()}"]
+                build-backend = "setuptools.build_meta"
+                """
+            ),
+        ))
+
+    make_sdist(dist_path, files)
 
 
 def make_nspkg_sdist(dist_path, distname, version):

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -15,7 +15,7 @@ from .textwrap import DALS
 from distutils.errors import DistutilsSetupError
 
 
-def test_dist_fetch_build_egg(tmpdir):
+def test_dist_fetch_build_egg(tmpdir, setuptools_wheel):
     """
     Check multiple calls to `Distribution.fetch_build_egg` work as expected.
     """
@@ -25,7 +25,9 @@ def test_dist_fetch_build_egg(tmpdir):
     def sdist_with_index(distname, version):
         dist_dir = index.mkdir(distname)
         dist_sdist = f'{distname}-{version}.tar.gz'
-        make_trivial_sdist(str(dist_dir.join(dist_sdist)), distname, version)
+        make_trivial_sdist(
+            str(dist_dir.join(dist_sdist)), distname, version, setuptools_wheel
+        )
         with dist_dir.join('index.html').open('w') as fp:
             fp.write(
                 DALS(


### PR DESCRIPTION
This is an attempt to fix #5108, even if quick-and-dirty.
It is the most direct/simple change I could think off that would fix the issue in the CI with this test specifically.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #5108 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
