### PR TITLE
Respect excluded subpackages in build_py

### DIFF
--- a/newsfragments/3260.bugfix.rst
+++ b/newsfragments/3260.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``packages.find.exclude`` so excluded nested Python subpackages are no
+longer copied into wheels through ``include_package_data=True``.

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -6,7 +6,7 @@ import operator
 import os
 import stat
 import textwrap
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from functools import partial
 from glob import glob
 from pathlib import Path
@@ -357,21 +357,30 @@ def _find_packages_exclude_patterns(dist: Distribution) -> tuple[str, ...]:
     with pyproject.open("rb") as file:
         data = tomllib.load(file)
 
-    patterns = (
-        data.get("tool", {})
-        .get("setuptools", {})
-        .get("packages", {})
-        .get("find", {})
-        .get("exclude", [])
-    )
-    return tuple(patterns)
+    setuptools_cfg = data.get("tool", {}).get("setuptools", {})
+    packages = setuptools_cfg.get("packages", {})
+    if not isinstance(packages, Mapping):
+        return ()
+
+    find = packages.get("find", {})
+    if not isinstance(find, Mapping):
+        return ()
+
+    patterns = find.get("exclude", [])
+    if isinstance(patterns, str):
+        return (patterns,)
+    if isinstance(patterns, Iterable):
+        return tuple(patterns)
+    return ()
 
 
 def _split_find_excludes(patterns: str) -> tuple[str, ...]:
     return tuple(filter(None, (line.strip() for line in patterns.splitlines())))
 
 
-def _is_explicitly_excluded(parent: str, filename: str, excluded: tuple[str, ...]) -> bool:
+def _is_explicitly_excluded(
+    parent: str, filename: str, excluded: tuple[str, ...]
+) -> bool:
     if not excluded:
         return False
 
@@ -470,7 +479,9 @@ class _IncludePackageDataAbuse:
         parts = list(itertools.takewhile(str.isidentifier, pkg.parts))
         if parts:
             importable = ".".join([parent, *parts])
-            if any(fnmatch.fnmatchcase(importable, pattern) for pattern in self._excluded):
+            if any(
+                fnmatch.fnmatchcase(importable, pattern) for pattern in self._excluded
+            ):
                 return None
             return importable
         return None

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -15,6 +15,7 @@ from typing import Any
 from more_itertools import unique_everseen
 
 from .._path import StrPath, StrPathT
+from ..compat.py310 import tomllib
 from ..dist import Distribution
 from ..warnings import SetuptoolsDeprecationWarning
 
@@ -196,9 +197,10 @@ class build_py(orig.build_py):
             egg_info_dir = ei_cmd.egg_info
             files = ei_cmd.filelist.files
 
-        check = _IncludePackageDataAbuse()
+        excluded = _find_packages_exclude_patterns(self.distribution)
+        check = _IncludePackageDataAbuse(excluded)
         for path in self._filter_build_files(files, egg_info_dir):
-            if dunder_path := _find_package_data_owner(path, src_dirs):
+            if dunder_path := _find_package_data_owner(path, src_dirs, excluded):
                 package, f, direct_path = dunder_path
                 if direct_path:
                     if check.is_module(f):
@@ -342,8 +344,52 @@ def _contains_python_sources(directory: str) -> bool:
     )
 
 
+def _find_packages_exclude_patterns(dist: Distribution) -> tuple[str, ...]:
+    setup_cfg = dist.command_options.get("options.packages.find", {})
+    if exclude := setup_cfg.get("exclude"):
+        _origin, patterns = exclude
+        return _split_find_excludes(patterns)
+
+    pyproject = Path("pyproject.toml")
+    if not pyproject.exists():
+        return ()
+
+    with pyproject.open("rb") as file:
+        data = tomllib.load(file)
+
+    patterns = (
+        data.get("tool", {})
+        .get("setuptools", {})
+        .get("packages", {})
+        .get("find", {})
+        .get("exclude", [])
+    )
+    return tuple(patterns)
+
+
+def _split_find_excludes(patterns: str) -> tuple[str, ...]:
+    return tuple(filter(None, (line.strip() for line in patterns.splitlines())))
+
+
+def _is_explicitly_excluded(parent: str, filename: str, excluded: tuple[str, ...]) -> bool:
+    if not excluded:
+        return False
+
+    package = Path(filename).parent
+    parts = list(itertools.takewhile(str.isidentifier, package.parts))
+    if not parts:
+        return False
+
+    candidates = (".".join([parent, *parts[: i + 1]]) for i in range(len(parts)))
+    return any(
+        fnmatch.fnmatchcase(candidate, pattern)
+        for candidate in candidates
+        for pattern in excluded
+    )
+
+
 def _find_package_data_owner(
-    path: str, src_dirs: dict[str, str]
+    path: str, src_dirs: dict[str, str], excluded: tuple[str, ...]
 ) -> tuple[str, str, bool] | None:
     directory, filename = os.path.split(assert_relative(path))
     previous = None
