### PR TITLE
Update dependencies dropping Python 3.9 (drop `importlib_metadata` dependency)

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -54,9 +54,8 @@ follow_untyped_imports = True
 #  - jaraco: Since mypy 1.12, the root name of the untyped namespace package gets called-out too
 #  - jaraco.develop: https://github.com/jaraco/jaraco.develop/issues/22
 #  - jaraco.envs: https://github.com/jaraco/jaraco.envs/issues/7
-#  - jaraco.packaging: https://github.com/jaraco/jaraco.packaging/issues/20
 #  - jaraco.path: https://github.com/jaraco/jaraco.path/issues/2
-[mypy-jaraco,jaraco.develop.*,jaraco.envs,jaraco.packaging.*,jaraco.path]
+[mypy-jaraco,jaraco.develop.*,jaraco.envs.*,jaraco.path]
 follow_untyped_imports = True
 
 # Even when excluding a module, import issues can show up due to following import

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,10 +18,6 @@ disable_error_code =
 
 ## local
 
-# CI should test for all versions, local development gets hints for oldest supported
-# But our testing setup doesn't allow passing CLI arguments, so local devs have to set this manually.
-# python_version = 3.9
-
 exclude = (?x)(
 	# Avoid scanning Python files in generated folders
 	^build/

--- a/newsfragments/5222.feature.rst
+++ b/newsfragments/5222.feature.rst
@@ -1,0 +1,1 @@
+Dropped dependency on :pypi:`importlib_metadata` -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ test = [
 	"pytest-timeout",
 	'pytest-perf; sys_platform != "cygwin"', # workaround for jaraco/inflect#195, pydantic/pydantic-core#773 (see #3986)
 	# for tools/finalize.py
-	'jaraco.develop >= 7.21; python_version >= "3.9" and sys_platform != "cygwin"',
+	'jaraco.develop >= 7.21; sys_platform != "cygwin"',
 	"pytest-home >= 0.5",
 	"pytest-subprocess",
 
@@ -98,7 +98,6 @@ core = [
 	"packaging>=24.2",
 	"more_itertools>=8.8",
 	"jaraco.text>=3.7",
-	"importlib_metadata>=6; python_version < '3.10'",
 	"tomli>=2.0.1; python_version < '3.11'",
 	"wheel>=0.43.0",
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -9,9 +9,12 @@
 		// These are vendored
 		"**/_vendor",
 		"setuptools/_distutils",
+		// Default excludes
+		"**/node_modules",
+		"**/__pycache__",
+		"**/.*",
+		".venv",
 	],
-	// Our testing setup doesn't allow passing CLI arguments, so local devs have to set this manually.
-	// "pythonVersion": "3.9",
 	// For now we don't mind if mypy's `type: ignore` comments accidentally suppresses pyright issues
 	"enableTypeIgnoreComments": true,
 	"typeCheckingMode": "basic",

--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -1,12 +1,12 @@
 import functools
 import itertools
 import operator
+from importlib import metadata
 
 from jaraco.functools import pass_none
 from jaraco.text import yield_lines
 from more_itertools import consume
 
-from ._importlib import metadata
 from ._itertools import ensure_unique
 from .errors import OptionError
 

--- a/setuptools/_importlib.py
+++ b/setuptools/_importlib.py
@@ -1,4 +1,0 @@
-from importlib import (
-    metadata,  # noqa: F401
-    resources,  # noqa: F401
-)

--- a/setuptools/_scripts.py
+++ b/setuptools/_scripts.py
@@ -9,9 +9,8 @@ import subprocess
 import sys
 import textwrap
 from collections.abc import Iterable
+from importlib import metadata, resources
 from typing import TYPE_CHECKING, TypedDict
-
-from ._importlib import metadata, resources
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -10,6 +10,7 @@ import re
 import sys
 import time
 from collections.abc import Callable
+from importlib import metadata
 from typing import ClassVar
 
 import packaging
@@ -23,7 +24,6 @@ from setuptools.command.setopt import edit_config
 from setuptools.glob import glob
 
 from .. import _entry_points, _normalization
-from .._importlib import metadata
 from ..warnings import SetuptoolsDeprecationWarning
 from . import _requirestxt
 

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -32,8 +32,9 @@ class install_scripts(orig.install_scripts):
 
     def _install_ep_scripts(self):
         # Delay import side-effects
+        from importlib import metadata
+
         from .. import _scripts
-        from .._importlib import metadata
 
         ei_cmd = self.get_finalized_command("egg_info")
         dist = metadata.Distribution.at(path=ei_cmd.egg_info)

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -4,10 +4,10 @@ import contextlib
 import os
 import re
 from collections.abc import Iterator
+from importlib import metadata
 from itertools import chain
 from typing import ClassVar
 
-from .._importlib import metadata
 from ..dist import Distribution
 from .build import _ORIGINAL_SUBCOMMANDS
 

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -27,9 +27,9 @@ from ..extension import Extension
 from ..warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
 
 if TYPE_CHECKING:
+    from importlib import metadata
     from typing import TypeAlias
 
-    from setuptools._importlib import metadata
     from setuptools.dist import Distribution
 
     from distutils.dist import _OptionsList  # Comes from typeshed
@@ -329,9 +329,9 @@ def _copy_command_options(pyproject: dict, dist: Distribution, filename: StrPath
 
 
 def _valid_command_options(cmdclass: Mapping = EMPTY) -> dict[str, set[str]]:
-    from setuptools.dist import Distribution
+    from importlib import metadata
 
-    from .._importlib import metadata
+    from setuptools.dist import Distribution
 
     valid_options = {"global": _normalise_cmd_options(Distribution.global_options)}
 

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -9,6 +9,7 @@ import re
 import sys
 from collections.abc import Iterable, Iterator, MutableMapping, Sequence
 from glob import glob
+from importlib import metadata
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -23,7 +24,6 @@ from . import (
     _static,
     command as _,  # noqa: F401 # imported for side-effects
 )
-from ._importlib import metadata
 from ._normalization import _canonicalize_license_expression
 from ._path import StrPath
 from ._reqs import _StrOrIter

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -60,8 +60,6 @@ Supported iterable types that are known to be:
 for use with `isinstance`.
 """
 _Sequence: TypeAlias = tuple[str, ...] | list[str]
-# This is how stringifying _Sequence would look in Python 3.10
-_sequence_type_repr = "tuple[str, ...] | list[str]"
 _OrderedStrSequence: TypeAlias = str | dict[str, Any] | Sequence[str]
 """
 :meta private:
@@ -101,7 +99,7 @@ def assert_string_list(dist, attr: str, value: _Sequence) -> None:
         assert ''.join(value) != value
     except (TypeError, ValueError, AttributeError, AssertionError) as e:
         raise DistutilsSetupError(
-            f"{attr!r} must be of type <{_sequence_type_repr}> (got {value!r})"
+            f"{attr!r} must be of type <{_Sequence}> (got {value!r})"
         ) from e
 
 
@@ -925,7 +923,7 @@ class Distribution(_Distribution):
         """Handle 'exclude()' for list/tuple attrs without a special handler"""
         if not isinstance(value, _sequence):
             raise DistutilsSetupError(
-                f"{name}: setting must be of type <{_sequence_type_repr}> (got {value!r})"
+                f"{name}: setting must be of type <{_Sequence}> (got {value!r})"
             )
         try:
             old = getattr(self, name)
@@ -943,7 +941,7 @@ class Distribution(_Distribution):
 
         if not isinstance(value, _sequence):
             raise DistutilsSetupError(
-                f"{name}: setting must be of type <{_sequence_type_repr}> (got {value!r})"
+                f"{name}: setting must be of type <{_Sequence}> (got {value!r})"
             )
         try:
             old = getattr(self, name)
@@ -985,7 +983,7 @@ class Distribution(_Distribution):
     def _exclude_packages(self, packages: _Sequence) -> None:
         if not isinstance(packages, _sequence):
             raise DistutilsSetupError(
-                f"packages: setting must be of type <{_sequence_type_repr}> (got {packages!r})"
+                f"packages: setting must be of type <{_Sequence}> (got {packages!r})"
             )
         list(map(self.exclude_package, packages))
 

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -6,12 +6,12 @@ import os
 import subprocess
 import sys
 import tempfile
+from importlib import metadata
 
 import packaging.requirements
 import packaging.utils
 
 from . import _reqs
-from ._importlib import metadata
 from .warnings import SetuptoolsDeprecationWarning
 from .wheel import Wheel
 

--- a/setuptools/tests/test_editable_install.py
+++ b/setuptools/tests/test_editable_install.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.resources
 import os
 import platform
 import stat
@@ -14,12 +15,10 @@ from typing import Any, ClassVar
 from unittest.mock import Mock
 from uuid import uuid4
 
-import jaraco.envs
 import jaraco.path
 import pytest
 from path import Path as _Path
 
-from setuptools._importlib import resources as importlib_resources
 from setuptools.command.editable_wheel import (
     _encode_pth,
     _find_namespaces,
@@ -494,7 +493,7 @@ class TestFinderTemplate:
 
             self.install_finder(template)
             pkg = import_module("ns.othername")
-            text = importlib_resources.files(pkg) / "text.txt"
+            text = importlib.resources.files(pkg) / "text.txt"
 
             expected = str((tmp_path / "pkg").resolve())
             assert_path(pkg, expected)
@@ -924,8 +923,8 @@ class TestOverallBehaviour:
         # Ensure resources are reachable
         cmd_get_resource = """\
         import mypkg.subpackage
-        from setuptools._importlib import resources as importlib_resources
-        text = importlib_resources.files(mypkg.subpackage) / "resource_file.txt"
+        import importlib.resources
+        text = importlib.resources.files(mypkg.subpackage) / "resource_file.txt"
         print(text.read_text(encoding="utf-8"))
         """
         out = venv.run(["python", "-c", dedent(cmd_get_resource)])
@@ -1022,9 +1021,9 @@ class TestLinkTree:
         # Ensure resource files excluded from distribution are not reachable
         cmd_get_resource = """\
         import mypkg
-        from setuptools._importlib import resources as importlib_resources
+        import importlib.resources
         try:
-            text = importlib_resources.files(mypkg) / "resource.not_in_manifest"
+            text = importlib.resources.files(mypkg) / "resource.not_in_manifest"
             print(text.read_text(encoding="utf-8"))
         except FileNotFoundError as ex:
             print(ex)

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -9,6 +9,7 @@ import sys
 import tarfile
 import tempfile
 import unicodedata
+from importlib import metadata
 from inspect import cleandoc
 from pathlib import Path
 from typing import ClassVar
@@ -18,7 +19,6 @@ import jaraco.path
 import pytest
 
 from setuptools import Command, SetuptoolsDeprecationWarning
-from setuptools._importlib import metadata
 from setuptools.command.egg_info import manifest_maker
 from setuptools.command.sdist import sdist
 from setuptools.dist import Distribution

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -12,13 +12,13 @@ import subprocess
 import sys
 import sysconfig
 import zipfile
+from importlib import metadata
 from typing import Any
 
 import pytest
 from jaraco import path
 from packaging.tags import parse_tag
 
-from setuptools._importlib import metadata
 from setuptools.wheel import Wheel
 
 from .contexts import tempdir

--- a/setuptools/tests/test_windows_wrappers.py
+++ b/setuptools/tests/test_windows_wrappers.py
@@ -17,10 +17,9 @@ import platform
 import subprocess
 import sys
 import textwrap
+from importlib import resources
 
 import pytest
-
-from setuptools._importlib import resources
 
 pytestmark = pytest.mark.skipif(sys.platform != 'win32', reason="Windows only")
 

--- a/setuptools/version.py
+++ b/setuptools/version.py
@@ -1,4 +1,4 @@
-from ._importlib import metadata
+from importlib import metadata
 
 try:
     __version__ = metadata.version('setuptools') or '0.dev0+unknown'

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -9,6 +9,7 @@ import posixpath
 import re
 import zipfile
 from collections.abc import Iterator
+from importlib import metadata
 
 from packaging.requirements import Requirement
 from packaging.tags import sys_tags
@@ -20,7 +21,6 @@ from setuptools.archive_util import _unpack_zipfile_obj
 from setuptools.command.egg_info import _egg_basename, write_requirements
 
 from ._discovery import extras_from_deps
-from ._importlib import metadata
 from .unicode_utils import _read_utf8_with_fallback
 
 from distutils.util import get_platform


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Following https://github.com/pypa/setuptools/pull/5220/, `importlib_metadata` is no longer used and can be dropped
Also removed a now obsolete CI workaround for Python 3.9

Obsoletes / Closes #4572

### Pull Request Checklist
- [x] Changes have tests (existing tests should already cover)
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
