### PR TITLE
Fix misleading `Multiple directories found` assertion in `_find_info_directory`

### DIFF
--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -356,12 +356,11 @@ class _BuildMetaBackend(_ConfigSettingsTranslator):
         for parent, dirs, _ in os.walk(metadata_directory):
             candidates = [f for f in dirs if f.endswith(suffix)]
 
-            if len(candidates) != 0:
-                assert len(candidates) == 1, f"Multiple {suffix} directories found"
+            if len(candidates) != 0 or len(dirs) != 1:
+                assert len(candidates) == 1, (
+                    f"Exactly one {suffix} should have been produced, but found {len(candidates)}: {candidates}"
+                )
                 return Path(parent, candidates[0])
-
-            if len(dirs) != 1:
-                break
 
         msg = f"No {suffix} directory found in {metadata_directory}"
         raise errors.InternalError(msg)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

If the search failed to find any candidates (len(candidates) == 0) in a directory that had no subdirectories or multiple subdirectories (len(dirs) != 1), the condition evaluated to True. This triggered the assertion checks for candidates == 1, resulting in a confusing AssertionError: Multiple {suffix} directories found, even though zero candidates were actually found.

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
