### PR TITLE
fix: treat empty install_requires as unset for dynamic requires-dist

### DIFF
--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -212,7 +212,8 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     _write_requirements(self, file)
 
     for field, attr in _POSSIBLE_DYNAMIC_FIELDS.items():
-        if (val := getattr(self, attr, None)) and not is_static(val):
+        val = getattr(self, attr, None)
+        if val is not None and not is_static(val):
             write_field('Dynamic', field)
 
     long_description = self.get_long_description()

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -488,6 +488,18 @@ class TestPEP643:
         metadata = _get_metadata(dist)
         assert set(metadata.get_all("Dynamic")) == set(fields)
 
+    def test_empty_install_requires_marked_as_dynamic(self, tmpdir_cwd):
+        # When install_requires=[] (non-static), Dynamic: requires-dist should be written.
+        # Fixes pypa/setuptools#5120
+        Path("pyproject.toml").write_text(
+            self.STATIC_CONFIG["pyproject.toml"], encoding="utf-8"
+        )
+        dist = _makedist()
+        dist.install_requires = []  # Plain list, non-static
+        dist.metadata.install_requires = []
+        metadata = _get_metadata(dist)
+        assert "requires-dist" in (metadata.get_all("Dynamic") or [])
+
     @pytest.mark.parametrize(
         "extra_toml",
         [


### PR DESCRIPTION
## Summary
- Don't let install_requires=[] override project.dynamic = ["dependencies"]
- Empty list should be treated as unset, not as an explicit empty value

## Root Cause
When install_requires=[] is set in setup.py alongside project.dynamic = ["dependencies"] in pyproject.toml, the empty list overrides the dynamic declaration, causing PKG-INFO to lack Dynamic: requires-dist.

## Testing
- Verified dynamic requires-dist is preserved when install_requires is empty

Fixes #5120