### PR TITLE
Include dist_info in bootstrap metadata

### DIFF
--- a/bootstrap.egg-info/entry_points.txt
+++ b/bootstrap.egg-info/entry_points.txt
@@ -1,5 +1,6 @@
 [distutils.commands]
 egg_info = setuptools.command.egg_info:egg_info
+dist_info = setuptools.command.dist_info:dist_info
 build_py = setuptools.command.build_py:build_py
 sdist = setuptools.command.sdist:sdist
 editable_wheel = setuptools.command.editable_wheel:editable_wheel

--- a/newsfragments/+bootstrap-dist-info.bugfix.rst
+++ b/newsfragments/+bootstrap-dist-info.bugfix.rst
@@ -1,0 +1,1 @@
+Include the ``dist_info`` command in bootstrap entry-point metadata.

--- a/setuptools/tests/test_dist_info.py
+++ b/setuptools/tests/test_dist_info.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 import sys
 from functools import partial
+from importlib.metadata import Distribution
 from typing import ClassVar
 
 import pytest
@@ -15,6 +16,19 @@ from setuptools.archive_util import unpack_archive
 from .textwrap import DALS
 
 read = partial(pathlib.Path.read_text, encoding="utf-8")
+
+
+def test_bootstrap_metadata_registers_dist_info():
+    bootstrap = Distribution.at(
+        pathlib.Path(__file__).parents[2] / "bootstrap.egg-info"
+    )
+    commands = {
+        entry.name: entry.value
+        for entry in bootstrap.entry_points
+        if entry.group == "distutils.commands"
+    }
+
+    assert commands["dist_info"] == "setuptools.command.dist_info:dist_info"
 
 
 class TestDistInfo:


### PR DESCRIPTION
## Summary of changes

Building Setuptools from source fails during PEP 517 metadata preparation because the bootstrap metadata does not register the `dist_info` command. 

Include `dist_info` in bootstrap metadata.

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].