### PR TITLE
Speed up setuptools imports on Python 3.15+ by adding `__lazy_modules__`

### DIFF
--- a/newsfragments/5257.feature.rst
+++ b/newsfragments/5257.feature.rst
@@ -1,0 +1,1 @@
+Speed up setuptools imports on Python 3.15+ by adding ``__lazy_modules__`` -- by :user:`Avasam`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ check = [
 
 	# Deprecated rules must now be selected by exact rule code
 	"ruff >= 0.13.0; sys_platform != 'cygwin'",
+	"flake8-lazy", # Until Ruff gains support for automatically inserting and validating __lazy_modules__
 ]
 
 cover = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,6 +5,7 @@ exclude = [
 ]
 
 [lint]
+external=["LZY"]
 extend-select = [
 	# upstream
 

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -7,6 +7,17 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{__spec__.parent}.depends",
+    f"{__spec__.parent}.dist",
+    f"{__spec__.parent}.extension",
+    f"{__spec__.parent}.version",
+    f"{__spec__.parent}.warnings",
+    "functools",
+}
+
 import functools
 import os
 import sys

--- a/setuptools/__init__.py
+++ b/setuptools/__init__.py
@@ -7,6 +7,17 @@
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "functools",
+    f"{__spec__.parent}.depends",
+    f"{__spec__.parent}.dist",
+    f"{__spec__.parent}.extension",
+    f"{__spec__.parent}.version",
+    f"{__spec__.parent}.warnings",
+}
+
 import functools
 import os
 import sys

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -6,6 +6,22 @@ See: https://packaging.python.org/en/latest/specifications/core-metadata/
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils",
+    "distutils.util",
+    "email",
+    "email.message",
+    f"{__spec__.parent}._static",
+    f"{__spec__.parent}.warnings",
+    "packaging",
+    "packaging.markers",
+    "packaging.requirements",
+    "packaging.utils",
+    "packaging.version",
+    "tempfile",
+    "textwrap",
+}
+
 import os
 import stat
 import textwrap

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -6,6 +6,22 @@ See: https://packaging.python.org/en/latest/specifications/core-metadata/
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils",
+    "distutils.util",
+    "email",
+    "email.message",
+    "packaging",
+    "packaging.markers",
+    "packaging.requirements",
+    "packaging.utils",
+    "packaging.version",
+    "tempfile",
+    "textwrap",
+    f"{__spec__.parent}._static",
+    f"{__spec__.parent}.warnings",
+}
+
 import os
 import stat
 import textwrap

--- a/setuptools/_discovery.py
+++ b/setuptools/_discovery.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"functools", "operator", "packaging", "packaging.requirements"}
+
 import functools
 import operator
 

--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -1,3 +1,14 @@
+__lazy_modules__ = {
+    f"{__spec__.parent}._importlib",
+    f"{__spec__.parent}._itertools",
+    f"{__spec__.parent}.errors",
+    "itertools",
+    "jaraco",
+    "jaraco.text",
+    "more_itertools",
+    "operator",
+}
+
 import functools
 import itertools
 import operator

--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -1,5 +1,4 @@
 __lazy_modules__ = {
-    f"{__spec__.parent}._importlib",
     f"{__spec__.parent}._itertools",
     f"{__spec__.parent}.errors",
     "itertools",
@@ -17,7 +16,7 @@ from jaraco.functools import pass_none
 from jaraco.text import yield_lines
 from more_itertools import consume
 
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from ._itertools import ensure_unique
 from .errors import OptionError
 

--- a/setuptools/_entry_points.py
+++ b/setuptools/_entry_points.py
@@ -1,3 +1,13 @@
+__lazy_modules__ = {
+    "itertools",
+    "jaraco",
+    "jaraco.text",
+    "more_itertools",
+    "operator",
+    f"{__spec__.parent}._itertools",
+    f"{__spec__.parent}.errors",
+}
+
 import functools
 import itertools
 import operator
@@ -6,7 +16,7 @@ from jaraco.functools import pass_none
 from jaraco.text import yield_lines
 from more_itertools import consume
 
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from ._itertools import ensure_unique
 from .errors import OptionError
 

--- a/setuptools/_imp.py
+++ b/setuptools/_imp.py
@@ -3,6 +3,8 @@ Re-implementation of find_module and get_frozen_object
 from the deprecated imp module.
 """
 
+__lazy_modules__ = {"importlib", "importlib.machinery", "importlib.util", "tokenize"}
+
 import importlib.machinery
 import importlib.util
 import os

--- a/setuptools/_importlib.py
+++ b/setuptools/_importlib.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"importlib"}
+
 from importlib import (
     metadata,  # noqa: F401
     resources,  # noqa: F401

--- a/setuptools/_itertools.py
+++ b/setuptools/_itertools.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"more_itertools"}
+
 from more_itertools import consume  # noqa: F401
 
 

--- a/setuptools/_normalization.py
+++ b/setuptools/_normalization.py
@@ -3,6 +3,8 @@ Helpers for normalization as expected in wheel/sdist/module file names
 and core metadata
 """
 
+__lazy_modules__ = {"packaging"}
+
 import re
 from typing import TYPE_CHECKING
 

--- a/setuptools/_path.py
+++ b/setuptools/_path.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"more_itertools"}
+
 import contextlib
 import os
 import sys

