### PR TITLE
Reject archive members that escape the extraction directory

### DIFF
--- a/newsfragments/+ghsa-grgh-hr87-3jpw.bugfix.rst
+++ b/newsfragments/+ghsa-grgh-hr87-3jpw.bugfix.rst
@@ -1,0 +1,8 @@
+``setuptools.archive_util`` no longer extracts archive members outside of the
+requested extraction directory. Both the tar and zip formats specify ``/`` as
+the only path separator, but the guard against ``..`` components split member
+names on ``/`` alone, so a name such as ``..\escaped.txt`` was treated as a
+single component and then resolved as a traversal by the filesystem on
+Windows. Member names containing a backslash, a drive letter, or a UNC prefix
+are now rejected, as are members whose resolved destination falls outside the
+extraction directory -- see GHSA-grgh-hr87-3jpw.

--- a/newsfragments/+ghsa-grgh-hr87-3jpw.bugfix.rst
+++ b/newsfragments/+ghsa-grgh-hr87-3jpw.bugfix.rst
@@ -4,5 +4,5 @@ the only path separator, but the guard against ``..`` components split member
 names on ``/`` alone, so a name such as ``..\escaped.txt`` was treated as a
 single component and then resolved as a traversal by the filesystem on
 Windows. Member names containing a backslash, a drive letter, or a UNC prefix
-are now rejected, as are members whose resolved destination falls outside the
-extraction directory -- see GHSA-grgh-hr87-3jpw.
+are now rejected on every platform, as are members whose resolved destination
+falls outside the extraction directory -- see GHSA-grgh-hr87-3jpw.

--- a/newsfragments/+ghsa-grgh-hr87-3jpw.feature.rst
+++ b/newsfragments/+ghsa-grgh-hr87-3jpw.feature.rst
@@ -3,7 +3,4 @@ an archive member would be extracted outside of the extraction directory,
 where previously such a member was silently skipped. Aborting makes a
 malicious or malformed archive visible to the caller instead of yielding a
 quietly incomplete extraction, and matches the behavior of the standard
-library's ``tarfile`` extraction filters. Note that this also rejects archives
-whose members use a backslash as a path separator, as produced by some
-non-conforming Windows archivers; such an archive must now be repaired rather
-than partially extracted.
+library's ``tarfile`` extraction filters.

--- a/newsfragments/+ghsa-grgh-hr87-3jpw.removal.rst
+++ b/newsfragments/+ghsa-grgh-hr87-3jpw.removal.rst
@@ -1,0 +1,9 @@
+``setuptools.archive_util`` now raises the new ``UnsafeMember`` exception when
+an archive member would be extracted outside of the extraction directory,
+where previously such a member was silently skipped. Aborting makes a
+malicious or malformed archive visible to the caller instead of yielding a
+quietly incomplete extraction, and matches the behavior of the standard
+library's ``tarfile`` extraction filters. Note that this also rejects archives
+whose members use a backslash as a path separator, as produced by some
+non-conforming Windows archivers; such an archive must now be repaired rather
+than partially extracted.

--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -67,13 +67,11 @@ def _resolve_dest(extract_dir, name):
 
     dest = os.path.join(extract_dir, *parts)
 
-    # Belt and braces: confirm the result really does resolve within the root.
+    # Belt and braces: confirm the result really does resolve within the root,
+    # catching an escape through a symlink already present in the destination.
     root = os.path.realpath(extract_dir)
-    try:
-        if os.path.commonpath([root, os.path.realpath(dest)]) != root:
-            return None
-    except ValueError:
-        # Paths on different drives are not comparable, and so not contained.
+    resolved = os.path.realpath(dest)
+    if resolved != root and not resolved.startswith(os.path.join(root, '')):
         return None
 
     return dest

