### PR TITLE
Log missing conventional README at debug level

### DIFF
--- a/newsfragments/4122.bugfix.rst
+++ b/newsfragments/4122.bugfix.rst
@@ -1,0 +1,1 @@
+Changed the missing conventional README diagnostic from a warning to debug output.

--- a/setuptools/command/sdist.py
+++ b/setuptools/command/sdist.py
@@ -170,7 +170,7 @@ class sdist(orig.sdist):
             if os.path.exists(f):
                 return
         else:
-            self.warn(
+            log.debug(
                 "standard file not found: should have one of " + ', '.join(self.READMES)
             )
 

--- a/setuptools/tests/test_sdist.py
+++ b/setuptools/tests/test_sdist.py
@@ -420,6 +420,20 @@ class TestSdistTest:
         assert 'setup.py' not in manifest, manifest
         assert 'setup.cfg' not in manifest, manifest
 
+    def test_nonstandard_readme_logs_at_debug(self, source_dir, caplog):
+        touch(source_dir / 'project.readme.md')
+        cmd = sdist(Distribution(SETUP_ATTRS))
+
+        with caplog.at_level(logging.DEBUG):
+            cmd.check_readme()
+
+        (record,) = [
+            record
+            for record in caplog.records
+            if "standard file not found" in record.getMessage()
+        ]
+        assert record.levelno == logging.DEBUG
+
     def test_exclude_dev_only_cache_folders(self, source_dir):
         included = {
             # Emulate problem in https://github.com/pypa/setuptools/issues/4601


### PR DESCRIPTION
## Summary of changes

The `sdist` command currently emits a warning when none of the conventional README filenames are present. That diagnostic is informational rather than actionable, and it can be misleading for projects that intentionally use a nonstandard README filename.

This changes the diagnostic from warning to debug output, keeping it available for troubleshooting without showing it during normal builds. It also adds a regression test that verifies the message is logged at the debug level.

Closes #4122

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_


[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