--- a/setuptools/_reqs.py
+++ b/setuptools/_reqs.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"jaraco"}
+
 from collections.abc import Callable, Iterable, Iterator
 from functools import lru_cache
 from typing import TYPE_CHECKING, TypeVar, overload

--- a/setuptools/_scripts.py
+++ b/setuptools/_scripts.py
@@ -7,7 +7,6 @@ __lazy_modules__ = {
     "distutils.command",
     "distutils.command.build_scripts",
     "distutils.util",
-    f"{__spec__.parent}._importlib",
     f"{__spec__.parent}.warnings",
     "re",
     "shlex",
@@ -28,7 +27,7 @@ import textwrap
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, TypedDict
 
-from ._importlib import metadata, resources
+from ._importlib import metadata, resources  # noqa: LZY102
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/setuptools/_scripts.py
+++ b/setuptools/_scripts.py
@@ -1,5 +1,22 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.command",
+    "distutils.command.build_scripts",
+    "distutils.util",
+    f"{__spec__.parent}._importlib",
+    f"{__spec__.parent}.warnings",
+    "re",
+    "shlex",
+    "shutil",
+    "struct",
+    "subprocess",
+    "textwrap",
+}
+
 import os
 import re
 import shlex

--- a/setuptools/_scripts.py
+++ b/setuptools/_scripts.py
@@ -1,5 +1,20 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.command",
+    "distutils.command.build_scripts",
+    "distutils.util",
+    "re",
+    "shlex",
+    "shutil",
+    "struct",
+    "subprocess",
+    f"{__spec__.parent}.warnings",
+}
+
 import os
 import re
 import shlex
@@ -11,7 +26,7 @@ import textwrap
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, TypedDict
 
-from ._importlib import metadata, resources
+from ._importlib import metadata, resources  # noqa: LZY102
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/setuptools/_shutil.py
+++ b/setuptools/_shutil.py
@@ -1,5 +1,12 @@
 """Convenience layer on top of stdlib's shutil and os"""
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    f"{__spec__.parent}.compat",
+}
+
 import os
 import stat
 from collections.abc import Callable

--- a/setuptools/_static.py
+++ b/setuptools/_static.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {f"{__spec__.parent}.warnings", "functools"}
+
 from functools import wraps
 from typing import TypeVar
 

--- a/setuptools/_static.py
+++ b/setuptools/_static.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"functools", f"{__spec__.parent}.warnings"}
+
 from functools import wraps
 from typing import TypeVar
 

--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -1,5 +1,13 @@
 """Utilities for extracting common archive formats"""
 
+__lazy_modules__ = {
+    "contextlib",
+    f"{__spec__.parent}._path",
+    "shutil",
+    "tarfile",
+    "zipfile",
+}
+
 import contextlib
 import os
 import posixpath

--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -1,5 +1,13 @@
 """Utilities for extracting common archive formats"""
 
+__lazy_modules__ = {
+    "contextlib",
+    "shutil",
+    "tarfile",
+    "zipfile",
+    f"{__spec__.parent}._path",
+}
+
 import contextlib
 import ntpath
 import os

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -28,6 +28,20 @@ Again, this is not a formal definition! Just a "taste" of the module.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils",
+    "distutils.util",
+    f"{__spec__.parent}._path",
+    f"{__spec__.parent}._reqs",
+    "io",
+    "pathlib",
+    "shlex",
+    "shutil",
+    "tempfile",
+    "tokenize",
+    "warnings",
+}
+
 import contextlib
 import io
 import os

--- a/setuptools/build_meta.py
+++ b/setuptools/build_meta.py
@@ -28,6 +28,20 @@ Again, this is not a formal definition! Just a "taste" of the module.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils",
+    "distutils.util",
+    "io",
+    "pathlib",
+    "shlex",
+    "shutil",
+    "tempfile",
+    "tokenize",
+    "warnings",
+    f"{__spec__.parent}._path",
+    f"{__spec__.parent}._reqs",
+}
+
 import contextlib
 import io
 import os

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -9,6 +9,18 @@ See https://setuptools.pypa.io/en/latest/deprecated/python_eggs.html#requires-tx
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._reqs",
+    "io",
+    "itertools",
+    "jaraco",
+    "jaraco.text",
+    "packaging",
+    "packaging.requirements",
+}
+
 import io
 from collections import defaultdict
 from collections.abc import Mapping

--- a/setuptools/command/_requirestxt.py
+++ b/setuptools/command/_requirestxt.py
@@ -9,6 +9,18 @@ See https://setuptools.pypa.io/en/latest/deprecated/python_eggs.html#requires-tx
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "io",
+    "itertools",
+    "jaraco",
+    "jaraco.text",
+    "packaging",
+    "packaging.requirements",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._reqs",
+}
+
 import io
 from collections import defaultdict
 from collections.abc import Mapping

