### PR TITLE
Docs: Fix intersphinx references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -239,8 +239,8 @@ favicons = [
 ]
 
 intersphinx_mapping.update({
-    'pip': ('https://pip.pypa.io/en/latest', None),
-    'build': ('https://build.pypa.io/en/latest', None),
+    'pip': ('https://pip.pypa.io/en/stable', None),
+    'build': ('https://build.pypa.io/en/stable', None),
     'PyPUG': ('https://packaging.python.org/en/latest', None),
     'pytest': ('https://docs.pytest.org/en/stable', None),
     'packaging': ('https://packaging.pypa.io/en/latest', None),


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

It seems that intersphinx can no longer find the `build` docs.
I think that is because now they seem to be building only the `stable` docs (instead of `latest`).

I also noticed that `pip` defaults to `stable`.

So hopefully these changes are enough to fix the failing tests on the CI.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
