### PR TITLE
[CI] Allow the action `check-changed-folders` to be skipped in the `check` action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,7 +180,7 @@ jobs:
     - name: Decide whether the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
-        allowed-skips: integration-test
+        allowed-skips: check-changed-folders, integration-test
         jobs: ${{ toJSON(needs) }}
 
   test_cygwin:
@@ -240,7 +240,7 @@ jobs:
             VM-${{ matrix.platform }},
             Py-${{ steps.python-install.outputs.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
-            
+
   check-changed-folders:
     name: Fail the job if files changed under _disutils/_vendor folders
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
`check-changed-folders` is always skipped outside of the PR context, as per https://github.com/pypa/setuptools/blob/6c8e504d60ff0bf8141600dbbfd805dfe2647a00/.github/workflows/main.yml#L246

So if we don't change this, the CI will always fail outside of PRs.

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes #5146 

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
