### PR TITLE
docs: document compiler migration paths

### DIFF
--- a/docs/deprecated/distutils-legacy.rst
+++ b/docs/deprecated/distutils-legacy.rst
@@ -36,6 +36,37 @@ As Distutils is deprecated, any usage of functions or objects from distutils is 
 
 ``distutils.errors.*`` → ``setuptools.errors.*`` [#errors]_
 
+The compiler APIs are moving to the standalone ``compilers`` package. There is
+intentionally no corresponding ``setuptools`` re-export. Use these import
+paths when migrating code that needs to create or inspect C compilers:
+
+``distutils.ccompiler`` → ``compilers.C``
+
+``distutils.ccompiler.CCompiler`` → ``compilers.C.Compiler``
+
+``distutils.ccompiler.new_compiler`` → ``compilers.C.new_compiler``
+
+``distutils.ccompiler.get_default_compiler`` → ``compilers.C.get_default_compiler``
+
+``distutils.ccompiler.show_compilers`` → ``compilers.C.show_compilers``
+
+``distutils.util.get_platform`` → ``compilers.platform.get_platform``
+
+For example:
+
+.. code-block:: python
+
+   from compilers.C import Compiler, new_compiler
+   from compilers.platform import get_platform
+
+   compiler: Compiler = new_compiler()
+   print(compiler)
+   print(get_platform())
+
+The ``compilers`` package is the supported home for this functionality. Do not
+import these implementation modules from ``setuptools._distutils``; that path
+is private and may change between Setuptools releases.
+
 
 Migration advice is also provided by :pep:`PEP 632 <632#migration-advice>`.
 


### PR DESCRIPTION
## Summary

- document the migration from `distutils.ccompiler` to the standalone `compilers.C` API
- add mappings for `Compiler`, `new_compiler`, `get_default_compiler`, and `show_compilers`
- document `compilers.platform.get_platform` as the replacement for `distutils.util.get_platform`
- clarify that `setuptools._distutils` is private and that Setuptools does not provide a re-export layer

Resolves #5272

## Validation

- `git diff --check`
- checked the documented names against the compiler package layout and the public API issue linked from #5272
- full documentation build not run locally because this sparse checkout does not include installed documentation dependencies

## AI disclosure

This draft was prepared with AI assistance. No claim of human review is made; it remains a draft for maintainer review.