@@ -359,7 +405,11 @@ def _find_package_data_owner(
     if directory not in src_dirs:
         return None
 
-    return src_dirs[directory], filename, filename == original
+    package = src_dirs[directory]
+    if _is_explicitly_excluded(package, filename, excluded):
+        return None
+
+    return package, filename, filename == original
 
 
 class _IncludePackageDataAbuse:
@@ -408,8 +458,9 @@ class _IncludePackageDataAbuse:
         # _DUE_DATE: still not defined as this is particularly controversial.
         # Warning initially introduced in May 2022. See issue #3340 for discussion.
 
-    def __init__(self) -> None:
+    def __init__(self, excluded: tuple[str, ...] = ()) -> None:
         self._already_warned = set[str]()
+        self._excluded = excluded
 
     def is_module(self, file):
         return file.endswith(".py") and file[: -len(".py")].isidentifier()
@@ -418,7 +469,10 @@ class _IncludePackageDataAbuse:
         pkg = Path(file).parent
         parts = list(itertools.takewhile(str.isidentifier, pkg.parts))
         if parts:
-            return ".".join([parent, *parts])
+            importable = ".".join([parent, *parts])
+            if any(fnmatch.fnmatchcase(importable, pattern) for pattern in self._excluded):
+                return None
+            return importable
         return None
 
     def warn(self, importable):

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -198,22 +198,16 @@ class build_py(orig.build_py):
 
         check = _IncludePackageDataAbuse()
         for path in self._filter_build_files(files, egg_info_dir):
-            d, f = os.path.split(assert_relative(path))
-            prev = None
-            oldf = f
-            while d and d != prev and d not in src_dirs:
-                prev = d
-                d, df = os.path.split(d)
-                f = os.path.join(df, f)
-            if d in src_dirs:
-                if f == oldf:
+            if dunder_path := _find_package_data_owner(path, src_dirs):
+                package, f, direct_path = dunder_path
+                if direct_path:
                     if check.is_module(f):
                         continue  # it's a module, not data
                 else:
-                    importable = check.importable_subpackage(src_dirs[d], f)
+                    importable = check.importable_subpackage(package, f)
                     if importable:
                         check.warn(importable)
-                self.manifest_files.setdefault(src_dirs[d], []).append(path)
+                self.manifest_files.setdefault(package, []).append(path)
 
     def _filter_build_files(
         self, files: Iterable[str], egg_info: StrPath
@@ -336,6 +330,36 @@ def assert_relative(path):
         % path
     )
     raise DistutilsSetupError(msg)
+
+
+def _contains_python_sources(directory: str) -> bool:
+    return any(
+        all(
+            part.isidentifier()
+            for part in candidate.relative_to(directory).with_suffix("").parts
+        )
+        for candidate in Path(directory).glob("**/*.py")
+    )
+
+
+def _find_package_data_owner(
+    path: str, src_dirs: dict[str, str]
+) -> tuple[str, str, bool] | None:
+    directory, filename = os.path.split(assert_relative(path))
+    previous = None
+    original = filename
+
+    while directory and directory != previous and directory not in src_dirs:
+        if _contains_python_sources(directory):
+            return None
+        previous = directory
+        directory, parent = os.path.split(directory)
+        filename = os.path.join(parent, filename)
+
+    if directory not in src_dirs:
+        return None
+
+    return src_dirs[directory], filename, filename == original
 
 
 class _IncludePackageDataAbuse:

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -287,7 +287,8 @@ def test_importable_data_subpackage_warns_and_includes_files(tmpdir_cwd):
     build_py = dist.get_command_obj("build_py")
     msg = r"Package 'mypkg\.plugins' is absent from the `packages` configuration\."
     build_py.finalize_options()
-    with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
+
+    def run_build_py():
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -296,6 +297,9 @@ def test_importable_data_subpackage_warns_and_includes_files(tmpdir_cwd):
                 # This warning is already fixed in pypa/distutils but not in stdlib
             )
             build_py.run()