--- a/setuptools/command/alias.py
+++ b/setuptools/command/alias.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"distutils", "distutils.errors"}
+
 from setuptools.command.setopt import config_file, edit_config, option_base
 
 from distutils.errors import DistutilsOptionError

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -4,6 +4,19 @@ Build .egg distributions"""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.dir_util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    "re",
+    "setuptools.extension",
+    "sysconfig",
+    "textwrap",
+    "types",
+}
+
 import marshal
 import os
 import re

--- a/setuptools/command/bdist_egg.py
+++ b/setuptools/command/bdist_egg.py
@@ -4,6 +4,19 @@ Build .egg distributions"""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.dir_util",
+    "re",
+    "setuptools.extension",
+    "sysconfig",
+    "textwrap",
+    "types",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+}
+
 import marshal
 import os
 import re

--- a/setuptools/command/bdist_rpm.py
+++ b/setuptools/command/bdist_rpm.py
@@ -1,3 +1,8 @@
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+}
+
 from ..dist import Distribution
 from ..warnings import SetuptoolsDeprecationWarning
 

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -6,6 +6,29 @@ A wheel is a built archive format.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "email",
+    "email.generator",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._core_metadata",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._normalization",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    f"{__spec__.parent}.egg_info",
+    "glob",
+    "packaging",
+    "re",
+    "shutil",
+    "struct",
+    "sysconfig",
+    "typing",
+    "warnings",
+    "wheel",
+    "wheel.wheelfile",
+    "zipfile",
+}
+
 import os
 import re
 import shutil

--- a/setuptools/command/bdist_wheel.py
+++ b/setuptools/command/bdist_wheel.py
@@ -6,6 +6,28 @@ A wheel is a built archive format.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "email",
+    "email.generator",
+    "glob",
+    "packaging",
+    "re",
+    "shutil",
+    "struct",
+    "sysconfig",
+    "typing",
+    "warnings",
+    "wheel",
+    "wheel.wheelfile",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._core_metadata",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._normalization",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    f"{__spec__.parent}.egg_info",
+}
+
 import os
 import re
 import shutil

--- a/setuptools/command/build.py
+++ b/setuptools/command/build.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist"}
+
 from typing import Protocol
 
 from ..dist import Distribution

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -1,3 +1,10 @@
+__lazy_modules__ = {
+    "distutils",
+    "distutils.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.modified",
+}
+
 from ..dist import Distribution
 from ..modified import newer_pairwise_group
 

--- a/setuptools/command/build_ext.py
+++ b/setuptools/command/build_ext.py
@@ -1,5 +1,22 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.ccompiler",
+    "importlib",
+    "importlib.machinery",
+    "importlib.util",
+    "itertools",
+    "operator",
+    "pathlib",
+    "setuptools.dist",
+    "setuptools.errors",
+    "setuptools.extension",
+    "textwrap",
+}
+
 import itertools
 import operator
 import os

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -1,5 +1,25 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.errors",
+    "distutils.util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    "fnmatch",
+    "functools",
+    "glob",
+    "itertools",
+    "more_itertools",
+    "operator",
+    "pathlib",
+    "textwrap",
+    "typing",
+}
+
 import fnmatch
 import itertools
 import operator

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -1,5 +1,24 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.errors",
+    "distutils.util",
+    "fnmatch",
+    "functools",
+    "glob",
+    "itertools",
+    "more_itertools",
+    "operator",
+    "pathlib",
+    "textwrap",
+    "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+}
+
 import fnmatch
 import itertools
 import operator

--- a/setuptools/command/develop.py
+++ b/setuptools/command/develop.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"subprocess", "typing"}
+
 import site
 import subprocess
 import sys

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -3,6 +3,16 @@ Create a dist_info directory
 As defined in the wheel specification
 """
 
+__lazy_modules__ = {
+    "contextlib",
+    "distutils",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._shutil",
+    f"{__spec__.parent}.egg_info",
+    "pathlib",
+    "shutil",
+    "typing",
+}
+
 import os
 import shutil
 from contextlib import contextmanager

--- a/setuptools/command/dist_info.py
+++ b/setuptools/command/dist_info.py
@@ -3,6 +3,15 @@ Create a dist_info directory
 As defined in the wheel specification
 """
 
+__lazy_modules__ = {
+    "distutils",
+    "pathlib",
+    "shutil",
+    "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._shutil",
+    f"{__spec__.parent}.egg_info",
+}
+
 import os
 import shutil
 from contextlib import contextmanager

