### PR TITLE
Exclude setuptools tests from wheel builds

### DIFF
--- a/newsfragments/5212.bugfix.rst
+++ b/newsfragments/5212.bugfix.rst
@@ -1,0 +1,1 @@
+Setuptools wheels no longer bundled the project's own test modules. -- by :user:`itscloud0`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,10 @@ namespaces = true
 [tool.setuptools.exclude-package-data]
 # Remove ruff.toml when installing vendored packages (#4652)
 "*" = ["ruff.toml"]
+# Avoid shipping setuptools' own test suite in wheels (#5212)
+"setuptools" = ["tests/*"]
+"setuptools._distutils" = ["tests/*"]
+"setuptools._distutils.compilers.C" = ["tests/*"]
 
 [tool.distutils.sdist]
 formats = "zip"

--- a/setuptools/tests/test_setuptools.py
+++ b/setuptools/tests/test_setuptools.py
@@ -269,7 +269,6 @@ def test_findall_missing_symlink(tmpdir):
         assert found == []
 
 
-@pytest.mark.xfail(reason="unable to exclude tests; #4475 #3260")
 def test_its_own_wheel_does_not_contain_tests(setuptools_wheel):
     with ZipFile(setuptools_wheel) as zipfile:
         contents = [f.replace(os.sep, '/') for f in zipfile.namelist()]


### PR DESCRIPTION
## Summary of changes

- exclude setuptools' own test package data from wheel builds via `tool.setuptools.exclude-package-data`
- keep the wheel regression in `setuptools/tests/test_setuptools.py` active instead of xfail
- add a Towncrier bugfix fragment for the wheel cleanup

Closes #5212

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]: https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request