### PR TITLE
Exclude files listed in scripts from auto-discovered py_modules

### DIFF
--- a/newsfragments/3851.bugfix.rst
+++ b/newsfragments/3851.bugfix.rst
@@ -1,0 +1,1 @@
+Files listed in ``scripts`` are no longer also auto-discovered as ``py_modules``, so a single-script project is no longer installed into both ``scripts`` and ``purelib``.

--- a/setuptools/discovery.py
+++ b/setuptools/discovery.py
@@ -426,6 +426,7 @@ class ConfigDiscovery:
         self.dist.package_dir = package_dir  # persist eventual modifications
         self.dist.packages = PEP420PackageFinder.find(src_dir)
         self.dist.py_modules = ModuleFinder.find(src_dir)
+        self._exclude_script_modules()
         log.debug(f"discovered packages -- {self.dist.packages}")
         log.debug(f"discovered py_modules -- {self.dist.py_modules}")
         return True
@@ -452,9 +453,30 @@ class ConfigDiscovery:
 
     def _analyse_flat_modules(self) -> bool:
         self.dist.py_modules = FlatLayoutModuleFinder.find(self._root_dir)
+        self._exclude_script_modules()
         log.debug(f"discovered py_modules -- {self.dist.py_modules}")
         self._ensure_no_accidental_inclusion(self.dist.py_modules, "modules")
         return bool(self.dist.py_modules)
+
+    def _exclude_script_modules(self) -> None:
+        """Drop auto-discovered modules that are already listed in ``scripts``.
+
+        Otherwise a lone ``script.py`` given via ``scripts=["script.py"]`` is
+        also treated as a ``py_module`` and installed into both ``scripts`` and
+        ``purelib`` (#3851).
+        """
+        if not self.dist.py_modules:
+            return
+        skip = {
+            os.path.splitext(os.path.basename(script))[0]
+            for script in self.dist.scripts or ()
+            if os.path.splitext(script)[1] == ".py"
+        }
+        skip.discard("")
+        if skip:
+            self.dist.py_modules = [
+                name for name in self.dist.py_modules if name not in skip
+            ]
 
     def _ensure_no_accidental_inclusion(self, detected: list[str], kind: str):
         if len(detected) > 1:

--- a/setuptools/tests/test_config_discovery.py
+++ b/setuptools/tests/test_config_discovery.py
@@ -235,6 +235,21 @@ class TestDiscoverPackagesAndPyModules:
         with pytest.raises(PackageDiscoveryError, match="multiple (packages|modules)"):
             _get_dist(tmp_path, {})
 
+    def test_scripts_not_auto_discovered_as_py_modules(self, tmp_path):
+        """A file listed in ``scripts`` must not also become a py_module (#3851)."""
+        files = ["script.py"]
+        options = {"scripts": ["script.py"]}
+        _populate_project_dir(tmp_path, files, options)
+        dist = _get_dist(tmp_path, options)
+        assert "script" not in (dist.py_modules or [])
+
+    def test_scripts_do_not_hide_other_discovered_modules(self, tmp_path):
+        files = ["pkg.py", "script.py"]
+        options = {"scripts": ["script.py"]}
+        _populate_project_dir(tmp_path, files, options)
+        dist = _get_dist(tmp_path, options)
+        assert set(dist.py_modules or []) == {"pkg"}
+
     def test_py_modules_when_wheel_dir_is_cwd(self, tmp_path):
         """Regression for issue 3692"""
         from setuptools import build_meta


### PR DESCRIPTION
Fixes #3851.

Auto-discovery treated a top-level `script.py` as a `py_module` even when that file was already listed in `scripts=`. The resulting wheel then installed the same file into both `scripts` and `purelib`.

Skip those filenames during flat- and src-layout module discovery so they stay scripts only. A neighboring real module is still discovered.