--- a/setuptools/command/easy_install.py
+++ b/setuptools/command/easy_install.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"types"}
+
 import os
 import sys
 import types

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -12,6 +12,31 @@ Create a wheel that, when installed, will make the source package 'editable'
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "contextlib",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.compat",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.discovery",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    f"{__spec__.parent}.build",
+    f"{__spec__.parent}.build_py",
+    f"{__spec__.parent}.dist_info",
+    f"{__spec__.parent}.egg_info",
+    f"{__spec__.parent}.install",
+    f"{__spec__.parent}.install_scripts",
+    "inspect",
+    "io",
+    "itertools",
+    "operator",
+    "pathlib",
+    "shutil",
+    "tempfile",
+    "traceback",
+    "types",
+}
+
 import io
 import logging
 import operator

--- a/setuptools/command/editable_wheel.py
+++ b/setuptools/command/editable_wheel.py
@@ -12,6 +12,30 @@ Create a wheel that, when installed, will make the source package 'editable'
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "contextlib",
+    "io",
+    "itertools",
+    "operator",
+    "pathlib",
+    "shutil",
+    "tempfile",
+    "traceback",
+    "types",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.compat",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.discovery",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    f"{__spec__.parent}.build",
+    f"{__spec__.parent}.build_py",
+    f"{__spec__.parent}.dist_info",
+    f"{__spec__.parent}.egg_info",
+    f"{__spec__.parent}.install",
+    f"{__spec__.parent}.install_scripts",
+}
+
 import io
 import logging
 import operator

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -4,6 +4,22 @@ Create a distribution's .egg-info directory and contents"""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.errors",
+    "distutils.util",
+    "functools",
+    "packaging",
+    "packaging.requirements",
+    "packaging.version",
+    "re",
+    "setuptools.command.setopt",
+    "setuptools.glob",
+    "typing",
+}
+
 import functools
 import os
 import re
@@ -23,7 +39,7 @@ from setuptools.command.setopt import edit_config
 from setuptools.glob import glob
 
 from .. import _entry_points, _normalization
-from .._importlib import metadata
+from .._importlib import metadata  # noqa: LZY102
 from ..warnings import SetuptoolsDeprecationWarning
 from . import _requirestxt
 

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -4,6 +4,23 @@ Create a distribution's .egg-info directory and contents"""
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.errors",
+    "distutils.util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._importlib",
+    "functools",
+    "packaging",
+    "packaging.requirements",
+    "packaging.version",
+    "re",
+    "setuptools.command.setopt",
+    "setuptools.glob",
+    "typing",
+}
+
 import functools
 import os
 import re

--- a/setuptools/command/egg_info.py
+++ b/setuptools/command/egg_info.py
@@ -10,7 +10,6 @@ __lazy_modules__ = {
     "distutils",
     "distutils.errors",
     "distutils.util",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._importlib",
     "functools",
     "packaging",
     "packaging.requirements",
@@ -40,7 +39,7 @@ from setuptools.command.setopt import edit_config
 from setuptools.glob import glob
 
 from .. import _entry_points, _normalization
-from .._importlib import metadata
+from .._importlib import metadata  # noqa: LZY102
 from ..warnings import SetuptoolsDeprecationWarning
 from . import _requirestxt
 

--- a/setuptools/command/install.py
+++ b/setuptools/command/install.py
@@ -1,5 +1,16 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    "inspect",
+    "platform",
+}
+
 import inspect
 import platform
 from collections.abc import Callable

--- a/setuptools/command/install.py
+++ b/setuptools/command/install.py
@@ -1,5 +1,16 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.errors",
+    "inspect",
+    "platform",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+}
+
 import inspect
 import platform
 from collections.abc import Callable

--- a/setuptools/command/install_egg_info.py
+++ b/setuptools/command/install_egg_info.py
@@ -1,3 +1,10 @@
+__lazy_modules__ = {
+    "distutils",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    "setuptools.archive_util",
+    "typing",
+}
+
 import os
 from typing import ClassVar
 

--- a/setuptools/command/install_egg_info.py
+++ b/setuptools/command/install_egg_info.py
@@ -1,3 +1,10 @@
+__lazy_modules__ = {
+    "distutils",
+    "setuptools.archive_util",
+    "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+}
+
 import os
 from typing import ClassVar
 

--- a/setuptools/command/install_lib.py
+++ b/setuptools/command/install_lib.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    "itertools",
+}
+
 import os
 import sys
 from itertools import product, starmap

--- a/setuptools/command/install_lib.py
+++ b/setuptools/command/install_lib.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "itertools",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+}
+
 import os
 import sys
 from itertools import product, starmap

--- a/setuptools/command/install_scripts.py
+++ b/setuptools/command/install_scripts.py
@@ -1,5 +1,11 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+}
+
 import os
 import sys
 

