### PR TITLE
Preserve Dynamic requires-dist for empty dependencies

### DIFF
--- a/newsfragments/5120.bugfix.rst
+++ b/newsfragments/5120.bugfix.rst
@@ -1,0 +1,1 @@
+Preserved ``Dynamic: requires-dist`` in generated metadata when dynamic dependencies are supplied as an empty ``install_requires=[]`` value.

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -212,7 +212,8 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     _write_requirements(self, file)
 
     for field, attr in _POSSIBLE_DYNAMIC_FIELDS.items():
-        if (val := getattr(self, attr, None)) and not is_static(val):
+        val = getattr(self, attr, None)
+        if (val or _include_empty_dynamic_requires_dist(field, val)) and not is_static(val):
             write_field('Dynamic', field)
 
     long_description = self.get_long_description()
@@ -335,3 +336,12 @@ _POSSIBLE_DYNAMIC_FIELDS = {
     "summary": "description",
     # "supported-platform": "supported_platforms",  # NOT USED
 }
+
+
+def _include_empty_dynamic_requires_dist(field: str, value: object) -> bool:
+    """
+    An empty, explicitly supplied dependency list should still produce
+    ``Dynamic: requires-dist``. ``Requires-Dist`` itself has no value to write
+    in that case, so truthiness alone is not enough to detect the dynamic field.
+    """
+    return field == "requires-dist" and isinstance(value, (list, tuple)) and not value

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -292,8 +292,8 @@ class Distribution(_Distribution):
         'license_expression': lambda: None,
         'license_file': lambda: None,
         'license_files': lambda: None,
-        'install_requires': list,
-        'extras_require': dict,
+        'install_requires': _static.List,
+        'extras_require': _static.Dict,
     }
 
     # Used by build_py, editable_wheel and install_lib commands for legacy namespaces
@@ -392,8 +392,13 @@ class Distribution(_Distribution):
 
     def _normalize_requires(self):
         """Make sure requirement-related attributes exist and are normalized"""
-        install_requires = getattr(self, "install_requires", None) or []
-        extras_require = getattr(self, "extras_require", None) or {}
+        install_requires = getattr(self, "install_requires", None)
+        if install_requires is None:
+            install_requires = _static.EMPTY_LIST
+
+        extras_require = getattr(self, "extras_require", None)
+        if extras_require is None:
+            extras_require = _static.EMPTY_DICT
 
         # Preserve the "static"-ness of values parsed from config files
         list_ = _static.List if _static.is_static(install_requires) else list

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -454,6 +454,36 @@ class TestPEP643:
         assert metadata.get_all("Dynamic") is None
         assert metadata.get_all("dynamic") is None
 
+    def test_empty_default_dependencies_are_not_dynamic(self, tmpdir_cwd):
+        Path("pyproject.toml").write_text(
+            cleandoc(
+                """
+                [project]
+                name = "package"
+                version = "0.0.1"
+                """
+            ),
+            encoding="utf-8",
+        )
+        metadata = _get_metadata()
+        assert metadata.get_all("Dynamic") is None
+
+    def test_empty_dynamic_dependencies_are_marked_as_dynamic(self, tmpdir_cwd):
+        Path("pyproject.toml").write_text(
+            cleandoc(
+                """
+                [project]
+                name = "package"
+                version = "0.0.1"
+                dynamic = ["dependencies"]
+                """
+            ),
+            encoding="utf-8",
+        )
+        metadata = _get_metadata(_makedist(install_requires=[]))
+        assert metadata.get_all("Requires-Dist") is None
+        assert metadata.get_all("Dynamic") == ["requires-dist"]
+
     @pytest.mark.parametrize("file", STATIC_CONFIG.keys())
     @pytest.mark.parametrize(
         "fields",


### PR DESCRIPTION
## Summary of changes

Preserve `Dynamic: requires-dist` in generated metadata when `project.dynamic = ["dependencies"]` is satisfied by an explicit empty `install_requires=[]` value.

Closes #5120

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].

Verification:
- `uv run --extra test --extra cover pytest setuptools/tests/test_core_metadata.py::TestPEP643 -q`
- `uv run --extra test --extra cover pytest setuptools/tests/test_core_metadata.py setuptools/tests/config/test_apply_pyprojecttoml.py::TestPresetField -q`
- `uv run --extra check ruff check setuptools/_core_metadata.py setuptools/dist.py setuptools/tests/test_core_metadata.py`
- `git diff --check`