### PR TITLE
Configuring lint.flake8-comprehensions.allow-dict-calls-with-keyword-arguments instead of disabling C408

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -46,10 +46,6 @@ ignore = [
 	"COM812",
 	"COM819",
 
-	# unnecessary-collection-call: retain the dict(a=1) call style rather than
-	# forcing string-keyed literals. See jaraco/skeleton#210.
-	"C408",
-
 	# local
 	"PERF203", # try-except-in-loop, micro-optimisation with many false-positive. Worth checking but don't block CI
 	"PT007", # temporarily disabled, TODO: configure and standardize to preference
@@ -77,6 +73,9 @@ sections.delayed = ["distutils"]
 
 [lint.flake8-annotations]
 ignore-fully-untyped = true
+
+[lint.flake8-comprehensions]
+allow-dict-calls-with-keyword-arguments = true
 
 [format]
 # Enable preview to get hugged parenthesis unwrapping and other nice surprises

--- a/setuptools/command/build_clib.py
+++ b/setuptools/command/build_clib.py
@@ -40,7 +40,7 @@ class build_clib(orig.build_clib):
             # Make sure everything is the correct type.
             # obj_deps should be a dictionary of keys as sources
             # and a list/tuple of files that are its dependencies.
-            obj_deps = build_info.get('obj_deps', dict())
+            obj_deps = build_info.get('obj_deps', {})
             if not isinstance(obj_deps, dict):
                 raise DistutilsSetupError(
                     f"in 'libraries' option (library '{lib_name}'), "
@@ -51,7 +51,7 @@ class build_clib(orig.build_clib):
 
             # Get the global dependencies that are specified by the '' key.
             # These will go into every source's dependency list.
-            global_deps = obj_deps.get('', list())
+            global_deps = obj_deps.get('', [])
             if not isinstance(global_deps, (list, tuple)):
                 raise DistutilsSetupError(
                     f"in 'libraries' option (library '{lib_name}'), "
@@ -64,7 +64,7 @@ class build_clib(orig.build_clib):
             for source in sources:
                 src_deps = [source]
                 src_deps.extend(global_deps)
-                extra_deps = obj_deps.get(source, list())
+                extra_deps = obj_deps.get(source, [])
                 if not isinstance(extra_deps, (list, tuple)):
                     raise DistutilsSetupError(
                         f"in 'libraries' option (library '{lib_name}'), "

--- a/setuptools/msvc.py
+++ b/setuptools/msvc.py
@@ -38,7 +38,7 @@ else:
         HKEY_LOCAL_MACHINE = None
         HKEY_CLASSES_ROOT = None
 
-    environ: dict[str, str] = dict()
+    environ: dict[str, str] = {}
 
 
 class PlatformInfo:

--- a/setuptools/tests/environment.py
+++ b/setuptools/tests/environment.py
@@ -49,7 +49,7 @@ def run_setup_py(cmd, pypath=None, path=None, data_stream=0, env=None):
     code directly to prevent accidental behavior issues
     """
     if env is None:
-        env = dict()
+        env = {}
         for envname in os.environ:
             env[envname] = os.environ[envname]
 


### PR DESCRIPTION
<!-- First time contributors: Take a moment to review https://setuptools.pypa.io/en/latest/development/developer-guide.html! -->
<!-- Remove sections if not applicable -->

## Summary of changes
Alternative to https://github.com/pypa/setuptools/commit/f2c32067e086e4838b5e7b97f6f7f4363c576bed#r194833616

### Pull Request Checklist
- [x] Changes have tests
- [N/A] News fragment added in [`newsfragments/`].
  _(See [documentation][PR docs] for details)_

[`newsfragments/`]: https://github.com/pypa/setuptools/tree/main/newsfragments
[PR docs]:
https://setuptools.pypa.io/en/latest/development/developer-guide.html#making-a-pull-request
