### PR TITLE
Fix case-insensitive extension lookup in CygwinCCompiler._make_out_path

### DIFF
--- a/setuptools/_distutils/compilers/C/cygwin.py
+++ b/setuptools/_distutils/compilers/C/cygwin.py
@@ -225,9 +225,12 @@ class Compiler(unix.Compiler):
     # -- Miscellaneous methods -----------------------------------------
 
     def _make_out_path(self, output_dir, strip_dir, src_name):
-        # use normcase to make sure '.rc' is really '.rc' and not '.RC'
-        norm_src_name = os.path.normcase(src_name)
-        return super()._make_out_path(output_dir, strip_dir, norm_src_name)
+        # Use normcase for case-insensitive extension lookup on Cygwin,
+        # where '.RC' should match '.rc' and '.S' should match '.s'.
+        return self._make_out_path_exts(
+            output_dir, strip_dir, os.path.normcase(src_name),
+            {os.path.normcase(k): v for k, v in super().out_extensions.items()},
+        )
 
     @property
     def out_extensions(self):


### PR DESCRIPTION
## Summary

`os.path.normcase` was applied to the source filename but not to the
extension lookup keys in `out_extensions`. On Cygwin/Windows, `normcase`
lowercases the filename, so a source file like `foo.S` would have its
suffix lowercased to `.s`. If `.s` was not a key in `out_extensions`
(e.g. only `.S` was added via `src_extensions.append(".S")`), this
raised `UnknownFileType: unknown file type '.s'`.

## Fix

Apply `os.path.normcase` to both the source name **and** the extension
dictionary keys so that any casing of `.rc`, `.S`, `.c`, etc. is handled
correctly regardless of how the extension was registered.

This preserves the original intent of the `normcase` call (handling
`.RC` → `.rc` for resource files) while also fixing uppercase extensions
like `.S` for assembly files.

Closes #5130