### PR TITLE
docs: clarify recursive-include requires a file pattern in MANIFEST.in

### DIFF
--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -214,6 +214,13 @@ Metadata
     The aliases given below are supported for compatibility reasons,
     but their use is not advised.
 
+.. note::
+    The ``license_file`` alias (singular) for ``license_files`` was deprecated
+    in ``setuptools`` 42.0.0.  If you see a warning like
+    ``The license_file parameter is deprecated, use license_files instead``,
+    change the key in your ``setup.cfg`` from ``license_file`` to
+    ``license_files``.
+
 ==============================  =================  =================  =============== ==========
 Key                             Aliases            Type               Minimum Version Notes
 ==============================  =================  =================  =============== ==========

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -113,6 +113,18 @@ brackets (which may contain character ranges, e.g., ``[a-z]`` or
 ``[a-fA-F0-9]``).  Setuptools also has support for ``**`` matching
 zero or more characters including forward slash, backslash, and colon.
 
+.. note::
+   ``recursive-include`` requires **at least one file pattern**; the directory
+   pattern alone is not enough.  For example, to include all ``.html`` files
+   under ``templates/``, write:
+
+   .. code-block:: bash
+
+      recursive-include templates *.html
+
+   Writing ``recursive-include templates`` (without a pattern) is invalid and
+   will include nothing.
+
 Directory patterns are relative to the root of the project directory; e.g.,
 ``graft example*`` will include a directory named :file:`examples` in the
 project root but will not include :file:`docs/examples/`.


### PR DESCRIPTION
Closes #4158.

Users often write `recursive-include folder` and are confused when it includes nothing, because the directory pattern alone is not sufficient — at least one file-pattern argument (e.g. `*.html`) is required. This PR adds a short note and example directly after the command table.