### PR TITLE
Remove `license` metadata from `pyproject.toml` to avoid misleading SPDX compliance

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+This project includes source code from other open-source projects to facilitate
+bootstrapping.
+
+The license information for those projects is distributed by setuptools under
+the directories:
+
+    setuptools/_vendor/*.dist-info/
+    setuptools/_vendor/*.dist-info/licenses/
+
+Please refer to the files in these directories for the complete license texts
+and attribution details of the included third-party components.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 	"Topic :: Utilities",
 ]
 requires-python = ">=3.9"
-license = "MIT"
+# For license information, please check license files included in the distribution.
 dependencies = [
 ]
 keywords = ["CPAN PyPI distutils eggs package management"]


### PR DESCRIPTION
Despite the fact that the `setuptools` own code is distributed under the MIT license, the project includes third-party code under different licenses.

For some downstream users, adding `license = "MIT"` to `pyproject.toml` is problematic under the lenses of PEP 639 because it may imply that *all* the files distributed by setuptools are licensed under MIT, which is not the case. See discussion in #5049.

By removing that metadata, setuptools should be "in the clear".

I understand that consumers of the package would prefer a complete SPDX license expression. However, as explained in #5049, this is currently not viable. In the future, setuptools may adopt SPDX expressions once tools exist in the Python ecosystem that can automatically compute them from a given set of files and directories.

For the time being, consumers interested in knowing license information should refer to the text in the license files being distributed.


<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #5049 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
