### PR TITLE
Update distutils docs references

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -192,16 +192,6 @@ nitpick_ignore += [
     ('py:mod', 'docutils'),  # there's no Sphinx site documenting this
 ]
 
-# Allow linking objects on other Sphinx sites seamlessly:
-intersphinx_mapping.update(
-    # python=('https://docs.python.org/3', None),
-    python=('https://docs.python.org/3.11', None),
-    # ^-- Python 3.11 is required because it still contains `distutils`.
-    #     Just leaving it as `3` would imply 3.12+, but that causes an
-    #     error with the cross references to distutils functions.
-    #     Inventory cache may cause errors, deleting it solves the problem.
-)
-
 # Add support for the unreleased "next-version" change notes
 extensions += ['sphinxcontrib.towncrier']
 # Extension needs a path from here to the towncrier config.

--- a/docs/deprecated/easy_install.rst
+++ b/docs/deprecated/easy_install.rst
@@ -678,8 +678,8 @@ if you are already using distutils configuration files to set default install
 locations, build options, etc., EasyInstall will respect your existing settings
 until and unless you override them explicitly in an ``[easy_install]`` section.
 
-For more information, see also the current Python documentation on the `use and
-location of distutils configuration files <https://docs.python.org/install/index.html#inst-config-files>`_.
+For more information, see also the distutils documentation on
+:doc:`the use and location of distutils configuration files <distutils/configfile>`.
 
 Notice that ``easy_install`` will use the ``setup.cfg`` from the current
 working directory only if it was triggered from ``setup.py`` through the


### PR DESCRIPTION
## Summary
- remove the Python 3.11 intersphinx workaround added for missing distutils objects in current CPython docs
- update the remaining distutils configuration-file reference in `easy_install` docs to point at Setuptools' self-hosted distutils docs

Fixes #4081.

## Validation
- `gh issue view 4081 --repo pypa/setuptools --json number,title,state,assignees,url` confirmed the issue is open and unassigned
- `gh pr list --repo pypa/setuptools --state open --search '4081 OR distutils CPython docs OR "Remove references to distutils"' --json number,title,author,url,headRefName` returned no open related PRs
- `git diff --check -- docs/conf.py docs/deprecated/easy_install.rst`
- `/opt/miniconda3/bin/python3.13 -m py_compile docs/conf.py`
- focused Python assertion that `docs/deprecated/easy_install.rst` links to `distutils/configfile` and that `docs/deprecated/distutils/configfile.rst` exists
- `rg` check for the removed CPython distutils-doc workaround and old `docs.python.org/install` link returned no matches

Full `tox -e docs` was intentionally not completed because its dependency installation became too heavy for the shared worker machine; the long-running docs/tox pip process was stopped and the partial `.tox/docs` environment was removed.
