### PR TITLE
docs: clarify that license_file alias is deprecated

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -214,6 +214,13 @@ Metadata
     The aliases given below are supported for compatibility reasons,
     but their use is not advised.
 
+.. note::
+    The ``license_file`` alias (singular) for ``license_files`` was deprecated
+    in ``setuptools`` 42.0.0.  If you see a warning like
+    ``The license_file parameter is deprecated, use license_files instead``,
+    change the key in your ``setup.cfg`` from ``license_file`` to
+    ``license_files``.
+
 ==============================  =================  =================  =============== ==========
 Key                             Aliases            Type               Minimum Version Notes
 ==============================  =================  =================  =============== ==========


### PR DESCRIPTION
Closes #4147.

The deprecation warning shown by setuptools links to the `declarative_config` page, but that page had no explanation of the deprecation. This adds a note explaining that `license_file` (singular) was deprecated in 42.0.0 and that users should rename the key to `license_files`.