### PR TITLE
Fix CI warning

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,7 @@ deps =
 	diff-cover
 commands =
 	pytest {posargs} --cov-report xml
-	diff-cover coverage.xml --compare-branch=origin/main --html-report diffcov.html
+	diff-cover coverage.xml --compare-branch=origin/main --format html:diffcov.html
 	diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:docs]


### PR DESCRIPTION
## Summary of changes

Address this warning:
```
UserWarning: The --html-report option is deprecated. Use --format html:diffcov.html instead.
```

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
