### PR TITLE
Honor ext_package when listing distribution names

### DIFF
--- a/newsfragments/3524.bugfix.rst
+++ b/newsfragments/3524.bugfix.rst
@@ -1,0 +1,3 @@
+``top_level.txt`` now lists the package extensions are built into when
+``ext_package`` is set, rather than the bare extension names, matching the
+names already reported for editable installs.

--- a/setuptools/dist.py
+++ b/setuptools/dist.py
@@ -1069,6 +1069,9 @@ class Distribution(_Distribution):
             else:
                 name = ext.name
             name = name.removesuffix('module')
+            if self.ext_package:
+                # extensions are built into ``ext_package`` (see build_ext)
+                name = f'{self.ext_package}.{name}'
             yield name
 
     def handle_display_options(self, option_order):

--- a/setuptools/tests/test_egg_info.py
+++ b/setuptools/tests/test_egg_info.py
@@ -13,7 +13,7 @@ from unittest import mock
 import pytest
 from jaraco import path
 
-from setuptools import errors
+from setuptools import Extension, errors
 from setuptools.command.egg_info import egg_info, manifest_maker, write_entries
 from setuptools.dist import Distribution
 
@@ -163,6 +163,27 @@ class TestEggInfo:
             'top_level.txt',
         ]
         assert sorted(actual) == expected
+
+    def test_top_level_with_ext_package(self, tmpdir_cwd, env):
+        """
+        Extensions are built inside ``ext_package``, so that package -- and
+        not the bare extension name -- is the top-level name.
+        """
+        path.build({'bar': {'__init__.py': ''}})
+        dist = Distribution({
+            'name': 'foo',
+            'version': '0.0.1',
+            'packages': ['bar'],
+            'ext_package': 'bar',
+            'ext_modules': [Extension('_baz', ['_baz.c'])],
+        })
+        dist.script_name = 'setup.py'
+        ei = egg_info(dist)
+        ei.finalize_options()
+        ei.run()
+
+        with open(os.path.join(ei.egg_info, 'top_level.txt'), encoding="utf-8") as f:
+            assert f.read().split() == ['bar']
 
     def test_handling_utime_error(self, tmpdir_cwd, env):
         dist = Distribution()


### PR DESCRIPTION
Fixes #3524.

`Distribution.iter_distribution_names()` yields the bare extension name and never consults `self.ext_package`. `write_toplevel_names()` records the first dotted segment of whatever it yields, so a project with `ext_package='a'` and `Extension('_hello_world')` gets `_hello_world` written into `top_level.txt` — a name that exists nowhere at top level in what actually ships.

That is the function you pointed at in the issue.

## Evidence

Minimal project: `packages=['a']`, `ext_package='a'`, `ext_modules=[Extension('_hello_world', ...)]`. On setuptools 83.0.0 and on current `main`:

```
$ cat a.egg-info/top_level.txt
_hello_world
a
```

It is not confined to the local `.egg-info` — the wrong name is published inside the wheel:

```
wheel members:
    a/__init__.py
    a/_hello_world.cpython-314-darwin.so     <- nested under `a`, as intended
    a-1.dist-info/top_level.txt

top_level.txt inside the wheel: '_hello_world\na\n'
```

So the build machinery places the extension correctly and only the recorded metadata disagrees. `build_ext` sets `self.package = self.distribution.ext_package` and `get_ext_fullname()` prefixes the name, which is why the `.so` lands under `a/`.

## Why this looks like an oversight rather than a decision

setuptools already gets this right on the other path. `editable_wheel.py` has an explicit `if dist.ext_package: yield dist.ext_package` in `_find_packages()`, and `if not dist.ext_package:` in `_find_top_level_modules()`. An editable install and a regular install of the same project therefore report different top-level names today.

## The change

Three lines in `iter_distribution_names()`, prefixing `ext_package` where `build_ext` would.

## The judgement call worth reviewing

I patched `iter_distribution_names()` rather than `write_toplevel_names()`, which also changes the other caller: `has_contents_for('a')` now returns `True` for the extension. I believe that is the correct meaning — the distribution genuinely does have contents for package `a` — but it is a behaviour change beyond `top_level.txt`, so it deserves a look rather than a nod.

If you would rather keep the blast radius to exactly the reported symptom, the narrower variant is to apply the prefix inside `write_toplevel_names()` instead and leave `iter_distribution_names()` alone. Happy to switch.

Also worth noting for the answer to your question in the issue: defining the extension as `a._hello_world` and omitting `ext_package` already produces the correct `top_level.txt` today. That workaround works, which is consistent with the bug being purely in the `ext_package` path.

## Tests

`test_top_level_with_ext_package` in `setuptools/tests/test_egg_info.py`, next to the existing `top_level.txt` assertions. Reverting only `setuptools/dist.py` and keeping the test fails with `assert ['_baz', 'bar'] == ['bar']`, so it binds to the defect.

`test_egg_info.py`, `test_dist.py`, `test_build_ext.py` and `test_dist_info.py` together: 144 passed, 1 xfailed on a clean checkout; 145 passed, 1 xfailed with this branch — the one extra is the new test. Newsfragment added per the PR template.

I used an AI assistant while working on this. The reproduction, the wheel inspection and the call about which function to patch are mine.
