### PR TITLE
fix: use correct compiler variable in _linker_params for C++ shared libraries

### DIFF
--- a/setuptools/_distutils/compilers/C/unix.py
+++ b/setuptools/_distutils/compilers/C/unix.py
@@ -299,7 +299,7 @@ class Compiler(base.Compiler):
                     _, compiler_cxx_ne = _split_env(self.compiler_cxx)
                     _, linker_exe_ne = _split_env(self.linker_exe_cxx)
 
-                    params = _linker_params(linker_na, linker_exe_ne)
+                    params = _linker_params(linker_na, compiler_cxx_ne)
                     linker = env + aix + compiler_cxx_ne + params
 
                 linker = compiler_fixup(linker, ld_args)


### PR DESCRIPTION
## Summary
- Fix `_linker_params()` to use the correct compiler variable for C++ shared library linking
- The `-shared` flag was being stripped, causing linking failures on Ubuntu

## Root Cause
In `_linker_params()`, `linker_exe_ne` was used instead of `compiler_cxx_ne`, which caused the `-shared` flag to be dropped from the linker command when building C++ shared libraries. On Ubuntu, `linker_exe_cxx` can be `['c++', '-shared']`, and when both parameters to `_linker_params()` are identical, it returns an empty list, stripping all flags.

## Changes
- `setuptools/_distutils/compilers/C/unix.py`: Change `_linker_params(linker_na, linker_exe_ne)` to `_linker_params(linker_na, compiler_cxx_ne)`

## Testing
- Verified that `-shared` flag is preserved in the linker command
- Change is minimal (1 line) and follows existing code patterns

Fixes #5123

Made with [Cursor](https://cursor.com)