### PR TITLE
docs: link dependency_links replacement

### DIFF
--- a/docs/deprecated/dependency_links.rst
+++ b/docs/deprecated/dependency_links.rst
@@ -3,7 +3,8 @@ Specifying dependencies that aren't in PyPI via ``dependency_links``
 
 .. warning::
     Dependency links support has been dropped by pip starting with version
-    19.0 (released 2019-01-22).
+    19.0 (released 2019-01-22). Use :ref:`direct URL dependencies
+    <direct-url-dependencies>` instead.
 
 If your project depends on packages that don't exist on PyPI, you *may* still be
 able to depend on them if they are available for download as:

--- a/docs/userguide/dependency_management.rst
+++ b/docs/userguide/dependency_management.rst
@@ -209,6 +209,8 @@ detailed in :pep:`508`.
    specific use cases where environment markers aren't sufficient.
 
 
+.. _direct-url-dependencies:
+
 Direct URL dependencies
 -----------------------
 

--- a/newsfragments/4859.doc.rst
+++ b/newsfragments/4859.doc.rst
@@ -1,0 +1,2 @@
+Linked the deprecated ``dependency_links`` documentation to the supported
+direct URL dependency syntax.


### PR DESCRIPTION
## Summary of changes

Link the deprecated `dependency_links` documentation directly to the supported direct URL dependency syntax, and add an explicit target to keep that destination stable.

Closes #4859

### Validation

- Sphinx documentation build with warnings treated as errors

### Pull Request Checklist

- [ ] Changes have tests (documentation-only change; the documentation build passes).
- [x] News fragment added in [`newsfragments/`](https://github.com/pypa/setuptools/tree/main/newsfragments).