### PR TITLE
docs: clarify 'directory structure' wording in package discovery

### DIFF
--- a/docs/userguide/package_discovery.rst
+++ b/docs/userguide/package_discovery.rst
@@ -50,7 +50,9 @@ Normally, you would specify the packages to be included manually in the followin
 
 
 If your packages are not in the root of the repository or do not correspond
-exactly to the directory structure, you also need to configure ``package_dir``:
+exactly to the directory structure (that is, the directory layout in your
+repository does not match the dotted package hierarchy you want installed on
+the end-user's machine), you also need to configure ``package_dir``:
 
 .. tab:: setup.cfg
 

--- a/newsfragments/4109.doc.rst
+++ b/newsfragments/4109.doc.rst
@@ -1,0 +1,2 @@
+Clarified what "correspond exactly to the directory structure" means in
+the ``packages`` section of the Package Discovery user guide.


### PR DESCRIPTION
## Summary of changes

Adds a parenthetical clarification in `docs/userguide/package_discovery.rst` explaining what "correspond exactly to the directory structure" means before the `package_dir` example, so readers know the phrase refers to the repository layout versus the dotted package hierarchy installed on the end-user's machine. This is the wording the reporter on #4109 specifically asked about, and @abravalheri confirmed on the same issue: "We are looking for volunteers to help update the documentations. Please feel free to open PRs if you feel you can help."

Closes #4109

### Pull Request Checklist
- [ ] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request