### PR TITLE
Materialize product() passed to parametrize (pytest 9.1 compat)

### DIFF
--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -6,6 +6,7 @@ from typing import cast
 
 import jaraco.path
 import pytest
+from jaraco.functools import compose
 from path import Path
 
 import setuptools  # noqa: F401 # force distutils.core to be patched
@@ -19,6 +20,16 @@ from .integration.helpers import get_sdist_members, get_wheel_members, run
 from .textwrap import DALS
 
 import distutils.core
+
+greedy_product = compose(list, product)
+"""
+``itertools.product`` rendered eager (a list rather than a one-shot iterator).
+
+``@pytest.mark.parametrize`` needs a re-iterable Collection for ``argvalues``:
+a bare iterator gets exhausted after the first of a class' test methods is
+collected, silently skipping the rest. Deprecated in pytest 9.1, raising
+``PytestRemovedIn10Warning`` (pytest-dev/pytest#13409).
+"""
 
 
 class TestFindParentPackage:
@@ -162,14 +173,10 @@ class TestDiscoverPackagesAndPyModules:
 
     @pytest.mark.parametrize(
         ("config_file", "param", "circumstance"),
-        # ``list`` because a one-shot iterator gets exhausted across this
-        # class' test methods; deprecated in pytest 9.1 (pytest-dev/pytest#13409).
-        list(
-            product(
-                ["setup.cfg", "setup.py", "pyproject.toml"],
-                ["packages", "py_modules"],
-                FILES.keys(),
-            )
+        greedy_product(
+            ["setup.cfg", "setup.py", "pyproject.toml"],
+            ["packages", "py_modules"],
+            FILES.keys(),
         ),
     )
     def test_purposefully_empty(self, tmp_path, config_file, param, circumstance):

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -1,12 +1,12 @@
 import os
 import sys
+from collections.abc import Iterable
 from configparser import ConfigParser
 from itertools import product
 from typing import cast
 
 import jaraco.path
 import pytest
-from jaraco.functools import compose
 from path import Path
 
 import setuptools  # noqa: F401 # force distutils.core to be patched
@@ -21,15 +21,17 @@ from .textwrap import DALS
 
 import distutils.core
 
-greedy_product = compose(list, product)
-"""
-``itertools.product`` rendered eager (a list rather than a one-shot iterator).
 
-``@pytest.mark.parametrize`` needs a re-iterable Collection for ``argvalues``:
-a bare iterator gets exhausted after the first of a class' test methods is
-collected, silently skipping the rest. Deprecated in pytest 9.1, raising
-``PytestRemovedIn10Warning`` (pytest-dev/pytest#13409).
-"""
+def greedy_product(*iterables: Iterable[object]) -> list[tuple[object, ...]]:
+    """
+    ``itertools.product`` rendered eager (a list rather than a one-shot iterator).
+
+    ``@pytest.mark.parametrize`` needs a re-iterable Collection for ``argvalues``:
+    a bare iterator gets exhausted after the first of a class' test methods is
+    collected, silently skipping the rest. Deprecated in pytest 9.1, raising
+    ``PytestRemovedIn10Warning`` (pytest-dev/pytest#13409).
+    """
+    return list(product(*iterables))
 
 
 class TestFindParentPackage:

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -162,10 +162,14 @@ class TestDiscoverPackagesAndPyModules:
 
     @pytest.mark.parametrize(
         ("config_file", "param", "circumstance"),
-        product(
-            ["setup.cfg", "setup.py", "pyproject.toml"],
-            ["packages", "py_modules"],
-            FILES.keys(),
+        # ``list`` because a one-shot iterator gets exhausted across this
+        # class' test methods; deprecated in pytest 9.1 (pytest-dev/pytest#13409).
+        list(
+            product(
+                ["setup.cfg", "setup.py", "pyproject.toml"],
+                ["packages", "py_modules"],
+                FILES.keys(),
+            )
         ),
     )
     def test_purposefully_empty(self, tmp_path, config_file, param, circumstance):

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -1,12 +1,12 @@
 import os
 import sys
-from collections.abc import Iterable
 from configparser import ConfigParser
 from itertools import product
 from typing import cast
 
 import jaraco.path
 import pytest
+from jaraco.functools import compose
 from path import Path
 
 import setuptools  # noqa: F401 # force distutils.core to be patched
@@ -21,17 +21,19 @@ from .textwrap import DALS
 
 import distutils.core
 
+greedy_product = compose(list, product)  # type: ignore[var-annotated,arg-type] # python/mypy#13540
+"""
+``itertools.product`` rendered eager (a list rather than a one-shot iterator).
 
-def greedy_product(*iterables: Iterable[object]) -> list[tuple[object, ...]]:
-    """
-    ``itertools.product`` rendered eager (a list rather than a one-shot iterator).
+``@pytest.mark.parametrize`` needs a re-iterable Collection for ``argvalues``:
+a bare iterator gets exhausted after the first of a class' test methods is
+collected, silently skipping the rest. Deprecated in pytest 9.1, raising
+``PytestRemovedIn10Warning`` (pytest-dev/pytest#13409).
 
-    ``@pytest.mark.parametrize`` needs a re-iterable Collection for ``argvalues``:
-    a bare iterator gets exhausted after the first of a class' test methods is
-    collected, silently skipping the rest. Deprecated in pytest 9.1, raising
-    ``PytestRemovedIn10Warning`` (pytest-dev/pytest#13409).
-    """
-    return list(product(*iterables))
+The ``type: ignore`` comments work around python/mypy#13540: mypy collapses the
+overloaded ``product`` to its first overload when it is passed by value through
+``compose``'s ParamSpec, mis-typing the result as a single-argument callable.
+"""
 
 
 class TestFindParentPackage:
@@ -175,7 +177,7 @@ class TestDiscoverPackagesAndPyModules:
 
     @pytest.mark.parametrize(
         ("config_file", "param", "circumstance"),
-        greedy_product(
+        greedy_product(  # type: ignore[call-arg] # python/mypy#13540
             ["setup.cfg", "setup.py", "pyproject.toml"],
             ["packages", "py_modules"],
             FILES.keys(),


### PR DESCRIPTION
## Problem

`setuptools/tests/test_config_discovery.py::TestDiscoverPackagesAndPyModules::test_purposefully_empty` passes an `itertools.product` (a one-shot iterator) directly as `argvalues` to `@pytest.mark.parametrize`.

pytest 9.1 deprecates non-Collection iterables for `argvalues` (`PytestRemovedIn10Warning`), which surfaces here as an **error during collection** — taking the whole `test_config_discovery.py` module down with it. The class-level decorator is exactly the hazard the deprecation targets: a bare iterator is exhausted after the first test method collects, silently skipping the rest.

See [pytest-dev/pytest#13409](https://github.com/pytest-dev/pytest/issues/13409) and the [deprecation note](https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators).

## Fix

Render the product eager via a small documented helper:

```python
greedy_product = compose(list, product)  # jaraco.functools.compose
```

so `argvalues` is a re-iterable `list`. The rationale lives in the helper's docstring.

`jaraco.functools` is already a setuptools test dependency, so no new requirement.

## Verification

- `test_purposefully_empty` now collects and passes (30 params).
- `ruff check` + `ruff format --check` clean.

Note: this only manifests with pytest >= 9.1; CI on an older pytest won't have flagged it yet, so this is a forward-compat fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)