### PR TITLE
Add PEP 794 import name metadata support

### DIFF
--- a/newsfragments/5112.feature.rst
+++ b/newsfragments/5112.feature.rst
@@ -1,0 +1,1 @@
+Added support for ``project.import-names`` and ``project.import-namespaces`` from PEP 794 when generating Core Metadata 2.5.

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -100,6 +100,8 @@ def read_pkg_file(self, file):
 
     self.platforms = _read_list_from_msg(msg, 'platform')
     self.classifiers = _read_list_from_msg(msg, 'classifier')
+    self.import_names = _read_list_from_msg(msg, 'import-name') or []
+    self.import_namespaces = _read_list_from_msg(msg, 'import-namespace') or []
 
     # PEP 314 - these fields only exist in 1.1
     if self.metadata_version == Version('1.1'):
@@ -150,6 +152,9 @@ def write_pkg_info(self, base_dir):
 def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     """Write the PKG-INFO format data to a file object."""
     version = self.get_metadata_version()
+    if (self.import_names or self.import_namespaces) and version < Version('2.5'):
+        version = Version('2.5')
+        self.metadata_version = version
 
     def write_field(key, value):
         file.write(f"{key}: {value}\n")
@@ -193,6 +198,8 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
         write_field('Platform', platform)
 
     self._write_list(file, 'Classifier', self.get_classifiers())
+    self._write_list(file, 'Import-Name', self.import_names)
+    self._write_list(file, 'Import-Namespace', self.import_namespaces)
 
     # PEP 314
     self._write_list(file, 'Requires', self.get_requires())
