### PR TITLE
Fix documentation grammar, typos, and clarity issues

### DIFF
--- a/docs/deprecated/easy_install.rst
+++ b/docs/deprecated/easy_install.rst
@@ -42,7 +42,7 @@ You will need at least Python 3.5 or 2.7.  An ``easy_install`` script will be
 installed in the normal location for Python scripts on your platform.
 
 Note that the instructions on the setuptools PyPI page assume that you are
-are installing to Python's primary ``site-packages`` directory.  If this is
+installing to Python's primary ``site-packages`` directory.  If this is
 not the case, you should consult the section below on `Custom Installation
 Locations`_ before installing.  (And, on Windows, you should not use the
 ``.exe`` installer when installing to an alternate location.)

--- a/docs/deprecated/index.rst
+++ b/docs/deprecated/index.rst
@@ -3,7 +3,7 @@ Guides on backward compatibility & deprecated practice
 ======================================================
 
 ``Setuptools`` has undergone tremendous changes since its first debut. As its
-development continues to roll forward, many of the practice and mechanisms it
+development continues to roll forward, many of the practices and mechanisms it
 had established are now considered deprecated. But they still remain relevant
 as a plethora of libraries continue to depend on them. Many people also find
 it necessary to equip themselves with the knowledge to better support backward

--- a/docs/references/keywords.rst
+++ b/docs/references/keywords.rst
@@ -54,7 +54,7 @@ extensions).
 .. _keyword/long_description_content_type:
 
 ``long_description_content_type``
-    A string specifying the content type is used for the ``long_description``
+    A string specifying the content type used for the ``long_description``
     (e.g. ``text/markdown``)
 
 .. _keyword/author:

