### PR TITLE
Avoid copying extension sources as package data

### DIFF
--- a/newsfragments/5133.bugfix.rst
+++ b/newsfragments/5133.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``build_py`` to avoid copying extension source files from ``SOURCES.txt``
+into ``build/lib`` as package data.

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -182,6 +182,7 @@ class build_py(orig.build_py):
         for package in self.packages or ():
             # Locate package source directory
             src_dirs[assert_relative(self.get_package_dir(package))] = package
+        extension_files = self._get_extension_source_files()
 
         if (
             self.existing_egg_info_dir
@@ -197,7 +198,12 @@ class build_py(orig.build_py):
             files = ei_cmd.filelist.files
 
         check = _IncludePackageDataAbuse()
-        for path in self._filter_build_files(files, egg_info_dir):
+        files = (
+            path
+            for path in self._filter_build_files(files, egg_info_dir)
+            if self._path_norm(path) not in extension_files
+        )
+        for path in files:
             d, f = os.path.split(assert_relative(path))
             prev = None
             oldf = f
@@ -214,6 +220,18 @@ class build_py(orig.build_py):
                     if importable:
                         check.warn(importable)
                 self.manifest_files.setdefault(src_dirs[d], []).append(path)
+
+    def _get_extension_source_files(self) -> set[str]:
+        """Return extension source files that are build inputs."""
+        return {
+            self._path_norm(path)
+            for ext in self.distribution.ext_modules or ()
+            for path in getattr(ext, "sources", None) or ()
+        }
+
+    @staticmethod
+    def _path_norm(path: StrPath) -> str:
+        return os.path.normcase(os.path.abspath(os.fspath(path)))
 
     def _filter_build_files(
         self, files: Iterable[str], egg_info: StrPath

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -10,6 +10,7 @@ import pytest
 
 from setuptools import SetuptoolsDeprecationWarning
 from setuptools.dist import Distribution
+from setuptools.extension import Extension
 
 from .textwrap import DALS
 
@@ -256,6 +257,48 @@ def test_existing_egg_info(tmpdir_cwd, monkeypatch):
     assert outputs
     example = str(Path(build_py.build_lib, "mypkg/__init__.py")).replace(os.sep, "/")
     assert example in outputs
+
+
+def test_extension_sources_are_not_package_data(tmpdir_cwd):
+    """
+    Extension source files belong in sdists, but build_py should not copy them
+    to build/lib as package data.
+    """
+    jaraco.path.build({
+        "src": {
+            "foo": {
+                "__init__.py": "",
+                "resource.txt": "",
+                "extension": {"bar.cpp": ""},
+            },
+        },
+    })
+    egg_info_dir = Path("src/foo.egg-info")
+    egg_info_dir.mkdir()
+    (egg_info_dir / "SOURCES.txt").write_text(
+        f"{os.path.join('src', 'foo', 'resource.txt')}\n"
+        f"{os.path.join('src', 'foo', 'extension', 'bar.cpp')}\n",
+        encoding="utf-8",
+    )
+    dist = Distribution({
+        "name": "foo",
+        "version": "1",
+        "script_name": "%build_py-test%",
+        "packages": ["foo"],
+        "package_dir": {"": "src"},
+        "include_package_data": True,
+        "ext_modules": [Extension("foo.extension", ["src/foo/extension/bar.cpp"])],
+    })
+
+    build_py = dist.get_command_obj("build_py")
+    build_py.finalize_options()
+    build_py.existing_egg_info_dir = egg_info_dir
+    build_py.run()
+
+    outputs = get_outputs(build_py)
+    assert "foo/__init__.py" in outputs
+    assert "foo/resource.txt" in outputs
+    assert "foo/extension/bar.cpp" not in outputs
 
 
 EXAMPLE_ARBITRARY_MAPPING = {


### PR DESCRIPTION
## Summary of changes

`build_py` now filters extension source files from manifest-derived package data before copying files into `build/lib`. Regular package data from `SOURCES.txt` is still copied, and extension sources remain available to sdist handling.

Closes #5133

## Tests

- `.venv\Scripts\python -m pytest setuptools\tests\test_build_py.py -q`
- `.venv\Scripts\python -m pytest setuptools\tests\test_sdist.py::TestSdistTest::test_extension_sources_in_sdist setuptools\tests\test_sdist.py::TestSdistTest::test_missing_extension_sources setuptools\tests\test_sdist.py::TestSdistTest::test_symlinked_extension_sources -q`
- `.venv\Scripts\python -m ruff check setuptools\command\build_py.py setuptools\tests\test_build_py.py`
- `.venv\Scripts\python -m ruff format --check setuptools\command\build_py.py setuptools\tests\test_build_py.py`
- `git diff --check`

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`](https://github.com/pypa/setuptools/tree/main/newsfragments).