+
+    with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
+        run_build_py()
 
     build_dir = Path(dist.get_command_obj("build_py").build_lib)
     assert (build_dir / "mypkg/plugins/data.txt").exists()

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -1,14 +1,12 @@
 import os
 import shutil
 import stat
-import warnings
 from pathlib import Path
 from unittest.mock import Mock
 
 import jaraco.path
 import pytest
 
-from setuptools import SetuptoolsDeprecationWarning
 from setuptools.dist import Distribution
 
 from .textwrap import DALS
@@ -163,25 +161,8 @@ def test_excluded_subpackages(tmpdir_cwd):
     dist.parse_config_files()
 
     build_py = dist.get_command_obj("build_py")
-
-    msg = r"Python recognizes 'mypkg\.tests' as an importable package"
-    with pytest.warns(SetuptoolsDeprecationWarning, match=msg):  # noqa: PT031
-        # TODO: To fix #3260 we need some transition period to deprecate the
-        # existing behavior of `include_package_data`. After the transition, we
-        # should remove the warning and fix the behavior.
-
-        if os.getenv("SETUPTOOLS_USE_DISTUTILS") == "stdlib":
-            # pytest.warns reset the warning filter temporarily
-            # https://github.com/pytest-dev/pytest/issues/4011#issuecomment-423494810
-            warnings.filterwarnings(
-                "ignore",
-                "'encoding' argument not specified",
-                module="distutils.text_file",
-                # This warning is already fixed in pypa/distutils but not in stdlib
-            )
-
-        build_py.finalize_options()
-        build_py.run()
+    build_py.finalize_options()
+    build_py.run()
 
     build_dir = Path(dist.get_command_obj("build_py").build_lib)
     assert (build_dir / "mypkg/__init__.py").exists()
@@ -195,12 +176,7 @@ def test_excluded_subpackages(tmpdir_cwd):
         "mypkg/tests/test_file.txt",
         "mypkg/tests",
     ]:
-        with pytest.raises(AssertionError):
-            # TODO: Enforce the following assertion once #3260 is fixed
-            # (remove context manager and the following xfail).
-            assert not (build_dir / f).exists()
-
-    pytest.xfail("#3260")
+        assert not (build_dir / f).exists()
 
 
 @pytest.mark.filterwarnings("ignore::setuptools.SetuptoolsDeprecationWarning")

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -1,7 +1,7 @@
+import importlib
 import os
 import shutil
 import stat
-import importlib
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -10,10 +10,10 @@ import pytest
 
 from setuptools import SetuptoolsDeprecationWarning
 from setuptools.command.build_py import (
-    _IncludePackageDataAbuse,
     _contains_python_sources,
     _find_package_data_owner,
     _find_packages_exclude_patterns,
+    _IncludePackageDataAbuse,
     _is_explicitly_excluded,
     _split_find_excludes,
 )
@@ -287,7 +287,7 @@ def test_importable_data_subpackage_warns_and_includes_files(tmpdir_cwd):
     msg = r"Package 'mypkg\.plugins' is absent from the `packages` configuration\."
     with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
         build_py.finalize_options()
