### PR TITLE
Improve missing module diagnostics for dynamic attrs

### DIFF
--- a/newsfragments/4926.bugfix.rst
+++ b/newsfragments/4926.bugfix.rst
@@ -1,0 +1,2 @@
+Improved ``ModuleNotFoundError`` messages for missing nested modules referenced
+by dynamic ``attr`` directives to report the complete configured module name.

--- a/setuptools/config/expand.py
+++ b/setuptools/config/expand.py
@@ -193,10 +193,28 @@ def read_attr(
 
 def _find_spec(module_name: str, module_path: StrPath | None) -> ModuleSpec:
     spec = importlib.util.spec_from_file_location(module_name, module_path)
-    spec = spec or importlib.util.find_spec(module_name)
+    try:
+        spec = spec or importlib.util.find_spec(module_name)
+    except ModuleNotFoundError as error:
+        missing_module = error.name
+        plain_missing_module = missing_module and error.args == (
+            f"No module named {missing_module!r}",
+        )
+        if plain_missing_module and (
+            missing_module == module_name
+            or module_name.startswith(f"{missing_module}.")
+        ):
+            raise ModuleNotFoundError(
+                f"No module named {module_name!r}",
+                name=module_name,
+            ) from error
+        raise
 
     if spec is None:
-        raise ModuleNotFoundError(module_name)
+        raise ModuleNotFoundError(
+            f"No module named {module_name!r}",
+            name=module_name,
+        )
 
     return spec
 

--- a/setuptools/tests/config/test_expand.py
+++ b/setuptools/tests/config/test_expand.py
@@ -165,6 +165,55 @@ class TestReadAttr:
         # `import super_complicated_dep` should not run, otherwise the build fails
         assert expand.read_attr(attr_desc, package_dir, tmp_path) == "42"
 
+    def test_missing_nested_module_reports_full_name(self, tmp_path):
+        files = {"src/project_pkg/__init__.py": ""}
+        write_files(files, tmp_path)
+
+        with pytest.raises(ModuleNotFoundError) as ctx:
+            expand.read_attr(
+                "project_pkg.missing.VERSION",
+                {"": "src"},
+                tmp_path,
+            )
+
+        assert str(ctx.value) == "No module named 'project_pkg.missing'"
+        assert ctx.value.name == "project_pkg.missing"
+
+    def test_missing_child_of_importable_package_reports_full_name(
+        self, tmp_path, monkeypatch
+    ):
+        write_files({"importable_pkg/__init__.py": ""}, tmp_path)
+        monkeypatch.syspath_prepend(tmp_path)
+
+        with pytest.raises(ModuleNotFoundError) as ctx:
+            expand._find_spec("importable_pkg.missing", None)
+
+        assert str(ctx.value) == "No module named 'importable_pkg.missing'"
+        assert ctx.value.name == "importable_pkg.missing"
+
+    def test_missing_dependency_keeps_its_name(self, tmp_path, monkeypatch):
+        files = {
+            "broken_pkg/__init__.py": "import unrelated_dependency",
+        }
+        write_files(files, tmp_path)
+        monkeypatch.syspath_prepend(tmp_path)
+
+        with pytest.raises(ModuleNotFoundError) as ctx:
+            expand.read_attr("broken_pkg.missing.VERSION", root_dir=tmp_path)
+
+        assert str(ctx.value) == "No module named 'unrelated_dependency'"
+        assert ctx.value.name == "unrelated_dependency"
+
+    def test_non_package_parent_keeps_importlib_diagnostic(self, tmp_path, monkeypatch):
+        write_files({"single_module.py": ""}, tmp_path)
+        monkeypatch.syspath_prepend(tmp_path)
+
+        with pytest.raises(ModuleNotFoundError) as ctx:
+            expand._find_spec("single_module.missing", None)
+
+        assert "__path__ attribute not found" in str(ctx.value)
+        assert ctx.value.name == "single_module.missing"
+
 
 @pytest.mark.parametrize(
     ("package_dir", "file", "module", "return_value"),


### PR DESCRIPTION
## Summary of changes

I updated dynamic `attr` resolution so a missing nested module reports the
complete configured module name instead of only the first missing parent.

For example, a reference to `build_bug_poc.__about__.__version__` now reports
`No module named 'build_bug_poc.__about__'`. The original exception remains
chained for context, while unrelated import failures and diagnostics such as
“parent is not a package” remain unchanged.

I added regression coverage for missing parent and child modules, unrelated
dependencies imported by a package, and non-package parents.

Closes #4926

### Verification

- `python -m pytest setuptools/tests/config` — 185 passed, 1 xfailed
- `python -m ruff check setuptools/config/expand.py setuptools/tests/config/test_expand.py`
- `python -m ruff format --check setuptools/config/expand.py setuptools/tests/config/test_expand.py`
- `git diff --check`

### Pull Request Checklist

- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