--- a/setuptools/command/rotate.py
+++ b/setuptools/command/rotate.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"distutils", "distutils.errors", "distutils.util", "typing"}
+
 import os
 from typing import ClassVar
 

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -5,7 +5,6 @@ __lazy_modules__ = {
     "collections.abc",
     "contextlib",
     "distutils",
-    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._importlib",
     f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
     f"{__spec__.parent}.build",
     "itertools",
@@ -20,7 +19,7 @@ from collections.abc import Iterator
 from itertools import chain
 from typing import ClassVar
 
-from .._importlib import metadata
+from .._importlib import metadata  # noqa: LZY102
 from ..dist import Distribution
 from .build import _ORIGINAL_SUBCOMMANDS
 

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "contextlib",
+    "distutils",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._importlib",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{__spec__.parent}.build",
+    "itertools",
+    "re",
+    "typing",
+}
+
 import contextlib
 import os
 import re

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -1,5 +1,16 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "itertools",
+    "re",
+    "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.dist",
+    f"{__spec__.parent}.build",
+}
+
 import contextlib
 import os
 import re
@@ -7,7 +18,7 @@ from collections.abc import Iterator
 from itertools import chain
 from typing import ClassVar
 
-from .._importlib import metadata
+from .._importlib import metadata  # noqa: LZY102
 from ..dist import Distribution
 from .build import _ORIGINAL_SUBCOMMANDS
 

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -1,3 +1,12 @@
+__lazy_modules__ = {
+    "configparser",
+    "distutils",
+    "distutils.errors",
+    "distutils.util",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.unicode_utils",
+    "typing",
+}
+
 import configparser
 import os
 from typing import ClassVar

--- a/setuptools/command/setopt.py
+++ b/setuptools/command/setopt.py
@@ -1,3 +1,12 @@
+__lazy_modules__ = {
+    "configparser",
+    "distutils",
+    "distutils.errors",
+    "distutils.util",
+    "typing",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.unicode_utils",
+}
+
 import configparser
 import os
 from typing import ClassVar

--- a/setuptools/command/test.py
+++ b/setuptools/command/test.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"setuptools.warnings", "typing"}
+
 from typing import ClassVar, NoReturn
 
 from setuptools import Command

--- a/setuptools/compat/py310.py
+++ b/setuptools/compat/py310.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"tomli", "tomllib"}
+
 import sys
 
 __all__ = ['tomllib']

--- a/setuptools/compat/py311.py
+++ b/setuptools/compat/py311.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+__lazy_modules__ = {"collections", "collections.abc", "shutil"}
+
 import shutil
 import sys
 from collections.abc import Callable
@@ -10,8 +12,10 @@ if TYPE_CHECKING:
 
     from _typeshed import ExcInfo, StrOrBytesPath
 
-# Same as shutil._OnExcCallback from typeshed
-_OnExcCallback: TypeAlias = Callable[[Callable[..., Any], str, BaseException], object]
+    # Same as shutil._OnExcCallback from typeshed
+    _OnExcCallback: TypeAlias = Callable[
+        [Callable[..., Any], str, BaseException], object
+    ]
 
 
 def shutil_rmtree(

--- a/setuptools/config/__init__.py
+++ b/setuptools/config/__init__.py
@@ -2,6 +2,11 @@
 ``setuptools.config.setupcfg``
 """
 
+__lazy_modules__ = {
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    "functools",
+}
+
 from collections.abc import Callable
 from functools import wraps
 from typing import TypeVar, cast

--- a/setuptools/config/__init__.py
+++ b/setuptools/config/__init__.py
@@ -2,6 +2,11 @@
 ``setuptools.config.setupcfg``
 """
 
+__lazy_modules__ = {
+    "functools",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+}
+
 from collections.abc import Callable
 from functools import wraps
 from typing import TypeVar, cast

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -10,6 +10,15 @@ need to be processed before being applied.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "email",
+    "email.headerregistry",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.extension",
+    "inspect",
+    "itertools",
+}
+
 import logging
 import os
 from collections.abc import Callable, Mapping

--- a/setuptools/config/_apply_pyprojecttoml.py
+++ b/setuptools/config/_apply_pyprojecttoml.py
@@ -10,6 +10,15 @@ need to be processed before being applied.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "email",
+    "email.headerregistry",
+    "inspect",
+    "itertools",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.extension",
+}
+
 import logging
 import os
 from collections.abc import Callable, Mapping

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -20,6 +20,22 @@ functions among several configuration file formats.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "ast",
+    "configparser",
+    "distutils",
+    "distutils.errors",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.discovery",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+    "glob",
+    "importlib",
+    "importlib.machinery",
+    "itertools",
+    "pathlib",
+    "types",
+}
+
 import ast
 import importlib
 import os

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -20,6 +20,22 @@ functions among several configuration file formats.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "ast",
+    "configparser",
+    "distutils",
+    "distutils.errors",
+    "glob",
+    "importlib",
+    "importlib.machinery",
+    "itertools",
+    "pathlib",
+    "types",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.discovery",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.warnings",
+}
+
 import ast
 import importlib
 import os

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -11,6 +11,16 @@ with the help of ``tomllib`` or ``tomli``.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{__spec__.parent}._apply_pyprojecttoml",
+    "functools",
+    "types",
+}
+
 import logging
 import os
 from collections.abc import Callable, Mapping