-        build_py.run()
+    build_py.run()
 
     build_dir = Path(dist.get_command_obj("build_py").build_lib)
     assert (build_dir / "mypkg/plugins/data.txt").exists()

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -680,7 +680,7 @@ def test_find_package_data_owner_handles_nested_and_excluded_paths(tmpdir_cwd):
     )
     assert _find_package_data_owner("src/mypkg/plugins/resource.txt", src_dirs, ()) == (
         "mypkg",
-        "plugins/resource.txt",
+        os.path.join("plugins", "resource.txt"),
         False,
     )
     assert (

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -155,6 +155,44 @@ EXAMPLE_WITH_MANIFEST = {
 }
 
 
+EXAMPLE_WITH_SRC_LAYOUT_EXCLUDED_SUBPACKAGE = {
+    "pyproject.toml": DALS(
+        """
+        [project]
+        name = "mypkg"
+        version = "42"
+
+        [tool.setuptools]
+        include-package-data = true
+
+        [tool.setuptools.packages.find]
+        where = ["src"]
+        exclude = ["mypkg.subpkg", "mypkg.subpkg.*"]
+        """
+    ),
+    "src": {
+        "mypkg": {
+            "__init__.py": "",
+            "data.txt": "",
+            "subpkg": {
+                "sample1.json": "{}",
+                "sample2.json": "{}",
+            },
+        },
+    },
+    "MANIFEST.in": DALS(
+        """
+        recursive-include src/mypkg *.txt
+        recursive-include src/mypkg/subpkg *.json
+        global-exclude *.py[cod]
+        prune dist
+        prune build
+        prune *.egg-info
+        """
+    ),
+}
+
+
 def test_excluded_subpackages(tmpdir_cwd):
     jaraco.path.build(EXAMPLE_WITH_MANIFEST)
     dist = Distribution({"script_name": "%PEP 517%"})
@@ -175,6 +213,27 @@ def test_excluded_subpackages(tmpdir_cwd):
         "mypkg/tests/test_mypkg.py",
         "mypkg/tests/test_file.txt",
         "mypkg/tests",
+    ]:
+        assert not (build_dir / f).exists()
+
+
+def test_excluded_subpackages_respect_pyproject_src_layout(tmpdir_cwd):
+    jaraco.path.build(EXAMPLE_WITH_SRC_LAYOUT_EXCLUDED_SUBPACKAGE)
+    dist = Distribution({"script_name": "%PEP 517%"})
+    dist.parse_config_files()
+
+    build_py = dist.get_command_obj("build_py")
+    build_py.finalize_options()
+    build_py.run()
+
+    build_dir = Path(dist.get_command_obj("build_py").build_lib)
+    assert (build_dir / "mypkg/__init__.py").exists()
+    assert (build_dir / "mypkg/data.txt").exists()
+
+    for f in [
+        "mypkg/subpkg",
+        "mypkg/subpkg/sample1.json",
+        "mypkg/subpkg/sample2.json",
     ]:
         assert not (build_dir / f).exists()
 

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -2,6 +2,7 @@ import importlib
 import os
 import shutil
 import stat
+import warnings
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -286,8 +287,16 @@ def test_importable_data_subpackage_warns_and_includes_files(tmpdir_cwd):
     build_py = dist.get_command_obj("build_py")
     msg = r"Package 'mypkg\.plugins' is absent from the `packages` configuration\."
     build_py.finalize_options()
-    with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
-        build_py.run()
+    with warnings.catch_warnings():
+        if os.getenv("SETUPTOOLS_USE_DISTUTILS") == "stdlib":
+            warnings.filterwarnings(
+                "ignore",
+                "'encoding' argument not specified",
+                module="distutils.text_file",
+                # This warning is already fixed in pypa/distutils but not in stdlib
+            )
+        with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
+            build_py.run()
 
     build_dir = Path(dist.get_command_obj("build_py").build_lib)
     assert (build_dir / "mypkg/plugins/data.txt").exists()

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -287,15 +287,14 @@ def test_importable_data_subpackage_warns_and_includes_files(tmpdir_cwd):
     build_py = dist.get_command_obj("build_py")
     msg = r"Package 'mypkg\.plugins' is absent from the `packages` configuration\."
     build_py.finalize_options()
-    with warnings.catch_warnings():
-        if os.getenv("SETUPTOOLS_USE_DISTUTILS") == "stdlib":
+    with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
+        with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
                 "'encoding' argument not specified",
                 module="distutils.text_file",
                 # This warning is already fixed in pypa/distutils but not in stdlib
             )
-        with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
             build_py.run()
 
     build_dir = Path(dist.get_command_obj("build_py").build_lib)

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -1,12 +1,22 @@
 import os
 import shutil
 import stat
+import importlib
 from pathlib import Path
 from unittest.mock import Mock
 
 import jaraco.path
 import pytest
 
+from setuptools import SetuptoolsDeprecationWarning
+from setuptools.command.build_py import (
+    _IncludePackageDataAbuse,
+    _contains_python_sources,
+    _find_package_data_owner,
+    _find_packages_exclude_patterns,
+    _is_explicitly_excluded,
+    _split_find_excludes,
+)
 from setuptools.dist import Distribution
 
 from .textwrap import DALS
@@ -193,6 +203,36 @@ EXAMPLE_WITH_SRC_LAYOUT_EXCLUDED_SUBPACKAGE = {
 }
 
 
