### PR TITLE
docs: document py-limited-api wheel tagging

### DIFF
--- a/docs/userguide/ext_modules.rst
+++ b/docs/userguide/ext_modules.rst
@@ -63,6 +63,27 @@ Optionally any other parameter of :class:`setuptools.Extension` can be defined
 in the configuration file (but in the case of ``pyproject.toml`` they must be
 written using :wiki:`kebab-case` convention).
 
+.. note::
+   ``Extension(..., py_limited_api=True)`` and wheel tagging are configured
+   separately. If the built wheel should be tagged with ``abi3`` for CPython's
+   limited API, configure the ``bdist_wheel`` ``py_limited_api`` option with
+   the minimum supported CPython tag, such as ``cp311``:
+
+   .. tab:: setup.cfg
+
+      .. code-block:: ini
+
+         [bdist_wheel]
+         py-limited-api = cp311
+
+   .. tab:: setup.py
+
+      .. code-block:: python
+
+         setup(
+             options={"bdist_wheel": {"py_limited_api": "cp311"}},
+         )
+
 .. seealso::
    You can find more information on the `Python docs about C/C++ extensions`_.
    Alternatively, you might also be interested in learning about `Cython`_.

--- a/newsfragments/4741.doc.rst
+++ b/newsfragments/4741.doc.rst
@@ -1,0 +1,2 @@
+Documented how ``bdist_wheel``'s ``py_limited_api`` option controls
+``abi3`` wheel tagging for extension modules -- by :user:`Himanshuagrawal4`


### PR DESCRIPTION
## Summary
- document that `Extension(..., py_limited_api=True)` and `bdist_wheel` wheel tagging are configured separately
- add examples for setting `bdist_wheel`'s `py_limited_api` option in `setup.cfg` and `setup.py`
- add a Towncrier docs fragment for #4741

## Checks
- `pre-commit run --all-files --show-diff-on-failure`
- `python -m sphinxlint docs/userguide/ext_modules.rst newsfragments/4741.doc.rst`