--- a/setuptools/config/pyprojecttoml.py
+++ b/setuptools/config/pyprojecttoml.py
@@ -11,6 +11,16 @@ with the help of ``tomllib`` or ``tomli``.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "functools",
+    "types",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    f"{__spec__.parent}._apply_pyprojecttoml",
+}
+
 import logging
 import os
 from collections.abc import Callable, Mapping

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -11,6 +11,19 @@ with the help of ``configparser``.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "contextlib",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+    "functools",
+    "packaging",
+    "packaging.markers",
+    "packaging.requirements",
+    "packaging.version",
+}
+
 import contextlib
 import functools
 import os

--- a/setuptools/config/setupcfg.py
+++ b/setuptools/config/setupcfg.py
@@ -11,6 +11,19 @@ with the help of ``configparser``.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "contextlib",
+    "functools",
+    "packaging",
+    "packaging.markers",
+    "packaging.requirements",
+    "packaging.version",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}._path",
+    f"{(__spec__.parent or '').rsplit('.', 1)[0]}.errors",
+}
+
 import contextlib
 import functools
 import os

--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "dis",
+    f"{__spec__.parent}._imp",
+    "packaging",
+    "packaging.version",
+    "types",
+}
+
 import contextlib
 import dis
 import marshal

--- a/setuptools/depends.py
+++ b/setuptools/depends.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "dis",
+    "packaging",
+    "packaging.version",
+    "types",
+    f"{__spec__.parent}._imp",
+}
+
 import contextlib
 import dis
 import marshal

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -39,6 +39,17 @@ For the purposes of this module, the following nomenclature is used:
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.util",
+    f"{__spec__.parent}._path",
+    "fnmatch",
+    "glob",
+    "pathlib",
+}
+
 import itertools
 import os
 from collections.abc import Iterable, Iterator, Mapping

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -39,6 +39,17 @@ For the purposes of this module, the following nomenclature is used:
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.util",
+    "fnmatch",
+    "glob",
+    "pathlib",
+    f"{__spec__.parent}._path",
+}
+
 import itertools
 import os
 from collections.abc import Iterable, Iterator, Mapping

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -1,5 +1,34 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils.cmd",
+    "distutils.command",
+    "distutils.debug",
+    "distutils.dist",
+    "distutils.errors",
+    "distutils.fancy_getopt",
+    "distutils.log",
+    "distutils.util",
+    f"{__spec__.parent}._importlib",
+    f"{__spec__.parent}._normalization",
+    f"{__spec__.parent}._path",
+    f"{__spec__.parent}._reqs",
+    f"{__spec__.parent}.config",
+    f"{__spec__.parent}.discovery",
+    f"{__spec__.parent}.errors",
+    "glob",
+    "io",
+    "itertools",
+    "more_itertools",
+    "numbers",
+    "packaging",
+    "packaging.markers",
+    "packaging.specifiers",
+    "packaging.version",
+    "pathlib",
+    "re",
+}
+
 import functools
 import io
 import itertools

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -9,7 +9,6 @@ __lazy_modules__ = {
     "distutils.fancy_getopt",
     "distutils.log",
     "distutils.util",
-    f"{__spec__.parent}._importlib",
     f"{__spec__.parent}._normalization",
     f"{__spec__.parent}._path",
     f"{__spec__.parent}._reqs",
@@ -52,7 +51,7 @@ from . import (
     _static,
     command as _,  # noqa: F401 # imported for side-effects
 )
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from ._normalization import _canonicalize_license_expression
 from ._path import StrPath
 from ._reqs import _StrOrIter

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -1,5 +1,33 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils.cmd",
+    "distutils.command",
+    "distutils.debug",
+    "distutils.dist",
+    "distutils.errors",
+    "distutils.fancy_getopt",
+    "distutils.log",
+    "distutils.util",
+    "glob",
+    "io",
+    "itertools",
+    "more_itertools",
+    "numbers",
+    "packaging",
+    "packaging.markers",
+    "packaging.specifiers",
+    "packaging.version",
+    "pathlib",
+    "re",
+    f"{__spec__.parent}._normalization",
+    f"{__spec__.parent}._path",
+    f"{__spec__.parent}._reqs",
+    f"{__spec__.parent}.config",
+    f"{__spec__.parent}.discovery",
+    f"{__spec__.parent}.errors",
+}
+
 import functools
 import io
 import itertools
@@ -23,7 +51,7 @@ from . import (
     _static,
     command as _,  # noqa: F401 # imported for side-effects
 )
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from ._normalization import _canonicalize_license_expression
 from ._path import StrPath
 from ._reqs import _StrOrIter

--- a/setuptools/extension.py
+++ b/setuptools/extension.py
@@ -1,5 +1,15 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils.errors",
+    "distutils.extension",
+    "functools",
+    "re",
+    "setuptools._path",
+}
+
 import functools
 import re
 from collections.abc import Iterable

--- a/setuptools/glob.py
+++ b/setuptools/glob.py
@@ -8,6 +8,8 @@ Changes include:
 
 from __future__ import annotations
 