+EXAMPLE_WITH_IMPORTABLE_DATA_SUBPACKAGE = {
+    "setup.cfg": DALS(
+        """
+        [metadata]
+        name = mypkg
+        version = 42
+
+        [options]
+        include_package_data = True
+        packages = find:
+        """
+    ),
+    "mypkg": {
+        "__init__.py": "",
+        "plugins": {
+            "data.txt": "",
+        },
+    },
+    "MANIFEST.in": DALS(
+        """
+        global-include *.txt
+        global-exclude *.py[cod]
+        prune dist
+        prune build
+        prune *.egg-info
+        """
+    ),
+}
+
+
 def test_excluded_subpackages(tmpdir_cwd):
     jaraco.path.build(EXAMPLE_WITH_MANIFEST)
     dist = Distribution({"script_name": "%PEP 517%"})
@@ -236,6 +276,21 @@ def test_excluded_subpackages_respect_pyproject_src_layout(tmpdir_cwd):
         "mypkg/subpkg/sample2.json",
     ]:
         assert not (build_dir / f).exists()
+
+
+def test_importable_data_subpackage_warns_and_includes_files(tmpdir_cwd):
+    jaraco.path.build(EXAMPLE_WITH_IMPORTABLE_DATA_SUBPACKAGE)
+    dist = Distribution({"script_name": "%PEP 517%"})
+    dist.parse_config_files()
+
+    build_py = dist.get_command_obj("build_py")
+    msg = r"Package 'mypkg\.plugins' is absent from the `packages` configuration\."
+    with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
+        build_py.finalize_options()
+        build_py.run()
+
+    build_dir = Path(dist.get_command_obj("build_py").build_lib)
+    assert (build_dir / "mypkg/plugins/data.txt").exists()
 
 
 @pytest.mark.filterwarnings("ignore::setuptools.SetuptoolsDeprecationWarning")
@@ -513,3 +568,131 @@ def get_outputs(build_py):
         os.path.relpath(x, build_dir).replace(os.sep, "/")
         for x in build_py.get_outputs()
     }
