### PR TITLE
Preserve dynamic metadata for empty dependencies

### DIFF
--- a/newsfragments/5120.bugfix.rst
+++ b/newsfragments/5120.bugfix.rst
@@ -1,0 +1,1 @@
+Preserved ``Dynamic: requires-dist`` in generated core metadata when ``dependencies`` is listed as dynamic and the resolved dependency list is empty.

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -211,8 +211,11 @@ def write_pkg_file(self, file):  # noqa: C901  # is too complex (14)  # FIXME
     self._write_list(file, 'License-File', safe_license_files)
     _write_requirements(self, file)
 
+    dynamic_fields = set(getattr(self, "_setuptools_dynamic", ()))
     for field, attr in _POSSIBLE_DYNAMIC_FIELDS.items():
-        if (val := getattr(self, attr, None)) and not is_static(val):
+        if field in dynamic_fields:
+            write_field('Dynamic', field)
+        elif (val := getattr(self, attr, None)) and not is_static(val):
             write_field('Dynamic', field)
 
     long_description = self.get_long_description()

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -73,6 +73,7 @@ def _apply_project_table(dist: Distribution, config: dict, root_dir: StrPath):
 
     project_table = {k: _static.attempt_conversion(v) for k, v in orig_config.items()}
     _handle_missing_dynamic(dist, project_table)
+    _handle_dynamic_metadata(dist, project_table)
     _unify_entry_points(project_table)
 
     for field, value in project_table.items():
@@ -135,6 +136,14 @@ def _handle_missing_dynamic(dist: Distribution, project_table: dict):
             if value:
                 _MissingDynamic.emit(field=field, value=value)
                 project_table[field] = _RESET_PREVIOUSLY_DEFINED.get(field)
+
+
+def _handle_dynamic_metadata(dist: Distribution, project_table: dict):
+    dynamic = set(project_table.get("dynamic", []))
+    if "dependencies" in dynamic:
+        metadata_dynamic = set(getattr(dist.metadata, "_setuptools_dynamic", ()))
+        metadata_dynamic.add("requires-dist")
+        dist.metadata._setuptools_dynamic = metadata_dynamic
 
 
 def json_compatible_key(key: str) -> str:

--- a/setuptools/tests/config/test_apply_pyprojecttoml.py
+++ b/setuptools/tests/config/test_apply_pyprojecttoml.py
@@ -646,6 +646,22 @@ class TestPresetField:
         dist_value = _some_attrgetter(f"metadata.{attr}", attr)(dist)
         assert dist_value == value
 
+    def test_empty_dynamic_dependencies_in_metadata(self, tmp_path):
+        pyproject = self.pyproject(tmp_path, ["dependencies"])
+        dist = makedist(tmp_path, install_requires=[])
+        dist = pyprojecttoml.apply_configuration(dist, pyproject)
+        metadata = core_metadata(dist)
+        assert "Dynamic: requires-dist\n" in metadata
+        assert "Requires-Dist:" not in metadata
+
+    def test_empty_static_dependencies_not_dynamic_in_metadata(self, tmp_path):
+        extra = "dependencies = []\n"
+        pyproject = self.pyproject(tmp_path, [], extra)
+        dist = pyprojecttoml.apply_configuration(makedist(tmp_path), pyproject)
+        metadata = core_metadata(dist)
+        assert "Dynamic:" not in metadata
+        assert "Requires-Dist:" not in metadata
+
     def test_license_files_exempt_from_dynamic(self, monkeypatch, tmp_path):
         """
         license-file is currently not considered in the context of dynamic.


### PR DESCRIPTION
## Summary of changes

Preserve dynamic core metadata for dependencies when `project.dynamic = ['dependencies']` is supplied and the resolved dependency list is empty.

Setuptools already marked non-empty dynamic dependency lists as `Dynamic: requires-dist` because those lists are non-static values. Empty lists were skipped by the metadata writer's truthiness check, so an explicit `install_requires=[]` from `setup.py` produced no `Dynamic` field. This change records the corresponding core metadata field while applying `pyproject.toml` dynamic metadata, allowing empty dynamic dependency lists to stay dynamic without marking static `dependencies = []` as dynamic.

Closes #5120

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

### Tests

- `python -m pytest -q setuptools/tests/config/test_apply_pyprojecttoml.py setuptools/tests/config/test_pyprojecttoml_dynamic_deps.py setuptools/tests/test_core_metadata.py`
- `python -m ruff check setuptools/_core_metadata.py setuptools/config/_apply_pyprojecttoml.py setuptools/tests/config/test_apply_pyprojecttoml.py`
- `python -m ruff format --check setuptools/_core_metadata.py setuptools/config/_apply_pyprojecttoml.py setuptools/tests/config/test_apply_pyprojecttoml.py`
- `python -m mypy setuptools/_core_metadata.py setuptools/config/_apply_pyprojecttoml.py`
- `git diff --check`

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