+__lazy_modules__ = {"collections", "collections.abc", "fnmatch"}
+
 import fnmatch
 import os
 import re

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 __lazy_modules__ = {
     "distutils",
     "distutils.errors",
-    f"{__spec__.parent}._importlib",
     f"{__spec__.parent}.wheel",
     "glob",
     "itertools",
@@ -25,7 +24,7 @@ import packaging.requirements
 import packaging.utils
 
 from . import _reqs
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from .warnings import SetuptoolsDeprecationWarning
 from .wheel import Wheel
 

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -1,5 +1,19 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils",
+    "distutils.errors",
+    f"{__spec__.parent}._importlib",
+    f"{__spec__.parent}.wheel",
+    "glob",
+    "itertools",
+    "packaging",
+    "packaging.requirements",
+    "packaging.utils",
+    "subprocess",
+    "tempfile",
+}
+
 import glob
 import itertools
 import os

--- a/setuptools/installer.py
+++ b/setuptools/installer.py
@@ -1,5 +1,18 @@
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "distutils",
+    "distutils.errors",
+    "glob",
+    "itertools",
+    "packaging",
+    "packaging.requirements",
+    "packaging.utils",
+    "subprocess",
+    "tempfile",
+    f"{__spec__.parent}.wheel",
+}
+
 import glob
 import itertools
 import os
@@ -11,7 +24,7 @@ import packaging.requirements
 import packaging.utils
 
 from . import _reqs
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from .warnings import SetuptoolsDeprecationWarning
 from .wheel import Wheel
 

--- a/setuptools/launch.py
+++ b/setuptools/launch.py
@@ -6,6 +6,8 @@ setuptools is bootstrapped via import.
 # Note that setuptools gets imported implicitly by the
 # invocation of this script using python -m setuptools.launch
 
+__lazy_modules__ = {"tokenize"}
+
 import sys
 import tokenize
 

--- a/setuptools/logging.py
+++ b/setuptools/logging.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"distutils", "distutils.log", "inspect", "logging"}
+
 import inspect
 import logging
 import sys

--- a/setuptools/monkey.py
+++ b/setuptools/monkey.py
@@ -4,6 +4,8 @@ Monkey patching of distutils.
 
 from __future__ import annotations
 
+__lazy_modules__ = {"distutils", "distutils.filelist", "inspect", "platform"}
+
 import inspect
 import platform
 import sys

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -7,6 +7,18 @@ Environment info about Microsoft Compilers.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "distutils",
+    "distutils.errors",
+    f"{__spec__.parent}._path",
+    f"{__spec__.parent}.compat",
+    "itertools",
+    "json",
+    "more_itertools",
+    "winreg",
+}
+
 import contextlib
 import itertools
 import json

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -7,6 +7,17 @@ Environment info about Microsoft Compilers.
 
 from __future__ import annotations
 
+__lazy_modules__ = {
+    "contextlib",
+    "distutils",
+    "distutils.errors",
+    "itertools",
+    "json",
+    "more_itertools",
+    f"{__spec__.parent}._path",
+    f"{__spec__.parent}.compat",
+}
+
 import contextlib
 import itertools
 import json

--- a/setuptools/namespaces.py
+++ b/setuptools/namespaces.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"distutils", f"{__spec__.parent}.compat"}
+
 import itertools
 import os
 

--- a/setuptools/unicode_utils.py
+++ b/setuptools/unicode_utils.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"configparser", "unicodedata"}
+
 import sys
 import unicodedata
 from configparser import RawConfigParser

--- a/setuptools/warnings.py
+++ b/setuptools/warnings.py
@@ -7,6 +7,8 @@ setuptools.
 
 from __future__ import annotations
 
