### PR TITLE
feat: Warn on mismatched typing classifiers and py.typed markers

### DIFF
--- a/newsfragments/5243.feature.rst
+++ b/newsfragments/5243.feature.rst
@@ -1,0 +1,1 @@
+Added warnings to detect mismatches between ``py.typed`` markers and ``Typing :: *`` classifiers during builds.

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -16,7 +16,7 @@ from more_itertools import unique_everseen
 
 from .._path import StrPath, StrPathT
 from ..dist import Distribution
-from ..warnings import SetuptoolsDeprecationWarning
+from ..warnings import SetuptoolsDeprecationWarning, SetuptoolsWarning
 
 import distutils.command.build_py as orig
 import distutils.errors
@@ -78,6 +78,7 @@ class build_py(orig.build_py):
         if self.packages:
             self.build_packages()
             self.build_package_data()
+            self._check_typing_classifier()
 
         # Only compile actual .py files, using our base class' idea of what our
         # output files are.
@@ -173,6 +174,51 @@ class build_py(orig.build_py):
             self.mkpath(os.path.dirname(target))
             _outf, _copied = self.copy_file(srcfile, target)
             make_writable(target)
+
+    def _check_typing_classifier(self) -> None:
+        """Warn when typing classifiers and ``py.typed`` markers are inconsistent."""
+        classifiers = self.distribution.metadata.get_classifiers()
+        has_typed_classifier = "Typing :: Typed" in classifiers
+        has_stubs_classifier = "Typing :: Stubs Only" in classifiers
+        has_any_typing_classifier = has_typed_classifier or has_stubs_classifier
+
+        packages = self.packages or ()
+        has_stubs_package = any(
+            pkg.split(".")[0].endswith("-stubs") for pkg in packages
+        )
+        has_py_typed = any("py.typed" in filenames for *_, filenames in self.data_files)
+
+        if has_py_typed and not has_any_typing_classifier:
+            SetuptoolsWarning.emit(
+                "Package includes a `py.typed` marker but is missing a "
+                "`Typing :: *` classifier.",
+                "Please consider adding either `Typing :: Typed` or "
+                "`Typing :: Stubs Only` to your classifiers.",
+                see_url=(
+                    "https://typing.python.org/en/latest/spec/distributing.html"
+                    "#packaging-type-information"
+                ),
+            )
+        elif has_typed_classifier and (not has_py_typed or has_stubs_package):
+            SetuptoolsWarning.emit(
+                "`Typing :: Typed` classifier is present but the package does "
+                "not ship a `py.typed` marker or is a stubs package.",
+                "Please either add a `py.typed` marker or use "
+                "`Typing :: Stubs Only` for stubs-only packages.",
+                see_url=(
+                    "https://typing.python.org/en/latest/spec/distributing.html"
+                    "#packaging-type-information"
+                ),
+            )
+        elif has_stubs_package and not has_stubs_classifier:
+            SetuptoolsWarning.emit(
+                "Stubs package is missing the `Typing :: Stubs Only` classifier.",
+                "Please consider adding `Typing :: Stubs Only` to your classifiers.",
+                see_url=(
+                    "https://typing.python.org/en/latest/spec/distributing.html"
+                    "#packaging-type-information"
+                ),
+            )
 
     def analyze_manifest(self) -> None:
         self.manifest_files: dict[str, list[str]] = {}