--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -14,6 +14,7 @@ from distutils.errors import DistutilsError
 
 __all__ = [
     "UnrecognizedFormat",
+    "UnsafeMember",
     "default_filter",
     "extraction_drivers",
     "unpack_archive",
@@ -27,6 +28,15 @@ class UnrecognizedFormat(DistutilsError):
     """Couldn't recognize the archive type"""
 
 
+class UnsafeMember(DistutilsError):
+    """An archive member that would be extracted outside the destination
+
+    Deliberately not an `UnrecognizedFormat`, which ``unpack_archive`` catches
+    to fall through to the next driver; an unsafe member must abort the
+    extraction rather than hand the archive to another driver.
+    """
+
+
 def default_filter(src, dst):
     """The default progress/filter callback; returns True for all files"""
     return dst
@@ -35,7 +45,7 @@ def default_filter(src, dst):
 def _resolve_dest(extract_dir, name):
     r"""
     Return the path where archive member `name` belongs under `extract_dir`,
-    or None if the member would be written outside of `extract_dir`.
+    raising `UnsafeMember` if the member would be written outside of it.
 
     Both the tar and zip formats specify '/' as the only path separator, so a
     backslash is never a legitimate separator in a member name and must not be
@@ -49,21 +59,18 @@ def _resolve_dest(extract_dir, name):
     True
     >>> _resolve_dest('dest', 'sub/dir/') == os.path.join('dest', 'sub', 'dir', '')
     True
-    >>> _resolve_dest('dest', '/etc/passwd')
-    >>> _resolve_dest('dest', '../escaped.txt')
-    >>> _resolve_dest('dest', 'sub/../../escaped.txt')
     >>> _resolve_dest('dest', '..\\escaped.txt')
-    >>> _resolve_dest('dest', 'sub\\..\\..\\escaped.txt')
-    >>> _resolve_dest('dest', 'C:escaped.txt')
-    >>> _resolve_dest('dest', '//server/share/escaped.txt')
+    Traceback (most recent call last):
+    ...
+    setuptools.archive_util.UnsafeMember: '..\\escaped.txt' would be extracted outside of 'dest'
     """
     if name.startswith('/') or '\\' in name or ntpath.splitdrive(name)[0]:
-        return None
+        raise UnsafeMember(f"{name!r} would be extracted outside of {extract_dir!r}")
 
     parts = name.split('/')
 
     if '..' in parts:
-        return None
+        raise UnsafeMember(f"{name!r} would be extracted outside of {extract_dir!r}")
 
     dest = os.path.join(extract_dir, *parts)
 
@@ -72,7 +79,7 @@ def _resolve_dest(extract_dir, name):
     root = os.path.realpath(extract_dir)
     resolved = os.path.realpath(dest)
     if resolved != root and not resolved.startswith(os.path.join(root, '')):
-        return None
+        raise UnsafeMember(f"{name!r} would be extracted outside of {extract_dir!r}")
 
     return dest
 
@@ -160,11 +167,7 @@ def _unpack_zipfile_obj(zipfile_obj, extract_dir, progress_filter=default_filter
     for info in zipfile_obj.infolist():
         name = info.filename
 
-        # don't extract members that escape the extraction directory
         target = _resolve_dest(extract_dir, name)
-        if target is None:
-            continue
-
         target = progress_filter(name, target)
         if not target:
             continue
@@ -211,10 +214,7 @@ def _iter_open_tar(tar_obj, extract_dir, progress_filter):
     with contextlib.closing(tar_obj):
         for member in tar_obj:
             name = member.name
-            # don't extract members that escape the extraction directory
             prelim_dst = _resolve_dest(extract_dir, name)
-            if prelim_dst is None:
-                continue
 
             try:
                 member = _resolve_tar_file_or_dir(tar_obj, member)

--- a/setuptools/archive_util.py
+++ b/setuptools/archive_util.py
@@ -1,6 +1,7 @@
 """Utilities for extracting common archive formats"""
 
 import contextlib
+import ntpath
 import os
 import posixpath
 import shutil
@@ -29,6 +30,53 @@ class UnrecognizedFormat(DistutilsError):
 def default_filter(src, dst):
     """The default progress/filter callback; returns True for all files"""
     return dst
+
+
+def _resolve_dest(extract_dir, name):
+    r"""
+    Return the path where archive member `name` belongs under `extract_dir`,
+    or None if the member would be written outside of `extract_dir`.
+
+    Both the tar and zip formats specify '/' as the only path separator, so a
+    backslash is never a legitimate separator in a member name and must not be
+    allowed to act as one on Windows (GHSA-grgh-hr87-3jpw). Names that are
+    absolute, drive-qualified, or UNC are rejected for the same reason.
+
+    A directory member keeps its trailing separator, as callers rely on it to
+    distinguish a directory from a file.
+
+    >>> _resolve_dest('dest', 'sub/file.txt') == os.path.join('dest', 'sub', 'file.txt')
+    True
+    >>> _resolve_dest('dest', 'sub/dir/') == os.path.join('dest', 'sub', 'dir', '')
+    True
+    >>> _resolve_dest('dest', '/etc/passwd')
+    >>> _resolve_dest('dest', '../escaped.txt')
+    >>> _resolve_dest('dest', 'sub/../../escaped.txt')
+    >>> _resolve_dest('dest', '..\\escaped.txt')
+    >>> _resolve_dest('dest', 'sub\\..\\..\\escaped.txt')
+    >>> _resolve_dest('dest', 'C:escaped.txt')
+    >>> _resolve_dest('dest', '//server/share/escaped.txt')
+    """
+    if name.startswith('/') or '\\' in name or ntpath.splitdrive(name)[0]:
+        return None
+
+    parts = name.split('/')
+
+    if '..' in parts:
+        return None
+
+    dest = os.path.join(extract_dir, *parts)
+
+    # Belt and braces: confirm the result really does resolve within the root.
+    root = os.path.realpath(extract_dir)
+    try:
+        if os.path.commonpath([root, os.path.realpath(dest)]) != root:
+            return None
+    except ValueError:
+        # Paths on different drives are not comparable, and so not contained.
+        return None
+
+    return dest
 
 
 def unpack_archive(
@@ -114,11 +162,11 @@ def _unpack_zipfile_obj(zipfile_obj, extract_dir, progress_filter=default_filter
     for info in zipfile_obj.infolist():
         name = info.filename
 
-        # don't extract absolute paths or ones with .. in them
-        if name.startswith('/') or '..' in name.split('/'):
+        # don't extract members that escape the extraction directory
+        target = _resolve_dest(extract_dir, name)
+        if target is None:
             continue
 
-        target = os.path.join(extract_dir, *name.split('/'))
         target = progress_filter(name, target)
         if not target:
             continue
@@ -165,11 +213,10 @@ def _iter_open_tar(tar_obj, extract_dir, progress_filter):
     with contextlib.closing(tar_obj):
         for member in tar_obj:
             name = member.name
-            # don't extract absolute paths or ones with .. in them
-            if name.startswith('/') or '..' in name.split('/'):
+            # don't extract members that escape the extraction directory
+            prelim_dst = _resolve_dest(extract_dir, name)
+            if prelim_dst is None:
                 continue
-
-            prelim_dst = os.path.join(extract_dir, *name.split('/'))
 
             try:
                 member = _resolve_tar_file_or_dir(tar_obj, member)

--- a/setuptools/tests/test_archive_util.py
+++ b/setuptools/tests/test_archive_util.py
@@ -51,10 +51,6 @@ TRAVERSAL_NAMES = [
     'C:escaped.txt',
 ]
 
-#: Extracted alongside each traversal attempt to prove that the archive was
-#: processed and that only the offending member was skipped.
-CONTROL_NAME = 'inside.txt'
-
 
 def _make_tarfile(path, names):
     with tarfile.open(path, mode='w:gz') as tgz:
@@ -77,29 +73,47 @@ def _make_zipfile(path, names):
     return str(path)
 
 
-@pytest.mark.parametrize('name', TRAVERSAL_NAMES)
-@pytest.mark.parametrize(
+drivers = pytest.mark.parametrize(
     ('suffix', 'make_archive'),
     [('.tar.gz', _make_tarfile), ('.zip', _make_zipfile)],
     ids=['tar', 'zip'],
 )
-def test_unpack_skips_traversal(tmp_path, name, suffix, make_archive):
+
+
+@drivers
+@pytest.mark.parametrize('name', TRAVERSAL_NAMES)
+def test_unpack_rejects_traversal(tmp_path, name, suffix, make_archive):
     """
-    A member that would land outside the extraction directory is skipped
-    rather than extracted (GHSA-grgh-hr87-3jpw).
+    A member that would land outside the extraction directory aborts the
+    extraction rather than being silently skipped (GHSA-grgh-hr87-3jpw).
     """
-    archive = make_archive(tmp_path / f'malicious{suffix}', [name, CONTROL_NAME])
+    archive = make_archive(tmp_path / f'malicious{suffix}', [name])
+    target = tmp_path / 'dest'
+
+    with pytest.raises(archive_util.UnsafeMember):
+        archive_util.unpack_archive(archive, str(target))
+
+    # nothing was written outside of the target
+    assert {path.name for path in tmp_path.iterdir()} <= {
+        f'malicious{suffix}',
+        'dest',
+    }
+
+
+@drivers
+def test_unpack_extracts_safe_members(tmp_path, suffix, make_archive):
+    """
+    Ordinary members are unaffected by the containment check.
+    """
+    names = ['inside.txt', 'sub/nested.txt', './dot-prefixed.txt']
+    archive = make_archive(tmp_path / f'safe{suffix}', names)
     target = tmp_path / 'dest'
 
     archive_util.unpack_archive(archive, str(target))
 
-    assert (target / CONTROL_NAME).read_text(encoding='utf-8') == CONTROL_NAME
-    # the traversal member was skipped, and nothing landed outside the target
-    assert [path.name for path in target.rglob('*')] == [CONTROL_NAME]
-    assert {path.name for path in tmp_path.iterdir()} == {
-        f'malicious{suffix}',
-        'dest',
-    }
+    assert (target / 'inside.txt').read_text(encoding='utf-8') == 'inside.txt'
+    assert (target / 'sub' / 'nested.txt').exists()
+    assert (target / 'dot-prefixed.txt').exists()
 
 
 def test_unpack_zipfile_creates_directory_members(tmp_path):
@@ -127,5 +141,7 @@ def test_resolve_dest_rejects_symlinked_escape(tmp_path):
     outside.mkdir()
     (target / 'sub').symlink_to(outside, target_is_directory=True)
 
-    assert archive_util._resolve_dest(str(target), 'sub/file.txt') is None
-    assert archive_util._resolve_dest(str(target), 'ok/file.txt') is not None
+    with pytest.raises(archive_util.UnsafeMember):
+        archive_util._resolve_dest(str(target), 'sub/file.txt')
+
+    assert archive_util._resolve_dest(str(target), 'ok/file.txt')

--- a/setuptools/tests/test_archive_util.py
+++ b/setuptools/tests/test_archive_util.py
@@ -1,9 +1,12 @@
 import io
 import tarfile
+import zipfile
 
 import pytest
 
 from setuptools import archive_util
+
+from .compat.py39 import os_helper
 
 
 @pytest.fixture
@@ -34,3 +37,95 @@ def tarfile_with_unicode(tmpdir):
 def test_unicode_files(tarfile_with_unicode, tmpdir):
     target = tmpdir / 'out'
     archive_util.unpack_archive(tarfile_with_unicode, str(target))
+
+
+#: Member names that must never be extracted, whatever the platform. The
+#: backslash variants only escape on Windows, but are rejected everywhere so
+#: that the behavior (and this test) is not platform-dependent.
+TRAVERSAL_NAMES = [
+    '../escaped.txt',
+    'sub/../../escaped.txt',
+    '..\\escaped.txt',
+    'sub\\..\\..\\escaped.txt',
+    '/absolute.txt',
+    'C:escaped.txt',
+]
+
+#: Extracted alongside each traversal attempt to prove that the archive was
+#: processed and that only the offending member was skipped.
+CONTROL_NAME = 'inside.txt'
+
+
+def _make_tarfile(path, names):
+    with tarfile.open(path, mode='w:gz') as tgz:
+        for name in names:
+            data = name.encode()
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tgz.addfile(info, io.BytesIO(data))
+    return str(path)
+
+
+def _make_zipfile(path, names):
+    with zipfile.ZipFile(path, mode='w') as zf:
+        for name in names:
+            # Assign the name after construction; ZipInfo rewrites os.sep to
+            # '/' on Windows, which would defeat the backslash cases.
+            info = zipfile.ZipInfo()
+            info.filename = name
+            zf.writestr(info, name.encode())
+    return str(path)
+
+
+@pytest.mark.parametrize('name', TRAVERSAL_NAMES)
+@pytest.mark.parametrize(
+    ('suffix', 'make_archive'),
+    [('.tar.gz', _make_tarfile), ('.zip', _make_zipfile)],
+    ids=['tar', 'zip'],
+)
+def test_unpack_skips_traversal(tmp_path, name, suffix, make_archive):
+    """
+    A member that would land outside the extraction directory is skipped
+    rather than extracted (GHSA-grgh-hr87-3jpw).
+    """
+    archive = make_archive(tmp_path / f'malicious{suffix}', [name, CONTROL_NAME])
+    target = tmp_path / 'dest'
+
+    archive_util.unpack_archive(archive, str(target))
+
+    assert (target / CONTROL_NAME).read_text(encoding='utf-8') == CONTROL_NAME
+    # the traversal member was skipped, and nothing landed outside the target
+    assert [path.name for path in target.rglob('*')] == [CONTROL_NAME]
+    assert {path.name for path in tmp_path.iterdir()} == {
+        f'malicious{suffix}',
+        'dest',
+    }
+
+
+def test_unpack_zipfile_creates_directory_members(tmp_path):
+    """
+    A zip directory entry still creates the directory itself, not just its
+    parent.
+    """
+    archive = _make_zipfile(tmp_path / 'dirs.zip', ['empty/'])
+    target = tmp_path / 'dest'
+
+    archive_util.unpack_archive(archive, str(target))
+
+    assert (target / 'empty').is_dir()
+
+
+@pytest.mark.skipif(not os_helper.can_symlink(), reason='Symlink support required')
+def test_resolve_dest_rejects_symlinked_escape(tmp_path):
+    """
+    A member name that is harmless in isolation must still not escape through
+    a symlink that already exists in the extraction directory.
+    """
+    target = tmp_path / 'dest'
+    target.mkdir()
+    outside = tmp_path / 'outside'
+    outside.mkdir()
+    (target / 'sub').symlink_to(outside, target_is_directory=True)
+
+    assert archive_util._resolve_dest(str(target), 'sub/file.txt') is None
+    assert archive_util._resolve_dest(str(target), 'ok/file.txt') is not None


### PR DESCRIPTION
## Summary

`setuptools.archive_util` guarded against traversal with:

```python
if name.startswith('/') or '..' in name.split('/'):
    continue
target = os.path.join(extract_dir, *name.split('/'))
```

Both the tar and zip formats specify `/` as the only path separator, so splitting on `/` alone is the natural reading — but a backslash is then carried into a single path component and handed to `os.path.join`, where Windows treats it as a separator after all:

| member name | old guard blocked? | resolved destination |
| --- | --- | --- |
| `..\escaped.txt` | no | `C:\escaped.txt` |
| `safe\..\escaped.txt` | no | `C:\dest\escaped.txt` |
| `C:evil.txt` | no | `C:\evil.txt` |
| `\\server\share\x` | no | `\\server\share\x` |

The drive-qualified and UNC cases are not traversal at all — `os.path.join` discards `extract_dir` outright, giving a fully attacker-chosen destination.

This affects the zip driver as well as the tar driver: `_unpack_zipfile_obj` carries a byte-identical guard. A `zipfile`-built PoC hides this, because `ZipInfo.__init__` rewrites `os.sep` to `/` when `os.sep != "/"`, so an archive *built* on Windows has its backslashes normalized away; one built on Linux (or written directly) preserves them.

Ref GHSA-grgh-hr87-3jpw, reported by @Faze-up.

## Impact

Low, hence a public PR rather than a private fix.

The tar driver has had no in-tree caller since `easy_install` and `package_index` were removed — `install_egg_info` passes a locally built `.egg-info` directory, which dispatches to `unpack_directory`. So the reported vector is third-party callers of the public API only.

The zip driver *is* still reachable in-tree, via `installer._fetch_build_egg_no_warn` → `Wheel.install_as_egg` → `_unpack_zipfile_obj`, on the deprecated `setup_requires` path. Even there the escalation is slight: a wheel unpacked by that path is about to be imported anyway.

## Approach

Both drivers now share one `_resolve_dest()`, so the two copies of the guard cannot drift apart again. It rejects names containing a backslash, `..` components, a leading `/`, or a drive/UNC prefix, and then — belt and braces — confirms the resolved destination really does fall under the resolved extraction directory.

Two details worth flagging for review:

- The containment check is applied to the *preliminary* destination, before `progress_filter`. The callback is documented as free to rewrite the destination, so asserting on the post-filter path would break filters that legitimately relocate files.
- Zip directory members keep their trailing separator. `ensure_directory` only creates the *parent* of its argument, so dropping it would leave empty directories uncreated — there is now a regression test pinning that.

## Tests

Traversal cases are parametrized over both drivers and asserted through `unpack_archive`, so they are meaningful on Linux CI rather than Windows-only: on POSIX the old code created a file *literally named* `..\escaped.txt` inside the target, so "the target contains only the control member" fails before the fix on every platform. Archive members are written with the name assigned after `ZipInfo` construction, so the backslash cases survive being built on Windows too.

There is also a symlink case covering the containment check specifically: a member name that is harmless in isolation still must not escape through a symlink already present in the extraction directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
