### PR TITLE
fix: use MSBuild\Current\bin for VS2017+ in MSBuild property

### DIFF
--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -1329,11 +1329,13 @@ class EnvironmentInfo:
         elif self.vs_ver < 15.0:
             base_path = self.si.ProgramFilesx86
             arch_subdir = self.pi.current_dir(hidex86=True)
+            path = rf'MSBuild\{self.vs_ver:0.1f}\bin{arch_subdir}'
         else:
             base_path = self.si.VSInstallDir
             arch_subdir = ''
+            # VS2017+ uses "Current" instead of version number in MSBuild path
+            path = r'MSBuild\Current\bin'
 
-        path = rf'MSBuild\{self.vs_ver:0.1f}\bin{arch_subdir}'
         build = [os.path.join(base_path, path)]
 
         if self.vs_ver >= 15.0:


### PR DESCRIPTION
﻿## Problem

The `MSBuild` property in `EnvironmentInfo` constructs the path as `MSBuild\{vs_ver}\bin`, but VS2017+ uses `MSBuild\Current\bin` instead. This causes the property to return incorrect paths that do not exist.

For example, VS2026 (18.0) would return:

- `MSBuild\18.0\bin` (does not exist)

Instead of the correct:

- `MSBuild\Current\bin`

## Fix

For `vs_ver >= 15.0`, use `MSBuild\Current\bin` as the path instead of `MSBuild\{vs_ver}\bin`.

## Verification

Tested on VS2026 (18.0):

- `MSBuild\Current\Bin` exists
- `MSBuild\18.0\Bin` does not exist

`
Old (buggy): D:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\18.0\bin
  Exists: False
New (fixed): D:\Program Files\Microsoft Visual Studio\18\Community\MSBuild\Current\bin
  Exists: True
`

Fixes #5275