### PR TITLE
Validate namespace package names during legacy wheel installation

### DIFF
--- a/newsfragments/+ghsa-xmj3-9gf7-h52w.bugfix.rst
+++ b/newsfragments/+ghsa-xmj3-9gf7-h52w.bugfix.rst
@@ -1,0 +1,11 @@
+``Wheel.install_as_egg`` no longer creates namespace package directories
+outside of the destination egg directory. Entries in a wheel's
+``namespace_packages.txt`` were split on ``.`` and passed straight to
+``os.path.join``, so an entry that was absolute, drive-qualified, or UNC
+discarded the destination and placed an ``__init__.py`` at a path chosen by
+the wheel. Namespace entries are now validated as dotted module names on
+every platform -- see GHSA-xmj3-9gf7-h52w.
+
+This code path is reached only by the deprecated ``setup_requires``
+mechanism when ``setup()`` is invoked outside a PEP 517 frontend; the
+setuptools build backend never reaches it.

--- a/setuptools/tests/test_wheel.py
+++ b/setuptools/tests/test_wheel.py
@@ -19,7 +19,7 @@ from jaraco import path
 from packaging.tags import parse_tag
 
 from setuptools._importlib import metadata
-from setuptools.wheel import Wheel
+from setuptools.wheel import Wheel, _resolve_namespace_dir
 
 from .contexts import tempdir
 from .textwrap import DALS
@@ -687,3 +687,57 @@ def test_wheel_mode():
         if sys.platform != 'win32':
             # Editable file mode has no effect on Windows
             assert oct(stat.S_IMODE(script_sh.stat().st_mode)) == "0o777"
+
+
+@pytest.mark.parametrize(
+    "mod",
+    [
+        pytest.param('/tmp/outside', id='posix_absolute'),
+        pytest.param(r'C:\Windows', id='drive_qualified'),
+        pytest.param(r'\\server\share', id='unc'),
+        pytest.param('foo/../../evil', id='separators'),
+        pytest.param('..', id='parent'),
+        pytest.param('', id='empty'),
+    ],
+)
+def test_namespace_package_escape(tmp_path, mod):
+    """
+    A namespace entry that is not a dotted module name must be rejected
+    rather than resolved as a path (GHSA-xmj3-9gf7-h52w).
+    """
+    with pytest.raises(ValueError, match='invalid namespace package name'):
+        _resolve_namespace_dir(str(tmp_path), mod)
+
+
+def test_namespace_package_resolves_dotted_name(tmp_path):
+    expected = tmp_path / 'ns' / 'pkg'
+    assert _resolve_namespace_dir(str(tmp_path), 'ns.pkg') == str(expected)
+
+
+def test_install_as_egg_rejects_namespace_escape(tmp_path):
+    """
+    An attacker-controlled ``namespace_packages.txt`` must not create files
+    outside the destination egg directory.
+    """
+    outside = tmp_path / 'outside'
+    outside.mkdir()
+    dest = tmp_path / 'destination'
+
+    whl = tmp_path / 'demo_pkg-1.0-py3-none-any.whl'
+    dist_info = 'demo_pkg-1.0.dist-info'
+    with zipfile.ZipFile(whl, 'w') as zf:
+        zf.writestr(
+            f'{dist_info}/WHEEL',
+            'Wheel-Version: 1.0\nGenerator: test\n'
+            'Root-Is-Purelib: true\nTag: py3-none-any\n',
+        )
+        zf.writestr(
+            f'{dist_info}/METADATA',
+            'Metadata-Version: 2.1\nName: demo-pkg\nVersion: 1.0\n',
+        )
+        zf.writestr(f'{dist_info}/namespace_packages.txt', f'{outside}\n')
+
+    with pytest.raises(ValueError, match='invalid namespace package name'):
+        Wheel(str(whl)).install_as_egg(str(dest))
+
+    assert not (outside / '__init__.py').exists()

--- a/setuptools/wheel.py
+++ b/setuptools/wheel.py
@@ -79,6 +79,44 @@ def disable_info_traces() -> Iterator[None]:
         log.set_threshold(saved)
 
 