--- a/docs/userguide/index.rst
+++ b/docs/userguide/index.rst
@@ -6,7 +6,7 @@ The first step towards sharing a Python library or program is to build a
 distribution package [#package-overload]_. This includes adding a set of
 additional files containing metadata and configuration to not only instruct
 ``setuptools`` on how the distribution should be built but also
-to help installer (such as :pypi:`pip`) during the installation process.
+to help installers (such as :pypi:`pip`) during the installation process.
 
 This document contains information to help Python developers through this
 process. Please check the :doc:`/userguide/quickstart` for an overview of

--- a/docs/userguide/interfaces.rst
+++ b/docs/userguide/interfaces.rst
@@ -54,7 +54,7 @@ carefully attempt to find alternatives before resorting to unscheduled removals.
    In the context of ``setuptools``, the introduction of :py:mod:`warnings`
    (including deprecation warnings) is not considered a breaking change *per se*.
    Instead it is considered a backwards compatible *communication action* that
-   precedes an upcoming breaking change. This is becauset code
+   precedes an upcoming breaking change. This is because code
    containing warnings typically does not fail and can successfully terminate
    execution, unless users explicitly opt into transforming those warnings
    into errors (e.g., via Python's :external+python:ref:`-W option or

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -24,7 +24,7 @@ files are included in a source distribution by default:
   in ``pyproject.toml`` and/or equivalent in ``setup.cfg``/``setup.py``;
   note that if you don't explicitly set this parameter, ``setuptools``
   will include any files that match the following glob patterns:
-  ``LICEN[CS]E*``, ``COPYING*``, ``NOTICE*``, ``AUTHORS**``;
+  ``LICEN[CS]E*``, ``COPYING*``, ``NOTICE*``, ``AUTHORS*``;
 - ``pyproject.toml``;
 - ``setup.cfg``;
 - ``setup.py``;

--- a/docs/userguide/pyproject_config.rst
+++ b/docs/userguide/pyproject_config.rst
@@ -170,7 +170,7 @@ existing packages should consider migrating to alternatives.
       packages = ["my_package"]
 
    If you want to publish a distribution that does not include any Python module
-   (e.g. a "meta-distribution" that just aggregate dependencies), please
+   (e.g. a "meta-distribution" that just aggregates dependencies), please
    consider something like the following:
 
    .. code-block:: toml

--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -9,7 +9,7 @@ You can install the latest version of ``setuptools`` using :pypi:`pip`::
 
     pip install --upgrade setuptools[core]
 
-Most of the times, however, you don't have to...
+Most of the time, however, you don't have to...
 
 Instead, when creating new Python packages, it is recommended to use
 a command line tool called :pypi:`build`. This tool will automatically download
@@ -33,7 +33,7 @@ This will allow you to run the command: ``python -m build``.
    check out :doc:`pip installation docs <pip:installation>`.
 
 
-Every python package must provide a ``pyproject.toml`` and specify
+Every Python package must provide a ``pyproject.toml`` and specify
 the backend (build system) it wants to use. The distribution can then
 be generated with whatever tool that provides a ``build sdist``-like
 functionality.
@@ -200,7 +200,7 @@ Package discovery
 For projects that follow a simple directory structure, ``setuptools`` should be
 able to automatically detect all :term:`packages <package>` and
 :term:`namespaces <namespace package>`. However, complex projects might include
-additional folders and supporting files that not necessarily should be
+additional folders and supporting files that should not necessarily be
 distributed (or that can confuse ``setuptools`` auto discovery algorithm).
 
 Therefore, ``setuptools`` provides a convenient way to customize

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -147,7 +147,7 @@ def safer_name(value: str) -> str:
 
 def safer_best_effort_version(value: str) -> str:
     """Like ``best_effort_version`` but can be used as filename component for wheel"""
-    # See bdist_wheel.safer_verion
+    # See bdist_wheel.safer_version
     # TODO: Replace with only safe_version in the future (no need for best effort)
     return filename_component(best_effort_version(value))
 

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -421,11 +421,11 @@ def _some_attrgetter(*items):
     True
     """
 
-    def _acessor(obj):
+    def _accessor(obj):
         values = (_attrgetter(i)(obj) for i in items)
         return next((i for i in values if i is not None), None)
 
-    return _acessor
+    return _accessor
 
 
 PYPROJECT_CORRESPONDENCE: dict[str, _Correspondence] = {

--- a/setuptools/config/_validate_pyproject/error_reporting.py
+++ b/setuptools/config/_validate_pyproject/error_reporting.py
@@ -224,7 +224,7 @@ class _SummaryWriter:
         if isinstance(schema, list):
             return self._handle_list(schema, prefix, _path)
 
-        filtered = self._filter_unecessary(schema, _path)
+        filtered = self._filter_unnecessary(schema, _path)
         simple = self._handle_simple_dict(filtered, _path)
         if simple:
             return f"{prefix}{simple}"
@@ -239,7 +239,7 @@ class _SummaryWriter:
                 buffer.write(f"{line_prefix}{self._label(child_path)}:")
                 # ^  just the first item should receive the complete prefix
                 if isinstance(value, dict):
-                    filtered = self._filter_unecessary(value, child_path)
+                    filtered = self._filter_unnecessary(value, child_path)
                     simple = self._handle_simple_dict(filtered, child_path)
                     buffer.write(
                         f" {simple}"
@@ -256,19 +256,19 @@ class _SummaryWriter:
                     buffer.write(f" {self._value(value, child_path)}\n")
             return buffer.getvalue()
 
-    def _is_unecessary(self, path: Sequence[str]) -> bool:
+    def _is_unnecessary(self, path: Sequence[str]) -> bool:
         if self._is_property(path) or not path:  # empty path => instruction @ root
             return False
         key = path[-1]
         return any(key.startswith(k) for k in "$_") or key in self._IGNORE
 
-    def _filter_unecessary(
+    def _filter_unnecessary(
         self, schema: dict[str, Any], path: Sequence[str]
     ) -> dict[str, Any]:
         return {
             key: value
             for key, value in schema.items()
-            if not self._is_unecessary([*path, key])
+            if not self._is_unnecessary([*path, key])
         }
 
     def _handle_simple_dict(self, value: dict, path: Sequence[str]) -> str | None:
@@ -281,7 +281,7 @@ class _SummaryWriter:
     def _handle_list(
         self, schemas: list, prefix: str = "", path: Sequence[str] = ()
     ) -> str:
-        if self._is_unecessary(path):
+        if self._is_unnecessary(path):
             return ""
 
         repr_ = repr(schemas)

--- a/setuptools/config/_validate_pyproject/extra_validations.py
+++ b/setuptools/config/_validate_pyproject/extra_validations.py
@@ -75,7 +75,7 @@ def validate_project_dynamic(pyproject: T) -> T:
     return pyproject
 
 
-def validate_include_depenency(pyproject: T) -> T:
+def validate_include_dependency(pyproject: T) -> T:
     dependency_groups = pyproject.get("dependency-groups", {})
     for key, value in dependency_groups.items():
         for each in value:
@@ -146,6 +146,6 @@ def validate_import_name_issues(pyproject: T) -> T:
 
 EXTRA_VALIDATIONS = (
     validate_project_dynamic,
-    validate_include_depenency,
+    validate_include_dependency,
     validate_import_name_issues,
 )

--- a/setuptools/config/_validate_pyproject/formats.py
+++ b/setuptools/config/_validate_pyproject/formats.py
@@ -270,9 +270,9 @@ def url(value: str) -> bool:
 # https://packaging.python.org/specifications/entry-points/
 ENTRYPOINT_PATTERN = r"[^\[\s=]([^=]*[^\s=])?"
 ENTRYPOINT_REGEX = re.compile(f"^{ENTRYPOINT_PATTERN}$", re.IGNORECASE)
-RECOMMEDED_ENTRYPOINT_PATTERN = r"[\w.-]+"
-RECOMMEDED_ENTRYPOINT_REGEX = re.compile(
-    f"^{RECOMMEDED_ENTRYPOINT_PATTERN}$", re.IGNORECASE
+RECOMMENDED_ENTRYPOINT_PATTERN = r"[\w.-]+"
+RECOMMENDED_ENTRYPOINT_REGEX = re.compile(
+    f"^{RECOMMENDED_ENTRYPOINT_PATTERN}$", re.IGNORECASE
 )
 ENTRYPOINT_GROUP_PATTERN = r"\w+(\.\w+)*"
 ENTRYPOINT_GROUP_REGEX = re.compile(f"^{ENTRYPOINT_GROUP_PATTERN}$", re.IGNORECASE)
@@ -334,9 +334,9 @@ def python_entrypoint_name(value: str) -> bool:
     """
     if not ENTRYPOINT_REGEX.match(value):
         return False
-    if not RECOMMEDED_ENTRYPOINT_REGEX.match(value):
+    if not RECOMMENDED_ENTRYPOINT_REGEX.match(value):
         msg = f"Entry point `{value}` does not follow recommended pattern: "
-        msg += RECOMMEDED_ENTRYPOINT_PATTERN
+        msg += RECOMMENDED_ENTRYPOINT_PATTERN
         _logger.warning(msg)
     return True
 

--- a/setuptools/tests/config/test_setupcfg.py
+++ b/setuptools/tests/config/test_setupcfg.py
@@ -350,7 +350,7 @@ class TestMetadata:
         with get_dist(tmpdir, parse=False) as dist:
             dist.parse_config_files()  # Skip unknown.
 
-    def test_usupported_section(self, tmpdir):
+    def test_unsupported_section(self, tmpdir):
         fake_env(tmpdir, '[metadata.some]\nkey = val\n')
         with get_dist(tmpdir, parse=False) as dist:
             with pytest.raises(DistutilsOptionError):

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -64,7 +64,7 @@ class BuildBackend(BuildBackendBase):
                 pytest.xfail(f"Backend did not respond before timeout ({TIMEOUT} s)")
             except (futures.process.BrokenProcessPool, MemoryError, OSError):
                 if IS_PYPY:
-                    pytest.xfail("PyPy frequently fails tests with ProcessPoolExector")
+                    pytest.xfail("PyPy frequently fails tests with ProcessPoolExecutor")
                 raise
 
         return method

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -78,7 +78,7 @@ class TestDiscoverPackagesAndPyModules:
         files, options = self._get_info(circumstance)
         _populate_project_dir(tmp_path, files, options)
 
-        _, cmd = _run_sdist_programatically(tmp_path, options)
+        _, cmd = _run_sdist_programmatically(tmp_path, options)
 
         manifest = [f.replace(os.sep, "/") for f in cmd.filelist.files]
         for file in files:
@@ -117,7 +117,7 @@ class TestDiscoverPackagesAndPyModules:
             assert "build" not in files
             assert "dist" not in files
 
-    PURPOSEFULLY_EMPY = {
+    PURPOSEFULLY_EMPYY = {
         "setup.cfg": DALS(
             """
             [metadata]
@@ -176,11 +176,11 @@ class TestDiscoverPackagesAndPyModules:
             template_param = param.replace("_", "-")
         else:
             # Make sure build works with or without setup.cfg
-            pyproject = self.PURPOSEFULLY_EMPY["template-pyproject.toml"]
+            pyproject = self.PURPOSEFULLY_EMPYY["template-pyproject.toml"]
             (tmp_path / "pyproject.toml").write_text(pyproject, encoding="utf-8")
             template_param = param
 
-        config = self.PURPOSEFULLY_EMPY[config_file].format(param=template_param)
+        config = self.PURPOSEFULLY_EMPYY[config_file].format(param=template_param)
         (tmp_path / config_file).write_text(config, encoding="utf-8")
 
         dist = _get_dist(tmp_path, {})
@@ -635,7 +635,7 @@ def _get_dist(dist_path, attrs):
     return dist
 
 
-def _run_sdist_programatically(dist_path, attrs):
+def _run_sdist_programmatically(dist_path, attrs):
     dist = _get_dist(dist_path, attrs)
     cmd = sdist(dist)
     cmd.ensure_finalized()

--- a/setuptools/tests/test_dist.py
+++ b/setuptools/tests/test_dist.py
@@ -183,11 +183,11 @@ def test_dist_default_py_modules(tmp_path, dist_name, py_module):
     dist.set_defaults()
     assert dist.py_modules == [py_module]
     # When `py_modules` is given, don't do anything
-    dist = Distribution({**attrs, "py_modules": ["explicity_py_module"]})
+    dist = Distribution({**attrs, "py_modules": ["explicitly_py_module"]})
     dist.set_defaults()
-    assert dist.py_modules == ["explicity_py_module"]
+    assert dist.py_modules == ["explicitly_py_module"]
     # When `packages` is given, don't do anything
-    dist = Distribution({**attrs, "packages": ["explicity_package"]})
+    dist = Distribution({**attrs, "packages": ["explicitly_package"]})
     dist.set_defaults()
     assert not dist.py_modules
 


### PR DESCRIPTION
- Fix typos
- Fix grammar: "help installer" → "help installers" in index.rst
- Fix phrase: "Most of the times" → "Most of the time" in quickstart.rst
- Fix capitalization: "python" → "Python" in quickstart.rst
- Fix word order: "that not necessarily should be" → "that should not necessarily be" in quickstart.rst
- Fix grammar: "content type is used" → "content type used" in keywords.rst
- Fix duplicate word: "are are" → "are" in easy_install.rst
- Fix subject-verb: "aggregate" → "aggregates" in pyproject_config.rst
- Fix plural: "practice" → "practices" in deprecated/index.rst
- Fix glob pattern: "AUTHORS**" → "AUTHORS*" in miscellaneous.rst

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