--- a/setuptools/tests/test_build_meta.py
+++ b/setuptools/tests/test_build_meta.py
@@ -333,7 +333,8 @@ class TestBuildMetaBackend:
                 dynamic = ["version", "readme"]
                 classifiers = [
                     "Development Status :: 5 - Production/Stable",
-                    "Intended Audience :: Developers"
+                    "Intended Audience :: Developers",
+                    "Typing :: Typed",
                 ]
                 urls = {Homepage = "http://github.com"}
                 dependencies = [

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -11,6 +11,7 @@ import pytest
 
 from setuptools import SetuptoolsDeprecationWarning
 from setuptools.dist import Distribution
+from setuptools.warnings import SetuptoolsWarning
 
 from .textwrap import DALS
 
@@ -463,6 +464,133 @@ class TestTypeInfoFiles:
         build_py = get_finalized_build_py()
         outputs = get_outputs(build_py)
         assert expected_type_files <= outputs
+
+
+class TestTypingClassifierWarnings:
+    def _build_py(self):
+        dist = Distribution({"script_name": "%build_py-test%"})
+        dist.parse_config_files()
+        dist.set_defaults()
+        build_py = dist.get_command_obj("build_py")
+        build_py.finalize_options()
+        return build_py
+
+    def test_py_typed_without_classifier_warns(self, tmpdir_cwd):
+        jaraco.path.build({
+            "pyproject.toml": DALS(
+                """
+                    [project]
+                    name = "foo"
+                    version = "1"
+                    """
+            ),
+            "foo": {"__init__.py": "", "py.typed": ""},
+        })
+        build_py = self._build_py()
+        msg = r"missing a `Typing :: \*` classifier"
+        with pytest.warns(SetuptoolsWarning, match=msg):
+            build_py.run()
+
+    def test_py_typed_with_typed_classifier_ok(self, tmpdir_cwd):
+        jaraco.path.build({
+            "pyproject.toml": DALS(
+                """
+                    [project]
+                    name = "foo"
+                    version = "1"
+                    classifiers = ["Typing :: Typed"]
+                    """
+            ),
+            "foo": {"__init__.py": "", "py.typed": ""},
+        })
+        build_py = self._build_py()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", SetuptoolsWarning)
+            build_py.run()
+
+    def test_py_typed_with_stubs_classifier_ok(self, tmpdir_cwd):
+        jaraco.path.build({
+            "pyproject.toml": DALS(
+                """
+                    [project]
+                    name = "foo"
+                    version = "1"
+                    classifiers = ["Typing :: Stubs Only"]
+                    """
+            ),
+            "foo": {"__init__.py": "", "py.typed": ""},
+        })
+        build_py = self._build_py()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", SetuptoolsWarning)
+            build_py.run()
+
+    def test_typed_classifier_without_py_typed_warns(self, tmpdir_cwd):
+        jaraco.path.build({
+            "pyproject.toml": DALS(
+                """
+                    [project]
+                    name = "foo"
+                    version = "1"
+                    classifiers = ["Typing :: Typed"]
+                    """
+            ),
+            "foo": {"__init__.py": ""},
+        })
+        build_py = self._build_py()
+        msg = "does not ship a `py.typed` marker"
+        with pytest.warns(SetuptoolsWarning, match=msg):
+            build_py.run()
+
+    def test_stubs_package_without_stubs_classifier_warns(self, tmpdir_cwd):
+        jaraco.path.build({
+            "pyproject.toml": DALS(
+                """
+                    [project]
+                    name = "foo-stubs"
+                    version = "1"
+                    """
+            ),
+            "foo-stubs": {"__init__.pyi": ""},
+        })
+        build_py = self._build_py()
+        msg = "missing the `Typing :: Stubs Only` classifier"
+        with pytest.warns(SetuptoolsWarning, match=msg):
+            build_py.run()
+
+    def test_stubs_package_with_stubs_classifier_ok(self, tmpdir_cwd):
+        jaraco.path.build({
+            "pyproject.toml": DALS(
+                """
+                    [project]
+                    name = "foo-stubs"
+                    version = "1"
+                    classifiers = ["Typing :: Stubs Only"]
+                    """
+            ),
+            "foo-stubs": {"__init__.pyi": ""},
+        })
+        build_py = self._build_py()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", SetuptoolsWarning)
+            build_py.run()
+
+    def test_typed_classifier_with_stubs_package_warns(self, tmpdir_cwd):
+        jaraco.path.build({
+            "pyproject.toml": DALS(
+                """
+                    [project]
+                    name = "foo-stubs"
+                    version = "1"
+                    classifiers = ["Typing :: Typed"]
+                    """
+            ),
+            "foo-stubs": {"__init__.pyi": ""},
+        })
+        build_py = self._build_py()
+        msg = "does not ship a `py.typed` marker"
+        with pytest.warns(SetuptoolsWarning, match=msg):
+            build_py.run()
 
 
 def get_finalized_build_py(script_name="%build_py-test%"):


### PR DESCRIPTION
Fixes #5243

Added warnings during `build_py` to detect mismatches between `py.typed` markers and `Typing :: *` classifiers. Packages shipping `py.typed` without a typing classifier, declaring `Typing :: Typed` without `py.typed`, or using a `-stubs` package without `Typing :: Stubs Only` will now see a warning.