### PR TITLE
Preserve project URLs when reading metadata

### DIFF
--- a/newsfragments/1578.bugfix.rst
+++ b/newsfragments/1578.bugfix.rst
@@ -1,0 +1,1 @@
+``DistributionMetadata.read_pkg_file`` preserved ``Project-URL`` metadata in the ``project_urls`` mapping.

--- a/setuptools/_core_metadata.py
+++ b/setuptools/_core_metadata.py
@@ -65,6 +65,15 @@ def _read_list_from_msg(msg: Message, field: str) -> list[str] | None:
     return values
 
 
+def _read_project_urls_from_msg(msg: Message) -> dict[str, str]:
+    """Read ``Project-URL`` fields into their label-to-URL mapping."""
+    project_urls = {}
+    for value in _read_list_from_msg(msg, 'project-url') or ():
+        label, _, url = value.partition(',')
+        project_urls[label.strip()] = url.strip()
+    return project_urls
+
+
 def _read_payload_from_msg(msg: Message) -> str | None:
     value = str(msg.get_payload()).strip()
     if value == 'UNKNOWN' or not value:
@@ -100,6 +109,7 @@ def read_pkg_file(self, file):
 
     self.platforms = _read_list_from_msg(msg, 'platform')
     self.classifiers = _read_list_from_msg(msg, 'classifier')
+    self.project_urls = _read_project_urls_from_msg(msg)
 
     # PEP 314 - these fields only exist in 1.1
     if self.metadata_version == Version('1.1'):

--- a/setuptools/tests/test_core_metadata.py
+++ b/setuptools/tests/test_core_metadata.py
@@ -103,11 +103,13 @@ def __read_test_cases():
                 python_requires='>=3.7',
             ),
         ),
-        pytest.param(
+        (
             'Metadata Version 1.2: Project-Url',
-            params(project_urls=dict(Foo='https://example.bar')),
-            marks=pytest.mark.xfail(
-                reason="Issue #1578: project_urls not read",
+            params(
+                project_urls={
+                    'Foo': 'https://example.bar',
+                    'Bug Tracker': 'https://example.bar/issues?labels=bug,help-wanted',
+                }
             ),
         ),
         (


### PR DESCRIPTION
## Summary of changes

`DistributionMetadata.write_pkg_file` serializes `project_urls` as repeated `Project-URL` fields, but `read_pkg_file` never restored those fields. As a result, a metadata write/read round trip dropped every project URL.

This change parses each `Project-URL` at its first comma, strips the label and URL, and stores the values in the existing `project_urls` mapping. The regression test removes the long-standing xfail and covers multiple fields plus a comma inside a URL. It also adds the required news fragment.

Closes #1578

### Validation

- `tox` (`1408 passed, 24 skipped, 15 xfailed, 2 xpassed`; mypy passed for 131 source files)
- `python -m build --outdir <isolated-output>`
- installed the built wheel into a fresh virtual environment and verified a two-entry `Project-URL` write/read round trip, including a comma in one URL

### Pull Request Checklist

- [x] Changes have tests
- [x] News fragment added in [`newsfragments/`](https://github.com/pypa/setuptools/tree/main/newsfragments)
