### PR TITLE
fix: use -O1 instead of bare -O for MinGW/Cygwin compilers

### DIFF
--- a/newsfragments/5265.bugfix.rst
+++ b/newsfragments/5265.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed MinGW/Cygwin compilers injecting bare ``-O``, which ``cc1`` rejects under ``-m32``; use ``-O1`` instead.

--- a/setuptools/_distutils/compilers/C/cygwin.py
+++ b/setuptools/_distutils/compilers/C/cygwin.py
@@ -78,10 +78,10 @@ class Compiler(unix.Compiler):
         shared_option = "-shared"
 
         self.set_executables(
-            compiler=f'{self.cc} -mcygwin -O -Wall',
-            compiler_so=f'{self.cc} -mcygwin -mdll -O -Wall',
-            compiler_cxx=f'{self.cxx} -mcygwin -O -Wall',
-            compiler_so_cxx=f'{self.cxx} -mcygwin -mdll -O -Wall',
+            compiler=f'{self.cc} -mcygwin -O1 -Wall',
+            compiler_so=f'{self.cc} -mcygwin -mdll -O1 -Wall',
+            compiler_cxx=f'{self.cxx} -mcygwin -O1 -Wall',
+            compiler_so_cxx=f'{self.cxx} -mcygwin -mdll -O1 -Wall',
             linker_exe=f'{self.cc} -mcygwin',
             linker_so=f'{self.linker_dll} -mcygwin {shared_option}',
             linker_exe_cxx=f'{self.cxx} -mcygwin',
@@ -256,11 +256,13 @@ class MinGW32Compiler(Compiler):
         if is_cygwincc(self.cc):
             raise Error('Cygwin gcc cannot be used with --compiler=mingw32')
 
+        # Use -O1 instead of bare -O: under -m32, cc1 rejects bare -O
+        # (requires a non-negative integer, g, s, or fast) (#4873 / #5265).
         self.set_executables(
-            compiler=f'{self.cc} -O -Wall',
-            compiler_so=f'{self.cc} -shared -O -Wall',
-            compiler_so_cxx=f'{self.cxx} -shared -O -Wall',
-            compiler_cxx=f'{self.cxx} -O -Wall',
+            compiler=f'{self.cc} -O1 -Wall',
+            compiler_so=f'{self.cc} -shared -O1 -Wall',
+            compiler_so_cxx=f'{self.cxx} -shared -O1 -Wall',
+            compiler_cxx=f'{self.cxx} -O1 -Wall',
             linker_exe=f'{self.cc}',
             linker_so=f'{self.linker_dll} {shared_option}',
             linker_exe_cxx=f'{self.cxx}',

--- a/setuptools/_distutils/compilers/C/tests/test_mingw.py
+++ b/setuptools/_distutils/compilers/C/tests/test_mingw.py
@@ -20,9 +20,9 @@ class TestMinGW32Compiler:
 
         compiler = cygwin.MinGW32Compiler()
 
-        assert compiler.compiler == split_quoted('cc -O -Wall')
-        assert compiler.compiler_so == split_quoted('cc -shared -O -Wall')
-        assert compiler.compiler_cxx == split_quoted('c++ -O -Wall')
+        assert compiler.compiler == split_quoted('cc -O1 -Wall')
+        assert compiler.compiler_so == split_quoted('cc -shared -O1 -Wall')
+        assert compiler.compiler_cxx == split_quoted('c++ -O1 -Wall')
         assert compiler.linker_exe == split_quoted('cc')
         assert compiler.linker_so == split_quoted('cc -shared')
 
@@ -46,3 +46,14 @@ class TestMinGW32Compiler:
         # https://github.com/pypa/setuptools/issues/4456
         compiler = cygwin.MinGW32Compiler()
         sysconfig.customize_compiler(compiler)
+
+
+    def test_default_optimize_flag_is_o1(self, monkeypatch):
+        """Bare -O is rejected by cc1 under -m32; defaults must use -O1 (#4873)."""
+        monkeypatch.setattr(cygwin, 'is_cygwincc', lambda _: False)
+        monkeypatch.setenv('CC', 'gcc')
+        monkeypatch.setenv('CXX', 'g++')
+        compiler = cygwin.MinGW32Compiler()
+        joined = ' '.join(compiler.compiler + compiler.compiler_so + compiler.compiler_cxx)
+        assert ' -O ' not in f' {joined} '
+        assert '-O1' in compiler.compiler


### PR DESCRIPTION
## Summary

MinGW defaults injected bare `-O`. Under `-m32`, `cc1` rejects that:

```text
cc1.exe: error: argument to '-O' should be a non-negative integer, 'g', 's' or 'fast'
```

64-bit builds accept bare `-O`; 32-bit does not (#4873).

## Fix

Use `-O1` in MinGW32 and Cygwin compiler default command lines (equivalent optimization level where bare `-O` was accepted).

## Tests

- Updated `test_mingw` expected flags to `-O1`
- Added `test_default_optimize_flag_is_o1` (always runs; mocks non-cygwin gcc)

## News

`newsfragments/5265.bugfix.rst`

## Linked Issues

Closes #5265  
Fixes #4873
