### PR TITLE
Fix mingw bare `-O` optimization flag under `-m32`

### DIFF
--- a/newsfragments/4873.bugfix.rst
+++ b/newsfragments/4873.bugfix.rst
@@ -1,0 +1,1 @@
+The mingw compiler now passes ``-O1`` instead of a bare ``-O``. The two are equivalent to GCC, but ``cc1`` rejected the bare form when building 32-bit extensions with ``-m32``. -- by :user:`dchaudhari7177`

--- a/setuptools/_distutils/compilers/C/cygwin.py
+++ b/setuptools/_distutils/compilers/C/cygwin.py
@@ -256,11 +256,14 @@ class MinGW32Compiler(Compiler):
         if is_cygwincc(self.cc):
             raise Error('Cygwin gcc cannot be used with --compiler=mingw32')
 
+        # Use ``-O1`` rather than a bare ``-O``. The two are equivalent to GCC,
+        # but ``cc1`` rejects the bare form under ``-m32``.
+        # https://github.com/pypa/setuptools/issues/4873
         self.set_executables(
-            compiler=f'{self.cc} -O -Wall',
-            compiler_so=f'{self.cc} -shared -O -Wall',
-            compiler_so_cxx=f'{self.cxx} -shared -O -Wall',
-            compiler_cxx=f'{self.cxx} -O -Wall',
+            compiler=f'{self.cc} -O1 -Wall',
+            compiler_so=f'{self.cc} -shared -O1 -Wall',
+            compiler_so_cxx=f'{self.cxx} -shared -O1 -Wall',
+            compiler_cxx=f'{self.cxx} -O1 -Wall',
             linker_exe=f'{self.cc}',
             linker_so=f'{self.linker_dll} {shared_option}',
             linker_exe_cxx=f'{self.cxx}',

--- a/setuptools/_distutils/compilers/C/tests/test_mingw.py
+++ b/setuptools/_distutils/compilers/C/tests/test_mingw.py
@@ -20,11 +20,25 @@ class TestMinGW32Compiler:
 
         compiler = cygwin.MinGW32Compiler()
 
-        assert compiler.compiler == split_quoted('cc -O -Wall')
-        assert compiler.compiler_so == split_quoted('cc -shared -O -Wall')
-        assert compiler.compiler_cxx == split_quoted('c++ -O -Wall')
+        assert compiler.compiler == split_quoted('cc -O1 -Wall')
+        assert compiler.compiler_so == split_quoted('cc -shared -O1 -Wall')
+        assert compiler.compiler_cxx == split_quoted('c++ -O1 -Wall')
         assert compiler.linker_exe == split_quoted('cc')
         assert compiler.linker_so == split_quoted('cc -shared')
+
+    @pytest.mark.skipif('sys.platform == "cygwin"')
+    def test_no_bare_optimization_flag(self):
+        # A bare ``-O`` is rejected by cc1 under ``-m32``.
+        # https://github.com/pypa/setuptools/issues/4873
+        compiler = cygwin.MinGW32Compiler()
+
+        for args in (
+            compiler.compiler,
+            compiler.compiler_so,
+            compiler.compiler_cxx,
+            compiler.compiler_so_cxx,
+        ):
+            assert '-O' not in args
 
     @pytest.mark.skipif(not is_mingw(), reason='not on mingw')
     def test_runtime_library_dir_option(self):


### PR DESCRIPTION
## Summary

`MinGW32Compiler` injected a bare `-O` into `compiler`, `compiler_so`, `compiler_cxx` and `compiler_so_cxx`. GCC documents `-O` and `-O1` as equivalent, but `cc1` rejects the bare form when targeting 32-bit:

```
cc1.exe: error: argument to '-O' should be a non-negative integer, 'g', 's' or 'fast'
```

so any `-m32` build fails, while 64-bit builds are unaffected. This emits `-O1` instead.

Closes #4873. Part of the Phase 1 warm-up in #5264 (filed as #5265).

## Approach

Of the two options suggested in #5265 — normalise the bare `-O` to `-O1`, or suppress it when a numbered `-O` is already present — I went with normalising, since it is the smaller change and is exactly equivalent for the 64-bit path that works today. Suppression would additionally have to decide which flag wins, which is a behaviour change for existing 64-bit users.

Scope is limited to `MinGW32Compiler`, matching the issue. `Compiler` (cygwin) also passes a bare `-O` at lines 81-84 and would hit the same `cc1` rejection under `-m32` — happy to fold that in if you'd like it in the same PR.

## Tests

Updated `test_set_executables` for the new flag, and added `test_no_bare_optimization_flag`.

The pre-existing tests in `test_mingw.py` are all gated on `is_mingw()`, so they skip everywhere except an actual mingw Python — including CI. The new test is gated only on cygwin, following `test_customize_compiler_with_msvc_python`, which already constructs a `MinGW32Compiler` on a stock Windows build. That way the regression is actually exercised rather than skipped.

Revert-verified: with the `cygwin.py` change backed out, the new test fails with `assert '-O' not in ['gcc', '-O', '-Wall']`.

## Local results (Windows 11, Python 3.12)

`pytest setuptools/_distutils/compilers/`

| | passed | failed | skipped | errors |
|---|---|---|---|---|
| clean tree | 8 | 1 | 7 | 19 |
| this branch | 9 | 1 | 7 | 19 |

The failure and errors are all in `test_unix.py` and reproduce identically on a clean tree — they are Windows-only and unrelated.

`ruff check` passes on both changed files. `ruff format --check` reports both files as unformatted, but does so on a clean tree as well (it wants double quotes throughout `cygwin.py`, including lines this PR does not touch), so I have not reformatted them.