+def _resolve_namespace_dir(destination_eggdir, mod):
+    r"""
+    Return the directory for namespace package `mod` under `destination_eggdir`.
+
+    `mod` is a dotted module name, so every component must be an identifier.
+    ``os.path.join`` interprets its arguments as paths, so a component that is
+    absolute, drive-qualified, or UNC discards `destination_eggdir` entirely,
+    and one containing a separator escapes it (GHSA-xmj3-9gf7-h52w). Only
+    Windows treats a drive letter that way, but an absolute POSIX path escapes
+    just as readily, so the name is validated on every platform.
+
+    >>> _resolve_namespace_dir('dest', 'ns.pkg') == os.path.join('dest', 'ns', 'pkg')
+    True
+    >>> _resolve_namespace_dir('dest', '/tmp/outside')
+    Traceback (most recent call last):
+    ...
+    ValueError: invalid namespace package name: '/tmp/outside'
+    >>> _resolve_namespace_dir('dest', r'C:\Windows')
+    Traceback (most recent call last):
+    ...
+    ValueError: invalid namespace package name: 'C:\\Windows'
+    """
+    parts = mod.split('.')
+
+    if not all(part.isidentifier() for part in parts):
+        raise ValueError(f"invalid namespace package name: {mod!r}")
+
+    dest = os.path.join(destination_eggdir, *parts)
+
+    # Belt and braces: confirm the result really does resolve within the egg
+    # directory, catching an escape through a symlink already present in it.
+    root = os.path.realpath(destination_eggdir)
+    if not os.path.realpath(dest).startswith(os.path.join(root, '')):
+        raise ValueError(f"invalid namespace package name: {mod!r}")
+
+    return dest
+
+
 class Wheel:
     def __init__(self, filename) -> None:
         match = WHEEL_NAME(os.path.basename(filename))
@@ -253,7 +291,7 @@ class Wheel:
             namespace_packages = _read_utf8_with_fallback(namespace_packages).split()
 
             for mod in namespace_packages:
-                mod_dir = os.path.join(destination_eggdir, *mod.split('.'))
+                mod_dir = _resolve_namespace_dir(destination_eggdir, mod)
                 mod_init = os.path.join(mod_dir, '__init__.py')
                 if not os.path.exists(mod_dir):
                     os.mkdir(mod_dir)


### PR DESCRIPTION
Hardening for GHSA-xmj3-9gf7-h52w, reported privately by @Hades2508.

## The issue

`Wheel._fix_namespace_packages` split each entry of a wheel's
`namespace_packages.txt` on `.` and passed the components straight to
`os.path.join`, which interprets its arguments as paths:

```python
mod_dir = os.path.join(destination_eggdir, *mod.split('.'))
```

An entry with no dots and an absolute form is a single component, so
`os.path.join` discards `destination_eggdir` and resolves to the
attacker-chosen path, where a fixed-content `__init__.py` is then created.

The report framed this as Windows-only (drive-qualified paths), but only
that *form* is Windows-specific — an absolute POSIX path escapes just as
readily, confirmed end-to-end against the real `install_as_egg` on macOS:

```
'/tmp/pwned'.split('.')  -> ['/tmp/pwned']  -> os.path.join(dest, '/tmp/pwned') == '/tmp/pwned'
```

Only bare `..` was already neutral, since `'..'.split('.')` yields empty
components.

## Impact

Low, and deliberately being handled in public rather than embargoed.

`setuptools.installer` is the only remaining caller of `install_as_egg`
(`easy_install` is now a stub), so the sink is reachable only via the
deprecated `setup_requires` mechanism with `setup()` invoked outside a
PEP 517 frontend. The build backend does not reach it — every hook either
runs under `no_install_setup_requires()` or under `Distribution.patch()`,
whose `fetch_build_eggs` reports requirements to the frontend instead of
installing them. Verified by instrumenting the sink:

```
build_meta.get_requires_for_build_wheel       sink_hits=0
build_meta.prepare_metadata_for_build_wheel   sink_hits=0
build_meta.build_wheel                        sink_hits=0
build_meta.build_sdist                        sink_hits=0
build_meta.__legacy__.build_wheel             sink_hits=0
setuptools.setup() directly (setup.py)        sink_hits=1
```

Moreover, an attacker who can satisfy the precondition — controlling the
wheel resolved for a `setup_requires` entry — already gets arbitrary code
execution, since `_fetch_build_eggs` prepends the resulting egg to
`sys.path` for the build to import. A fixed-content, non-overwriting
`__init__.py` whose parent directory must already exist is strictly weaker
than what that attacker already has.

The one residue not fully subsumed: writing `__init__.py` into an existing
PEP 420 namespace portion could alter import resolution. That motivates
fixing it as defense in depth.

## The change

Namespace entries are dotted module names, so every component must be an
identifier. That single check rejects separators, absolute paths, drive
letters, UNC prefixes, `..`, and empty components on every platform, and a
`realpath` containment check follows as belt and braces — mirroring
`_resolve_dest` from #5325.

Invalid entries now raise `ValueError`, consistent with the other
malformed-wheel errors in this module.