### PR TITLE
docs: explain editable installs from source

### DIFF
--- a/docs/development/developer-guide.rst
+++ b/docs/development/developer-guide.rst
@@ -5,6 +5,22 @@ Developer's Guide for Setuptools
 If you want to know more about contributing on Setuptools, this is the place.
 
 
+-----------------------
+Using the latest source
+-----------------------
+
+To work on the latest version from a checkout, create a virtual environment
+and install the checkout in editable mode::
+
+    $ python -m venv .venv
+    $ . .venv/bin/activate
+    $ python -m pip install --editable .
+
+The editable installation makes the working tree importable, so source changes
+are immediately available while you develop. Use a fresh virtual environment
+for each checkout to keep its dependencies isolated.
+
+
 -------------------
 Recommended Reading
 -------------------

--- a/newsfragments/2532.doc.rst
+++ b/newsfragments/2532.doc.rst
@@ -1,0 +1,1 @@
+Documented how to install a checkout in editable mode when developing the latest source.


### PR DESCRIPTION
## Summary

Fixes #2532.

The Developer's Guide now explains how to create an isolated virtual environment and install a checkout in editable mode with `python -m pip install --editable .`, so contributors can work from the latest source without the historical bootstrap step.

## Evidence

- Added `newsfragments/2532.doc.rst` per the repository's Towncrier convention.
- `uv pip install --python <Python 3.13 venv> --no-deps --editable .` completed successfully and importing `setuptools` reported `84.0.0`.
- `python -m sphinx -W --keep-going . <temporary output>` from `docs/` (succeeded).
- `python -m sphinxlint .` from `docs/` (no problems found).
- `git diff --check`

No maintainer-only, legal, or contributor-account action is required.
