### PR TITLE
Fix integration test for pip's flit_core build backend

### DIFF
--- a/setuptools/tests/integration/test_pip_install_sdist.py
+++ b/setuptools/tests/integration/test_pip_install_sdist.py
@@ -215,9 +215,15 @@ def build_deps(package, sdist_file):
 
 
 def _read_pyproject(archive):
-    contents = (
-        archive.get_content(member)
+    members = [
+        member
         for member in archive
         if os.path.basename(archive.get_name(member)) == "pyproject.toml"
-    )
-    return next(contents, "")
+    ]
+    if not members:
+        return ""
+    # An sdist may contain nested pyproject.toml files (e.g. pip ships a
+    # ``build-project/`` helper). The project's own build metadata lives in the
+    # top-level ``{name}-{version}/pyproject.toml``, i.e. the shallowest one.
+    top = min(members, key=lambda m: archive.get_name(m).count("/"))
+    return archive.get_content(top)


### PR DESCRIPTION
## Problem

The `tests` workflow for the v84.0.0 tagged release failed in the `integration-test` job: `test_install_sdist[pip-v.LATEST]` errored with

```
pip._vendor.pyproject_hooks._impl.BackendUnavailable: Cannot import 'flit_core.buildapi'
```

This is **not** a regression from anything in the release — the failure is at pip's metadata-generation step, before any build/compile, and it would fail identically on 83.0.0. It's an integration-test bug newly triggered by an upstream change in pip.

## Root cause

- pip 26.2.1 builds with **flit_core** (`build-backend = "flit_core.buildapi"`, `requires = ["flit-core >=3.11,<4"]`).
- pip 26.2.1's sdist now ships **two** files named `pyproject.toml`:
  - `pip-26.2.1/build-project/pyproject.toml` — appears *first* in the archive, and has **no `[build-system]`** table
  - `pip-26.2.1/pyproject.toml` — the real one, with the flit-core requirement
- `_read_pyproject` returned the *first* basename match (`next(contents, "")`), i.e. the `build-project/` helper. So `build_deps("pip", …)` found no build requirements and returned `[]`.
- Because the integration test installs sdists with `--no-build-isolation`, it must install build deps itself. With an empty dep list, flit-core was never installed, and building pip failed with `BackendUnavailable`.

## Fix

Select the **shallowest** `pyproject.toml` (the project's own top-level `{name}-{version}/pyproject.toml`) instead of the first one encountered. Verified against the real pip 26.2.1 sdist: `build_deps("pip", …)` now returns `['flit-core >=3.11,<4']`. The change is inert for the common single-`pyproject.toml` sdist, so the other examples are unaffected.

Test-only change; no newsfragment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)