### PR TITLE
Refresh project structure (skeleton)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,31 +34,31 @@ jobs:
       # https://blog.jaraco.com/efficient-use-of-ci-resources/
       matrix:
         python:
-        - "3.9"
+        - "3.10"
         - "3.13"
         platform:
         - ubuntu-latest
         - macos-latest
         - windows-latest
         include:
-        - python: "3.10"
-          platform: ubuntu-latest
         - python: "3.11"
           platform: ubuntu-latest
         - python: "3.12"
           platform: ubuntu-latest
         - python: "3.14"
           platform: ubuntu-latest
+        - python: "3.15"
+          platform: ubuntu-latest
         - python: pypy3.10
           platform: ubuntu-latest
     runs-on: ${{ matrix.platform }}
-    continue-on-error: ${{ matrix.python == '3.14' }}
+    continue-on-error: ${{ matrix.python == '3.15' }}
     steps:
       - uses: actions/checkout@v4
       - name: Install build dependencies
         # Install dependencies for building packages on pre-release Pythons
         # jaraco/skeleton#161
-        if: matrix.python == '3.14' && matrix.platform == 'ubuntu-latest'
+        if: matrix.python == '3.15' && matrix.platform == 'ubuntu-latest'
         run: |
           sudo apt update
           sudo apt install -y libxml2-dev libxslt-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -187,7 +187,7 @@ jobs:
     strategy:
       matrix:
         python:
-        - 39
+        - 312
         platform:
         - windows-latest
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -42,8 +42,8 @@ jobs:
       # https://blog.jaraco.com/efficient-use-of-ci-resources/
       matrix:
         python:
