### PR TITLE
Warn when tool dynamic fields are not listed

### DIFF
--- a/newsfragments/4523.feature.rst
+++ b/newsfragments/4523.feature.rst
@@ -1,0 +1,1 @@
+Added a warning when ``tool.setuptools.dynamic`` defines a field that is not listed in ``project.dynamic``.

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -215,6 +215,7 @@ class _ConfigExpander:
         self._expand_packages()
         self._canonic_package_data()
         self._canonic_package_data("exclude-package-data")
+        self._warn_about_missing_dynamic()
 
         # A distribution object is required for discovering the correct package_dir
         dist = self._ensure_dist()
@@ -227,6 +228,19 @@ class _ConfigExpander:
 
         dist._referenced_files.update(self._referenced_files)
         return self.config
+
+    def _warn_about_missing_dynamic(self) -> None:
+        """Warn when a directive cannot be used because ``project.dynamic`` omits it."""
+        for field in sorted(self.dynamic_cfg):
+            if not self._uses_dynamic_directive(field):
+                _MissingDynamicDirective.emit(field=field)
+
+    def _uses_dynamic_directive(self, field: str) -> bool:
+        if field in self.dynamic:
+            return True
+        return field == "entry-points" and any(
+            item in self.dynamic for item in ("scripts", "gui-scripts")
+        )
 
     def _expand_packages(self):
         packages = self.setuptools_cfg.get("packages")
@@ -475,3 +489,19 @@ class _ToolsTypoInMetadata(SetuptoolsWarning):
     _SUMMARY = (
         "Ignoring [tools.setuptools] in pyproject.toml, did you mean [tool.setuptools]?"
     )
+
+
+class _MissingDynamicDirective(SetuptoolsWarning):
+    _SUMMARY = "`tool.setuptools.dynamic.{field}` is ignored."
+
+    _DETAILS = """
+    The following seems to be defined in `tool.setuptools.dynamic`:
+
+    `{field}`
+
+    According to the spec, setuptools cannot use this value unless `{field}` is
+    listed as `dynamic` in the `[project]` table.
+
+    To prevent this problem, you can list `{field}` under `project.dynamic` or
+    remove the corresponding `tool.setuptools.dynamic.{field}` configuration.
+    """

--- a/setuptools/tests/config/test_pyprojecttoml.py
+++ b/setuptools/tests/config/test_pyprojecttoml.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from configparser import ConfigParser
 from inspect import cleandoc
 
@@ -209,6 +210,23 @@ class TestEntryPoints:
         msg = f"defined outside of `pyproject.toml`:.*{missing_dynamic}"
         with pytest.raises(OptionError, match=re.compile(msg, re.DOTALL)):
             expand_configuration(self.pyproject(dynamic), tmp_path)
+
+    def test_entry_points_file_used_for_scripts_without_warning(self, tmp_path):
+        entry_points = ConfigParser()
+        entry_points.read_dict({"console_scripts": {"a": "mod.a:func"}})
+        with open(tmp_path / "entry-points.txt", "w", encoding="utf-8") as f:
+            entry_points.write(f)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            expanded = expand_configuration(self.pyproject(["scripts"]), tmp_path)
+
+        assert expanded["project"]["scripts"]["a"] == "mod.a:func"
+        assert not [
+            warning
+            for warning in caught
+            if "tool.setuptools.dynamic.entry-points" in str(warning.message)
+        ]
 
 
 class TestClassifiers:

--- a/setuptools/tests/config/test_pyprojecttoml_dynamic_deps.py
+++ b/setuptools/tests/config/test_pyprojecttoml_dynamic_deps.py
@@ -33,6 +33,31 @@ def test_dynamic_dependencies(tmp_path):
     assert dist.install_requires == ["six"]
 
 
+def test_warns_when_dynamic_dependencies_not_listed(tmp_path):
+    files = {
+        "requirements.txt": "six\n",
+        "pyproject.toml": cleandoc(
+            """
+            [project]
+            name = "myproj"
+            version = "1.0"
+
+            [tool.setuptools.dynamic.dependencies]
+            file = ["requirements.txt"]
+            """
+        ),
+    }
+    path.build(files, prefix=tmp_path)
+    dist = Distribution()
+    with pytest.warns(
+        SetuptoolsWarning,
+        match=r"(?s)tool\.setuptools\.dynamic\.dependencies.*project\.dynamic",
+    ):
+        dist = apply_configuration(dist, tmp_path / "pyproject.toml")
+
+    assert not dist.install_requires
+
+
 def test_dynamic_optional_dependencies(tmp_path):
     files = {
         "requirements-docs.txt": "sphinx\n  # comment\n",


### PR DESCRIPTION
Closes #4523.

This adds a warning for pyproject configurations where a field is configured under `tool.setuptools.dynamic` but is not listed in `project.dynamic`, so the directive would otherwise be silently ignored.

I kept the existing entry-points behavior intact: `tool.setuptools.dynamic.entry-points` is still considered used when `scripts` or `gui-scripts` are dynamic, since those are expanded from the entry-points file.

Validation:
- `uv run --extra test --extra cover python -m pytest setuptools/tests/config/test_pyprojecttoml_dynamic_deps.py setuptools/tests/config/test_apply_pyprojecttoml.py::TestPresetField setuptools/tests/config/test_pyprojecttoml.py -q`
- `uv run --extra check ruff check setuptools/config/pyprojecttoml.py setuptools/tests/config/test_pyprojecttoml_dynamic_deps.py setuptools/tests/config/test_pyprojecttoml.py`
- `git diff --check`
- `review-fix-loop` clean after fixing the entry-points review finding
