### PR TITLE
Fix broken build:installation cross-reference failing the docs build

### DIFF
--- a/docs/userguide/quickstart.rst
+++ b/docs/userguide/quickstart.rst
@@ -19,7 +19,7 @@ your package, as indicated in the :ref:`following section <basic-use>`.
 
 .. _install-build:
 
-You can also :doc:`install build <build:installation>` using :pypi:`pip`::
+You can also :doc:`install build <build:how-to/install>` using :pypi:`pip`::
 
     pip install --upgrade build
 

--- a/newsfragments/+build-install-xref.doc.rst
+++ b/newsfragments/+build-install-xref.doc.rst
@@ -1,0 +1,1 @@
+Fixed a broken cross-reference to :pypi:`build`'s installation guide in the Quick Start documentation, which was failing the docs build.


### PR DESCRIPTION
## Problem

The `collateral (docs)` job fails on `main`. The Quick Start guide cross-references :pypi:`build`'s installation page through the `build:installation` intersphinx target, but `build` restructured its documentation and that page no longer exists, so Sphinx (run with warnings-as-errors) fails:

```
docs/userguide/quickstart.rst:22: WARNING: unknown document: 'build:installation' [ref.doc]
build finished with problems, 1 warning (with warnings treated as errors).
```

## Verification of the new target

- Old target: `https://build.pypa.io/en/stable/installation.html` -> **404**
- New target: `https://build.pypa.io/en/stable/how-to/install.html` -> **exists** (titled "Installation")

So the document moved from `installation` to `how-to/install`.

## Change

One line in `docs/userguide/quickstart.rst`:

```diff
-You can also :doc:`install build <build:installation>` using :pypi:`pip`::
+You can also :doc:`install build <build:how-to/install>` using :pypi:`pip`::
```

This resolves the only `ref.doc` warning in the docs build. A `newsfragments/` entry is included.

Note: the same CI run also shows unrelated failures (a cygwin/`GitHub raw` network flake and a couple of test jobs) that this docs-only change does not touch.

---
Disclosure: authored with AI assistance (Claude), reviewed and verified before submitting.