### PR TITLE
fix(build_py): preserve executable bit on .py package data in wheels

### DIFF
--- a/newsfragments/5296.bugfix.rst
+++ b/newsfragments/5296.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``build_py`` dropping the executable bit on ``.py`` files included as package data in built wheels -- by :user:`aryansk`

--- a/setuptools/command/build_py.py
+++ b/setuptools/command/build_py.py
@@ -173,6 +173,11 @@ class build_py(orig.build_py):
             self.mkpath(os.path.dirname(target))
             _outf, _copied = self.copy_file(srcfile, target)
             make_writable(target)
+            # The copy may have been skipped as up-to-date (e.g. when the
+            # destination was already created by ``build_module`` with
+            # ``preserve_mode=False``), so re-apply the source's permission
+            # bits explicitly to honor the executable bit on package data.
+            os.chmod(target, stat.S_IMODE(os.stat(srcfile).st_mode))
 
     def analyze_manifest(self) -> None:
         self.manifest_files: dict[str, list[str]] = {}

--- a/setuptools/tests/test_build_py.py
+++ b/setuptools/tests/test_build_py.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import stat
 import warnings
+import zipfile
 from pathlib import Path
 from typing import ClassVar
 from unittest.mock import Mock
@@ -119,6 +120,60 @@ def test_executable_data(tmpdir_cwd):
 
     assert os.stat('build/lib/pkg/run-me').st_mode & stat.S_IEXEC, (
         "Script is not executable"
+    )
+
+
+@pytest.mark.xfail(
+    'platform.system() == "Windows"',
+    reason="On Windows, files do not have executable bits",
+    raises=AssertionError,
+    strict=True,
+)
+def test_executable_py_package_data(tmpdir_cwd):
+    """
+    Ensure the executable bit is preserved on ``.py`` files declared as
+    package data in built wheels, even though the file is also picked up
+    as a module and copied without mode preservation.
+
+    #5296
+    """
+    from setuptools.build_meta import build_wheel
+
+    jaraco.path.build(
+        {
+            "pyproject.toml": DALS(
+                """
+                [build-system]
+                requires = ["setuptools"]
+                build-backend = "setuptools.build_meta"
+
+                [project]
+                name = "pkg"
+                version = "0.0.1"
+
+                [tool.setuptools.package-data]
+                pkg = ["scripts/*"]
+                """
+            ),
+            "pkg": {
+                "__init__.py": "",
+                "scripts": {"run-me.py": ""},
+            },
+        }
+    )
+    os.chmod('pkg/scripts/run-me.py', 0o700)
+
+    dist_dir = os.path.abspath('pip-wheel')
+    os.makedirs(dist_dir)
+    build_wheel(dist_dir)
+
+    wheel_file = next(
+        f for f in os.listdir(dist_dir) if f.endswith('.whl')
+    )
+    with zipfile.ZipFile(os.path.join(dist_dir, wheel_file)) as zf:
+        info = zf.getinfo('pkg/scripts/run-me.py')
+    assert stat.S_IMODE(info.external_attr >> 16) & stat.S_IEXEC, (
+        "Script is not executable in the wheel"
     )
 
 


### PR DESCRIPTION
## Summary of changes

When a `.py` file is declared as package data, it is also picked up as a module and copied by `build_module` with `preserve_mode=False`. The subsequent `build_package_data` copy with `preserve_mode=True` is then skipped as up-to-date (equal mtimes after the ns-precision `os.utime` change), so the executable bit is dropped from `build/lib` and the built wheel.

This re-applies the source file's permission bits explicitly after the package-data copy, so scripts shipped as `.py` package data keep their `+x` bit in wheels.

Repro (before): `python -m build --wheel` on a package with `readme`-style `.py` script in `package-data` produced a wheel entry with mode `0o644`; after the fix it is `0o755`.

Closes #5296

### Pull Request Checklist
- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`].
