### PR TITLE
upgrade actions checkout and upload artifact to v4

### DIFF
--- a/.github/workflows/ci-sage.yml
+++ b/.github/workflows/ci-sage.yml
@@ -73,7 +73,7 @@ jobs:
           && echo "sage-package create ${{ env.SPKG }} --pypi --source normal --type standard; sage-package create ${{ env.SPKG }} --version git --tarball ${{ env.SPKG }}-git.tar.gz --type=standard" > upstream/update-pkgs.sh \
           && if [ -n "${{ env.REMOVE_PATCHES }}" ]; then echo "(cd ../build/pkgs/${{ env.SPKG }}/patches && rm -f ${{ env.REMOVE_PATCHES }}; :)" >> upstream/update-pkgs.sh; fi \
           && ls -l upstream/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: upstream
           name: upstream

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,7 +247,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Check if files changed in the _distutils folder


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html!   -->
<!-- Remove sections if not applicable -->

## Summary of changes

Upgraded GitHub Actions in `.github/workflows/` from deprecated v3 to v4:
- `actions/checkout@v3` → `actions/checkout@v4`
- `actions/upload-artifact@v3` → `actions/upload-artifact@v4`

The v3 versions of these actions have reached end-of-life and are no longer maintained.  This upgrade addresses potential CI failures from deprecated action versions and ensures the CI/CD pipelines use actively maintained, supported versions of these critical workflow actions. 

Closes #5148

### Pull Request Checklist
- [x] Changes have tests (CI workflows are validated through execution)
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]: 
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request