-          - "3.9"
-          - "3.13"
+          - "3.10"
+          - "3.14"
         platform:
           - ubuntu-latest
     runs-on: ${{ matrix.platform }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.9
+  rev: v0.12.0
   hooks:
   - id: ruff
     args: [--fix, --unsafe-fixes]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,6 @@ repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.12.0
   hooks:
-  - id: ruff
+  - id: ruff-check
     args: [--fix, --unsafe-fixes]
   - id: ruff-format

--- a/README.rst
+++ b/README.rst
@@ -14,5 +14,5 @@
 .. .. image:: https://readthedocs.org/projects/PROJECT_RTD/badge/?version=latest
 ..    :target: https://PROJECT_RTD.readthedocs.io/en/latest/?badge=latest
 
-.. image:: https://img.shields.io/badge/skeleton-2025-informational
+.. image:: https://img.shields.io/badge/skeleton-2026-informational
    :target: https://blog.jaraco.com/skeleton

--- a/newsfragments/+0af71c41.feature.rst
+++ b/newsfragments/+0af71c41.feature.rst
@@ -1,0 +1,1 @@
+Require Python 3.10 or later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,12 +58,12 @@ cover = [
 ]
 
 enabler = [
-	"pytest-enabler >= 2.2",
+	"pytest-enabler >= 3.4",
 ]
 
 type = [
 	# upstream
-	"pytest-mypy",
+	"pytest-mypy >= 1.0.1",
 
 	# local
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ type = [
 	# upstream
 	"pytest-mypy >= 1.0.1",
 
+	## workaround for python/mypy#20454
+	"mypy < 1.19; python_implementation == 'PyPy'",
+
 	# local
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 	"Programming Language :: Python :: 3",
 	"Programming Language :: Python :: 3 :: Only",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "MIT"
 dependencies = [
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,9 @@ enabler = [
 
 type = [
 	# upstream
-	"pytest-mypy >= 1.0.1",
-
-	## workaround for python/mypy#20454
-	"mypy < 1.19; python_implementation == 'PyPy'",
+	
+    # Exclude PyPy from type checks (python/mypy#20454 jaraco/skeleton#187)
+	"pytest-mypy >= 1.0.1; platform_python_implementation != 'PyPy'",
 
 	# local
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ doc = [
 ]
 
 check = [
-	"pytest-checkdocs >= 2.4",
+	"pytest-checkdocs >= 2.14",
 	"pytest-ruff >= 0.2.1; sys_platform != 'cygwin'",
 ]
 

--- a/setuptools/_importlib.py
+++ b/setuptools/_importlib.py
@@ -1,9 +1,2 @@
-import sys
-
-if sys.version_info < (3, 10):
-    import importlib_metadata as metadata  # pragma: no cover
-else:
-    import importlib.metadata as metadata  # noqa: F401
-
-
+import importlib.metadata as metadata  # noqa: F401
 import importlib.resources as resources  # noqa: F401

--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-from typing import TYPE_CHECKING, TypeVar, Union
+from typing import TYPE_CHECKING, TypeVar
 
 from more_itertools import unique_everseen
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
-StrPath: TypeAlias = Union[str, os.PathLike[str]]  #  Same as _typeshed.StrPath
-StrPathT = TypeVar("StrPathT", bound=Union[str, os.PathLike[str]])
+StrPath: TypeAlias = str | os.PathLike[str]  #  Same as _typeshed.StrPath
+StrPathT = TypeVar("StrPathT", bound=str | os.PathLike[str])
 
 
 def ensure_directory(path):

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache
-from typing import TYPE_CHECKING, Callable, TypeVar, Union, overload
+from typing import TYPE_CHECKING, TypeVar, overload
 
 import jaraco.text as text
 from packaging.requirements import Requirement
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 _T = TypeVar("_T")
-_StrOrIter: TypeAlias = Union[str, Iterable[str]]
+_StrOrIter: TypeAlias = str | Iterable[str]
 
 
 parse_req: Callable[[str], Requirement] = lru_cache()(Requirement)

--- a/setuptools/_shutil.py
+++ b/setuptools/_shutil.py
@@ -2,7 +2,8 @@
 
 import os
 import stat
-from typing import Callable, TypeVar
+from collections.abc import Callable
+from typing import TypeVar
 
 from .compat import py311
 

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -39,7 +39,7 @@ import tokenize
 import warnings
 from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn, Union
+from typing import TYPE_CHECKING, NoReturn
 
 import setuptools
 
@@ -52,7 +52,7 @@ import distutils
 from distutils.util import strtobool
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 __all__ = [
     'get_requires_for_build_sdist',
@@ -144,7 +144,7 @@ def suppress_known_deprecation():
         yield
 
 
-_ConfigSettings: TypeAlias = Union[Mapping[str, Union[str, list[str], None]], None]
+_ConfigSettings: TypeAlias = Mapping[str, str | list[str] | None] | None
 """
 Currently the user can run::
 

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -23,8 +23,9 @@ from distutils import log
 from distutils.dir_util import mkpath, remove_tree
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from _typeshed import GenericPath
-    from typing_extensions import TypeAlias
 
 # Same as zipfile._ZipFileMode from typeshed
 _ZipFileMode: TypeAlias = Literal["r", "w", "x", "a"]

--- a/setuptools/compat/py311.py
+++ b/setuptools/compat/py311.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import shutil
 import sys
-from typing import TYPE_CHECKING, Any, Callable
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from typing import TypeAlias
+
     from _typeshed import ExcInfo, StrOrBytesPath
-    from typing_extensions import TypeAlias
 
 # Same as shutil._OnExcCallback from typeshed
 _OnExcCallback: TypeAlias = Callable[[Callable[..., Any], str, BaseException], object]

--- a/setuptools/config/__init__.py
+++ b/setuptools/config/__init__.py
@@ -2,8 +2,9 @@
 ``setuptools.config.setupcfg``
 """
 
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, TypeVar, cast
+from typing import TypeVar, cast
 
 from ..warnings import SetuptoolsDeprecationWarning
 from . import setupcfg

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -12,13 +12,13 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from email.headerregistry import Address
 from functools import partial, reduce
 from inspect import cleandoc
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Callable, TypeVar, Union
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from .. import _static
 from .._path import StrPath
@@ -27,7 +27,7 @@ from ..extension import Extension
 from ..warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from setuptools._importlib import metadata
     from setuptools.dist import Distribution
@@ -36,8 +36,8 @@ if TYPE_CHECKING:
 
 
 EMPTY: Mapping = MappingProxyType({})  # Immutable dict-like
-_ProjectReadmeValue: TypeAlias = Union[str, dict[str, str]]
-_Correspondence: TypeAlias = Callable[["Distribution", Any, Union[StrPath, None]], None]
+_ProjectReadmeValue: TypeAlias = str | dict[str, str]
+_Correspondence: TypeAlias = Callable[["Distribution", Any, StrPath | None], None]
 _T = TypeVar("_T")
 
 _logger = logging.getLogger(__name__)

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -25,14 +25,14 @@ import importlib
 import os
 import pathlib
 import sys
-from collections.abc import Iterable, Iterator, Mapping
+from collections.abc import Callable, Iterable, Iterator, Mapping
 from configparser import ConfigParser
 from glob import iglob
 from importlib.machinery import ModuleSpec, all_suffixes
 from itertools import chain
 from pathlib import Path
 from types import ModuleType, TracebackType
-from typing import TYPE_CHECKING, Any, Callable, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from .. import _static
 from .._path import StrPath, same_path as _same_path

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -13,11 +13,11 @@ from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager
 from functools import partial
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from .._path import StrPath
 from ..errors import FileError, InvalidConfigError

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -16,9 +16,9 @@ import functools
 import os
 from abc import abstractmethod
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
 from packaging.markers import default_environment as marker_env
 from packaging.requirements import InvalidRequirement, Requirement
@@ -31,7 +31,7 @@ from ..warnings import SetuptoolsDeprecationWarning
 from . import expand
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from setuptools.dist import Distribution
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -10,7 +10,7 @@ import sys
 from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from glob import glob
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 from more_itertools import partition, unique_everseen
 from packaging.markers import InvalidMarker, Marker
@@ -44,7 +44,7 @@ from distutils.fancy_getopt import translate_longopt
 from distutils.util import strtobool
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ['Distribution']
@@ -59,10 +59,10 @@ Supported iterable types that are known to be:
 - not imply a nested type (like `dict`)
 for use with `isinstance`.
 """
-_Sequence: TypeAlias = Union[tuple[str, ...], list[str]]
+_Sequence: TypeAlias = tuple[str, ...] | list[str]
 # This is how stringifying _Sequence would look in Python 3.10
 _sequence_type_repr = "tuple[str, ...] | list[str]"
-_OrderedStrSequence: TypeAlias = Union[str, dict[str, Any], Sequence[str]]
+_OrderedStrSequence: TypeAlias = str | dict[str, Any] | Sequence[str]
 """
 :meta private:
 Avoid single-use iterable. Disallow sets.

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -7,9 +7,10 @@ import signal
 import sys
 import tarfile
 import warnings
+from collections.abc import Callable
 from concurrent import futures
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from zipfile import ZipFile
 
 import pytest

--- a/setuptools/warnings.py
+++ b/setuptools/warnings.py
@@ -15,7 +15,7 @@ from textwrap import indent
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 _DueDate: TypeAlias = tuple[int, int, int]  # time tuple
 _INDENT = 8 * " "

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,2 +1,3 @@
 [tool.towncrier]
 title_format = "{version}"
+directory = "newsfragments"  # jaraco/skeleton#184

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 	diff-cover
 commands =
 	pytest {posargs} --cov-report xml
-	diff-cover coverage.xml --compare-branch=origin/main --html-report diffcov.html
+	diff-cover coverage.xml --compare-branch=origin/main --format html:diffcov.html
 	diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:docs]


### PR DESCRIPTION
- **Update pre-commit ruff (jaraco/skeleton#181)**
- **Log filenames when running pytest-mypy (jaraco/skeleton#177)**
- **Specify the directory for news fragments.**
- **Pin mypy on PyPy.**
- **Update pre-commit ruff legacy alias (jaraco/skeleton#183)**
- **Don't install (nor run) mypy on PyPy (librt build failures) (jaraco/skeleton#187)**
- **Bump `pytest-checkdocs` to `>= 2.14` to resolve deprecation warnings (jaraco/skeleton#189)**
- **Bump Python versions: drop 3.9 (EOL), add 3.15 (jaraco/skeleton#193)**
- **Fix CI warning in diffcov report (jaraco/skeleton#194)**
- **Bump badge for 2026.**
- **👹 Feed the hobgoblins (delint).**
- **Add news fragment.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