+__lazy_modules__ = {"datetime", "inspect", "textwrap", "warnings"}
+
 import os
 import warnings
 from datetime import date

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -1,5 +1,26 @@
 """Wheels support."""
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.util",
+    "email",
+    f"{__spec__.parent}._discovery",
+    f"{__spec__.parent}._importlib",
+    f"{__spec__.parent}.unicode_utils",
+    "itertools",
+    "packaging",
+    "packaging.requirements",
+    "packaging.tags",
+    "packaging.utils",
+    "packaging.version",
+    "setuptools.archive_util",
+    "setuptools.command",
+    "setuptools.command.egg_info",
+    "zipfile",
+}
+
 import contextlib
 import email
 import functools

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -7,7 +7,6 @@ __lazy_modules__ = {
     "distutils.util",
     "email",
     f"{__spec__.parent}._discovery",
-    f"{__spec__.parent}._importlib",
     f"{__spec__.parent}.unicode_utils",
     "itertools",
     "packaging",
@@ -41,7 +40,7 @@ from setuptools.archive_util import _unpack_zipfile_obj
 from setuptools.command.egg_info import _egg_basename, write_requirements
 
 from ._discovery import extras_from_deps
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from .unicode_utils import _read_utf8_with_fallback
 
 from distutils.util import get_platform

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -1,5 +1,25 @@
 """Wheels support."""
 
+__lazy_modules__ = {
+    "collections",
+    "collections.abc",
+    "distutils",
+    "distutils.util",
+    "email",
+    "itertools",
+    "packaging",
+    "packaging.requirements",
+    "packaging.tags",
+    "packaging.utils",
+    "packaging.version",
+    "setuptools.archive_util",
+    "setuptools.command",
+    "setuptools.command.egg_info",
+    "zipfile",
+    f"{__spec__.parent}._discovery",
+    f"{__spec__.parent}.unicode_utils",
+}
+
 import contextlib
 import email
 import functools
@@ -20,7 +40,7 @@ from setuptools.archive_util import _unpack_zipfile_obj
 from setuptools.command.egg_info import _egg_basename, write_requirements
 
 from ._discovery import extras_from_deps
-from ._importlib import metadata
+from ._importlib import metadata  # noqa: LZY102
 from .unicode_utils import _read_utf8_with_fallback
 
 from distutils.util import get_platform

--- a/setuptools/windows_support.py
+++ b/setuptools/windows_support.py
@@ -1,3 +1,5 @@
+__lazy_modules__ = {"platform"}
+
 import platform
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,14 @@ setenv =
 	SETUPTOOLS_ENFORCE_DEPRECATION = {env:SETUPTOOLS_ENFORCE_DEPRECATION:0}  # TODO: return to 1 (temporarily disabled)
 commands =
 	pytest {posargs}
+	# flake8-lazy has no pytest plugin; run its CLI over the package sources.
+	# tox doesn't shell-glob, so expand the file list cross-platform via Python
+	# and drop test dirs (lazy-import hygiene is irrelevant there) plus the
+	# vendored/distutils trees (maintained upstream, not our lazy-import concern).
+	python -c "import glob, os, subprocess, sys; \
+		skip = {'tests', '_distutils', '_vendor', '_validate_pyproject'}; \
+		files = [f for f in glob.glob('setuptools/**/*.py', recursive=True) if not skip & set(f.split(os.sep))]; \
+		subprocess.check_call([sys.executable, '-m', 'flake8_lazy', *files])"
 usedevelop = True
 extras =
 	test

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,10 @@ setenv =
 	SETUPTOOLS_ENFORCE_DEPRECATION = {env:SETUPTOOLS_ENFORCE_DEPRECATION:0}  # TODO: return to 1 (temporarily disabled)
 commands =
 	pytest {posargs}
+	# flake8-lazy has no pytest plugin; run its CLI over the package sources.
+	# Avoid vendored/distutils trees (maintained upstream, not our lazy-import concern).
+	# As well as test dirs (lazy-import hygiene is irrelevant there).
+	python -m flake8_lazy setuptools/*.py setuptools/command/ setuptools/compat/ setuptools/config/*.py --apply=set --strict-typing
 usedevelop = True
 extras =
 	test

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,13 @@ setenv =
 commands =
 	pytest {posargs}
 	# flake8-lazy has no pytest plugin; run its CLI over the package sources.
-	# Avoid vendored/distutils trees (maintained upstream, not our lazy-import concern).
-	# As well as test dirs (lazy-import hygiene is irrelevant there).
-	python -m flake8_lazy setuptools/*.py setuptools/command/ setuptools/compat/ setuptools/config/*.py --apply=set --strict-typing
+	# tox doesn't shell-glob, so expand the file list cross-platform via Python
+	# and drop test dirs (lazy-import hygiene is irrelevant there) plus the
+	# vendored/distutils trees (maintained upstream, not our lazy-import concern).
+	python -c "import glob, os, subprocess, sys; \
+		skip = {'tests', '_distutils', '_vendor', '_validate_pyproject'}; \
+		files = [f for f in glob.glob('setuptools/**/*.py', recursive=True) if not skip & set(f.split(os.sep))]; \
+		subprocess.check_call([sys.executable, '-m', 'flake8_lazy', *files])"
 usedevelop = True
 extras =
 	test


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes

Alternative dynamic mode: https://flake8-lazy.readthedocs.io/en/latest/cli/#dynamic-mode

<!-- Summary goes here -->

Once https://github.com/pypa/distutils/pull/414 is also merged, this will 
- Close https://github.com/pypa/setuptools/issues/3585
- Close https://github.com/pypa/setuptools/issues/3441

Autofixed by running

```py
import glob, os, subprocess, sys
skip = {'tests', '_distutils', '_vendor', '_validate_pyproject'}
files = [f for f in glob.glob('setuptools/**/*.py', recursive=True) if not skip & set(f.split(os.sep))]
subprocess.check_call([sys.executable, '-m', 'flake8_lazy', *files, '--apply=set', '--strict-typing'])
```

Note: Merging https://github.com/pypa/setuptools/pull/5222 first should reduce import reification related errors found by test.

### Pull Request Checklist
- [X] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
