### PR TITLE
Remove `typing.AnyStr` usage

### DIFF
--- a/setuptools/_distutils/util.py
+++ b/setuptools/_distutils/util.py
@@ -17,7 +17,7 @@ import sys
 import sysconfig
 import tempfile
 from collections.abc import Callable, Iterable, Mapping
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, AnyStr
 
 from jaraco.functools import pass_none
 
@@ -30,8 +30,6 @@ if TYPE_CHECKING:
     from typing_extensions import TypeVarTuple, Unpack
 
     _Ts = TypeVarTuple("_Ts")
-
-    _StrBytes = TypeVar("_StrBytes", str, bytes)
 
 
 def get_host_platform() -> str:
@@ -142,8 +140,8 @@ def convert_path(pathname: str | os.PathLike[str]) -> str:
 
 
 def change_root(
-    new_root: _StrBytes | os.PathLike[_StrBytes], pathname: _StrBytes | os.PathLike[_StrBytes]
-) -> _StrBytes:
+    new_root: AnyStr | os.PathLike[AnyStr], pathname: AnyStr | os.PathLike[AnyStr]
+) -> AnyStr:
     """Return 'pathname' with 'new_root' prepended.  If 'pathname' is
     relative, this is equivalent to "os.path.join(new_root,pathname)".
     Otherwise, it requires making 'pathname' relative and then joining the

--- a/setuptools/_distutils/util.py
+++ b/setuptools/_distutils/util.py
@@ -17,7 +17,7 @@ import sys
 import sysconfig
 import tempfile
 from collections.abc import Callable, Iterable, Mapping
-from typing import TYPE_CHECKING, AnyStr
+from typing import TYPE_CHECKING, TypeVar
 
 from jaraco.functools import pass_none
 
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from typing_extensions import TypeVarTuple, Unpack
 
     _Ts = TypeVarTuple("_Ts")
+
+    _StrBytes = TypeVar("_StrBytes", str, bytes)
 
 
 def get_host_platform() -> str:
@@ -140,8 +142,8 @@ def convert_path(pathname: str | os.PathLike[str]) -> str:
 
 
 def change_root(
-    new_root: AnyStr | os.PathLike[AnyStr], pathname: AnyStr | os.PathLike[AnyStr]
-) -> AnyStr:
+    new_root: _StrBytes | os.PathLike[_StrBytes], pathname: _StrBytes | os.PathLike[_StrBytes]
+) -> _StrBytes:
     """Return 'pathname' with 'new_root' prepended.  If 'pathname' is
     relative, this is equivalent to "os.path.join(new_root,pathname)".
     Otherwise, it requires making 'pathname' relative and then joining the

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -12,7 +12,7 @@ import textwrap
 from collections.abc import Iterator
 from sysconfig import get_path, get_platform, get_python_version
 from types import CodeType
-from typing import TYPE_CHECKING, AnyStr, Literal
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from setuptools import Command
 from setuptools.extension import Library
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
     from typing import TypeAlias
 
     from _typeshed import GenericPath
+
+    _StrOrBytesT = TypeVar("_StrOrBytesT", bound=str | bytes)
 
 # Same as zipfile._ZipFileMode from typeshed
 _ZipFileMode: TypeAlias = Literal["r", "w", "x", "a"]
@@ -43,8 +45,8 @@ def strip_module(filename):
 
 
 def sorted_walk(
-    dir: GenericPath[AnyStr],
-) -> Iterator[tuple[AnyStr, list[AnyStr], list[AnyStr]]]:
+    dir: GenericPath[_StrOrBytesT],
+) -> Iterator[tuple[_StrOrBytesT, list[_StrOrBytesT], list[_StrOrBytesT]]]:
     """Do os.walk in a reproducible way,
     independent of indeterministic filesystem readdir order
     """

--- a/setuptools/glob.py
+++ b/setuptools/glob.py
@@ -12,15 +12,17 @@ import fnmatch
 import os
 import re
 from collections.abc import Iterable, Iterator
-from typing import TYPE_CHECKING, AnyStr, overload
+from typing import TYPE_CHECKING, TypeVar, overload
 
 if TYPE_CHECKING:
     from _typeshed import BytesPath, StrOrBytesPath, StrPath
 
+    _StrOrBytesT = TypeVar("_StrOrBytesT", bound=str | bytes)
+
 __all__ = ["glob", "iglob", "escape"]
 
 
-def glob(pathname: AnyStr, recursive: bool = False) -> list[AnyStr]:
+def glob(pathname: _StrOrBytesT, recursive: bool = False) -> list[_StrOrBytesT]:
     """Return a list of paths matching a pathname pattern.
 
     The pattern may contain simple shell-style wildcards a la
@@ -34,7 +36,7 @@ def glob(pathname: AnyStr, recursive: bool = False) -> list[AnyStr]:
     return list(iglob(pathname, recursive=recursive))
 
 
-def iglob(pathname: AnyStr, recursive: bool = False) -> Iterator[AnyStr]:
+def iglob(pathname: _StrOrBytesT, recursive: bool = False) -> Iterator[_StrOrBytesT]:
     """Return an iterator which yields the paths matching a pathname pattern.
 
     The pattern may contain simple shell-style wildcards a la
@@ -52,7 +54,7 @@ def iglob(pathname: AnyStr, recursive: bool = False) -> Iterator[AnyStr]:
     return it
 
 
-def _iglob(pathname: AnyStr, recursive: bool) -> Iterator[AnyStr]:
+def _iglob(pathname: _StrOrBytesT, recursive: bool) -> Iterator[_StrOrBytesT]:
     dirname, basename = os.path.split(pathname)
     glob_in_dir = glob2 if recursive and _isrecursive(basename) else glob1
 
@@ -73,7 +75,7 @@ def _iglob(pathname: AnyStr, recursive: bool) -> Iterator[AnyStr]:
     # drive or UNC path.  Prevent an infinite recursion if a drive or UNC path
     # contains magic characters (i.e. r'\\?\C:').
     if dirname != pathname and has_magic(dirname):
-        dirs: Iterable[AnyStr] = _iglob(dirname, recursive)
+        dirs: Iterable[_StrOrBytesT] = _iglob(dirname, recursive)
     else:
         dirs = [dirname]
     if not has_magic(basename):


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Hi 👋 
We are deprecating `AnyStr` with a warning since Python 3.16, this is a proactive PR to replace it with a modern alternative.
Context https://github.com/python/cpython/pull/150190

<!-- Summary goes here -->

### Pull Request Checklist
- [ ] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request

This is not really a user-facing change (at least it should not be), so no changelog entries. 