### PR TITLE
fix failing test in freethreaded pythons

### DIFF
--- a/setuptools/tests/test_bdist_wheel.py
+++ b/setuptools/tests/test_bdist_wheel.py
@@ -189,30 +189,42 @@ EXAMPLES = {
 }
 
 
-if sys.platform != "win32" and not sysconfig.get_config_var("Py_GIL_DISABLED"):
-    # ABI3 extensions don't really work on Windows.
-    # Free-threaded builds also reject Py_LIMITED_API for now.
-    # See https://github.com/python/cpython/issues/146636 (PEP 803 / abi3t).
-    EXAMPLES["abi3extension-dist"] = {
-        "setup.py": cleandoc(
-            """
-            from setuptools import Extension, setup
+def abi3extension_dist():
+    if sys.platform == 'win32':
+        # ABI3 extensions don't really work on Windows.
+        return
 
-            setup(
-                name="extension.dist",
-                version="0.1",
-                description="A testing distribution \N{SNOWMAN}",
-                ext_modules=[
-                    Extension(
-                        name="extension", sources=["extension.c"], py_limited_api=True
-                    )
-                ],
-            )
-            """
-        ),
-        "setup.cfg": "[bdist_wheel]\npy_limited_api=cp32",
-        "extension.c": "#define Py_LIMITED_API 0x03020000\n#include <Python.h>",
-    }
+    if sysconfig.get_config_var('Py_GIL_DISABLED'):
+        # Free-threaded builds also reject Py_LIMITED_API for now.
+        # See https://github.com/python/cpython/issues/146636 (PEP 803 / abi3t).
+        return
+
+    yield (
+        'abi3extension-dist',
+        {
+            "setup.py": cleandoc(
+                """
+                from setuptools import Extension, setup
+
+                setup(
+                    name="extension.dist",
+                    version="0.1",
+                    description="A testing distribution \N{SNOWMAN}",
+                    ext_modules=[
+                        Extension(
+                            name="extension", sources=["extension.c"], py_limited_api=True
+                        )
+                    ],
+                )
+                """
+            ),
+            "setup.cfg": "[bdist_wheel]\npy_limited_api=cp32",
+            "extension.c": "#define Py_LIMITED_API 0x03020000\n#include <Python.h>",
+        },
+    )
+
+
+EXAMPLES.update(abi3extension_dist())
 
 
 def bdist_wheel_cmd(**kwargs):

--- a/setuptools/tests/test_bdist_wheel.py
+++ b/setuptools/tests/test_bdist_wheel.py
@@ -189,8 +189,10 @@ EXAMPLES = {
 }
 
 
-if sys.platform != "win32":
-    # ABI3 extensions don't really work on Windows
+if sys.platform != "win32" and not sysconfig.get_config_var("Py_GIL_DISABLED"):
+    # ABI3 extensions don't really work on Windows.
+    # Free-threaded builds also reject Py_LIMITED_API for now.
+    # See https://github.com/python/cpython/issues/146636 (PEP 803 / abi3t).
     EXAMPLES["abi3extension-dist"] = {
         "setup.py": cleandoc(
             """


### PR DESCRIPTION
- **Skip abi3extension example on free-threaded Python**
- **Disentangle Windows and Freethreading concerns in a generator.**

<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

<!-- Summary goes here -->

Closes <!-- issue number here -->

### Pull Request Checklist
- [x] Changes have tests
- [ ] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
