### PR TITLE
Enable flake8-type-checking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -175,6 +175,7 @@ nitpick_ignore += [
     ('py:class', 'OptionDummy'),  # undocumented
     ('py:class', 'setuptools.dist.Distribution'),  # undocumented
     ('py:class', 'UnixCCompiler'),  # undocumented
+    ('py:class', 'StrPath'),  # type import
     ('py:exc', 'CompileError'),  # undocumented
     ('py:exc', 'DistutilsExecError'),  # undocumented
     ('py:exc', 'DistutilsFileError'),  # undocumented

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,6 +31,9 @@ extend-select = [
 	"TRY", # tryceratops
 	"UP", # pyupgrade
 	"YTT", # flake8-2020
+	# Helps prevent circular imports, reduce runtime cost of typing symbols,
+	# and prevent leaking implementations details into modules
+  	"TC", # flake8-type-checking
 ]
 ignore = [
 	# upstream
@@ -55,6 +58,9 @@ ignore = [
 	"TRY301", # raise-within-try, it's handy
 	# Only enforcing return type annotations for public functions
 	"ANN202", # missing-return-type-private-function
+	# stdlib is not at risk of circular import, is clearly not public API,
+	# and assume it's gonna be included in the import chain at some point anyway 
+  	"TC003", # typing-only-standard-library-import
 ]
 
 [lint.flake8-comprehensions]
@@ -78,6 +84,9 @@ sections.delayed = ["distutils"]
 
 [lint.flake8-annotations]
 ignore-fully-untyped = true
+
+[lint.flake8-type-checking]
+quote-annotations = true
 
 [format]
 # Enable preview to get hugged parenthesis unwrapping and other nice surprises

--- a/ruff.toml
+++ b/ruff.toml
@@ -31,6 +31,9 @@ extend-select = [
 	"TRY", # tryceratops
 	"UP", # pyupgrade
 	"YTT", # flake8-2020
+	# Helps prevent circular imports, reduce runtime cost of typing symbols,
+	# and prevent leaking implementations details into modules
+  	"TC", # flake8-type-checking
 ]
 ignore = [
 	# upstream
@@ -59,6 +62,9 @@ ignore = [
 	"TRY301", # raise-within-try, it's handy
 	# Only enforcing return type annotations for public functions
 	"ANN202", # missing-return-type-private-function
+	# stdlib is not at risk of circular import, is clearly not public API,
+	# and assume it's gonna be included in the import chain at some point anyway 
+  	"TC003", # typing-only-standard-library-import
 ]
 
 [lint.per-file-ignores]
@@ -77,6 +83,9 @@ sections.delayed = ["distutils"]
 
 [lint.flake8-annotations]
 ignore-fully-untyped = true
+
+[lint.flake8-type-checking]
+quote-annotations = true
 
 [format]
 # Enable preview to get hugged parenthesis unwrapping and other nice surprises

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -13,13 +13,15 @@ import io
 from collections import defaultdict
 from collections.abc import Mapping
 from itertools import filterfalse
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 from jaraco.text import yield_lines
 from packaging.requirements import Requirement
 
 from .. import _reqs
-from .._reqs import _StrOrIter
+
+if TYPE_CHECKING:
+    from .._reqs import _StrOrIter
 
 # dict can work as an ordered set
 _T = TypeVar("_T")

--- a/setuptools/command/bdist_rpm.py
+++ b/setuptools/command/bdist_rpm.py
@@ -1,7 +1,13 @@
-from ..dist import Distribution
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ..warnings import SetuptoolsDeprecationWarning
 
 import distutils.command.bdist_rpm as orig
+
+if TYPE_CHECKING:
+    from ..dist import Distribution
 
 
 class bdist_rpm(orig.bdist_rpm):

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -16,7 +16,7 @@ import warnings
 from collections.abc import Iterable, Sequence
 from email.generator import BytesGenerator
 from glob import iglob
-from typing import ClassVar, Literal, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, cast
 from zipfile import ZIP_DEFLATED, ZIP_STORED
 
 from packaging import tags, version as _packaging_version
@@ -26,9 +26,11 @@ from .. import Command, __version__, _shutil
 from .._core_metadata import _safe_license_file
 from .._normalization import safer_name
 from ..warnings import SetuptoolsDeprecationWarning
-from .egg_info import egg_info as egg_info_cls
 
 from distutils import log
+
+if TYPE_CHECKING:
+    from .egg_info import egg_info as egg_info_cls
 
 
 def safe_version(version: str) -> str:
@@ -248,7 +250,9 @@ class bdist_wheel(Command):
             self.bdist_dir = os.path.join(bdist_base, "wheel")
 
         if self.dist_info_dir is None:
-            egg_info = cast(egg_info_cls, self.distribution.get_command_obj("egg_info"))
+            egg_info = cast(
+                "egg_info_cls", self.distribution.get_command_obj("egg_info")
+            )
             egg_info.ensure_finalized()  # needed for correct `wheel_dist_name`
 
         self.data_dir = self.wheel_dist_name + ".data"
@@ -507,7 +511,7 @@ class bdist_wheel(Command):
         metadata = self.distribution.get_option_dict("metadata")
         if setuptools_major_version >= 42:
             # Setuptools recognizes the license_files option but does not do globbing
-            patterns = cast(Sequence[str], self.distribution.metadata.license_files)
+            patterns = cast("Sequence[str]", self.distribution.metadata.license_files)
         else:
             # Prior to those, wheel is entirely responsible for handling license files
             if "license_files" in metadata:

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import Protocol
-
-from ..dist import Distribution
+from typing import TYPE_CHECKING, Protocol
 
 from distutils.command.build import build as _build
+
+if TYPE_CHECKING:
+    from ..dist import Distribution
 
 _ORIGINAL_SUBCOMMANDS = {"build_py", "build_clib", "build_ext", "build_scripts"}
 

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -1,9 +1,15 @@
-from ..dist import Distribution
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from ..modified import newer_pairwise_group
 
 import distutils.command.build_clib as orig
 from distutils import log
 from distutils.errors import DistutilsSetupError
+
+if TYPE_CHECKING:
+    from ..dist import Distribution
 
 
 class build_clib(orig.build_clib):

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -11,7 +11,6 @@ from importlib.util import cache_from_source as _compiled_file_name
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from setuptools.dist import Distribution
 from setuptools.errors import BaseError
 from setuptools.extension import Extension, Library
 
@@ -20,6 +19,8 @@ from distutils.ccompiler import new_compiler
 from distutils.sysconfig import customize_compiler, get_config_var
 
 if TYPE_CHECKING:
+    from setuptools.dist import Distribution
+
     # Cython not installed on CI tests, causing _build_ext to be `Any`
     from distutils.command.build_ext import build_ext as _build_ext
 else:

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -10,17 +10,19 @@ from collections.abc import Iterable, Iterator
 from functools import partial
 from glob import glob
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from more_itertools import unique_everseen
 
-from .._path import StrPath, StrPathT
-from ..dist import Distribution
 from ..warnings import SetuptoolsDeprecationWarning
 
 import distutils.command.build_py as orig
 import distutils.errors
 from distutils.util import convert_path
+
+if TYPE_CHECKING:
+    from .._path import StrPath, StrPathT
+    from ..dist import Distribution
 
 _IMPLICIT_DATA_FILES = ('*.pyi', 'py.typed')
 

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -33,7 +33,7 @@ class develop(Command):
     def run(self) -> None:
         # Casting because mypy doesn't understand bool mult conditionals
         cmd = cast(
-            list[str],
+            "list[str]",
             [sys.executable, '-m', 'pip', 'install', '-e', '.', '--use-pep517']
             + ['--target', self.install_dir] * bool(self.install_dir)
             + ['--no-deps'] * self.no_deps

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -7,14 +7,16 @@ import os
 import shutil
 from contextlib import contextmanager
 from pathlib import Path
-from typing import ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, cast
 
 from .. import _normalization
 from .._shutil import rmdir as _rm
-from .egg_info import egg_info as egg_info_cls
 
 from distutils import log
 from distutils.core import Command
+
+if TYPE_CHECKING:
+    from .egg_info import egg_info as egg_info_cls
 
 
 class dist_info(Command):
@@ -58,7 +60,7 @@ class dist_info(Command):
         project_dir = dist.src_root or os.curdir
         self.output_dir = Path(self.output_dir or project_dir)
 
-        egg_info = cast(egg_info_cls, self.reinitialize_command("egg_info"))
+        egg_info = cast("egg_info_cls", self.reinitialize_command("egg_info"))
         egg_info.egg_base = str(self.output_dir)
 
         if self.tag_date:

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -29,24 +29,25 @@ from types import TracebackType
 from typing import TYPE_CHECKING, ClassVar, Protocol, TypeVar, cast
 
 from .. import Command, _normalization, _path, _shutil, errors, namespaces
-from .._path import StrPath
 from ..compat import py310, py312
 from ..discovery import find_package_path
-from ..dist import Distribution
 from ..warnings import InformationOnly, SetuptoolsDeprecationWarning
-from .build import build as build_cls
 from .build_py import build_py as build_py_cls
-from .dist_info import dist_info as dist_info_cls
-from .egg_info import egg_info as egg_info_cls
-from .install import install as install_cls
-from .install_scripts import install_scripts as install_scripts_cls
 
 if TYPE_CHECKING:
     from typing_extensions import Self
 
+    from .._path import StrPath
     from .._vendor.wheel.wheelfile import WheelFile
+    from ..dist import Distribution
+    from .build import build as build_cls
+    from .dist_info import dist_info as dist_info_cls
+    from .egg_info import egg_info as egg_info_cls
+    from .install import install as install_cls
+    from .install_scripts import install_scripts as install_scripts_cls
 
-_P = TypeVar("_P", bound=StrPath)
+    _P = TypeVar("_P", bound=StrPath)
+
 _logger = logging.getLogger(__name__)
 
 
@@ -152,7 +153,7 @@ class editable_wheel(Command):
 
     def _ensure_dist_info(self):
         if self.dist_info_dir is None:
-            dist_info = cast(dist_info_cls, self.reinitialize_command("dist_info"))
+            dist_info = cast("dist_info_cls", self.reinitialize_command("dist_info"))
             dist_info.output_dir = self.dist_dir
             dist_info.ensure_finalized()
             dist_info.run()
@@ -200,16 +201,17 @@ class editable_wheel(Command):
 
         # egg-info may be generated again to create a manifest (used for package data)
         egg_info = cast(
-            egg_info_cls, dist.reinitialize_command("egg_info", reinit_subcommands=True)
+            "egg_info_cls",
+            dist.reinitialize_command("egg_info", reinit_subcommands=True),
         )
         egg_info.egg_base = str(tmp_dir)
         egg_info.ignore_egg_info_in_manifest = True
 
         build = cast(
-            build_cls, dist.reinitialize_command("build", reinit_subcommands=True)
+            "build_cls", dist.reinitialize_command("build", reinit_subcommands=True)
         )
         install = cast(
-            install_cls, dist.reinitialize_command("install", reinit_subcommands=True)
+            "install_cls", dist.reinitialize_command("install", reinit_subcommands=True)
         )
 
         build.build_platlib = build.build_purelib = build.build_lib = build_lib
@@ -224,13 +226,13 @@ class editable_wheel(Command):
         build_scripts.executable = 'python'
 
         install_scripts = cast(
-            install_scripts_cls, dist.get_command_obj("install_scripts")
+            "install_scripts_cls", dist.get_command_obj("install_scripts")
         )
         install_scripts.no_ep = True
 
         build.build_temp = str(tmp_dir)
 
-        build_py = cast(build_py_cls, dist.get_command_obj("build_py"))
+        build_py = cast("build_py_cls", dist.get_command_obj("build_py"))
         build_py.compile = False
         build_py.existing_egg_info_dir = self._find_egg_info_dir()
 

--- a/setuptools/command/install.py
+++ b/setuptools/command/install.py
@@ -5,17 +5,13 @@ import platform
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from ..dist import Distribution
 from ..warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
 
 import distutils.command.install as orig
 from distutils.errors import DistutilsArgError
 
 if TYPE_CHECKING:
-    # This is only used for a type-cast, don't import at runtime or it'll cause deprecation warnings
-    from .easy_install import easy_install as easy_install_cls
-else:
-    easy_install_cls = None
+    from ..dist import Distribution
 
 
 def __getattr__(name: str):  # pragma: no cover

--- a/setuptools/command/install_lib.py
+++ b/setuptools/command/install_lib.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import os
 import sys
 from itertools import product, starmap
-
-from .._path import StrPath
-from ..dist import Distribution
+from typing import TYPE_CHECKING
 
 import distutils.command.install_lib as orig
+
+if TYPE_CHECKING:
+    from .._path import StrPath
+    from ..dist import Distribution
 
 
 class install_lib(orig.install_lib):

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import os
 import sys
+from typing import TYPE_CHECKING
 
 from .._path import ensure_directory
-from ..dist import Distribution
 
 import distutils.command.install_scripts as orig
 from distutils import log
+
+if TYPE_CHECKING:
+    from ..dist import Distribution
 
 
 class install_scripts(orig.install_scripts):

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -5,14 +5,16 @@ import os
 import re
 from collections.abc import Iterator
 from itertools import chain
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from .._importlib import metadata
-from ..dist import Distribution
 from .build import _ORIGINAL_SUBCOMMANDS
 
 import distutils.command.sdist as orig
 from distutils import log
+
+if TYPE_CHECKING:
+    from ..dist import Distribution
 
 _default_revctrl = list
 

--- a/setuptools/config/__init__.py
+++ b/setuptools/config/__init__.py
@@ -37,7 +37,7 @@ def _deprecation_notice(fn: Fn) -> Fn:
         )
         return fn(*args, **kwargs)
 
-    return cast(Fn, _wrapper)
+    return cast("Fn", _wrapper)
 
 
 read_configuration = _deprecation_notice(setupcfg.read_configuration)

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -19,7 +19,6 @@ from functools import partial
 from types import TracebackType
 from typing import TYPE_CHECKING, Any
 
-from .._path import StrPath
 from ..errors import FileError, InvalidConfigError
 from ..warnings import SetuptoolsWarning
 from . import expand as _expand
@@ -29,6 +28,8 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     from setuptools.dist import Distribution
+
+    from .._path import StrPath
 
 _logger = logging.getLogger(__name__)
 

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -25,7 +25,6 @@ from packaging.requirements import InvalidRequirement, Requirement
 from packaging.version import InvalidVersion, Version
 
 from .. import _static
-from .._path import StrPath
 from ..errors import FileError, OptionError
 from ..warnings import SetuptoolsDeprecationWarning
 from . import expand
@@ -34,6 +33,8 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     from setuptools.dist import Distribution
+
+    from .._path import StrPath
 
     from distutils.dist import DistributionMetadata
 
@@ -103,7 +104,7 @@ def _apply(
 
     try:
         # TODO: Temporary cast until mypy 1.12 is released with upstream fixes from typeshed
-        _Distribution.parse_config_files(dist, filenames=cast(list[str], filenames))
+        _Distribution.parse_config_files(dist, filenames=cast("list[str]", filenames))
         handlers = parse_configuration(
             dist, dist.command_options, ignore_option_errors=ignore_option_errors
         )

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -49,13 +49,13 @@ from typing import TYPE_CHECKING, ClassVar
 
 import _distutils_hack.override  # noqa: F401
 
-from ._path import StrPath
-
 from distutils import log
 from distutils.util import convert_path
 
 if TYPE_CHECKING:
     from setuptools import Distribution
+
+    from ._path import StrPath
 
 chain_iter = itertools.chain.from_iterable
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -25,8 +25,6 @@ from . import (
 )
 from ._importlib import metadata
 from ._normalization import _canonicalize_license_expression
-from ._path import StrPath
-from ._reqs import _StrOrIter
 from .config import pyprojecttoml, setupcfg
 from .discovery import ConfigDiscovery
 from .errors import InvalidConfigError
@@ -45,6 +43,9 @@ from distutils.util import strtobool
 
 if TYPE_CHECKING:
     from typing import TypeAlias
+
+    from ._path import StrPath
+    from ._reqs import _StrOrIter
 
 
 __all__ = ['Distribution']

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -5,13 +5,14 @@ import re
 from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
-from setuptools._path import StrPath
-
 from .monkey import get_unpatched
 
 import distutils.core
 import distutils.errors
 import distutils.extension
+
+if TYPE_CHECKING:
+    from setuptools._path import StrPath
 
 
 def _have_cython() -> bool:
@@ -31,6 +32,7 @@ def _have_cython() -> bool:
 have_pyrex = _have_cython
 if TYPE_CHECKING:
     # Work around a mypy issue where type[T] can't be used as a base: https://github.com/python/mypy/issues/10962
+
     from distutils.core import Extension as _Extension
 else:
     _Extension = get_unpatched(distutils.core.Extension)

--- a/setuptools/glob.py
+++ b/setuptools/glob.py
@@ -15,7 +15,9 @@ from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING, TypeVar, overload
 
 if TYPE_CHECKING:
-    from _typeshed import BytesPath, StrOrBytesPath, StrPath
+    from _typeshed import BytesPath, StrOrBytesPath
+
+    from ._path import StrPath
 
     _StrOrBytesT = TypeVar("_StrOrBytesT", str, bytes)
 

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -58,7 +58,7 @@ def get_unpatched_class(cls: type[_T]) -> type[_T]:
     first.
     """
     external_bases = (
-        cast(type[_T], cls)
+        cast("type[_T]", cls)
         for cls in _get_mro(cls)
         if not cls.__module__.startswith('setuptools')
     )

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -17,13 +17,14 @@ from typing import TYPE_CHECKING, TypedDict, overload
 
 from more_itertools import unique_everseen
 
-from ._path import StrPath
 from .compat import py310
 
 import distutils.errors
 
 if TYPE_CHECKING:
     from typing_extensions import LiteralString, NotRequired
+
+    from ._path import StrPath
 
 # https://github.com/python/mypy/issues/8166
 if not TYPE_CHECKING and platform.system() == 'Windows':

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -614,7 +614,7 @@ def _get_dist(dist_path, attrs):
     if script.exists():
         with Path(dist_path):
             dist = cast(
-                Distribution,
+                "Distribution",
                 distutils.core.run_setup("setup.py", {}, stop_after="init"),
             )
     else:


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Enables [flake8-type-checking (TC)](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) without the mental overhead of having to think about it:
- Helps prevent accidental circular imports
- Reduce runtime cost of importing typing-only symbols (more of a micro-optimization, but works towards https://github.com/pypa/setuptools/issues/3441)
- Reduces implementation/typing details leaks into modules at runtime

Not applying to stdlib ([typing-only-standard-library-import (TC003)](https://docs.astral.sh/ruff/rules/typing-only-standard-library-import/#typing-only-standard-library-import-tc003)) because:
- stdlib is not at risk of causing a circular import
- We can reasonably assume that most stdlib imports will be part of the initial import chain anyway
  - Although I could be wrong, worth checking
- stdlib imports are clearly not meant as re-exported symbols for the public API

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
