### PR TITLE
Work around typing issue from more_itertools

### DIFF
--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -122,9 +122,9 @@ def read_files(
     from more_itertools import always_iterable
 
     root_dir = os.path.abspath(root_dir or os.getcwd())
-    _filepaths = (os.path.join(root_dir, path) for path in
-                  # work around more_itertools/more_itertools#1143
-                  cast('Iterable[StrPath]', always_iterable(filepaths)))
+    # work around more_itertools/more_itertools#1143
+    _filepaths = cast('Iterable[StrPath]', always_iterable(filepaths))
+    _filepaths = (os.path.join(root_dir, path) for path in _filepaths)
     return '\n'.join(
         _read_file(path)
         for path in _filter_existing_files(_filepaths)

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -32,7 +32,7 @@ from importlib.machinery import ModuleSpec, all_suffixes
 from itertools import chain
 from pathlib import Path
 from types import ModuleType, TracebackType
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 from .. import _static
 from .._path import StrPath, same_path as _same_path
@@ -122,7 +122,9 @@ def read_files(
     from more_itertools import always_iterable
 
     root_dir = os.path.abspath(root_dir or os.getcwd())
-    _filepaths = (os.path.join(root_dir, path) for path in always_iterable(filepaths))
+    _filepaths = (os.path.join(root_dir, path) for path in
+                  # work around more_itertools/more_itertools#1143
+                  cast('Iterable[StrPath]', always_iterable(filepaths)))
     return '\n'.join(
         _read_file(path)
         for path in _filter_existing_files(_filepaths)


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Running the tests with the latest versions of the test dependencies will fail due to an issue in more_itertools: https://github.com/more-itertools/more-itertools/issues/1143.

For now, to unbreak CI, I'm adding a runtime cast to avoid the type checking issue.

Closes <!-- issue number here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
