### PR TITLE
Docs: Remove workaround for distutils in CPython docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -195,7 +195,7 @@ nitpick_ignore += [
 # Allow linking objects on other Sphinx sites seamlessly:
 intersphinx_mapping.update(
     # python=('https://docs.python.org/3', None),
-    python=('https://docs.python.org/3.11', None),
+    python=('https://docs.python.org/3', None),
     # ^-- Python 3.11 is required because it still contains `distutils`.
     #     Just leaving it as `3` would imply 3.12+, but that causes an
     #     error with the cross references to distutils functions.

--- a/docs/deprecated/distutils/apiref.rst
+++ b/docs/deprecated/distutils/apiref.rst
@@ -1259,8 +1259,8 @@ other utility module.
    doing, leave it set to ``None``.
 
    .. versionchanged:: 3.2.3
-      Create ``.pyc`` files with an :func:`import magic tag
-      <imp.get_tag>` in their name, in a :file:`__pycache__` subdirectory
+      Create ``.pyc`` files with an import magic tag
+      (``imp.get_tag``) in their name, in a :file:`__pycache__` subdirectory
       instead of files without tag in the current directory.
 
    .. versionchanged:: 3.5

--- a/docs/userguide/declarative_config.rst
+++ b/docs/userguide/declarative_config.rst
@@ -214,6 +214,13 @@ Metadata
     The aliases given below are supported for compatibility reasons,
     but their use is not advised.
 
+.. note::
+    The ``license_file`` alias (singular) for ``license_files`` was deprecated
+    in ``setuptools`` 42.0.0.  If you see a warning like
+    ``The license_file parameter is deprecated, use license_files instead``,
+    change the key in your ``setup.cfg`` from ``license_file`` to
+    ``license_files``.
+
 ==============================  =================  =================  =============== ==========
 Key                             Aliases            Type               Minimum Version Notes
 ==============================  =================  =================  =============== ==========

--- a/docs/userguide/miscellaneous.rst
+++ b/docs/userguide/miscellaneous.rst
@@ -113,6 +113,18 @@ brackets (which may contain character ranges, e.g., ``[a-z]`` or
 ``[a-fA-F0-9]``).  Setuptools also has support for ``**`` matching
 zero or more characters including forward slash, backslash, and colon.
 
+.. note::
+   ``recursive-include`` requires **at least one file pattern**; the directory
+   pattern alone is not enough.  For example, to include all ``.html`` files
+   under ``templates/``, write:
+
+   .. code-block:: bash
+
+      recursive-include templates *.html
+
+   Writing ``recursive-include templates`` (without a pattern) is invalid and
+   will include nothing.
+
 Directory patterns are relative to the root of the project directory; e.g.,
 ``graft example*`` will include a directory named :file:`examples` in the
 project root but will not include :file:`docs/examples/`.


### PR DESCRIPTION
Closes #4081.

Since Setuptools now hosts the deprecated distutils documentation, the intersphinx references correctly resolve internally without pointing to CPython. We no longer need the workaround that pinned Python to 3.11 in `intersphinx_mapping`.

Also changes an external reference to `imp.get_tag` (which is also removed in Python 3.12) to standard literal text in `docs/deprecated/distutils/apiref.rst` to prevent a build warning.