### PR TITLE
fix: Remove incorrect _restore_install_lib override (closes #2728)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,16 +43,6 @@ class install_with_pth(install):
 
     def finalize_options(self):
         install.finalize_options(self)
-        self._restore_install_lib()
-
-    def _restore_install_lib(self):
-        """
-        Undo secondary effect of `extra_path` adding to `install_lib`
-        """
-        suffix = os.path.relpath(self.install_lib, self.install_libbase)
-
-        if suffix.strip() == self._pth_contents.strip():
-            self.install_lib = self.install_libbase
 
 
 setup_params = dict(


### PR DESCRIPTION
## What
In v57.1.0, the custom install command `install_with_pth` overrides `install_lib` incorrectly, causing installation paths to be corrupted and leading to SSL/certificate errors during dependency resolution on Python 3.6 (especially on macOS/Windows). The `_restore_install_lib` method attempts to undo a secondary effect of `extra_path` but compares a path suffix with Python code, which never matches, thus always resetting `install_lib` to `install_libbase`.

## Fix
Remove the `_restore_install_lib` method and its call in `finalize_options`. The `extra_path` mechanism does not actually require this correction; the original `finalize_options` from `install` already handles paths correctly.

Closes #2728