@@ -312,6 +319,8 @@ _POSSIBLE_DYNAMIC_FIELDS = {
     "download-url": "download_url",
     "home-page": "url",
     "keywords": "keywords",
+    "import-name": "import_names",
+    "import-namespace": "import_namespaces",
     "license": "license",
     # XXX: License-File is complicated because the user gives globs that are expanded
     #      during the build. Without special handling it is likely always

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -454,6 +454,8 @@ TOOL_TABLE_CORRESPONDENCE = {
 }
 
 SETUPTOOLS_PATCHES = {
+    "import_names",
+    "import_namespaces",
     "long_description_content_type",
     "project_urls",
     "provides_extras",
@@ -480,6 +482,8 @@ _PREVIOUSLY_DEFINED = {
     "keywords": _attrgetter("metadata.keywords"),
     "classifiers": _attrgetter("metadata.classifiers"),
     "urls": _attrgetter("metadata.project_urls"),
+    "import-names": _attrgetter("metadata.import_names"),
+    "import-namespaces": _attrgetter("metadata.import_namespaces"),
     "entry-points": _get_previous_entrypoints,
     "scripts": _get_previous_scripts,
     "gui-scripts": _get_previous_gui_scripts,
@@ -500,6 +504,8 @@ _RESET_PREVIOUSLY_DEFINED: dict = {
     "keywords": _static.EMPTY_LIST,
     "classifiers": _static.EMPTY_LIST,
     "urls": _static.EMPTY_DICT,
+    "import-names": _static.EMPTY_LIST,
+    "import-namespaces": _static.EMPTY_LIST,
     "entry-points": _static.EMPTY_DICT,
     "scripts": _static.EMPTY_DICT,
     "gui-scripts": _static.EMPTY_DICT,

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -134,15 +134,6 @@ def read_configuration(
     if "ext-modules" in setuptools_table:
         _ExperimentalConfiguration.emit(subject="[tool.setuptools.ext-modules]")
 
-    fields = ("import-names", "import-namespaces")
-    places = (project_table, project_table.get("dynamic", []))
-    if any(field in place for field in fields for place in places):
-        raise NotImplementedError(
-            "Setuptools does not support `import-names` and `import-namespaces`"
-            " in `pyproject.toml` yet. If your are interested in this feature, "
-            " please consider submitting a contribution via pull requests."
-        )
-
     with _ignore_errors(ignore_option_errors):
         # Don't complain about unrelated errors (e.g. tools not using the "tool" table)
         subset = {"project": project_table, "tool": {"setuptools": setuptools_table}}

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -289,6 +289,8 @@ class Distribution(_Distribution):
         'long_description_content_type': lambda: None,
         'project_urls': dict,
         'provides_extras': dict,  # behaves like an ordered set
+        'import_names': list,
+        'import_namespaces': list,
         'license_expression': lambda: None,
         'license_file': lambda: None,
         'license_files': lambda: None,

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -287,15 +287,30 @@ class TestClassifiers:
 
 
 class TestImportNames:
-    EXAMPLES = [
-        'import-names = ["hello", "world"]',
-        'import-namespaces = ["hello", "world"]',
-        'dynamic = ["import-names"]',
-        'dynamic = ["import-namespaces"]',
-    ]
+    def test_apply_static_import_names(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        pyproject = Path("pyproject.toml")
+        toml_config = """
+        [project]
+        name = 'proj'
+        version = '42'
+        import-names = ['hello', 'hello._private']
+        import-namespaces = ['world']
+        """
+        pyproject.write_text(cleandoc(toml_config), encoding="utf-8")
+        dist = apply_configuration(Distribution({}), pyproject)
 
-    @pytest.mark.parametrize("example", EXAMPLES)
-    def test_not_implemented(self, monkeypatch, tmp_path, example):
+        assert dist.metadata.import_names == ['hello', 'hello._private']
+        assert dist.metadata.import_namespaces == ['world']
+
+    @pytest.mark.parametrize(
+        "example",
+        (
+            'import-names = ["hello"]\nimport-namespaces = ["hello"]',
+            'import-names = ["hello.world"]',
+        ),
+    )
+    def test_validate_import_name_issues(self, monkeypatch, tmp_path, example):
         monkeypatch.chdir(tmp_path)
         pyproject = Path("pyproject.toml")
         toml_config = f"""
@@ -305,7 +320,8 @@ class TestImportNames:
         {example}
         """
         pyproject.write_text(cleandoc(toml_config), encoding="utf-8")
-        with pytest.raises(NotImplementedError, match='import-names'):
+
+        with pytest.raises(ValueError, match='import-names'):
             apply_configuration(Distribution({}), pyproject)
 
 

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -162,6 +162,13 @@ def __read_test_cases():
                 version=sic('1.0.0a'),
             ),
         ),
+        (
+            'Metadata Version 2.5: Import names',
+            params(
+                import_names=['package', 'package._private'],
+                import_namespaces=['package.plugins'],
+            ),
+        ),
     ]
 
 
@@ -200,6 +207,8 @@ def test_read_metadata(name, attrs):
         ('classifiers', dist_class.get_classifiers),
         ('project_urls', lambda s: getattr(s, 'project_urls', {})),
         ('provides_extras', lambda s: getattr(s, 'provides_extras', {})),
+        ('import_names', lambda s: getattr(s, 'import_names', [])),
+        ('import_namespaces', lambda s: getattr(s, 'import_namespaces', [])),
     ]
 
     for attr, getter in tested_attrs:
@@ -527,6 +536,21 @@ class TestPEP643:
             "AUTHORS.txt",
             "LICENSE.md",
         }
+
+    def test_import_names(self):
+        dist = Distribution(
+            {
+                "name": "package",
+                "version": "0.0.1",
+                "import_names": ["package", "package._private"],
+                "import_namespaces": ["package.plugins"],
+            }
+        )
+        metadata = _get_metadata(dist)
+
+        assert metadata["Metadata-Version"] == "2.5"
+        assert metadata.get_all("Import-Name") == ["package", "package._private"]
+        assert metadata.get_all("Import-Namespace") == ["package.plugins"]
 
 
 def _makedist(**attrs):


### PR DESCRIPTION
## Summary

- accept static `project.import-names` and `project.import-namespaces` values from `pyproject.toml`
- emit `Import-Name` / `Import-Namespace` Core Metadata 2.5 headers and read them back from PKG-INFO
- preserve existing PEP 794 validation for duplicate names and missing parents

Closes #5112.

## Testing

- `python -m pytest setuptools\tests\config\test_pyprojecttoml.py setuptools\tests\test_core_metadata.py setuptools\tests\config\test_apply_pyprojecttoml.py -q`
- `git diff --check` (passes with existing LF-to-CRLF warnings on Windows)

## Checklist

- [x] News fragment added in `newsfragments/`.