### PR TITLE
Move `from typing import TypeAlias` outside `if TYPE_CHECKING`

### DIFF
--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import contextlib
 import os
 import sys
-from typing import TYPE_CHECKING, TypeVar
+from typing import TypeAlias, TypeVar
 
 from more_itertools import unique_everseen
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
 
 StrPath: TypeAlias = str | os.PathLike[str]  #  Same as _typeshed.StrPath
 StrPathT = TypeVar("StrPathT", bound=str | os.PathLike[str])

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -2,13 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TypeAlias, TypeVar, overload
 
 from jaraco import text
 from packaging.requirements import Requirement
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
 
 _T = TypeVar("_T")
 _StrOrIter: TypeAlias = str | Iterable[str]

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -39,7 +39,7 @@ import tokenize
 import warnings
 from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
-from typing import TYPE_CHECKING, NoReturn
+from typing import NoReturn, TypeAlias
 
 import setuptools
 
@@ -50,9 +50,6 @@ from .warnings import SetuptoolsDeprecationWarning
 
 import distutils
 from distutils.util import strtobool
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
 
 __all__ = [
     'SetupRequirementsError',

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -12,7 +12,7 @@ import textwrap
 from collections.abc import Iterator
 from sysconfig import get_path, get_platform, get_python_version
 from types import CodeType
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeVar
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, TypeVar
 
 from setuptools import Command
 from setuptools.extension import Library
@@ -23,8 +23,6 @@ from distutils import log
 from distutils.dir_util import mkpath, remove_tree
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
-
     from _typeshed import GenericPath
 
     _StrOrBytesT = TypeVar("_StrOrBytesT", str, bytes)

--- a/setuptools/compat/py311.py
+++ b/setuptools/compat/py311.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 import shutil
 import sys
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
-
     from _typeshed import ExcInfo, StrOrBytesPath
 
 # Same as shutil._OnExcCallback from typeshed

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -18,7 +18,7 @@ from functools import partial, reduce
 from inspect import cleandoc
 from itertools import chain
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
 from .. import _static
 from .._path import StrPath
@@ -27,8 +27,6 @@ from ..extension import Extension
 from ..warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
-
     from setuptools._importlib import metadata
     from setuptools.dist import Distribution
 

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -18,7 +18,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator
 from functools import partial, wraps
-from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeAlias, TypeVar, cast
 
 from packaging.markers import default_environment as marker_env
 from packaging.requirements import InvalidRequirement, Requirement
@@ -31,8 +31,6 @@ from ..warnings import SetuptoolsDeprecationWarning
 from . import expand
 
 if TYPE_CHECKING:
-    from typing import TypeAlias
-
     from setuptools.dist import Distribution
 
     from distutils.dist import DistributionMetadata

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -10,7 +10,7 @@ import sys
 from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from glob import glob
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 from more_itertools import partition, unique_everseen
 from packaging.markers import InvalidMarker, Marker
@@ -42,10 +42,6 @@ from distutils.debug import DEBUG
 from distutils.errors import DistutilsOptionError, DistutilsSetupError
 from distutils.fancy_getopt import translate_longopt
 from distutils.util import strtobool
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
-
 
 __all__ = ['Distribution']
 

--- a/setuptools/warnings.py
+++ b/setuptools/warnings.py
@@ -12,10 +12,7 @@ import warnings
 from datetime import date
 from inspect import cleandoc
 from textwrap import indent
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from typing import TypeAlias
+from typing import TypeAlias
 
 _DueDate: TypeAlias = tuple[int, int, int]  # time tuple
 _INDENT = 8 * " "


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Follow-up to https://github.com/pypa/setuptools/pull/5220, removes now redundant `TYPE_CHECKING` blocks

### Pull Request Checklist
- [N/A] Changes have tests (nothing new to tests, existing tests should cover)
- [N/A] News fragment added in [`newsfragments/`]. (not public facing)
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
