### PR TITLE
Remove out-of-date Python 3.14 CI configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,20 +63,13 @@ jobs:
           python: "3.10"
           distutils: stdlib
     runs-on: ${{ matrix.platform }}
-    continue-on-error: ${{ matrix.python == '3.14' || matrix.python == 'pypy3.10' }}
+    continue-on-error: ${{ matrix.python == 'pypy3.10' }}
     # XXX: pypy seems to be flaky with unrelated tests in #6345
     env:
       SETUPTOOLS_USE_DISTUTILS: ${{ matrix.distutils || 'local' }}
     timeout-minutes: 75
     steps:
       - uses: actions/checkout@v4
-      - name: Install build dependencies
-        # Install dependencies for building packages on pre-release Pythons
-        # jaraco/skeleton#161
-        if: matrix.python == '3.14' && matrix.platform == 'ubuntu-latest'
-        run: |
-          sudo apt update
-          sudo apt install -y libxml2-dev libxslt-dev
       - name: Setup Python
         id: python-install
         uses: actions/setup-python@v5


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Removes out-of-date CI configuration added before the 3.14 final release. I checked the last few runs on the `main` branch and saw no errors for 3.14. I think PR reviewers would probably want to know about breakage that only happens on Python 3.14.

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
