### PR TITLE
Revert "[CI] Constraint transient test dependency on pyobjc"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ test = [
 	"tomli-w>=1.0.0",
 	"pytest-timeout",
 	'pytest-perf; sys_platform != "cygwin"', # workaround for jaraco/inflect#195, pydantic/pydantic-core#773 (see #3986)
-	'pyobjc<12; sys_platform == "darwin" and python_version <= "3.9"', # workaround for #5105
 	# for tools/finalize.py
 	'jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"',
 	"pytest-home >= 0.5",


### PR DESCRIPTION

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Revert "[CI] Constraint transient test dependency on pyobjc"

This reverts commit 4fd42a06ebcb89f1e41105994b063a518cc05f36.

pyobjc release 12.0 was yanked and 12.1 is properly marked as Python 3.10+

See https://pypi.org/project/pyobjc/12.0/ and https://github.com/ronaldoussoren/pyobjc/issues/661#issuecomment-3533570350

CC @abravalheri 

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