+
+
+def test_build_py_module_reload():
+    import setuptools.command.build_py as build_py_module
+
+    importlib.reload(build_py_module)
+
+
+def test_split_find_excludes_strips_blank_lines():
+    assert _split_find_excludes("\nfoo\n  bar.*  \n\nbaz\n") == (
+        "foo",
+        "bar.*",
+        "baz",
+    )
+
+
+def test_find_packages_exclude_patterns_prefers_setup_cfg(tmpdir_cwd):
+    Path("pyproject.toml").write_text(
+        DALS(
+            """
+            [tool.setuptools.packages.find]
+            exclude = ["ignored"]
+            """
+        ),
+        encoding="utf-8",
+    )
+    dist = Distribution()
+    dist.command_options = {
+        "options.packages.find": {"exclude": ("setup.cfg", "\nfoo\nbar.*\n")}
+    }
+
+    assert _find_packages_exclude_patterns(dist) == ("foo", "bar.*")
+
+
+def test_find_packages_exclude_patterns_without_pyproject(tmpdir_cwd):
+    assert _find_packages_exclude_patterns(Distribution()) == ()
+
+
+@pytest.mark.parametrize(
+    ("pyproject", "expected"),
+    [
+        ("[tool.setuptools]\npackages = ['mypkg']\n", ()),
+        ("[tool.setuptools.packages]\nfind = 'invalid'\n", ()),
+        (
+            "[tool.setuptools.packages.find]\nexclude = 'mypkg.tests'\n",
+            ("mypkg.tests",),
+        ),
+        (
+            "[tool.setuptools.packages.find]\nexclude = ['mypkg.tests', 'mypkg.tests.*']\n",
+            ("mypkg.tests", "mypkg.tests.*"),
+        ),
+        ("[tool.setuptools.packages.find]\nexclude = 3\n", ()),
+    ],
+)
+def test_find_packages_exclude_patterns_from_pyproject(tmpdir_cwd, pyproject, expected):
+    Path("pyproject.toml").write_text(pyproject, encoding="utf-8")
+
+    assert _find_packages_exclude_patterns(Distribution()) == expected
+
+
+def test_contains_python_sources_filters_non_identifier_paths(tmpdir_cwd):
+    jaraco.path.build({
+        "pkg": {"valid.py": ""},
+        "data": {"file.txt": "", "not-valid.py": ""},
+    })
+
+    assert _contains_python_sources("pkg")
+    assert not _contains_python_sources("data")
+
+
+def test_is_explicitly_excluded_matches_nested_packages():
+    assert not _is_explicitly_excluded("mypkg", "plugins/data.txt", ())
+    assert not _is_explicitly_excluded(
+        "mypkg", "not-valid/data.txt", ("mypkg.not-valid",)
+    )
+    assert _is_explicitly_excluded(
+        "mypkg", "plugins/nested/data.txt", ("mypkg.plugins", "mypkg.plugins.*")
+    )
+
+
+def test_find_package_data_owner_handles_nested_and_excluded_paths(tmpdir_cwd):
+    jaraco.path.build({
+        "src": {
+            "mypkg": {
+                "__init__.py": "",
+                "data.txt": "",
+                "plugins": {"resource.txt": ""},
+                "nested": {"module.py": "", "resource.txt": ""},
+            }
+        }
+    })
+    src_dirs = {"src/mypkg": "mypkg"}
+
+    assert _find_package_data_owner("src/mypkg/data.txt", src_dirs, ()) == (
+        "mypkg",
+        "data.txt",
+        True,
+    )
+    assert _find_package_data_owner("src/mypkg/plugins/resource.txt", src_dirs, ()) == (
+        "mypkg",
+        "plugins/resource.txt",
+        False,
+    )
+    assert (
+        _find_package_data_owner("src/mypkg/nested/resource.txt", src_dirs, ()) is None
+    )
+    assert (
+        _find_package_data_owner(
+            "src/mypkg/plugins/resource.txt", src_dirs, ("mypkg.plugins",)
+        )
+        is None
+    )
+    assert _find_package_data_owner("orphan/data.txt", src_dirs, ()) is None
+
+
+def test_include_package_data_abuse_respects_excluded_patterns():
+    excluded = _IncludePackageDataAbuse(("mypkg.plugins",))
+
+    assert excluded.is_module("module.py")
+    assert excluded.importable_subpackage("mypkg", "plugins/data.txt") is None
+    assert (
+        _IncludePackageDataAbuse().importable_subpackage("mypkg", "plugins/data.txt")
+        == "mypkg.plugins"
+    )
+    assert (
+        _IncludePackageDataAbuse().importable_subpackage("mypkg", "not-valid/data.txt")
+        is None
+    )

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -285,9 +285,9 @@ def test_importable_data_subpackage_warns_and_includes_files(tmpdir_cwd):
 
     build_py = dist.get_command_obj("build_py")
     msg = r"Package 'mypkg\.plugins' is absent from the `packages` configuration\."
+    build_py.finalize_options()
     with pytest.warns(SetuptoolsDeprecationWarning, match=msg):
-        build_py.finalize_options()
-    build_py.run()
+        build_py.run()
 
     build_dir = Path(dist.get_command_obj("build_py").build_lib)
     assert (build_dir / "mypkg/plugins/data.txt").exists()


### PR DESCRIPTION
## Summary of changes

Fix `packages.find.exclude` so excluded nested Python subpackages are not copied into wheels through `include_package_data=True`.

Closes #3260.

## Problem

On current `main`, a project configured with:

- `include_package_data = True`
- `packages = find:`
- `exclude = *.tests*`

still ships `mypkg/tests/*` in the built wheel when those files are pulled in through `MANIFEST.in`.

The repo already had an xfailed regression for this case in `setuptools/tests/test_build_py.py`, and a direct repro on current `main` still produced a wheel containing `mypkg/tests/test_mypkg.py` and `mypkg/tests/test_file.txt`.

## Solution

When `build_py` walks manifest entries, stop promoting files from nested directories that already contain Python sources into the parent package's data files. That keeps explicitly excluded subpackages out of the wheel instead of reintroducing them through `include_package_data`.

The existing regression now asserts the intended behavior directly instead of warning and xfail-ing.

## Verification

- `uv run --extra test --extra cover pytest setuptools/tests/test_build_py.py -q`
- `uvx ruff check setuptools/command/build_py.py setuptools/tests/test_build_py.py`
- `uvx ruff format --check setuptools/command/build_py.py setuptools/tests/test_build_py.py`
- Reproduced the issue's toy `mypkg/tests` wheel build on `main`, then reran it after the patch and confirmed the wheel no longer contains `mypkg/tests/*`.
