### PR TITLE
Prevent object file collisions in parallel extension builds

### DIFF
--- a/newsfragments/3942.bugfix.rst
+++ b/newsfragments/3942.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed non-deterministic parallel builds of extensions that share source files.

--- a/setuptools/_distutils/command/build_ext.py
+++ b/setuptools/_distutils/command/build_ext.py
@@ -562,9 +562,12 @@ class build_ext(Command):
         for undef in ext.undef_macros:
             macros.append((undef,))
 
+        # Per-extension build dir to avoid conflicts in parallel builds.
+        ext_build_temp = os.path.join(self.build_temp, ext.name)
+
         objects = self.compiler.compile(
             sources,
-            output_dir=self.build_temp,
+            output_dir=ext_build_temp,
             macros=macros,
             include_dirs=ext.include_dirs,
             debug=self.debug,
@@ -595,7 +598,7 @@ class build_ext(Command):
             extra_postargs=extra_args,
             export_symbols=self.get_export_symbols(ext),
             debug=self.debug,
-            build_temp=self.build_temp,
+            build_temp=ext_build_temp,
             target_lang=language,
         )
 


### PR DESCRIPTION
## Summary of changes

Parallel builds of extensions that share source files may write to the same object file paths under a common build directory, resulting in race conditions and non-deterministic build outputs.

Use a per-extension subdirectory within build_temp to isolate object files and ensure deterministic, parallel-safe builds.

### Pull Request Checklist
- [X] Changes have tests
- [X] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request

### Tests
I tested this change downstream at Gentoo after encountering https://bugs.gentoo.org/967476 and https://bugs.gentoo.org/945376 (packages https://pypi.org/project/librt and https://pypi.org/project/pymongo/). Since the build failures are encountered non-determinstically, i compiled both librt and pymongo as often as needed, capping the compilation attempts to 100.
- Before the change I encountered the build failures after at most 10 compilations
- After the change I didn't encounter the issue, compiling both librt and pymongo successfully 100 times.